### PR TITLE
Add option for srpm build with unchanged release

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -2,9 +2,11 @@ mkfile_dir := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 repo_root := $(mkfile_dir)/../
 yum_or_dnf := $(shell command -v dnf || command -v yum)
 
-srpm:
+install_build_deps:
 	@echo --- Installing SRPM build requirements ---
 	@$(yum_or_dnf) install -y git python2 python2-setuptools rpmlint rpm-build
+
+srpm: install_build_deps
 	@echo --- Building SRPM ---
 	$(repo_root)/packaging/epel/create_epel_srpm.sh
 	@mv $(repo_root)/SRPMS/*.rpm $(outdir)

--- a/packaging/epel/create_epel_srpm.sh
+++ b/packaging/epel/create_epel_srpm.sh
@@ -5,6 +5,9 @@ cleanup() {
   rm -rf ${REPO_ROOT}/dist/
   popd
 }
+CHANGE_RELEASE=true
+# Do not change the release in spec, e.g. for Koji builds
+[ "$1" = "--orig-release" ] && CHANGE_RELEASE=false
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 REPO_ROOT=${SCRIPTPATH}/../..
@@ -20,7 +23,10 @@ TIMESTAMP=`date +%Y%m%d%H%MZ -u`
 GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 RELEASE="0"
 [ "${GIT_BRANCH}" = "master" ] && RELEASE="1"
-sed -i "s/1%{?dist}/${RELEASE}.${TIMESTAMP}.${GIT_BRANCH}%{?dist}/g" convert2rhel.spec
+if [ "$CHANGE_RELEASE" = true ]; then
+    # Suitable for Continous Delivery
+    sed -i "s/1%{?dist}/${RELEASE}.${TIMESTAMP}.${GIT_BRANCH}%{?dist}/g" convert2rhel.spec
+fi
 
 rpmbuild -bs convert2rhel.spec --define "debug_package %{nil}" \
     --define "_sourcedir ${REPO_ROOT}/dist" \


### PR DESCRIPTION
- `--orig-release`: suitable for example for Koji builds
- the changed release with timestamp and git branch is suitable for CD