### PR TITLE
Return the setuptools dependency on CentOS/OL 6

### DIFF
--- a/packaging/centos_ol/convert2rhel.spec
+++ b/packaging/centos_ol/convert2rhel.spec
@@ -42,6 +42,7 @@ Requires:       python-simplejson
 %endif
 %if 0%{?rhel} && 0%{?rhel} == 6
 Requires:       python-decorator
+Requires:       python-setuptools
 Requires:       python-six
 Requires:       pygobject2
 %endif

--- a/packaging/epel/convert2rhel.spec
+++ b/packaging/epel/convert2rhel.spec
@@ -31,6 +31,7 @@ Requires:       yum-utils
 
 %if 0%{?el6} && 0%{?epel}
 Requires:       python-decorator
+Requires:       python-setuptools
 Requires:       python-six
 Requires:       pygobject2
 %endif


### PR DESCRIPTION
- It was accidentally removed with https://github.com/oamg/convert2rhel/pull/19