### PR TITLE
add: Clear yum versionlock

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -72,6 +72,9 @@ def main():
         redhatrelease.yum_conf.backup()
         subscription.rhn_reg_file.backup()
 
+        loggerinst.task("Prepare: Clear yum version locks")
+        pkghandler.clear_yum_versionlock()
+
         # begin conversion process
         process_phase = ConversionPhase.PRE_PONR_CHANGES
         pre_ponr_conversion()
@@ -213,6 +216,8 @@ def rollback_changes():
     redhatrelease.system_release_file.restore()
     subscription.rhn_reg_file.restore()
     redhatrelease.yum_conf.restore()
+    pkghandler.versionlock_file.restore()
+
     return
 
 


### PR DESCRIPTION
Users may have locked some of the installed packages to a certain version using `yum-plugin-versionlock`. This would most probably cause the conversion to fail because the RHEL equivalent of the package may easily have a different version.

This PR check if `yum-plugin-versionlock` is installed, if so, ask user if want to continue, if yes clear the versionlock list, if no conversion will stop.

See https://access.redhat.com/solutions/98873 for more information.

Signed-off-by: Fellipe Henrique <fpedrosa@redhat.com>