### PR TITLE
Pylint fix warnings: [C0103 invalid-name]

### DIFF
--- a/convert2rhel/cert.py
+++ b/convert2rhel/cert.py
@@ -21,8 +21,8 @@ import shutil
 from convert2rhel.systeminfo import system_info
 from convert2rhel import utils
 
-_redhat_release_cert_dir = "/etc/pki/product-default/"
-_subscription_manager_cert_dir = "/etc/pki/product/"
+_REDHAT_RELEASE_CERT_DIR = "/etc/pki/product-default/"
+_SUBSCRIPTION_MANAGER_CERT_DIR = "/etc/pki/product/"
 
 
 def copy_cert_for_rhel_5():
@@ -34,6 +34,6 @@ def copy_cert_for_rhel_5():
     WONTFIX status.
     """
     if system_info.version == "5":
-        for cert in glob.glob(_redhat_release_cert_dir + "*.pem"):
-            utils.mkdir_p(_subscription_manager_cert_dir)
-            shutil.copy(cert, _subscription_manager_cert_dir)
+        for cert in glob.glob(_REDHAT_RELEASE_CERT_DIR + "*.pem"):
+            utils.mkdir_p(_SUBSCRIPTION_MANAGER_CERT_DIR)
+            shutil.copy(cert, _SUBSCRIPTION_MANAGER_CERT_DIR)

--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -31,12 +31,12 @@ import os
 
 LOG_DIR = "/var/log/convert2rhel"
 
-class LOG_LEVEL_TASK:
+class LogLevelTask:
     level = 15
     label = "TASK"
 
 
-class LOG_LEVEL_FILE:
+class LogLevelFile:
     level = 5
     label = "FILE"
 
@@ -52,8 +52,8 @@ def initialize_logger(log_name):
     # set custom class
     logging.setLoggerClass(CustomLogger)
     # set custom labels
-    logging.addLevelName(LOG_LEVEL_TASK.level, LOG_LEVEL_TASK.label)
-    logging.addLevelName(LOG_LEVEL_FILE.level, LOG_LEVEL_FILE.label)
+    logging.addLevelName(LogLevelTask.level, LogLevelTask.label)
+    logging.addLevelName(LogLevelFile.level, LogLevelFile.label)
     # enable raising exceptions
     logging.raiseExceptions = True
     # get root logger
@@ -61,7 +61,7 @@ def initialize_logger(log_name):
     # propagate
     logger.propagate = False
     # set default logging level
-    logger.setLevel(LOG_LEVEL_FILE.level)
+    logger.setLevel(LogLevelFile.level)
 
     # create sys.stdout handler for info/debug
     stdout_handler = logging.StreamHandler(sys.stdout)
@@ -76,7 +76,7 @@ def initialize_logger(log_name):
     handler = logging.FileHandler(os.path.join(LOG_DIR, log_name), "w")
     formatter = CustomFormatter("%(message)s")
     handler.setFormatter(formatter)
-    handler.setLevel(LOG_LEVEL_FILE.level)
+    handler.setLevel(LogLevelFile.level)
     logger.addHandler(handler)
 
 
@@ -88,11 +88,11 @@ class CustomLogger(logging.Logger, object):
         classobj' so we use multiple inheritance to get around the problem.
     """
     def task(self, msg, *args, **kwargs):
-        super(CustomLogger, self).log(LOG_LEVEL_TASK.level, msg, *args,
+        super(CustomLogger, self).log(LogLevelTask.level, msg, *args,
                                       **kwargs)
 
     def file(self, msg, *args, **kwargs):
-        super(CustomLogger, self).log(LOG_LEVEL_FILE.level, msg, *args,
+        super(CustomLogger, self).log(LogLevelFile.level, msg, *args,
                                       **kwargs)
 
     def critical(self, msg, *args, **kwargs):
@@ -118,11 +118,11 @@ class CustomFormatter(logging.Formatter, object):
         classobj' so we use multiple inheritance to get around the problem.
     """
     def format(self, record):
-        if record.levelno == LOG_LEVEL_TASK.level:
+        if record.levelno == LogLevelTask.level:
             temp = '*' * (90 - len(record.msg) - 25)
             self._fmt = "\n[%(asctime)s] %(levelname)s - [%(message)s] " + temp
             self.datefmt = "%m/%d/%Y %H:%M:%S"
-        elif record.levelno in [logging.INFO, LOG_LEVEL_FILE.level]:
+        elif record.levelno in [logging.INFO, LogLevelFile.level]:
             self._fmt = "%(message)s"
             self.datefmt = ""
         elif record.levelno in [logging.WARNING]:

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -68,8 +68,8 @@ def main():
 
         # backup system release file before starting conversion process
         loggerinst.task("Prepare: Backup System")
-        redhatrelease.system_release_file.backup()
-        redhatrelease.yum_conf.backup()
+        redhatrelease.SYSTEM_RELEASE_FILE.backup()
+        redhatrelease.YUM_CONF.backup()
 
         # begin conversion process
         process_phase = ConversionPhase.PRE_PONR_CHANGES
@@ -126,7 +126,7 @@ def user_to_accept_eula():
     loggerinst = logging.getLogger(__name__)
 
     eula_filename = "GLOBAL_EULA_RHEL"
-    eula_filepath = os.path.join(utils.data_dir, eula_filename)
+    eula_filepath = os.path.join(utils.DATA_DIR, eula_filename)
     eula_text = utils.get_file_content(eula_filepath)
     if eula_text:
         loggerinst.info(eula_text)
@@ -206,9 +206,9 @@ def rollback_changes():
     loggerinst = logging.getLogger(__name__)
 
     loggerinst.warn("Abnormal exit! Performing rollback ...")
-    utils.changed_pkgs_control.restore_pkgs()
-    redhatrelease.system_release_file.restore()
-    redhatrelease.yum_conf.restore()
+    utils.CHANGED_PKGS_CONTROL.restore_pkgs()
+    redhatrelease.SYSTEM_RELEASE_FILE.restore()
+    redhatrelease.YUM_CONF.restore()
     subscription.rollback_renamed_repo_files()
     return
 

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -456,7 +456,7 @@ def replace_non_rhel_installed_kernel(version):
     pkg = "kernel-%s" % version
 
     ret_code = utils.download_pkg(
-        pkg=pkg, dest=utils.tmp_dir, disablerepo=tool_opts.disablerepo,
+        pkg=pkg, dest=utils.TMP_DIR, disablerepo=tool_opts.disablerepo,
         enablerepo=tool_opts.enablerepo)
     if ret_code != 0:
         loggerinst.critical("Unable to download %s from RHEL repository" % pkg)
@@ -464,7 +464,7 @@ def replace_non_rhel_installed_kernel(version):
 
     loggerinst.info("Replacing %s %s with RHEL kernel with the same NEVRA ... " % (system_info.name, pkg))
     output, ret_code = utils.run_subprocess(
-        'rpm -i --force --replacepkgs %s*' % os.path.join(utils.tmp_dir, pkg),
+        'rpm -i --force --replacepkgs %s*' % os.path.join(utils.TMP_DIR, pkg),
         print_output=False)
     if ret_code != 0:
         loggerinst.critical("Unable to replace kernel package: %s" % output)

--- a/convert2rhel/redhatrelease.py
+++ b/convert2rhel/redhatrelease.py
@@ -29,8 +29,8 @@ def install_release_pkg():
     loggerinst = logging.getLogger(__name__)
     loggerinst.info("Installing %s package" % get_release_pkg_name())
 
-    system_release_file.remove()
-    pkg_path = os.path.join(utils.data_dir, "redhat-release",
+    SYSTEM_RELEASE_FILE.remove()
+    pkg_path = os.path.join(utils.DATA_DIR, "redhat-release",
                             tool_opts.variant, "redhat-release-*")
 
     success = utils.install_pkgs(glob.glob(pkg_path))
@@ -133,5 +133,5 @@ class YumConf(object):
 
 
 # Code to be executed upon module import
-system_release_file = utils.RestorableFile(get_system_release_filepath())
-yum_conf = utils.RestorableFile(YumConf.get_yum_conf_filepath())
+SYSTEM_RELEASE_FILE = utils.RestorableFile(get_system_release_filepath())
+YUM_CONF = utils.RestorableFile(YumConf.get_yum_conf_filepath())

--- a/convert2rhel/repo.py
+++ b/convert2rhel/repo.py
@@ -67,7 +67,7 @@ def package_analysis():
 
 def get_repo_data_files():
     """Get list of paths to dark matrix-generated repository files."""
-    path = os.path.join(utils.data_dir, "repo-mapping", system_info.id)
+    path = os.path.join(utils.DATA_DIR, "repo-mapping", system_info.id)
     # Skip the files for a different variant than the one in
     # config file. Note: 'Common' files hold pkg names of all
     # variants.
@@ -179,7 +179,7 @@ def get_supported_repos():
     loggerinst = logging.getLogger(__name__)
     loggerinst.info("Getting supported %s repositories ... "
                     % tool_opts.variant)
-    minimap_path = os.path.join(utils.data_dir, "repo-mapping", "repo_minimap")
+    minimap_path = os.path.join(utils.DATA_DIR, "repo-mapping", "repo_minimap")
     minimap = utils.get_file_content(minimap_path, as_list=True)
     repos = {}
     for line in minimap:
@@ -285,7 +285,7 @@ def get_avail_repos():
     repo_id_prefix = "Repo-id      : "
     for line in repos_raw.split("\n"):
         if (line.startswith(repo_id_prefix)):
-            repoID = line.split(repo_id_prefix)[1]
-            repos.append(repoID)
+            repo_id = line.split(repo_id_prefix)[1]
+            repos.append(repo_id)
 
     return repos

--- a/convert2rhel/rhelvariant.py
+++ b/convert2rhel/rhelvariant.py
@@ -20,7 +20,7 @@ import re
 import logging
 from convert2rhel import utils
 
-_supported_variants = None
+_SUPPORTED_VARIANTS = None
 
 
 def is_variant_supported(variant):
@@ -66,17 +66,17 @@ def get_supported_variants():
     """Set the global variable once to not load the supported variants
     from file every time.
     """
-    global _supported_variants
-    if not _supported_variants:
-        _supported_variants = _load_supported_variants_from_file()
-    return _supported_variants
+    global _SUPPORTED_VARIANTS
+    if not _SUPPORTED_VARIANTS:
+        _SUPPORTED_VARIANTS = _load_supported_variants_from_file()
+    return _SUPPORTED_VARIANTS
 
 
 def _load_supported_variants_from_file():
     """The repo_minimap contains all the available repos whose name are
     prepended by a variant.
     """
-    minimap_path = os.path.join(utils.data_dir, "repo-mapping", "repo_minimap")
+    minimap_path = os.path.join(utils.DATA_DIR, "repo-mapping", "repo_minimap")
     minimap = utils.get_file_content(minimap_path, as_list=True)
     supported_variants = []
     for line in minimap:

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -125,7 +125,7 @@ def hide_password(cmd):
 def install_subscription_manager():
     """Install subscription-manager RPM and its dependencies."""
     loggerinst = logging.getLogger(__name__)
-    sm_dir = os.path.join(utils.data_dir, "subscription-manager")
+    sm_dir = os.path.join(utils.DATA_DIR, "subscription-manager")
     if not os.path.isdir(sm_dir) or not os.listdir(sm_dir):
         loggerinst.critical("The %s directory does not exist or is empty."
                             " Using the subscription-manager is not documented"

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -30,7 +30,7 @@ class SystemInfo(object):
         # Operating system name (e.g. Oracle Linux)
         self.name = None
         # Single-word lowercase identificator of the system (e.g. oracle)
-        self.id = None
+        self.id = None  # pylint: disable=C0103
         # Major version of the operating system (e.g. 6)
         self.version = None
         # Platform architecture
@@ -62,7 +62,7 @@ class SystemInfo(object):
         self.id = self.name.split()[0].lower()
         self.version = self._get_system_version()
         self.arch = self._get_architecture()
-        utils.mkdir_p(utils.tmp_dir)
+        utils.mkdir_p(utils.TMP_DIR)
 
         self.cfg_filename = self._get_cfg_filename()
         self.cfg_content = self._get_cfg_content()
@@ -109,7 +109,7 @@ class SystemInfo(object):
         file.
         """
         cfg_parser = ConfigParser.ConfigParser()
-        cfg_filepath = os.path.join(utils.data_dir, "configs",
+        cfg_filepath = os.path.join(utils.DATA_DIR, "configs",
                                     self.cfg_filename)
         if not cfg_parser.read(cfg_filepath):
             self.logger.critical("Current combination of system distribution"
@@ -158,4 +158,4 @@ class SystemInfo(object):
 
 
 # Code to be executed upon module import
-system_info = SystemInfo()
+system_info = SystemInfo()  # pylint: disable=C0103

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -160,7 +160,7 @@ class CLI(object):
         loggerinst = logging.getLogger(__name__)
         parsed_opts, _ = self._parser.parse_args()
 
-        global tool_opts
+        global tool_opts  # pylint: disable=C0103
         if parsed_opts.debug:
             tool_opts.debug = True
 
@@ -223,7 +223,7 @@ def print_non_interactive_opts():
     loggerinst = logging.getLogger(__name__)
     loggerinst.info("For the non-interactive use of the tool, run the"
                     " following command:")
-    global tool_opts
+    global tool_opts  # pylint: disable=C0103
     cmd = utils.get_executable_name()
 
     if tool_opts.disable_submgr:
@@ -252,4 +252,4 @@ def print_non_interactive_opts():
 
 
 # Code to be executed upon module import
-tool_opts = ToolOpts()
+tool_opts = ToolOpts()  # pylint: disable=C0103

--- a/convert2rhel/unit_tests/__init__.py
+++ b/convert2rhel/unit_tests/__init__.py
@@ -19,11 +19,11 @@ import os
 
 from convert2rhel import logger
 
-tmp_dir = "/tmp/convert2rhel_test/"
-nonexisting_dir = os.path.join(tmp_dir, "nonexisting_dir/")
-nonexisting_file = os.path.join(tmp_dir, "nonexisting.file")
+TMP_DIR = "/tmp/convert2rhel_test/"
+NONEXISTING_DIR = os.path.join(TMP_DIR, "nonexisting_dir/")
+NONEXISTING_FILE = os.path.join(TMP_DIR, "nonexisting.file")
 # Dummy file for built-in open function
-dummy_file = os.path.join(os.path.dirname(__file__), "dummy_file")
+DUMMY_FILE = os.path.join(os.path.dirname(__file__), "dummy_file")
 
 try:
     from functools import wraps
@@ -110,10 +110,10 @@ def mock(class_or_module, orig_obj, mock_obj):
     -- replaces the gpgkey module-scoped variable gpg_key_system_dir with the
        "/nonexisting_dir/" string
     """
-    def wrap(fn):
+    def wrap(func):
         # The @wraps decorator below makes sure the original object name
         # and docstring (in case of a method/function) are preserved.
-        @wraps(fn)
+        @wraps(func)
         def wrapped_fn(*args, **kwargs):
             # Save temporarily the original object
             orig_obj_saved = getattr(class_or_module, orig_obj)
@@ -129,7 +129,7 @@ def mock(class_or_module, orig_obj, mock_obj):
             return_value = None
             try:
                 try:
-                    return_value = fn(*args, **kwargs)
+                    return_value = func(*args, **kwargs)
                 except:
                     raise
             finally:

--- a/convert2rhel/unit_tests/cert_test.py
+++ b/convert2rhel/unit_tests/cert_test.py
@@ -34,7 +34,7 @@ class TestCert(unittest.TestCase):
 
     class GlobMocked(unit_tests.MockFunction):
         def __call__(self, *args, **kwargs):
-            return [os.path.join(cert._redhat_release_cert_dir, "69.pem")]
+            return [os.path.join(cert._REDHAT_RELEASE_CERT_DIR, "69.pem")]
 
     class MkdirPMocked(unit_tests.MockFunction):
         def __call__(self, *args, **kwargs):
@@ -52,9 +52,9 @@ class TestCert(unittest.TestCase):
     @unit_tests.mock(utils, "mkdir_p", MkdirPMocked())
     @unit_tests.mock(shutil, "copy", CopyMocked())
     @unit_tests.mock(system_info, "version", "5")
-    @unit_tests.mock(utils, "data_dir", base_data_dir)
+    @unit_tests.mock(utils, "DATA_DIR", base_data_dir)
     def test_copy_cert_for_rhel_5(self):
         cert.copy_cert_for_rhel_5()
         self.assertEqual(shutil.copy.source,
-                         os.path.join(cert._redhat_release_cert_dir, "69.pem"))
-        self.assertEqual(shutil.copy.dest, cert._subscription_manager_cert_dir)
+                         os.path.join(cert._REDHAT_RELEASE_CERT_DIR, "69.pem"))
+        self.assertEqual(shutil.copy.dest, cert._SUBSCRIPTION_MANAGER_CERT_DIR)

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -31,10 +31,10 @@ from convert2rhel.toolopts import tool_opts
 
 class TestLogger(unittest.TestCase):
 
-    @unit_tests.mock(logger, "LOG_DIR", unit_tests.tmp_dir)
+    @unit_tests.mock(logger, "LOG_DIR", unit_tests.TMP_DIR)
     def setUp(self):
         # initialize class variables
-        self.LOG_DIR = logger.LOG_DIR
+        self.log_dir = logger.LOG_DIR
         self.log_file = "convert2rhel.log"
         self.test_msg = "testmsg"
 
@@ -54,21 +54,21 @@ class TestLogger(unittest.TestCase):
             handlers = loggerinst.handlers
 
         # verify both StreamHandler and FileHandler have been created
-        hasStreamHandlerInstance = False
-        hasFileHandlerInstance = False
+        has_stream_handler_instance = False
+        has_file_handler_instance = False
         for handler in handlers:
             if isinstance(handler, logging.StreamHandler):
-                hasStreamHandlerInstance = True
+                has_stream_handler_instance = True
             if isinstance(handler, logging.FileHandler):
-                hasFileHandlerInstance = True
+                has_file_handler_instance = True
 
-        self.assertTrue(hasStreamHandlerInstance)
-        self.assertTrue(hasFileHandlerInstance)
+        self.assertTrue(has_stream_handler_instance)
+        self.assertTrue(has_file_handler_instance)
 
         # verify log file name
         for handler in handlers:
             if type(handler) is logging.FileHandler:
-                log_path = os.path.join(self.LOG_DIR, self.log_file)
+                log_path = os.path.join(self.log_dir, self.log_file)
                 self.assertEqual(log_path, handler.baseFilename)
 
     def test_log_format(self):

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -37,13 +37,13 @@ class TestMain(unittest.TestCase):
                                 "..", "data", "version-independent"))
 
     @unit_tests.mock(utils, "ask_to_continue", AskToContinueMocked())
-    @unit_tests.mock(utils, "data_dir", eula_dir)
+    @unit_tests.mock(utils, "DATA_DIR", eula_dir)
     def test_user_to_accept_eula(self):
         main.user_to_accept_eula()
 
     class GetFileContentMocked(unit_tests.MockFunction):
         def __call__(self, filename):
-            return utils.get_file_content_orig(unit_tests.nonexisting_file)
+            return utils.get_file_content_orig(unit_tests.NONEXISTING_FILE)
 
     class GetLoggerMocked(unit_tests.MockFunction):
         def __init__(self):

--- a/convert2rhel/unit_tests/other_test.py
+++ b/convert2rhel/unit_tests/other_test.py
@@ -30,11 +30,11 @@ class TestOther(unittest.TestCase):
 
     def test_correct_constants(self):
         # Prevents unintentional change of constants
-        self.assertEqual(utils.tmp_dir, "/tmp/convert2rhel/")
-        self.assertEqual(utils.data_dir, "/usr/share/convert2rhel/")
-        self.assertEqual(cert._redhat_release_cert_dir,
+        self.assertEqual(utils.TMP_DIR, "/tmp/convert2rhel/")
+        self.assertEqual(utils.DATA_DIR, "/usr/share/convert2rhel/")
+        self.assertEqual(cert._REDHAT_RELEASE_CERT_DIR,
                          "/etc/pki/product-default/")
-        self.assertEqual(cert._subscription_manager_cert_dir,
+        self.assertEqual(cert._SUBSCRIPTION_MANAGER_CERT_DIR,
                          "/etc/pki/product/")
         self.assertEqual(pkghandler.MAX_YUM_CMD_CALLS, 2)
         self.assertEqual(logger.LOG_DIR, "/var/log/convert2rhel")

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -98,13 +98,13 @@ class TestPkgHandler(unittest.TestCase):
         error_pkgs = pkghandler.get_problematic_pkgs("", [])
         self.assertEqual(error_pkgs, [])
 
-        error_pkgs = pkghandler.get_problematic_pkgs(yum_protected_error, [])
+        error_pkgs = pkghandler.get_problematic_pkgs(YUM_PROTECTED_ERROR, [])
         self.assertEqual(error_pkgs, ["systemd", "yum"])
 
-        error_pkgs = pkghandler.get_problematic_pkgs(yum_requires_error, [])
+        error_pkgs = pkghandler.get_problematic_pkgs(YUM_REQUIRES_ERROR, [])
         self.assertEqual(error_pkgs, ["libreport-anaconda", "abrt-cli", "libreport-plugin-rhtsupport"])
 
-        error_pkgs = pkghandler.get_problematic_pkgs(yum_multilib_error, [])
+        error_pkgs = pkghandler.get_problematic_pkgs(YUM_MULTILIB_ERROR, [])
         self.assertEqual(error_pkgs, ["openldap", "p11-kit"])
 
     @unit_tests.mock(pkghandler, "call_yum_cmd", CallYumCmdMocked())
@@ -112,7 +112,7 @@ class TestPkgHandler(unittest.TestCase):
     def test_resolve_dep_errors_one_downgrade_fixes_the_error(self):
         pkghandler.call_yum_cmd.fail_once = True
 
-        pkghandler.resolve_dep_errors(yum_protected_error, [])
+        pkghandler.resolve_dep_errors(YUM_PROTECTED_ERROR, [])
 
         self.assertEqual(pkghandler.call_yum_cmd.called, 1)
 
@@ -120,9 +120,9 @@ class TestPkgHandler(unittest.TestCase):
     @unit_tests.mock(system_info, "version", "5")
     def test_resolve_dep_errors_unable_to_fix_by_downgrades(self):
         pkghandler.call_yum_cmd.return_code = 1
-        pkghandler.call_yum_cmd.return_string = yum_multilib_error
+        pkghandler.call_yum_cmd.return_string = YUM_MULTILIB_ERROR
 
-        pkghandler.resolve_dep_errors(yum_protected_error, [])
+        pkghandler.resolve_dep_errors(YUM_PROTECTED_ERROR, [])
 
         # Firts call of the resolve_dep_errors, pkgs from protected error
         # are detected, the second call pkgs from multilib error are detected,
@@ -436,24 +436,24 @@ class TestPkgHandler(unittest.TestCase):
 
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     def test_get_kernel_availability(self):
-        utils.run_subprocess.output = yum_kernel_list_older_available
+        utils.run_subprocess.output = YUM_KERNEL_LIST_OLDER_AVAILABLE
         installed, available = pkghandler.get_kernel_availability()
         self.assertEqual(installed, ['4.7.4-200.fc24'])
         self.assertEqual(available, ['4.5.5-300.fc24', '4.7.2-201.fc24', '4.7.4-200.fc24'])
 
-        utils.run_subprocess.output = yum_kernel_list_older_not_available
+        utils.run_subprocess.output = YUM_KERNEL_LIST_OLDER_NOT_AVAILABLE
         installed, available = pkghandler.get_kernel_availability()
         self.assertEqual(installed, ['4.7.4-200.fc24'])
         self.assertEqual(available, ['4.7.4-200.fc24'])
 
-        utils.run_subprocess.output = yum_kernel_list_older_not_available_multiple_installed
+        utils.run_subprocess.output = YUM_KERNEL_LIST_OLDER_NOT_AVAILABLE_MULTIPLE_INSTALLED
         installed, available = pkghandler.get_kernel_availability()
         self.assertEqual(installed, ['4.7.2-201.fc24', '4.7.4-200.fc24'])
         self.assertEqual(available, ['4.7.4-200.fc24'])
 
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     def test_handle_older_rhel_kernel_available(self):
-        utils.run_subprocess.output = yum_kernel_list_older_available
+        utils.run_subprocess.output = YUM_KERNEL_LIST_OLDER_AVAILABLE
 
         pkghandler.handle_no_newer_rhel_kernel_available()
 
@@ -472,7 +472,7 @@ class TestPkgHandler(unittest.TestCase):
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     @unit_tests.mock(pkghandler, "replace_non_rhel_installed_kernel", ReplaceNonRhelInstalledKernelMocked())
     def test_handle_older_rhel_kernel_not_available(self):
-        utils.run_subprocess.output = yum_kernel_list_older_not_available
+        utils.run_subprocess.output = YUM_KERNEL_LIST_OLDER_NOT_AVAILABLE
 
         pkghandler.handle_no_newer_rhel_kernel_available()
 
@@ -481,7 +481,7 @@ class TestPkgHandler(unittest.TestCase):
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     @unit_tests.mock(utils, "remove_pkgs", RemovePkgsMocked())
     def test_handle_older_rhel_kernel_not_available_multiple_installed(self):
-        utils.run_subprocess.output = yum_kernel_list_older_not_available_multiple_installed
+        utils.run_subprocess.output = YUM_KERNEL_LIST_OLDER_NOT_AVAILABLE_MULTIPLE_INSTALLED
 
         pkghandler.handle_no_newer_rhel_kernel_available()
 
@@ -518,7 +518,7 @@ class TestPkgHandler(unittest.TestCase):
 
     def test_get_kernel(self):
         kernel_version = list(pkghandler.get_kernel(
-            yum_kernel_list_older_not_available))
+            YUM_KERNEL_LIST_OLDER_NOT_AVAILABLE))
 
         self.assertEqual(kernel_version, ["4.7.4-200.fc24", "4.7.4-200.fc24"])
 
@@ -548,10 +548,10 @@ class TestPkgHandler(unittest.TestCase):
         self.assertEqual(pkghandler.call_yum_cmd.called, 2)
 
 
-yum_protected_error = """Error: Trying to remove "systemd", which is protected
+YUM_PROTECTED_ERROR = """Error: Trying to remove "systemd", which is protected
 Error: Trying to remove "yum", which is protected"""
 
-yum_requires_error = """Error: Package: libreport-anaconda-2.1.11-30.el7.x86_64 (rhel-7-server-rpms)
+YUM_REQUIRES_ERROR = """Error: Package: libreport-anaconda-2.1.11-30.el7.x86_64 (rhel-7-server-rpms)
            Requires: libreport-plugin-rhtsupport = 2.1.11-30.el7
            Available: libreport-plugin-rhtsupport-2.1.11-10.el7.x86_64 (rhel-7-server-rpms)
                libreport-plugin-rhtsupport = 2.1.11-10.el7
@@ -564,30 +564,30 @@ Error: Package: abrt-cli-2.1.11-34.el7.x86_64 (rhel-7-server-rpms)
            Installing: libreport-plugin-rhtsupport-2.1.11-21.el7.x86_64 (rhel-7-server-rpms)
                libreport-plugin-rhtsupport = 2.1.11-21.el7"""
 
-yum_multilib_error = """Error: Protected multilib versions: 2:p11-kit-0.18.7-1.fc19.i686 != p11-kit-0.18.3-1.fc19.x86_64
+YUM_MULTILIB_ERROR = """Error: Protected multilib versions: 2:p11-kit-0.18.7-1.fc19.i686 != p11-kit-0.18.3-1.fc19.x86_64
 Error: Protected multilib versions: openldap-2.4.36-4.fc19.i686 != openldap-2.4.35-4.fc19.x86_64"""
 
 # The following yum error is currently not being handled by the tool. The
 # tool would somehow need to decide, which of the two packages to remove and
 # ask the user to confirm the removal.
-yum_file_conflict_error = """Transaction Check Error:
+YUM_FILE_CONFLICT_ERROR = """Transaction Check Error:
   file /lib/firmware/ql2500_fw.bin from install of ql2500-firmware-7.03.00-1.el6_5.noarch conflicts with file from package linux-firmware-20140911-0.1.git365e80c.0.8.el6.noarch
   file /lib/firmware/ql2400_fw.bin from install of ql2400-firmware-7.03.00-1.el6_5.noarch conflicts with file from package linux-firmware-20140911-0.1.git365e80c.0.8.el6.noarch
   file /lib/firmware/phanfw.bin from install of netxen-firmware-4.0.534-3.1.el6.noarch conflicts with file from package linux-firmware-20140911-0.1.git365e80c.0.8.el6.noarch"""
 
-yum_kernel_list_older_available = """Installed Packages
+YUM_KERNEL_LIST_OLDER_AVAILABLE = """Installed Packages
 kernel.x86_64    4.7.4-200.fc24   @updates
 Available Packages
 kernel.x86_64    4.5.5-300.fc24   fedora
 kernel.x86_64    4.7.2-201.fc24   @updates
 kernel.x86_64    4.7.4-200.fc24   @updates"""
 
-yum_kernel_list_older_not_available = """Installed Packages
+YUM_KERNEL_LIST_OLDER_NOT_AVAILABLE = """Installed Packages
 kernel.x86_64    4.7.4-200.fc24   @updates
 Available Packages
 kernel.x86_64    4.7.4-200.fc24   @updates"""
 
-yum_kernel_list_older_not_available_multiple_installed = """Installed Packages
+YUM_KERNEL_LIST_OLDER_NOT_AVAILABLE_MULTIPLE_INSTALLED = """Installed Packages
 kernel.x86_64    4.7.2-201.fc24   @updates
 kernel.x86_64    4.7.4-200.fc24   @updates
 Available Packages

--- a/convert2rhel/unit_tests/redhatrelease_test.py
+++ b/convert2rhel/unit_tests/redhatrelease_test.py
@@ -38,8 +38,8 @@ class TestRedHatRelease(unittest.TestCase):
 
     class GlobMocked(unit_tests.MockFunction):
         def __call__(self, *args, **kwargs):
-            return [unit_tests.tmp_dir + "redhat-release/pkg1.rpm",
-                    unit_tests.tmp_dir + "redhat-release/pkg2.rpm",
+            return [unit_tests.TMP_DIR + "redhat-release/pkg1.rpm",
+                    unit_tests.TMP_DIR + "redhat-release/pkg2.rpm",
                     "Server/redhat-release-7/pkg1.rpm",
                     "Server/redhat-release-7/pkg2.rpm"]
 
@@ -52,7 +52,7 @@ class TestRedHatRelease(unittest.TestCase):
             return "Test output", 0
 
     @unit_tests.mock(utils.RestorableFile, "remove", DumbMocked())
-    @unit_tests.mock(utils, "data_dir", unit_tests.tmp_dir)
+    @unit_tests.mock(utils, "DATA_DIR", unit_tests.TMP_DIR)
     @unit_tests.mock(tool_opts, "variant", "Server")
     @unit_tests.mock(system_info, "version", "to_be_changed")
     @unit_tests.mock(glob, "glob", GlobMocked())
@@ -69,19 +69,19 @@ class TestRedHatRelease(unittest.TestCase):
                              " Server/redhat-release-7/pkg1.rpm" +
                              " Server/redhat-release-7/pkg2.rpm")
 
-    @unit_tests.mock(redhatrelease.YumConf, "_yum_conf_path", unit_tests.dummy_file)
+    @unit_tests.mock(redhatrelease.YumConf, "_yum_conf_path", unit_tests.DUMMY_FILE)
     def test_get_yum_conf_content(self):
         yum_conf = redhatrelease.YumConf()
 
         self.assertTrue("Dummy file to read" in yum_conf._yum_conf_content)
 
     def test_patch_yum_conf_missing_distroverpkg(self):
-        self.patch_yum_conf(yum_conf_without_distroverpkg)
+        self.patch_yum_conf(YUM_CONF_WITHOUT_DISTROVERPKG)
 
     def test_patch_yum_conf_existing_distroverpkg(self):
-        self.patch_yum_conf(yum_conf_with_distroverpkg)
+        self.patch_yum_conf(YUM_CONF_WITH_DISTROVERPKG)
 
-    @unit_tests.mock(redhatrelease.YumConf, "_yum_conf_path", unit_tests.dummy_file)
+    @unit_tests.mock(redhatrelease.YumConf, "_yum_conf_path", unit_tests.DUMMY_FILE)
     @unit_tests.mock(system_info, "version", "to_be_changed")
     @unit_tests.mock(tool_opts, "variant", "Server")
     def patch_yum_conf(self, yum_conf_content):
@@ -100,12 +100,12 @@ class TestRedHatRelease(unittest.TestCase):
                                 "\ndistroverpkg="), 1)
 
 
-yum_conf_without_distroverpkg = """[main]
+YUM_CONF_WITHOUT_DISTROVERPKG = """[main]
 installonly_limit=3
 
 #  This is the default"""
 
-yum_conf_with_distroverpkg = """[main]
+YUM_CONF_WITH_DISTROVERPKG = """[main]
 installonly_limit=3
 distroverpkg=centos-release
 

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -54,18 +54,18 @@ class TestSysteminfo(unittest.TestCase):
     ##########################################################################
 
     def setUp(self):
-        if os.path.exists(unit_tests.tmp_dir):
-            shutil.rmtree(unit_tests.tmp_dir)
-        os.makedirs(unit_tests.tmp_dir)
+        if os.path.exists(unit_tests.TMP_DIR):
+            shutil.rmtree(unit_tests.TMP_DIR)
+        os.makedirs(unit_tests.TMP_DIR)
         system_info.logger = logging.getLogger(__name__)
 
-        self.rpmva_output_file = os.path.join(unit_tests.tmp_dir, "rpm_va.log")
+        self.rpmva_output_file = os.path.join(unit_tests.TMP_DIR, "rpm_va.log")
 
     def tearDown(self):
-        if os.path.exists(unit_tests.tmp_dir):
-            shutil.rmtree(unit_tests.tmp_dir)
+        if os.path.exists(unit_tests.TMP_DIR):
+            shutil.rmtree(unit_tests.TMP_DIR)
 
-    @unit_tests.mock(logger, "LOG_DIR", unit_tests.tmp_dir)
+    @unit_tests.mock(logger, "LOG_DIR", unit_tests.TMP_DIR)
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked(
         ("rpmva\n", 0)))
     def test_generate_rpm_va(self):
@@ -79,7 +79,7 @@ class TestSysteminfo(unittest.TestCase):
         self.assertEqual(utils.get_file_content(self.rpmva_output_file),
                          "rpmva\n")
 
-    @unit_tests.mock(logger, "LOG_DIR", unit_tests.tmp_dir)
+    @unit_tests.mock(logger, "LOG_DIR", unit_tests.TMP_DIR)
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     def test_generate_rpm_va_skip(self):
         # Check that rpm -Va is not called when the --no-rpm-va option is used.

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -27,7 +27,7 @@ import sys
 import traceback
 
 
-class color:
+class Color:
     PURPLE = '\033[95m'
     CYAN = '\033[96m'
     DARKCYAN = '\033[36m'
@@ -41,9 +41,9 @@ class color:
 
 
 # Absolute path of a directory holding data for this tool
-data_dir = "/usr/share/convert2rhel/"
+DATA_DIR = "/usr/share/convert2rhel/"
 # Directory for temporary data to be stored during runtime
-tmp_dir = "/tmp/convert2rhel/"
+TMP_DIR = "/tmp/convert2rhel/"
 
 
 def get_executable_name():
@@ -188,7 +188,7 @@ def ask_to_continue():
 
 def prompt_user(question, password=False):
     loggerinst = logging.getLogger(__name__)
-    color_question = color.BOLD + question + color.END
+    color_question = Color.BOLD + question + Color.END
     if password:
         response = getpass.getpass(color_question)
     else:
@@ -294,7 +294,7 @@ def remove_pkgs(pkgs_to_remove, should_backup=True, critical=True):
         # impossible to access the repositories to download a backup. For this
         # reason we first backup all packages and only after that we remove
         for nvra in pkgs_to_remove:
-            changed_pkgs_control.backup_and_track_removed_pkg(nvra)
+            CHANGED_PKGS_CONTROL.backup_and_track_removed_pkg(nvra)
 
     if not pkgs_to_remove:
         loggerinst.info("No package to remove")
@@ -342,12 +342,12 @@ def install_pkgs(pkgs_to_install, replace=False, critical=True):
 
     for path in pkgs_to_install:
         nvra, _ = os.path.splitext(os.path.basename(path))
-        changed_pkgs_control.track_installed_pkg(nvra)
+        CHANGED_PKGS_CONTROL.track_installed_pkg(nvra)
 
     return True
 
 
-def download_pkg(pkg, dest=tmp_dir, disablerepo=[], enablerepo=[]):
+def download_pkg(pkg, dest=TMP_DIR, disablerepo=[], enablerepo=[]):
     """Download the specified package."""
     cmd = "yumdownloader"
 
@@ -374,21 +374,21 @@ class RestorableFile(object):
         loggerinst = logging.getLogger(__name__)
         loggerinst.info("Backing up %s" % self.filepath)
         if (os.path.isfile(self.filepath) and
-                os.path.isdir(tmp_dir)):
+                os.path.isdir(TMP_DIR)):
             try:
-                loggerinst.info("Copying %s to %s" % (self.filepath, tmp_dir))
-                shutil.copy2(self.filepath, tmp_dir)
+                loggerinst.info("Copying %s to %s" % (self.filepath, TMP_DIR))
+                shutil.copy2(self.filepath, TMP_DIR)
             except IOError, err:
                 loggerinst.critical("I/O error(%s): %s" % (err.errno,
                                                            err.strerror))
         else:
             loggerinst.warning("Can't find %s or %s"
-                               % (self.filepath, tmp_dir))
+                               % (self.filepath, TMP_DIR))
 
     def restore(self):
         """ Restore a previously backed up file """
         loggerinst = logging.getLogger(__name__)
-        backup_filepath = os.path.join(tmp_dir,
+        backup_filepath = os.path.join(TMP_DIR,
                                        os.path.basename(self.filepath))
         loggerinst.task("Rollback: Restoring %s from backup" % self.filepath)
 
@@ -428,21 +428,21 @@ class RestorablePackage(object):
         """ Save version of RPM package """
         loggerinst = logging.getLogger(__name__)
         loggerinst.info("Backing up %s" % self.name)
-        if os.path.isdir(tmp_dir):
+        if os.path.isdir(TMP_DIR):
             ret_code = download_pkg(self.name)
             if ret_code != 0:
                 loggerinst.warning("Couldn't download %s package." % self.name)
                 return
 
-            for file in os.listdir(tmp_dir):
+            for file in os.listdir(TMP_DIR):
                 if file.startswith(self.name):
-                    self.path = os.path.join(tmp_dir, file)
+                    self.path = os.path.join(TMP_DIR, file)
 
             if self.path is None:
                 loggerinst.warning("Couldn't retrieve downloaded %s package."
                                    % self.name)
         else:
-            loggerinst.warning("Can't find %s" % tmp_dir)
+            loggerinst.warning("Can't find %s" % TMP_DIR)
 
 
-changed_pkgs_control = ChangedRPMPackagesController()
+CHANGED_PKGS_CONTROL = ChangedRPMPackagesController()


### PR DESCRIPTION
As discussed in https://github.com/oamg/convert2rhel/pull/50#issuecomment-631512340
Disabled pylint checks for the:
```
[C0103 invalid-name] Constant name "tool_opts" doesn't conform to UPPER_CASE naming style File: convert2rhel/toolopts.py, line 226, in print_non_interactive_opts
[C0103 invalid-name] Constant name "tool_opts" doesn't conform to UPPER_CASE naming style File: convert2rhel/toolopts.py, line 255, in 
[C0103 invalid-name] Constant name "system_info" doesn't conform to UPPER_CASE naming style File: convert2rhel/systeminfo.py, line 161, in 
```
by adding comment `# pylint: disable=invalid-name  # noqa`