### PR TITLE
Blacklist kmod-kvdo on CentOS7

### DIFF
--- a/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
@@ -13,6 +13,7 @@ pkg_blacklist =
   centos-indexhtml
   centos-release*
   geoipupdate
+  kmod-kvdo
   redhat-release*
   libreport-centos
   libreport-plugin-mantisbt


### PR DESCRIPTION
- it causes a transaction failure during the conversion to RHEL7
  https://bugzilla.redhat.com/show_bug.cgi?id=1798226