### PR TITLE
fix: Logfile is overwritten instead of appended

### DIFF
--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -77,7 +77,7 @@ def initialize_logger(log_name):
     # create file handler
     if not os.path.isdir(LOG_DIR):
         os.makedirs(LOG_DIR)
-    handler = logging.FileHandler(os.path.join(LOG_DIR, log_name), "w")
+    handler = logging.FileHandler(os.path.join(LOG_DIR, log_name), "a")
     formatter = CustomFormatter("%(message)s")
     handler.setFormatter(formatter)
     handler.setLevel(LogLevelFile.level)


### PR DESCRIPTION
Logfile is always overwritten for each execution instead of appended.
This PR fix that, adding appended argument for logging.FileHandler

Signed-off-by: Fellipe Henrique <fpedrosa@redhat.com>