### PR TITLE
setuptools: Fix description, license tag, and install package entries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,14 +30,14 @@ def read(fname):
 setup(
     name='convert2rhel',
     version='0.9',
-    description='Automates the conversion of the installed other-than-RHEL'
-                ' distribution to Red Hat Enterprise Linux (RHEL)',
+    description='Automates the conversion of Red Hat Enterprise Linux'
+                ' derivative distributions to Red Hat Enterprise Linux.',
     long_description=read('README'),
     author='Michal Bocek',
     author_email='mbocek@redhat.com',
     url='www.redhat.com',
-    license='GNU General Public License v3 (GPLv3)',
-    packages=find_packages(),
+    license='GNU General Public License v3 or later (GPLv3+)',
+    packages=['convert2rhel'],
     entry_points={
         'console_scripts': [
             'convert2rhel = convert2rhel.main:main',


### PR DESCRIPTION
The description is a bit weird and does not exactly describe what
this tool does. This is an attempt to better describe what it does.

Also, adjust the license name to match what the code actually says it
is: GPLv3+.

Additionally, this script installs stuff that should not be installed
because of its usage of `find_packages()`. Since there's only one
actual package that needs to be installed, we just list it now.