### PR TITLE
Fix packit conf on proposing a downstream release

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -24,6 +24,6 @@ jobs:
 - job: propose_downstream
   trigger: release
   metadata:
-    dist-git-branch:
+    dist_git_branches:
     - el6
     - epel7


### PR DESCRIPTION
For the downstream release proposal, packit configuration requires dist_git_branches instead of dist-git-branch: https://packit.dev/docs/configuration/#packit-service-jobs

The incorrect key most probably caused that the proposal https://src.fedoraproject.org/rpms/convert2rhel/pull-request/1# has targeted Fedora rawhide instead of EPEL.