### PR TITLE
Let packit create copr builds on merges to master

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -15,6 +15,15 @@ jobs:
     - epel-6-x86_64
     - epel-7-x86_64
   trigger: pull_request
+- job: copr_build
+  metadata:
+    branch: master
+    owner: "@oamg"
+    project: convert2rhel
+    targets:
+    - epel-6-x86_64
+    - epel-7-x86_64
+  trigger: commit
 - job: tests
   metadata:
     targets:


### PR DESCRIPTION
The packit team has added the new "commit" trigger so now we can have copr builds created after each merge to master.
Unfortunately, it's not possible to have multiple triggers for one job (https://github.com/packit-service/packit-service/issues/647).

Related: https://github.com/packit-service/packit-service/issues/239