### PR TITLE
fix: critical logging exit with message

### DIFF
--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -102,7 +102,7 @@ class CustomLogger(logging.Logger, object):
 
     def critical(self, msg, *args, **kwargs):
         super(CustomLogger, self).critical(msg, *args, **kwargs)
-        sys.exit(1)
+        sys.exit(msg)
 
     def debug(self, msg, *args, **kwargs):
         from convert2rhel.toolopts import tool_opts


### PR DESCRIPTION
Fixes #79 

Python by default exits as 1 if you input a string:

```bash
$ python -c "import sys; sys.exit('testing')"; echo $?
testing
1
```