### PR TITLE
fix/lint errors

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,5 +1,20 @@
 name: pylint
 
+env:
+  interpreted_pylint: |
+    function fail_on_fatal_or_error_only() {
+      # We care about fatal (1) and error (2) messages only.
+      # The exit code is a sum of numbers corresponding to the message severity level.
+      # E.g. if there are both error (2) and warning (4) messages, the exit code is 6.
+      local exit_code=0
+      pylint --rcfile=.pylintrc convert2rhel/ || exit_code=$?
+      if ! [ $((exit_code & 3)) -eq 0 ]; then
+        return $exit_code;
+      fi;
+      return 0;
+    }
+    fail_on_fatal_or_error_only
+
 on:
   push:
     branches: [ master ]
@@ -25,16 +40,7 @@ jobs:
         pip install astroid==1.2
 
     - name: Run Pylint Checks
-      run: |
-         function interpreted_pylint() {
-            local error_code=0
-            pylint --rcfile=.pylintrc convert2rhel/ || error_code=$?
-            if ! [ $((error_code & 3)) -eq 0 ]; then
-                return $error_code;
-            fi;
-            return 0;
-         }
-         interpreted_pylint
+      run: ${{ env.interpreted_pylint }}
 
   pylint_check_2_7:
     runs-on: ubuntu-latest
@@ -52,13 +58,4 @@ jobs:
         pip install pylint
 
     - name: Run Pylint Checks
-      run: |
-         function interpreted_pylint() {
-            local error_code=0
-            pylint --rcfile=.pylintrc convert2rhel/ || error_code=$?
-            if ! [ $((error_code & 3)) -eq 0 ]; then
-                return $error_code;
-            fi;
-            return 0;
-         }
-         interpreted_pylint
+      run: ${{ env.interpreted_pylint }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -12,7 +12,9 @@ jobs:
     container: centos:centos6.9
 
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout Code
+      uses: actions/checkout@v1
+
 
     - name: Install Requirements
       run: |
@@ -21,11 +23,19 @@ jobs:
         python get-pip.py
         pip install pylint==1.1.0
         pip install astroid==1.2
-        
+
     - name: Run Pylint Checks
       run: |
-        pylint --rcfile=.pylintrc convert2rhel/
-        
+         function interpreted_pylint() {
+            local error_code=0
+            pylint --rcfile=.pylintrc convert2rhel/ || error_code=$?
+            if ! [ $((error_code & 3)) -eq 0 ]; then
+                return $error_code;
+            fi;
+            return 0;
+         }
+         interpreted_pylint
+
   pylint_check_2_7:
     runs-on: ubuntu-latest
     container: centos:centos7.7.1908
@@ -40,7 +50,15 @@ jobs:
         pip install --upgrade pip
         pip install setuptools
         pip install pylint
-        
+
     - name: Run Pylint Checks
       run: |
-        pylint --rcfile=.pylintrc convert2rhel/
+         function interpreted_pylint() {
+            local error_code=0
+            pylint --rcfile=.pylintrc convert2rhel/ || error_code=$?
+            if ! [ $((error_code & 3)) -eq 0 ]; then
+                return $error_code;
+            fi;
+            return 0;
+         }
+         interpreted_pylint

--- a/.pylintrc
+++ b/.pylintrc
@@ -7,8 +7,9 @@ function-rgx=[a-z_][a-z0-9_]{2,50}$
 
 disable=
 # "E" Error for important programming issues (likely bugs)
+# skip redefined function false positive
+ E0102,
  no-member,
-# "W" Warnings for stylistic problems or minor programming issues
  arguments-differ,
 # we can drop this when we drop py2.4 support
  broad-except,
@@ -23,7 +24,22 @@ disable=
  old-style-class,
 # "R" Refactor recommendations
  too-few-public-methods,
-
+# do not warn about pylint checks being disabled through comments in the code
+ locally-disabled,
+# For some reason, pylint doesn't get right instance members, and some types could not be inferred
+# Eg: [E1103 maybe-no-member] Instance of 'RootLogger' has no 'task' member File: convert2rhel/main.py, line 60, in main
+# we have several logger task, and s good approach to disable here, instead of each line
+ maybe-no-member,
+# Disable these Refactor message since most of our tests use more then 20 public methods, and we are not refactor all
+# of our tests right now
+ too-many-public-methods,
+ too-many-branches,
+ too-many-instance-attributes,
 [REPORTS]
 
 msg-template='[{msg_id} {symbol}] {msg} File: {path}, line {line}, in {obj}'
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=120

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,9 @@ images:
 tests:
 	@docker run --rm -v $(shell pwd):/data:Z $(IMAGE)/centos6 ./run_unit_tests.sh
 	@docker run --rm -v $(shell pwd):/data:Z $(IMAGE)/centos7 ./run_unit_tests.sh
+
+lint:
+	@pylint --rcfile=.pylintrc convert2rhel/
+
+lint-errors:
+	@pylint --rcfile=.pylintrc convert2rhel/ --errors-only

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -196,8 +196,8 @@ def get_installed_pkg_objects(name=""):
     yum_base.doConfigSetup(init_plugins=False)
     if name:
         return yum_base.rpmdb.returnPackages(patterns=[name])
-    else:
-        return yum_base.rpmdb.returnPackages()
+
+    return yum_base.rpmdb.returnPackages()
 
 
 def get_third_party_pkgs():

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -69,7 +69,8 @@ class SystemInfo(object):
         self.fingerprints_orig_os = self._get_gpg_key_fingerprints()
         self._generate_rpm_va()
 
-    def _get_system_release_file_content(self):
+    @staticmethod
+    def _get_system_release_file_content():
         from convert2rhel import redhatrelease
         return redhatrelease.get_system_release_content()
 

--- a/convert2rhel/unit_tests/example_test.py
+++ b/convert2rhel/unit_tests/example_test.py
@@ -27,7 +27,6 @@ try:
 except ImportError:
     import unittest
 
-from nose.tools import timed
 from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel import utils
 
@@ -44,7 +43,6 @@ class TestExample(unittest.TestCase):
             self.ret = (self.prefix + self.ret[0], self.ret[1])
             return self.ret
 
-    @timed(2)  # Check that the test function does not last more than 2 sec
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     def test_example(self):
         # Set a tuple to be returned by the RunSubprocessMocked function

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -193,7 +193,7 @@ class TestSubscription(unittest.TestCase):
     def test_subscribe_system_fail_once(self):
         tool_opts.username = 'user'
         tool_opts.password = 'pass'
-        subscription.subscribe_system()
+        subscription.subscribe_system()  # pylint: disable=function-redefined
         self.assertEqual(subscription.register_system.called, 2)
 
     @unit_tests.mock(subscription.logging, "getLogger", GetLoggerMocked())

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -193,7 +193,7 @@ class TestSubscription(unittest.TestCase):
     def test_subscribe_system_fail_once(self):
         tool_opts.username = 'user'
         tool_opts.password = 'pass'
-        subscription.subscribe_system()  # pylint: disable=function-redefined
+        subscription.subscribe_system()
         self.assertEqual(subscription.register_system.called, 2)
 
     @unit_tests.mock(subscription.logging, "getLogger", GetLoggerMocked())

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -82,8 +82,8 @@ def get_file_content(filename, as_list=False):
     if as_list:
         # remove newline character from each line
         return [x.strip() for x in lines]
-    else:
-        return "".join(lines)
+
+    return "".join(lines)
 
 
 def store_content_to_file(filename, content):
@@ -345,9 +345,9 @@ def install_pkgs(pkgs_to_install, replace=False, critical=True):
         if critical:
             loggerinst.critical("Error: Couldn't install %s packages." % pkgs)
             return False
-        else:
-            loggerinst.warning("Couldn't install %s packages." % pkgs)
-            return False
+
+        loggerinst.warning("Couldn't install %s packages." % pkgs)
+        return False
 
     for path in pkgs_to_install:
         nvra, _ = os.path.splitext(os.path.basename(path))


### PR DESCRIPTION
These PR will 
- Fix py26 and py27 lint errors
- Add  `make lint` to run lint on local machine
- Add `make lint-errors` to run lint on local machine and show **only** errors

Signed-off-by: Fellipe Henrique <fpedrosa@redhat.com>