### PR TITLE
Fix names of copr builds

### DIFF
--- a/packaging/epel/create_epel_srpm.sh
+++ b/packaging/epel/create_epel_srpm.sh
@@ -20,7 +20,7 @@ cp ${SCRIPTPATH}/convert2rhel.spec convert2rhel.spec
 rpmlint convert2rhel.spec
 
 TIMESTAMP=`date +%Y%m%d%H%MZ -u`
-GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+GIT_BRANCH=$(git for-each-ref --format='%(objectname) %(refname:short)' refs/heads | awk "{print \$2}")
 RELEASE="0"
 [ "${GIT_BRANCH}" = "master" ] && RELEASE="1"
 if [ "$CHANGE_RELEASE" = true ]; then


### PR DESCRIPTION
- there was 'HEAD' instead of 'master' when built from the master branch
  in https://copr.fedorainfracloud.org/coprs/g/oamg/convert2rhel/builds/