### PR TITLE
fix:English locale before all c2r process

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -39,9 +39,6 @@ class ConversionPhase:
 
 
 def main():
-    # setting locale to LANG=C before start convert2rhel process
-    utils.set_env_locale()
-
     """Perform all steps for the entire conversion process."""
 
     # the tool will not run if not executed under the root user

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -39,6 +39,9 @@ class ConversionPhase:
 
 
 def main():
+    # setting locale to LANG=C before start convert2rhel process
+    utils.set_env_locale()
+
     """Perform all steps for the entire conversion process."""
 
     # the tool will not run if not executed under the root user

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -29,7 +29,6 @@ from convert2rhel import utils
 
 
 class TestUtils(unittest.TestCase):
-
     class DummyFuncMocked(unit_tests.MockFunction):
         def __init__(self):
             self.called = 0
@@ -53,7 +52,8 @@ class TestUtils(unittest.TestCase):
 
     class DummyGetUID(unit_tests.MockFunction):
         def __init__(self, uid):
-        	self.uid = uid
+            self.uid = uid
+
         def __call__(self, *args, **kargs):
             return self.uid
 
@@ -64,17 +64,6 @@ class TestUtils(unittest.TestCase):
     @unit_tests.mock(os, "geteuid", DummyGetUID(0))
     def test_require_root_is_root(self):
         self.assertEqual(utils.require_root(), None)
-
-    def test_locale(self):
-        utils.set_env_locale()
-        self.assertEqual(os.environ["LC_ALL"], "C")
-        self.assertEqual(os.environ["LC_CTYPE"], "en_US.UTF-8")
-        self.assertEqual(os.environ["LANGUAGE"], "en_US.UTF-8")
-
-        utils.set_env_locale(lc_all_str='test', lc_ctype_str='test', language_str='test')
-        self.assertEqual(os.environ["LC_ALL"], "test")
-        self.assertEqual(os.environ["LC_CTYPE"], "test")
-        self.assertEqual(os.environ["LANGUAGE"], "test")
 
     def test_track_installed_pkg(self):
         control = utils.ChangedRPMPackagesController()

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -65,6 +65,17 @@ class TestUtils(unittest.TestCase):
     def test_require_root_is_root(self):
         self.assertEqual(utils.require_root(), None)
 
+    def test_locale(self):
+        utils.set_env_locale()
+        self.assertEqual(os.environ["LC_ALL"], "C")
+        self.assertEqual(os.environ["LC_CTYPE"], "en_US.UTF-8")
+        self.assertEqual(os.environ["LANGUAGE"], "en_US.UTF-8")
+
+        utils.set_env_locale(lc_all_str='test', lc_ctype_str='test', language_str='test')
+        self.assertEqual(os.environ["LC_ALL"], "test")
+        self.assertEqual(os.environ["LC_CTYPE"], "test")
+        self.assertEqual(os.environ["LANGUAGE"], "test")
+
     def test_track_installed_pkg(self):
         control = utils.ChangedRPMPackagesController()
         pkgs = ['pkg1', 'pkg2', 'pkg3']

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -47,12 +47,6 @@ DATA_DIR = "/usr/share/convert2rhel/"
 TMP_DIR = "/var/lib/convert2rhel/"
 
 
-def set_env_locale(lc_all_str="C", lc_ctype_str="en_US.UTF-8", language_str="en_US.UTF-8"):
-    os.environ["LC_ALL"] = lc_all_str
-    os.environ["LC_CTYPE"] = lc_ctype_str
-    os.environ["LANGUAGE"] = language_str
-
-
 def format_msg_with_datetime(msg, level):
     """Return a string with msg formatted according to the level"""
     temp_date = datetime.datetime.now().strftime("%m/%d/%Y %H:%M:%S")
@@ -135,7 +129,8 @@ def run_subprocess(cmd="", **kwargs):
     sp_popen = subprocess.Popen(cmd,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT,
-                                bufsize=1)
+                                bufsize=1,
+                                env={'LC_ALL':'C'})
     stdout = ''
     for line in iter(sp_popen.stdout.readline, ''):
         # communicate() method buffers everything in memory, we will

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -47,6 +47,12 @@ DATA_DIR = "/usr/share/convert2rhel/"
 TMP_DIR = "/var/lib/convert2rhel/"
 
 
+def set_env_locale(lc_all_str="C", lc_ctype_str="en_US.UTF-8", language_str="en_US.UTF-8"):
+    os.environ["LC_ALL"] = lc_all_str
+    os.environ["LC_CTYPE"] = lc_ctype_str
+    os.environ["LANGUAGE"] = language_str
+
+
 def format_msg_with_datetime(msg, level):
     """Return a string with msg formatted according to the level"""
     temp_date = datetime.datetime.now().strftime("%m/%d/%Y %H:%M:%S")


### PR DESCRIPTION
Some regexp are hardcoded in English, the locale must be set to LANG=C before running the tool.

Signed-off-by: Fellipe Henrique <fpedrosa@redhat.com>