### PR TITLE
Create the temp dir in spec

### DIFF
--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -63,7 +63,6 @@ class SystemInfo(object):
         self.id = self.name.split()[0].lower()
         self.version = self._get_system_version()
         self.arch = self._get_architecture()
-        utils.mkdir_p(utils.TMP_DIR)
 
         self.cfg_filename = self._get_cfg_filename()
         self.cfg_content = self._get_cfg_content()

--- a/convert2rhel/unit_tests/other_test.py
+++ b/convert2rhel/unit_tests/other_test.py
@@ -30,7 +30,7 @@ class TestOther(unittest.TestCase):
 
     def test_correct_constants(self):
         # Prevents unintentional change of constants
-        self.assertEqual(utils.TMP_DIR, "/tmp/convert2rhel/")
+        self.assertEqual(utils.TMP_DIR, "/var/lib/convert2rhel/")
         self.assertEqual(utils.DATA_DIR, "/usr/share/convert2rhel/")
         self.assertEqual(cert._REDHAT_RELEASE_CERT_DIR,
                          "/etc/pki/product-default/")

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -546,7 +546,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertEqual(utils.download_pkg.called, 1)
         self.assertEqual(utils.download_pkg.pkg, "kernel-4.7.4-200.fc24")
         self.assertEqual(utils.run_subprocess.cmd,
-                         "rpm -i --force --replacepkgs /tmp/convert2rhel/kernel-4.7.4-200.fc24*")
+                         "rpm -i --force --replacepkgs %skernel-4.7.4-200.fc24*" % utils.TMP_DIR)
 
     def test_get_kernel(self):
         kernel_version = list(pkghandler.get_kernel(

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -44,7 +44,7 @@ class Color:
 # Absolute path of a directory holding data for this tool
 DATA_DIR = "/usr/share/convert2rhel/"
 # Directory for temporary data to be stored during runtime
-TMP_DIR = "/tmp/convert2rhel/"
+TMP_DIR = "/var/lib/convert2rhel/"
 
 
 def format_msg_with_datetime(msg, level):
@@ -382,8 +382,7 @@ class RestorableFile(object):
         """ Save current version of a file """
         loggerinst = logging.getLogger(__name__)
         loggerinst.info("Backing up %s" % self.filepath)
-        if (os.path.isfile(self.filepath) and
-                os.path.isdir(TMP_DIR)):
+        if os.path.isfile(self.filepath):
             try:
                 loggerinst.info("Copying %s to %s" % (self.filepath, TMP_DIR))
                 shutil.copy2(self.filepath, TMP_DIR)
@@ -391,8 +390,7 @@ class RestorableFile(object):
                 loggerinst.critical("I/O error(%s): %s" % (err.errno,
                                                            err.strerror))
         else:
-            loggerinst.warning("Can't find %s or %s"
-                               % (self.filepath, TMP_DIR))
+            loggerinst.info("Can't find %s", self.filepath)
 
     def restore(self):
         """ Restore a previously backed up file """
@@ -451,7 +449,7 @@ class RestorablePackage(object):
                 loggerinst.warning("Couldn't retrieve downloaded %s package."
                                    % self.name)
         else:
-            loggerinst.warning("Can't find %s" % TMP_DIR)
+            loggerinst.warning("Can't access %s" % TMP_DIR)
 
 
 changed_pkgs_control = ChangedRPMPackagesController()  # pylint: disable=C0103

--- a/packaging/centos_ol/convert2rhel.spec
+++ b/packaging/centos_ol/convert2rhel.spec
@@ -87,6 +87,9 @@ cp -a build/lib/%{name}/data/version-independent/. \
 cp -a build/lib/%{name}/data/%{rhel}/%{_arch}/. \
       %{buildroot}%{_datadir}/%{name}
 
+# Temporary directory used mainly for backing up files during the conversion
+install -d %{buildroot}%{_sharedstatedir}/%{name}
+
 install -d -m 755 %{buildroot}%{_mandir}/man8
 install -p man/%{name}.8 %{buildroot}%{_mandir}/man8/
 
@@ -95,6 +98,7 @@ install -p man/%{name}.8 %{buildroot}%{_mandir}/man8/
 
 %{python2_sitelib}/%{name}*
 %{_datadir}/%{name}
+%{_sharedstatedir}/%{name}
 
 %{!?_licensedir:%global license %%doc}
 %license LICENSE

--- a/packaging/epel/convert2rhel.spec
+++ b/packaging/epel/convert2rhel.spec
@@ -77,6 +77,9 @@ cp -a build/lib/%{name}/data/version-independent/. \
 cp -a build/lib/%{name}/data/%{rhel}/x86_64/. \
       %{buildroot}%{_datadir}/%{name}
 
+# Temporary directory used mainly for backing up files during the conversion
+install -d %{buildroot}%{_sharedstatedir}/%{name}
+
 install -d -m 755 %{buildroot}%{_mandir}/man8
 install -p man/%{name}.8 %{buildroot}%{_mandir}/man8/
 
@@ -85,6 +88,7 @@ install -p man/%{name}.8 %{buildroot}%{_mandir}/man8/
 
 %{python2_sitelib}/%{name}*
 %{_datadir}/%{name}
+%{_sharedstatedir}/%{name}
 
 %license LICENSE
 %doc README.md


### PR DESCRIPTION
- to let convert2rhel rpm to be its owner
- use /var/lib/convert2rhel instead of /tmp/convert2rhel as the latter
  is cleared upon booting