### PR TITLE
Pylint fix bad-whitespace, wrong-import-order, bad-continuation

### DIFF
--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from itertools import imap
+
 import logging
 import os
 import re
@@ -316,8 +317,7 @@ def remove_blacklisted_pkgs():
     loggerinst.info("\n")
     print_pkg_info(installed_blacklisted_pkgs)
     utils.ask_to_continue()
-    utils.remove_pkgs([get_pkg_nvra(pkg)
-                      for pkg in installed_blacklisted_pkgs])
+    utils.remove_pkgs([get_pkg_nvra(pkg) for pkg in installed_blacklisted_pkgs])
     return
 
 
@@ -474,7 +474,8 @@ def replace_non_rhel_installed_kernel(version):
         loggerinst.critical("Unable to download %s from RHEL repository" % pkg)
         return
 
-    loggerinst.info("Replacing %s %s with RHEL kernel with the same NEVRA ... " % (system_info.name, pkg))
+    loggerinst.info(
+        "Replacing %s %s with RHEL kernel with the same NEVRA ... " % (system_info.name, pkg))
     output, ret_code = utils.run_subprocess(
         'rpm -i --force --replacepkgs %s*' % os.path.join(utils.TMP_DIR, pkg),
         print_output=False)

--- a/convert2rhel/repo.py
+++ b/convert2rhel/repo.py
@@ -47,8 +47,7 @@ def package_analysis():
         rhel_repos_content = read_repo_files(repo_data_files)
         repos_needed = match_repo_pkgs_to_installed(rhel_repos_content)
         loggerinst.info("Repositories needed: %s" % "\n".join(repos_needed) + "\n")
-        loggerinst.info("Listing non-%s and non-Red Hat packages ... "
-                    % system_info.name)
+        loggerinst.info("Listing non-%s and non-Red Hat packages ... " % system_info.name)
     else:
         loggerinst.debug("Offline snapshot of RHEL repositories not found.")
         repos_needed = [system_info.default_repository_id]

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -185,7 +185,8 @@ class CLI(object):
         if parsed_opts.disable_submgr:
             tool_opts.disable_submgr = True
             if not tool_opts.enablerepo:
-                loggerinst.critical("Error: --enablerepo is required if --disable-submgr is passed ")
+                loggerinst.critical(
+                    "Error: --enablerepo is required if --disable-submgr is passed ")
             if not tool_opts.disablerepo:
                 tool_opts.disablerepo = "*"  # Default to disable everything
 

--- a/convert2rhel/unit_tests/__init__.py
+++ b/convert2rhel/unit_tests/__init__.py
@@ -21,7 +21,6 @@ try:
 except ImportError:
     import unittest
 
-from convert2rhel import logger
 
 TMP_DIR = "/tmp/convert2rhel_test/"
 NONEXISTING_DIR = os.path.join(TMP_DIR, "nonexisting_dir/")
@@ -48,8 +47,8 @@ except ImportError:
     WRAPPER_UPDATES = ('__dict__',)
     def update_wrapper(wrapper,
                        wrapped,
-                       assigned = WRAPPER_ASSIGNMENTS,
-                       updated = WRAPPER_UPDATES):
+                       assigned=WRAPPER_ASSIGNMENTS,
+                       updated=WRAPPER_UPDATES):
         """Update a wrapper function to look like the wrapped function
 
            wrapper is the function to be updated
@@ -75,8 +74,8 @@ except ImportError:
 
 
     def wraps(wrapped,
-              assigned = WRAPPER_ASSIGNMENTS,
-              updated = WRAPPER_UPDATES):
+              assigned=WRAPPER_ASSIGNMENTS,
+              updated=WRAPPER_UPDATES):
         """Decorator factory to apply update_wrapper() to a wrapper function
 
            Returns a decorator that invokes update_wrapper() with the decorated
@@ -105,9 +104,9 @@ def mock(class_or_module, orig_obj, mock_obj):
                -- string
 
     Example:
-    @tests.mock(utils, "run_subprocess", run_subprocess_mocked())
+    @tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     -- replaces the original run_subprocess function from the utils module
-       with the run_subprocess_mocked function.
+       with the RunSubprocessMocked function.
     @tests.mock(logging.FileHandler, "_open", FileHandler_open_mocked())
     -- replaces the original _open method of the FileHandler class within
        the logging module with the FileHandler_open_mocked function.
@@ -201,7 +200,7 @@ class MockFunction(object):
 
     Example:
     from convert2rhel import tests  # Imports tests/__init__.py
-    class run_subprocess_mocked(tests.MockFunction):
+    class RunSubprocessMocked(tests.MockFunction):
         ...
     """
 

--- a/convert2rhel/unit_tests/cert_test.py
+++ b/convert2rhel/unit_tests/cert_test.py
@@ -15,20 +15,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
-try:
-    import unittest2 as unittest  # Python 2.6 support
-except ImportError:
-    import unittest
 
 import glob
 import os
 import shutil
 
-from convert2rhel import cert
-from convert2rhel.systeminfo import system_info
-from convert2rhel import utils
+try:
+    import unittest2 as unittest  # Python 2.6 support
+except ImportError:
+    import unittest
 
+from convert2rhel import cert
+from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
+from convert2rhel import utils
+from convert2rhel.systeminfo import system_info
 
 class TestCert(unittest.TestCase):
 

--- a/convert2rhel/unit_tests/example_test.py
+++ b/convert2rhel/unit_tests/example_test.py
@@ -20,13 +20,15 @@ This is an example test file containing a simple test.
 """
 
 # Required imports:
-from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
+
+
 try:
     import unittest2 as unittest  # Python 2.6 support
 except ImportError:
     import unittest
 
 from nose.tools import timed
+from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel import utils
 
 
@@ -45,7 +47,7 @@ class TestExample(unittest.TestCase):
     @timed(2)  # Check that the test function does not last more than 2 sec
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     def test_example(self):
-        # Set a tuple to be returned by the run_subprocess_mocked function
+        # Set a tuple to be returned by the RunSubprocessMocked function
         utils.run_subprocess.ret = ("ls output", 0)
         output, ret_code = utils.run_subprocess("ls -l")
         self.assertEqual(output, "this ain't ls output")

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -15,17 +15,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
-try:
-    import unittest2 as unittest  # Python 2.6 support
-except ImportError:
-    import unittest
 
 import logging
 import os
 import shutil
 
+try:
+    import unittest2 as unittest  # Python 2.6 support
+except ImportError:
+    import unittest
+
 from convert2rhel import logger
+from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel.toolopts import tool_opts
 
 

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -15,15 +15,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
+
+import os
+
 try:
     import unittest2 as unittest  # Python 2.6 support
 except ImportError:
     import unittest
 
-import os
-
 from convert2rhel import main
+from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel import utils
 
 
@@ -34,7 +35,7 @@ class TestMain(unittest.TestCase):
             return
 
     eula_dir = os.path.realpath(os.path.join(os.path.dirname(__file__),
-                                "..", "data", "version-independent"))
+                                             "..", "data", "version-independent"))
 
     @unit_tests.mock(utils, "ask_to_continue", AskToContinueMocked())
     @unit_tests.mock(utils, "DATA_DIR", eula_dir)

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -15,18 +15,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
-
 import glob
-import logging
 import os
 import re
 import yum
 
 from convert2rhel import logger
 from convert2rhel import pkghandler
-from convert2rhel.systeminfo import system_info
 from convert2rhel import utils
+from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
+from convert2rhel.systeminfo import system_info
 
 
 class TestPkgHandler(unit_tests.ExtendedTestCase):
@@ -101,7 +99,8 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertEqual(error_pkgs, ["systemd", "yum"])
 
         error_pkgs = pkghandler.get_problematic_pkgs(YUM_REQUIRES_ERROR, [])
-        self.assertEqual(error_pkgs, ["libreport-anaconda", "abrt-cli", "libreport-plugin-rhtsupport"])
+        self.assertEqual(error_pkgs,
+                         ["libreport-anaconda", "abrt-cli", "libreport-plugin-rhtsupport"])
 
         error_pkgs = pkghandler.get_problematic_pkgs(YUM_MULTILIB_ERROR, [])
         self.assertEqual(error_pkgs, ["openldap", "p11-kit"])
@@ -401,7 +400,9 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
 
         self.assertNotEqual(len(gpg_keys), 0)
         for gpg_key in gpg_keys:
-            self.assertIn('rpm --import %s' % os.path.join(gpg_dir, gpg_key), utils.run_subprocess.cmds)
+            self.assertIn(
+                'rpm --import %s' % os.path.join(gpg_dir, gpg_key),
+                utils.run_subprocess.cmds)
 
     class GetInstalledPkgsWDifferentFingerprintMocked(
             unit_tests.MockFunction):
@@ -412,12 +413,20 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
             if self.is_only_rhel_kernel_installed:
                 return []  # No third-party kernel
             else:
-                return [TestPkgHandler.create_pkg_obj("kernel", "0.1", "1", "x86_64", 295, "Oracle"),
-                        TestPkgHandler.create_pkg_obj("kernel-uek", "0.1", "1", "x86_64", 295, "Oracle"),
-                        TestPkgHandler.create_pkg_obj("kernel-headers", "0.1", "1", "x86_64", 295, "Oracle"),
-                        TestPkgHandler.create_pkg_obj("kernel-uek-headers", "0.1", "1", "x86_64", 295, "Oracle"),
-                        TestPkgHandler.create_pkg_obj("kernel-firmware", "0.1", "1", "x86_64", 295, "Oracle"),
-                        TestPkgHandler.create_pkg_obj("kernel-uek-firmware", "0.1", "1", "x86_64", 295, "Oracle")]
+                return [
+                    TestPkgHandler.create_pkg_obj(
+                        "kernel", "0.1", "1", "x86_64", 295, "Oracle"),
+                    TestPkgHandler.create_pkg_obj(
+                        "kernel-uek", "0.1", "1", "x86_64", 295, "Oracle"),
+                    TestPkgHandler.create_pkg_obj(
+                        "kernel-headers", "0.1", "1", "x86_64", 295, "Oracle"),
+                    TestPkgHandler.create_pkg_obj(
+                        "kernel-uek-headers", "0.1", "1", "x86_64", 295, "Oracle"),
+                    TestPkgHandler.create_pkg_obj(
+                        "kernel-firmware", "0.1", "1", "x86_64", 295, "Oracle"),
+                    TestPkgHandler.create_pkg_obj(
+                        "kernel-uek-firmware", "0.1", "1", "x86_64", 295, "Oracle")
+                ]
 
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     @unit_tests.mock(pkghandler, "handle_no_newer_rhel_kernel_available",
@@ -488,7 +497,9 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
             self.version = version
 
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
-    @unit_tests.mock(pkghandler, "replace_non_rhel_installed_kernel", ReplaceNonRhelInstalledKernelMocked())
+    @unit_tests.mock(pkghandler,
+                     "replace_non_rhel_installed_kernel",
+                     ReplaceNonRhelInstalledKernelMocked())
     def test_handle_older_rhel_kernel_not_available(self):
         utils.run_subprocess.output = YUM_KERNEL_LIST_OLDER_NOT_AVAILABLE
 
@@ -532,7 +543,8 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         pkghandler.replace_non_rhel_installed_kernel(version)
         self.assertEqual(utils.download_pkg.called, 1)
         self.assertEqual(utils.download_pkg.pkg, "kernel-4.7.4-200.fc24")
-        self.assertEqual(utils.run_subprocess.cmd, "rpm -i --force --replacepkgs /tmp/convert2rhel/kernel-4.7.4-200.fc24*")
+        self.assertEqual(utils.run_subprocess.cmd,
+                         "rpm -i --force --replacepkgs /tmp/convert2rhel/kernel-4.7.4-200.fc24*")
 
     def test_get_kernel(self):
         kernel_version = list(pkghandler.get_kernel(
@@ -582,7 +594,8 @@ Error: Package: abrt-cli-2.1.11-34.el7.x86_64 (rhel-7-server-rpms)
            Installing: libreport-plugin-rhtsupport-2.1.11-21.el7.x86_64 (rhel-7-server-rpms)
                libreport-plugin-rhtsupport = 2.1.11-21.el7"""
 
-YUM_MULTILIB_ERROR = """Error: Protected multilib versions: 2:p11-kit-0.18.7-1.fc19.i686 != p11-kit-0.18.3-1.fc19.x86_64
+YUM_MULTILIB_ERROR = """
+Error: Protected multilib versions: 2:p11-kit-0.18.7-1.fc19.i686 != p11-kit-0.18.3-1.fc19.x86_64
 Error: Protected multilib versions: openldap-2.4.36-4.fc19.i686 != openldap-2.4.35-4.fc19.x86_64"""
 
 # The following yum error is currently not being handled by the tool. The
@@ -591,7 +604,7 @@ Error: Protected multilib versions: openldap-2.4.36-4.fc19.i686 != openldap-2.4.
 YUM_FILE_CONFLICT_ERROR = """Transaction Check Error:
   file /lib/firmware/ql2500_fw.bin from install of ql2500-firmware-7.03.00-1.el6_5.noarch conflicts with file from package linux-firmware-20140911-0.1.git365e80c.0.8.el6.noarch
   file /lib/firmware/ql2400_fw.bin from install of ql2400-firmware-7.03.00-1.el6_5.noarch conflicts with file from package linux-firmware-20140911-0.1.git365e80c.0.8.el6.noarch
-  file /lib/firmware/phanfw.bin from install of netxen-firmware-4.0.534-3.1.el6.noarch conflicts with file from package linux-firmware-20140911-0.1.git365e80c.0.8.el6.noarch"""
+  file /lib/firmware/phanfw.bin from install of netxen-firmware-4.0.534-3.1.el6.noarch conflicts with file from package linux-firmware-20140911-0.1.git365e80c.0.8.el6.noarch""" # pylint: disable=C0301
 
 YUM_KERNEL_LIST_OLDER_AVAILABLE = """Installed Packages
 kernel.x86_64    4.7.4-200.fc24   @updates

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -115,7 +115,8 @@ class TestSubscription(unittest.TestCase):
     def test_get_registration_cmd(self):
         tool_opts.username = 'user'
         tool_opts.password = 'pass with space'
-        expected = 'subscription-manager register --force --username=user --password="pass with space"'
+        expected = \
+            'subscription-manager register --force --username=user --password="pass with space"'
         self.assertEqual(subscription.get_registration_cmd(), expected)
 
     @unit_tests.mock(subscription, "get_avail_subs", GetAvailSubsMocked())
@@ -159,11 +160,9 @@ class TestSubscription(unittest.TestCase):
         self.assertRaises(SystemExit, subscription.register_system)
         self.assertEqual(len(subscription.logging.getLogger.critical_msgs), 1)
 
-    @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked(tuples=[
-                                                ("nope", 1),
-                                                ("nope", 2),
-                                                ("Success", 0),
-                                                ]))
+    @unit_tests.mock(utils,
+                     "run_subprocess",
+                     RunSubprocessMocked(tuples=[("nope", 1), ("nope", 2), ("Success", 0)]))
     @unit_tests.mock(subscription.logging, "getLogger", GetLoggerMocked())
     @unit_tests.mock(subscription, "get_registration_cmd", GetRegistrationCmdMocked())
     def test_register_system_fail_interactive(self):
@@ -175,7 +174,8 @@ class TestSubscription(unittest.TestCase):
         self.assertEqual(len(subscription.logging.getLogger.critical_msgs), 0)
 
     def test_hiding_password(self):
-        test_cmd = 'subscription-manager register --force --username=jdoe --password="%s" --org=0123'
+        test_cmd = 'subscription-manager register --force ' \
+                   '--username=jdoe --password="%s" --org=0123'
         pswds_to_test = [
             "my favourite password",
             "\\)(*&^%f %##@^%&*&^(",
@@ -185,38 +185,40 @@ class TestSubscription(unittest.TestCase):
         for pswd in pswds_to_test:
             sanitized_cmd = subscription.hide_password(test_cmd % pswd)
             self.assertEqual(
-                sanitized_cmd, 'subscription-manager register --force --username=jdoe --password="*****" --org=0123')
+                sanitized_cmd,
+                'subscription-manager register --force '
+                '--username=jdoe --password="*****" --org=0123')
 
     class FakeSubscription:
         def __init__(self):
             self.subscription = (
-                    "Subscription Name: Good subscription\n"
-                    "Provides:          Something good\n"
-                    "SKU:               00EEE00EE\n"
-                    "Contract:          01234567\n"
-                    "Pool ID:           8aaaa123045897fb564240aa00aa0000\n"
-                    "Available:         1\n"
-                    "Suggested:         1\n"
-                    "Service Level:     Self-icko\n"
-                    "Service Type:      L1-L3\n"
-                    "Subscription Type: Standard\n"
-                    "Ends:              %s\n"
-                    "System Type:       Virtual\n"
-                    )
+                "Subscription Name: Good subscription\n"
+                "Provides:          Something good\n"
+                "SKU:               00EEE00EE\n"
+                "Contract:          01234567\n"
+                "Pool ID:           8aaaa123045897fb564240aa00aa0000\n"
+                "Available:         1\n"
+                "Suggested:         1\n"
+                "Service Level:     Self-icko\n"
+                "Service Type:      L1-L3\n"
+                "Subscription Type: Standard\n"
+                "Ends:              %s\n"
+                "System Type:       Virtual\n"
+            )
             self.dates_formats = [
-                    "26.07.2018",
-                    "26. 07. 2018",
-                    "26/07/2018",
-                    "H26.07.2018",
-                    "26-07-2018",
-                    "07.26.2018",
-                    "2018/07/26",
-                    "2018.07.26",
-                    "2018-07-26",
-                    "2018-26-07",
-                    "2018.26.07",
-                    "2018/26/07"
-                ]
+                "26.07.2018",
+                "26. 07. 2018",
+                "26/07/2018",
+                "H26.07.2018",
+                "26-07-2018",
+                "07.26.2018",
+                "2018/07/26",
+                "2018.07.26",
+                "2018-07-26",
+                "2018-26-07",
+                "2018.26.07",
+                "2018/26/07"
+            ]
 
         def __call__(self, date):
             return self.subscription % date
@@ -227,5 +229,4 @@ class TestSubscription(unittest.TestCase):
         sku = self.FakeSubscription()
         for i in sku.dates_formats:
             self.assertEqual(subscription.parse_sub_attrs(sku(i))["ends"], i)
-            self.assertEqual(len(subscription.logging.getLogger.critical_msgs),
-                             0)
+            self.assertEqual(len(subscription.logging.getLogger.critical_msgs),0)

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -16,19 +16,22 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # Required imports:
-from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
+
+
+import logging
+import os
+import shutil
+
 try:
     import unittest2 as unittest  # Python 2.6 support
 except ImportError:
     import unittest
 
-import logging
-import os
-import shutil
+from convert2rhel import logger
+from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel import utils
 from convert2rhel.toolopts import tool_opts
 from convert2rhel.systeminfo import system_info
-from convert2rhel import logger
 
 
 class TestSysteminfo(unittest.TestCase):

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -16,14 +16,16 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # Required imports:
-from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
+
+
+import sys
+
 try:
     import unittest2 as unittest  # Python 2.6 support
 except ImportError:
     import unittest
 
-import sys
-
+from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 import convert2rhel.toolopts
 from convert2rhel.toolopts import tool_opts
 
@@ -48,8 +50,8 @@ class TestToolopts(unittest.TestCase):
         self.assertFalse(tool_opts.credentials_thru_cli)
 
     @unit_tests.mock(sys, "argv", _params(["--username", "uname",
-                                          "--password", "passwd"]))
-    def test_cmdline_non_interactive_with_credentials(self):
+                                           "--password", "passwd"]))
+    def test_cmdline_non_ineractive_with_credentials(self):
         convert2rhel.toolopts.CLI()
         self.assertEqual(tool_opts.username, "uname")
         self.assertEqual(tool_opts.password, "passwd")

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -15,14 +15,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
+
+import re
+
 try:
     import unittest2 as unittest  # Python 2.6 support
 except ImportError:
     import unittest
 
-import re
-
+from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel import utils
 
 
@@ -71,12 +72,15 @@ class TestUtils(unittest.TestCase):
         utils.remove_pkgs([])
         self.assertEqual(utils.run_subprocess.called, 0)
 
-    @unit_tests.mock(utils.ChangedRPMPackagesController, "backup_and_track_removed_pkg", DummyFuncMocked())
+    @unit_tests.mock(utils.ChangedRPMPackagesController,
+                     "backup_and_track_removed_pkg",
+                     DummyFuncMocked())
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     def test_remove_pkgs_without_backup(self):
         pkgs = ['pkg1', 'pkg2', 'pkg3']
         utils.remove_pkgs(pkgs, False)
-        self.assertEqual(utils.ChangedRPMPackagesController.backup_and_track_removed_pkg.called, 0)
+        self.assertEqual(
+            utils.ChangedRPMPackagesController.backup_and_track_removed_pkg.called, 0)
 
         self.assertEqual(utils.run_subprocess.called, len(pkgs))
 
@@ -84,12 +88,15 @@ class TestUtils(unittest.TestCase):
         self.assertTrue(re.search(r"^%s pkg" % rpm_remove_cmd,
                                   utils.run_subprocess.cmds, re.MULTILINE))
 
-    @unit_tests.mock(utils.ChangedRPMPackagesController, "backup_and_track_removed_pkg", DummyFuncMocked())
+    @unit_tests.mock(utils.ChangedRPMPackagesController,
+                     "backup_and_track_removed_pkg",
+                     DummyFuncMocked())
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     def test_remove_pkgs_with_backup(self):
         pkgs = ['pkg1', 'pkg2', 'pkg3']
         utils.remove_pkgs(pkgs)
-        self.assertEqual(utils.ChangedRPMPackagesController.backup_and_track_removed_pkg.called, len(pkgs))
+        self.assertEqual(
+            utils.ChangedRPMPackagesController.backup_and_track_removed_pkg.called, len(pkgs))
 
         self.assertEqual(utils.run_subprocess.called, len(pkgs))
 
@@ -102,22 +109,28 @@ class TestUtils(unittest.TestCase):
         utils.install_pkgs([])
         self.assertEqual(utils.run_subprocess.called, 0)
 
-    @unit_tests.mock(utils.ChangedRPMPackagesController, "track_installed_pkg", DummyFuncMocked())
+    @unit_tests.mock(utils.ChangedRPMPackagesController,
+                     "track_installed_pkg",
+                     DummyFuncMocked())
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     def test_install_pkgs_without_replace(self):
         pkgs = ['pkg1', 'pkg2', 'pkg3']
         utils.install_pkgs(pkgs)
-        self.assertEqual(utils.ChangedRPMPackagesController.track_installed_pkg.called, len(pkgs))
+        self.assertEqual(
+            utils.ChangedRPMPackagesController.track_installed_pkg.called, len(pkgs))
 
         self.assertEqual(utils.run_subprocess.called, 1)
         self.assertTrue("rpm -i pkg1 pkg2 pkg3", utils.run_subprocess.cmd)
 
-    @unit_tests.mock(utils.ChangedRPMPackagesController, "track_installed_pkg", DummyFuncMocked())
+    @unit_tests.mock(utils.ChangedRPMPackagesController,
+                     "track_installed_pkg",
+                     DummyFuncMocked())
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     def test_install_pkgs_with_replace(self):
         pkgs = ['pkg1', 'pkg2', 'pkg3']
         utils.install_pkgs(pkgs, True)
-        self.assertEqual(utils.ChangedRPMPackagesController.track_installed_pkg.called, len(pkgs))
+        self.assertEqual(
+            utils.ChangedRPMPackagesController.track_installed_pkg.called, len(pkgs))
 
         self.assertEqual(utils.run_subprocess.called, 1)
         self.assertTrue("rpm -i --replacepkgs pkg1 pkg2 pkg3", utils.run_subprocess.cmd)


### PR DESCRIPTION
[C0326 bad-whitespace] No space allowed around keyword argument assignment
[C0411 wrong-import-order] standard import
[C0330 bad-continuation] Wrong continued indentation