### PR TITLE
Update system tests script

### DIFF
--- a/run_system_tests.sh
+++ b/run_system_tests.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Note: The <RHEL6_repo_URL> and <RHEL7_repo_URL> are to be changed before executing this script.
+# The system tests require the access to RHEL repositories through yum repo "baseurl" (HTTP/FTP).
+# RHEL repositories are not publicly available. You can download the RHEL ISOs from
+# https://access.redhat.com/downloads/, mount them and then serve them through your local FTP or web server.
+
 # Start all defined system testing VMs
 branch_name=master
 
@@ -19,15 +24,16 @@ run_vagrant() {
 
 ret_code=0
 pushd "${BASH_SOURCE%/*}" || exit
-run_vagrant "system_tests/vmdefs/centos5/" \
-            "https://<copr_hostname>/results/mbocek/convert2rhel/rhel-5-x86_64/" \
-            "http://<rhel_storage_hostname>/pub/rhel/released/RHEL-5-Server/U11/x86_64/os/Server/"
+# There's no public copr with EPEL5 chroot
+#run_vagrant "system_tests/vmdefs/centos5/" \
+#            "<convert2rhel repo with RHEL5-compatible builds>" \
+#            "<RHEL5_repo_URL>"
 run_vagrant "system_tests/vmdefs/centos6/" \
-            "https://<copr_hostname>/results/mbocek/convert2rhel/rhel-6-x86_64/" \
-            "http://<rhel_storage_hostname>/pub/rhel/released/RHEL-6/6.10/Server/x86_64/os/"
+            "https://download.copr.fedorainfracloud.org/results/@oamg/convert2rhel/epel-6-x86_64/" \
+            "<RHEL6_repo_URL>"
 run_vagrant "system_tests/vmdefs/centos7/" \
-            "https://<copr_hostname>/results/mbocek/convert2rhel/rhel-7-x86_64/" \
-            "http://<rhel_storage_hostname>/pub/rhel/released/RHEL-7/7.6/Server/x86_64/os/"
+            "https://download.copr.fedorainfracloud.org/results/@oamg/convert2rhel/epel-7-x86_64/" \
+            "<RHEL7_repo_URL>"
 popd > /dev/null
 
 exit $ret_code


### PR DESCRIPTION
- to describe how to make system tests work
- to not run system tests on CentOS 5 vagrant box for the lack of public copr builds for it