### PR TITLE
Fix copr release for master branch

### DIFF
--- a/packaging/epel/create_epel_srpm.sh
+++ b/packaging/epel/create_epel_srpm.sh
@@ -23,7 +23,7 @@ TIMESTAMP=`date +%Y%m%d%H%MZ -u`
 GIT_BRANCH=$(git for-each-ref --format='%(objectname) %(refname:short)' refs/heads | head -n1 | awk "{print \$2}")
 echo GIT_BRANCH: ${GIT_BRANCH}
 RELEASE="0"
-[ "${GIT_BRANCH}" = "master" ] && RELEASE="1"
+[ "${GIT_BRANCH}" = "master" ] && RELEASE="100"
 if [ "$CHANGE_RELEASE" = true ]; then
     # Suitable for Continous Delivery
     sed -i "s/1%{?dist}/${RELEASE}.${TIMESTAMP}.${GIT_BRANCH}%{?dist}/g" convert2rhel.spec


### PR DESCRIPTION
- to make sure the master branch is installed instead of
PR-related builds from copr with cmd `yum install convert2rhel`
- using this script is temporary until the following packit issues are
  dealt with:
    https://github.com/packit-service/packit/issues/761
    https://github.com/packit-service/packit-service/issues/239
- similar: https://github.com/oamg/leapp-repository/pull/327