### PR TITLE
Improve logging of the system unregistration

### DIFF
--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -54,7 +54,7 @@ def unregister_system():
     """Unregister the system from RHSM"""
     loggerinst = logging.getLogger(__name__)
     unregistration_cmd = "subscription-manager unregister"
-    loggerinst.info("Unregistering the system from RHSM ...")
+    loggerinst.task("Rollback: Unregistering the system from RHSM")
     output, ret_code = utils.run_subprocess(unregistration_cmd, print_output=False)
     if ret_code != 0:
         loggerinst.warn("System unregistration failed with return code %d and message:\n%s", ret_code, output)

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -94,6 +94,7 @@ class TestSubscription(unittest.TestCase):
 
     class GetLoggerMocked(unit_tests.MockFunction):
         def __init__(self):
+            self.task_msgs = []
             self.info_msgs = []
             self.warning_msgs = []
             self.critical_msgs = []
@@ -104,6 +105,9 @@ class TestSubscription(unittest.TestCase):
         def critical(self, msg):
             self.critical_msgs.append(msg)
             raise SystemExit(1)
+
+        def task(self, msg):
+            self.task_msgs.append(msg)
 
         def info(self, msg):
             self.info_msgs.append(msg)
@@ -292,7 +296,8 @@ class TestSubscription(unittest.TestCase):
         subscription.unregister_system()
         self.assertEqual(utils.run_subprocess.called, 1)
         self.assertEqual(utils.run_subprocess.cmd, unregistration_cmd)
-        self.assertEqual(len(subscription.logging.getLogger.info_msgs), 2)
+        self.assertEqual(len(subscription.logging.getLogger.info_msgs), 1)
+        self.assertEqual(len(subscription.logging.getLogger.task_msgs), 1)
         self.assertEqual(len(subscription.logging.getLogger.warning_msgs), 0)
 
 
@@ -303,7 +308,8 @@ class TestSubscription(unittest.TestCase):
         subscription.unregister_system()
         self.assertEqual(utils.run_subprocess.called, 1)
         self.assertEqual(utils.run_subprocess.cmd, unregistration_cmd)
-        self.assertEqual(len(subscription.logging.getLogger.info_msgs), 1)
+        self.assertEqual(len(subscription.logging.getLogger.info_msgs), 0)
+        self.assertEqual(len(subscription.logging.getLogger.task_msgs), 1)
         self.assertEqual(len(subscription.logging.getLogger.warning_msgs), 1)
 
     @unit_tests.mock(subscription, "rollback_renamed_repo_files", unit_tests.CountableMockObject())


### PR DESCRIPTION
- To have the log message consistent with the other rollback msgs
- Before:
```
[06/15/2020 20:14:57] TASK - [Rollback: Rollback all non-Red Hat .repo files renamed in /etc/yum.repos.d/] 
No .repo files to rollback
Unregistering the system from RHSM ...
WARNING - subscription-manager not installed, skipping

[06/15/2020 20:14:57] TASK - [Rollback: Removing installed packages] ****************************
```
- After:
```
[06/15/2020 20:14:57] TASK - [Rollback: Rollback all non-Red Hat .repo files renamed in /etc/yum.repos.d/] 
No .repo files to rollback

[06/15/2020 20:14:57] TASK - [Rollback: Unregistering the system from RHSM] *******************
WARNING - subscription-manager not installed, skipping

[06/15/2020 20:14:57] TASK - [Rollback: Removing installed packages] ****************************
```