### PR TITLE
Fix: Require --enablerepo with --disable-submgr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ SRPMS/
 *.pyc
 system_tests/vmdefs/centos*/.vagrant/
 *.copr.conf
+.vscode/*

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -175,12 +175,16 @@ class CLI(object):
             tool_opts.password = utils.get_file_content(
                 parsed_opts.password_from_file)
 
-        if parsed_opts.disable_submgr:
-            tool_opts.disable_submgr = True
         if parsed_opts.enablerepo:
             tool_opts.enablerepo = parsed_opts.enablerepo
         if parsed_opts.disablerepo:
             tool_opts.disablerepo = parsed_opts.disablerepo
+        if parsed_opts.disable_submgr:
+            tool_opts.disable_submgr = True
+            if not tool_opts.enablerepo:
+                loggerinst.critical("Error: --enablerepo is required if --disable-submgr is passed ")
+            if not tool_opts.disablerepo:
+                tool_opts.disablerepo = "*"  # Default to disable everything
 
         if parsed_opts.pool:
             tool_opts.pool = parsed_opts.pool

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -84,7 +84,9 @@ class CLI(object):
         self._parser.add_option("--disablerepo", metavar="repoidglob",
                                 action="append", help="Disable specific"
                                 " repositories by ID or glob. Use this option"
-                                " multiple times to add many repositories.")
+                                " multiple times to add many repositories."
+                                " If --disable-submgr is used this defaults"
+                                " to all repositories.")
         group = optparse.OptionGroup(self._parser,
                                      "Subscription Manager Options",
                                      "The following options are specific to"
@@ -137,7 +139,8 @@ class CLI(object):
                          " custom repositories instead. See"
                          " --enablerepo/--disablerepo options. Without this"
                          " option, the subscription-manager is used to access"
-                         " RHEL repositories by default.")
+                         " RHEL repositories by default. It requires to have"
+                         " the --enablerepo specified.")
         self._parser.add_option_group(group)
 
         group = optparse.OptionGroup(self._parser, "Automation Options",

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -49,7 +49,7 @@ class TestToolopts(unittest.TestCase):
 
     @unit_tests.mock(sys, "argv", _params(["--username", "uname",
                                           "--password", "passwd"]))
-    def test_cmdline_non_ineractive_with_credentials(self):
+    def test_cmdline_non_interactive_with_credentials(self):
         convert2rhel.toolopts.CLI()
         self.assertEqual(tool_opts.username, "uname")
         self.assertEqual(tool_opts.password, "passwd")

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -54,3 +54,15 @@ class TestToolopts(unittest.TestCase):
         self.assertEqual(tool_opts.username, "uname")
         self.assertEqual(tool_opts.password, "passwd")
         self.assertTrue(tool_opts.credentials_thru_cli)
+
+    @unit_tests.mock(sys, "argv", _params(["--disable-submgr", ""
+                                           "--enablerepo", "foo"]))
+    def test_cmdline_defaults_disablerepo_to_asterisk_with_disable_submgr(self):
+        convert2rhel.toolopts.CLI()
+        self.assertEqual(tool_opts.enablerepo, ["foo"])
+        self.assertEqual(tool_opts.disablerepo, "*")
+        self.assertTrue(tool_opts.disable_submgr)
+
+    @unit_tests.mock(sys, "argv", _params(["--disable-submgr"]))
+    def test_cmdline_exits_on_empty_enablerepo_with_disable_submgr(self):
+        self.assertRaises(SystemExit, convert2rhel.toolopts.CLI)


### PR DESCRIPTION
If `--enablerepo` is empty when providing `--disable-submgr`, the tool will fail to function correctly and go past point of no recovery. This PR fixes that by requiring `--enablerepo` if `--disable-submgr` is given

Few more things:

* `--disablerepo` defaults to `*` if `--disable-submgr` is given
* Added `.vscode/` dir to `.gitignore`

It passes the new tests, but I've not tested it manually