### PR TITLE
Fix: Subscriptions attached to a Sat6 activation key ignored

### DIFF
--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -184,6 +184,10 @@ def attach_subscription():
     #       all the appropriate subscriptions during registration already.
 
     loggerinst = logging.getLogger(__name__)
+
+    if tool_opts.activation_key:
+        return True
+
     if tool_opts.auto_attach:
         pool = "--auto"
         tool_opts.pool = "-a"

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -172,6 +172,13 @@ class TestSubscription(unittest.TestCase):
     def test_attach_subscription_available(self):
         self.assertEqual(subscription.attach_subscription(), True)
 
+    @unit_tests.mock(subscription, "get_avail_subs", GetAvailSubsMocked())
+    @unit_tests.mock(utils, "let_user_choose_item", LetUserChooseItemMocked())
+    @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
+    @unit_tests.mock(tool_opts, "activation_key", "dummy_activate_key")
+    def test_attach_subscription_available_with_activation_key(self):
+        self.assertEqual(subscription.attach_subscription(), True)
+
     @unit_tests.mock(subscription, "get_avail_subs", GetNoAvailSubsMocked())
     def test_attach_subscription_none_available(self):
         self.assertEqual(subscription.attach_subscription(), False)


### PR DESCRIPTION
Subscriptions attached to an activation key are ignored and the script stops to prompt for a subscription, despite the fact that one  as already been attached, This PR fix that.

Signed-off-by: Fellipe Henrique <fpedrosa@redhat.com>