### PR TITLE
Revert renaming global variables as constants

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -68,8 +68,8 @@ def main():
 
         # backup system release file before starting conversion process
         loggerinst.task("Prepare: Backup System")
-        redhatrelease.SYSTEM_RELEASE_FILE.backup()
-        redhatrelease.YUM_CONF.backup()
+        redhatrelease.system_release_file.backup()
+        redhatrelease.yum_conf.backup()
 
         # begin conversion process
         process_phase = ConversionPhase.PRE_PONR_CHANGES
@@ -206,9 +206,9 @@ def rollback_changes():
     loggerinst = logging.getLogger(__name__)
 
     loggerinst.warn("Abnormal exit! Performing rollback ...")
-    utils.CHANGED_PKGS_CONTROL.restore_pkgs()
-    redhatrelease.SYSTEM_RELEASE_FILE.restore()
-    redhatrelease.YUM_CONF.restore()
+    utils.changed_pkgs_control.restore_pkgs()
+    redhatrelease.system_release_file.restore()
+    redhatrelease.yum_conf.restore()
     subscription.rollback_renamed_repo_files()
     return
 

--- a/convert2rhel/redhatrelease.py
+++ b/convert2rhel/redhatrelease.py
@@ -29,7 +29,7 @@ def install_release_pkg():
     loggerinst = logging.getLogger(__name__)
     loggerinst.info("Installing %s package" % get_release_pkg_name())
 
-    SYSTEM_RELEASE_FILE.remove()
+    system_release_file.remove()
     pkg_path = os.path.join(utils.DATA_DIR, "redhat-release",
                             tool_opts.variant, "redhat-release-*")
 
@@ -133,5 +133,5 @@ class YumConf(object):
 
 
 # Code to be executed upon module import
-SYSTEM_RELEASE_FILE = utils.RestorableFile(get_system_release_filepath())
-YUM_CONF = utils.RestorableFile(YumConf.get_yum_conf_filepath())
+system_release_file = utils.RestorableFile(get_system_release_filepath())  # pylint: disable=C0103
+yum_conf = utils.RestorableFile(YumConf.get_yum_conf_filepath())  # pylint: disable=C0103

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -294,7 +294,7 @@ def remove_pkgs(pkgs_to_remove, should_backup=True, critical=True):
         # impossible to access the repositories to download a backup. For this
         # reason we first backup all packages and only after that we remove
         for nvra in pkgs_to_remove:
-            CHANGED_PKGS_CONTROL.backup_and_track_removed_pkg(nvra)
+            changed_pkgs_control.backup_and_track_removed_pkg(nvra)
 
     if not pkgs_to_remove:
         loggerinst.info("No package to remove")
@@ -342,7 +342,7 @@ def install_pkgs(pkgs_to_install, replace=False, critical=True):
 
     for path in pkgs_to_install:
         nvra, _ = os.path.splitext(os.path.basename(path))
-        CHANGED_PKGS_CONTROL.track_installed_pkg(nvra)
+        changed_pkgs_control.track_installed_pkg(nvra)
 
     return True
 
@@ -445,4 +445,4 @@ class RestorablePackage(object):
             loggerinst.warning("Can't find %s" % TMP_DIR)
 
 
-CHANGED_PKGS_CONTROL = ChangedRPMPackagesController()
+changed_pkgs_control = ChangedRPMPackagesController()  # pylint: disable=C0103


### PR DESCRIPTION
- these objects are not constants but mutable objects
- the change being reverted has been done under https://github.com/oamg/convert2rhel/pull/54

Sorry, @sturivny, I missed three other globals that shouldn't be considered constants.