### PR TITLE
packit: bump release for builds in master branch

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,6 +13,12 @@ jobs:
     - epel-7-x86_64
   trigger: pull_request
 - job: copr_build
+  trigger: commit
+  actions:
+    # bump spec so we get release starting with 2 and hence all master builds will
+    # have higher NVR than all the PR builds
+    post-upstream-clone:
+    - rpmdev-bumpspec --comment='latest upstream build' ./packaging/epel/convert2rhel.spec
   metadata:
     branch: master
     owner: "@oamg"
@@ -20,7 +26,6 @@ jobs:
     targets:
     - epel-6-x86_64
     - epel-7-x86_64
-  trigger: commit
 - job: tests
   metadata:
     targets:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,7 +1,4 @@
 specfile_path: packaging/epel/convert2rhel.spec
-synced_files:
-    - convert2rhel.spec
-    - .packit.yaml
 upstream_package_name: convert2rhel
 downstream_package_name: convert2rhel
 upstream_project_url: https://github.com/oamg/convert2rhel


### PR DESCRIPTION
With this change, every build of c2r in the master branch will start with release number 2 which should make it higher than all the PR builds.

https://github.com/TomasTomecek/convert2rhel/commit/0c39103eee70c88e2d43f6df6209f7b803cbdf41
https://prod.packit.dev/copr-build/54592
https://copr.fedorainfracloud.org/coprs/packit/TomasTomecek-convert2rhel-master/build/1541479/