### PR TITLE
fix/dependency issues during converting from CentOS7.7-RHEL7.7

### DIFF
--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from itertools import imap
+
 import logging
 import os
 import re
@@ -457,6 +458,11 @@ def replace_non_rhel_installed_kernel(version):
     utils.ask_to_continue()
 
     pkg = "kernel-%s" % version
+
+    utils.remove_pkgs(['kmod-kvdo', 'libreport'], critical=False)
+    for pkgname in set(system_info.pkg_blacklist):
+
+        utils.install_pkgs([pkgname.replace("centos", "redhat"), pkgname.replace("centos", "rhel")], replace=True)
 
     ret_code = utils.download_pkg(
         pkg=pkg, dest=utils.TMP_DIR, disablerepo=tool_opts.disablerepo,


### PR DESCRIPTION
Convert2rhel failed when try to convert from CentOS 7.7 (1908) to RHEL 7.7 with "error: Failed dependencies: system-release is needed by kernel-3.10.0-1062.el7.x86_64"

These PR fixed these fail

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1821726

Signed-off-by: Fellipe Henrique <fpedrosa@redhat.com>