### PR TITLE
Fix: Do not rename .repo files

### DIFF
--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -82,14 +82,14 @@ class CLI(object):
                                 " its output is stored in a log file.")
         self._parser.add_option("--enablerepo", metavar="repoidglob",
                                 action="append", help="Enable specific"
-                                " repositories by ID or glob. Use this option"
-                                " multiple times to add many repositories.")
+                                " repositories by ID or glob. For more repositories to enable, use this option"
+                                " multiple times. If you don't use the --disable-submgr option, you can use this option"
+                                " to override the default RHEL CDN repoids that convert2rhel enables through"
+                                " subscription-manager.")
         self._parser.add_option("--disablerepo", metavar="repoidglob",
                                 action="append", help="Disable specific"
-                                " repositories by ID or glob. Use this option"
-                                " multiple times to add many repositories."
-                                " If --disable-submgr is used this defaults"
-                                " to all repositories.")
+                                " repositories by ID or glob. For more repositories to disable, use this option"
+                                " multiple times. This option defaults to all repositories ('*').")
         group = optparse.OptionGroup(self._parser,
                                      "Subscription Manager Options",
                                      "The following options are specific to"
@@ -190,8 +190,11 @@ class CLI(object):
             if not tool_opts.enablerepo:
                 loggerinst.critical(
                     "Error: --enablerepo is required if --disable-submgr is passed ")
-            if not tool_opts.disablerepo:
-                tool_opts.disablerepo = "*"  # Default to disable everything
+        if not tool_opts.disablerepo:
+            # Default to disable every repo except:
+            # - the ones passed through --enablerepo
+            # - the ones enabled through subscription-manager based on convert2rhel config files
+            tool_opts.disablerepo = ["*"]
 
         if parsed_opts.pool:
             tool_opts.pool = parsed_opts.pool

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -244,7 +244,6 @@ class TestSubscription(unittest.TestCase):
                 'subscription-manager register --force '
                 '--username=jdoe --password="*****" --org=0123')
 
-
     def test_rhsm_serverurl(self):
         tool_opts.username = 'user'
         tool_opts.password = 'pass'
@@ -253,14 +252,12 @@ class TestSubscription(unittest.TestCase):
             'subscription-manager register --force --username=user --password="pass" --serverurl="url"'
         self.assertEqual(subscription.get_registration_cmd(), expected)
 
-
     @unit_tests.mock(subscription.logging, "getLogger", GetLoggerMocked())
     def test_get_pool_id(self):
         # Check that we can distill the pool id from the subscription description
         pool_id = subscription.get_pool_id(self.SUBSCRIPTION_DETAILS)
 
         self.assertEqual(pool_id, "8aaaa123045897fb564240aa00aa0000")
-
 
     # Details of one subscription as output by `subscription-manager list --available`
     SUBSCRIPTION_DETAILS = (
@@ -278,7 +275,6 @@ class TestSubscription(unittest.TestCase):
         "System Type:       Virtual\n\n"  # this has changed to Entitlement Type since RHEL 7.8
     )
 
-
     @unit_tests.mock(subscription.logging, "getLogger", GetLoggerMocked())
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     def test_unregister_system_successfully(self):
@@ -289,7 +285,6 @@ class TestSubscription(unittest.TestCase):
         self.assertEqual(len(subscription.logging.getLogger.info_msgs), 1)
         self.assertEqual(len(subscription.logging.getLogger.task_msgs), 1)
         self.assertEqual(len(subscription.logging.getLogger.warning_msgs), 0)
-
 
     @unit_tests.mock(subscription.logging, "getLogger", GetLoggerMocked())
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked([('output', 1)]))

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -62,13 +62,11 @@ class TestToolopts(unittest.TestCase):
         convert2rhel.toolopts.CLI()
         self.assertEqual(tool_opts.serverurl, "url")
 
-    @unit_tests.mock(sys, "argv", _params(["--disable-submgr", ""
-                                           "--enablerepo", "foo"]))
-    def test_cmdline_defaults_disablerepo_to_asterisk_with_disable_submgr(self):
+    @unit_tests.mock(sys, "argv", _params(["--enablerepo", "foo"]))
+    def test_cmdline_disablerepo_defaults_to_asterisk(self):
         convert2rhel.toolopts.CLI()
         self.assertEqual(tool_opts.enablerepo, ["foo"])
-        self.assertEqual(tool_opts.disablerepo, "*")
-        self.assertTrue(tool_opts.disable_submgr)
+        self.assertEqual(tool_opts.disablerepo, ["*"])
 
     @unit_tests.mock(sys, "argv", _params(["--disable-submgr"]))
     def test_cmdline_exits_on_empty_enablerepo_with_disable_submgr(self):


### PR DESCRIPTION
Currently, when using RHSM, convert2rhel renames all non-RHSM repofiles to make sure only the RHSM ones are used. That causes a problem when somebody passes --enablerepo together with using RHSM, and this repo is in some other repofile than /etc/yum.repos.d/redhat.repo. Because of the repofile renaming, this repository is then unexpectedly not used during the conversion.

Some unit tests need to be changed to reflect `--disable=*` from yum command

A/C:
- Add `--disable=*` as default for yum command (if user pass `--disablerepo` arg would have priority over that)
- When using RHSM, use `--enable=XXX` for each of enabled repository from these command: `subscription-manager repos --list-enabled`

Signed-off-by: Fellipe Henrique <fpedrosa@redhat.com>