### PR TITLE
style: Add Black formatter config

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,6 +3,9 @@
 # Regular expression matching correct function names
 function-rgx=[a-z_][a-z0-9_]{2,50}$
 
+indent-string='    '
+max-line-length=120
+
 [MESSAGES CONTROL]
 
 disable=
@@ -23,6 +26,8 @@ disable=
  old-style-class,
 # "R" Refactor recommendations
  too-few-public-methods,
+# Doesn't follow PEP8, removed in later versions of pylint
+ bad-continuation,
 
 [REPORTS]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,3 +22,17 @@ Or by installing locally using `pipenv`
 
     $ pipenv install
     $ pipenv run pylint convert2rhel/
+
+## Formatting
+To automatically format your code, we recommend installing [Black](https://black.readthedocs.io/en/stable/index.html).
+Install globally using pip
+
+```bash
+$ pip install black
+```
+
+There's two options for running Black: you can either integrate Black with your editor, or run black itseld
+
+```bash
+$ black .
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.black]
+line-length = 120
+target-version = ['py27']
+include = '\.pyi?$'
+exclude = '''
+
+(
+  /(
+      \.eggs
+    | \.git
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | buck-out
+    | build
+    | dist
+  )/
+  | setup.py
+)
+'''


### PR DESCRIPTION
This adds [Black code formatter](https://black.readthedocs.io/en/stable/index.html) configuration and information on how to use it.

Blocked by #59 #55

I've also created #68 to showcase what would be changed currently.