### PR TITLE
Do not backup original kernel pkgs

### DIFF
--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -422,7 +422,7 @@ def handle_no_newer_rhel_kernel_available():
             # of them - the one that has the same version as the available RHEL
             # kernel
             older = available[-1]
-            utils.remove_pkgs(["kernel-%s" % older])
+            utils.remove_pkgs(pkgs_to_remove=["kernel-%s" % older], should_backup=False)
             call_yum_cmd(command="install", args="kernel-%s" % older)
         else:
             replace_non_rhel_installed_kernel(installed[0])
@@ -493,7 +493,7 @@ def remove_non_rhel_kernels():
     if non_rhel_kernels:
         loggerinst.info("Removing non-RHEL kernels")
         print_pkg_info(non_rhel_kernels)
-        utils.remove_pkgs([get_pkg_nvra(pkg) for pkg in non_rhel_kernels])
+        utils.remove_pkgs(pkgs_to_remove=[get_pkg_nvra(pkg) for pkg in non_rhel_kernels], should_backup=False)
     else:
         loggerinst.info("None found.")
     return non_rhel_kernels

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -322,9 +322,9 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
             self.pkgs = None
             self.should_bkp = False
 
-        def __call__(self, pkgs, should_bkp=False):
-            self.pkgs = pkgs
-            self.should_bkp = should_bkp
+        def __call__(self, pkgs_to_remove, should_backup=False):
+            self.pkgs = pkgs_to_remove
+            self.should_bkp = should_backup
 
     @unit_tests.mock(system_info, "pkg_blacklist", ["installed_pkg",
                                                     "not_installed_pkg"])


### PR DESCRIPTION
There's no need for it since that phase is already past the point of no return, so the backup wouldn't be used for a rollback anyway.