### PR TITLE
Copr build version from spec

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,6 +12,10 @@ jobs:
     - epel-6-x86_64
     - epel-7-x86_64
   trigger: pull_request
+  actions:
+    # do not get the version from a tag (git describe) but from the spec file
+    get-current-version:
+    - grep -oP '^Version:\s+\K\S+' packaging/epel/convert2rhel.spec
 - job: copr_build
   trigger: commit
   actions:
@@ -19,6 +23,9 @@ jobs:
     # have higher NVR than all the PR builds
     post-upstream-clone:
     - rpmdev-bumpspec --comment='latest upstream build' ./packaging/epel/convert2rhel.spec
+    # do not get the version from a tag (git describe) but from the spec file
+    get-current-version:
+    - grep -oP '^Version:\s+\K\S+' packaging/epel/convert2rhel.spec
   metadata:
     branch: master
     owner: "@oamg"


### PR DESCRIPTION
For copr build from packit, use the version from the spec file instead of from the latest git tag (which is the packit default).

Up until now, the copr builds created by packit had their version based on the convert2rhel tags (https://github.com/oamg/convert2rhel/tags), which caused them to have NEVR like:
`convert2rhel-v0.11-1.20200804110826746138.pr82.84.gb821881.fc31`

The `v` is the problem here.

After this change, the version should be taken from the `packaging/epel/convert2rhel.spec` file, causing the NEVR be like:
`convert2rhel-0.11-1.20200804110826746138.pr82.84.gb821881.fc31`