### PR TITLE
Fix: throws message when not running as root

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -40,6 +40,10 @@ class ConversionPhase:
 
 def main():
     """Perform all steps for the entire conversion process."""
+
+    # the tool will not run if not executed under the root user
+    utils.require_root()
+
     process_phase = ConversionPhase.INIT
     # initialize logging
     logger.initialize_logger("convert2rhel.log")
@@ -51,9 +55,6 @@ def main():
         toolopts.CLI()
 
         process_phase = ConversionPhase.POST_CLI
-
-        # the tool will not run if not executed under the root user
-        utils.require_root()
 
         # license agreement
         loggerinst.task("Prepare: End user license agreement")
@@ -159,7 +160,6 @@ def pre_ponr_conversion():
     # package analysis
     loggerinst.task("Convert: Package analysis")
     repos_needed = repo.package_analysis()
-
     if toolopts.tool_opts.disable_submgr:
         loggerinst.task("Convert: Check required repos")
         repo.check_needed_repos_availability(repos_needed)

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -52,13 +52,16 @@ class TestUtils(unittest.TestCase):
             return self.output, self.ret_code
 
     class DummyGetUID(unit_tests.MockFunction):
+        def __init__(self, uid):
+        	self.uid = uid
         def __call__(self, *args, **kargs):
-            return 1
+            return self.uid
 
-    @unit_tests.mock(os, "geteuid", DummyGetUID())
+    @unit_tests.mock(os, "geteuid", DummyGetUID(1000))
     def test_require_root_is_not_root(self):
         self.assertRaises(SystemExit, utils.require_root)
 
+    @unit_tests.mock(os, "geteuid", DummyGetUID(0))
     def test_require_root_is_root(self):
         self.assertEqual(utils.require_root(), None)
 

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -17,6 +17,7 @@
 
 
 import re
+import os
 
 try:
     import unittest2 as unittest  # Python 2.6 support
@@ -49,6 +50,17 @@ class TestUtils(unittest.TestCase):
             self.cmds += "%s\n" % cmd
             self.called += 1
             return self.output, self.ret_code
+
+    class DummyGetUID(unit_tests.MockFunction):
+        def __call__(self, *args, **kargs):
+            return 1
+
+    @unit_tests.mock(os, "geteuid", DummyGetUID())
+    def test_require_root_is_not_root(self):
+        self.assertRaises(SystemExit, utils.require_root)
+
+    def test_require_root_is_root(self):
+        self.assertEqual(utils.require_root(), None)
 
     def test_track_installed_pkg(self):
         control = utils.ChangedRPMPackagesController()

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -60,9 +60,9 @@ def get_executable_name():
 
 def require_root():
     if os.geteuid() != 0:
-        loggerinst = logging.getLogger(__name__)
-        loggerinst.critical("The tool needs to be run under the root user.")
-    return
+        print("The tool needs to be run under the root user.")
+        print("\nNo changes were made to the system.")
+        sys.exit(1)
 
 
 def get_file_content(filename, as_list=False):


### PR DESCRIPTION
Currently logging is instantiated before utils.require_root() is called which throws a permissions exception.  This PR fix these bug throwing a error message and exiting with code 1, before initialization process started.