### PR TITLE
Always log debug info to the log file

### DIFF
--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-'''
+"""
 Customized logging functionality
 
 CRITICAL  (50)    Calls critical() function and sys.exit(1)
@@ -24,12 +24,15 @@ INFO      (20)    Prints info message (no date/time, just plain message)
 TASK      (15)    CUSTOM LABEL - Prints a task header message (using asterisks)
 DEBUG     (10)    Prints debug message (using date/time)
 FILE      (5)     CUSTOM LABEL - Prints only to file handler (using date/time)
-'''
+"""
+from convert2rhel.toolopts import tool_opts
 import logging
-import sys
 import os
+import sys
+from utils import format_msg_with_datetime
 
 LOG_DIR = "/var/log/convert2rhel"
+
 
 class LogLevelTask:
     level = 15
@@ -42,10 +45,10 @@ class LogLevelFile:
 
 
 def initialize_logger(log_name):
-    '''Initialize custom logging levels, handlers, and so on. Call this method
+    """Initialize custom logging levels, handlers, and so on. Call this method
     from your application's main start point.
         log_name = the name for the log file
-    '''
+    """
     # check if already initialized with custom class
     if logging.getLoggerClass() == CustomLogger:
         return
@@ -87,6 +90,7 @@ class CustomLogger(logging.Logger, object):
         class and causes 'TypeError: super() argument 1 must be type, not
         classobj' so we use multiple inheritance to get around the problem.
     """
+
     def task(self, msg, *args, **kwargs):
         super(CustomLogger, self).log(LogLevelTask.level, msg, *args,
                                       **kwargs)
@@ -104,7 +108,9 @@ class CustomLogger(logging.Logger, object):
         if tool_opts.debug:
             super(CustomLogger, self).debug(msg, *args, **kwargs)
         else:
-            pass
+            super(CustomLogger, self).log(LogLevelFile.level,
+                                          format_msg_with_datetime(msg, "debug"),
+                                          *args, **kwargs)
 
     def info(self, msg, *args, **kwargs):
         super(CustomLogger, self).info(msg, *args, **kwargs)
@@ -117,6 +123,7 @@ class CustomFormatter(logging.Formatter, object):
         class and causes 'TypeError: super() argument 1 must be type, not
         classobj' so we use multiple inheritance to get around the problem.
     """
+
     def format(self, record):
         if record.levelno == LogLevelTask.level:
             temp = '*' * (90 - len(record.msg) - 25)

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -122,4 +122,4 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(logging.Handler.handle.called, 6)
         tool_opts.debug = False
         loggerinst.debug("debugmsg2")
-        self.assertEqual(logging.Handler.handle.called, 6)
+        self.assertEqual(logging.Handler.handle.called, 7)

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import datetime
 import errno
 import getpass
 import inspect
@@ -44,6 +45,12 @@ class Color:
 DATA_DIR = "/usr/share/convert2rhel/"
 # Directory for temporary data to be stored during runtime
 TMP_DIR = "/tmp/convert2rhel/"
+
+
+def format_msg_with_datetime(msg, level):
+    """Return a string with msg formatted according to the level"""
+    temp_date = datetime.datetime.now().strftime("%m/%d/%Y %H:%M:%S")
+    return "[%s] %s - %s", temp_date, level.upper(), msg
 
 
 def get_executable_name():
@@ -220,6 +227,7 @@ def get_traceback_str():
 
 class DictWListValues(dict):
     """Python 2.4 replacement for Python 2.5+ collections.defaultdict(list)."""
+
     def __getitem__(self, item):
         if item not in self.iterkeys():
             self[item] = []
@@ -229,6 +237,7 @@ class DictWListValues(dict):
 
 class ChangedRPMPackagesController(object):
     """Keep control of installed/removed RPM pkgs for backup/restore."""
+
     def __init__(self):
         self.installed_pkgs = []
         self.removed_pkgs = []


### PR DESCRIPTION
Now debug info is stored inside log file, whatever the user use or not
`--debug` argument.

Fixed when user not pass `--debug` information, the info was passed to
stdout, now these info only passed to the stdout if user add the debug
argument.

Signed-off-by: Fellipe Henrique <fpedrosa@redhat.com>