### PR TITLE
Bump version to 0.12

### DIFF
--- a/packaging/centos_ol/convert2rhel.spec
+++ b/packaging/centos_ol/convert2rhel.spec
@@ -3,7 +3,7 @@
 %{!?python2_sitearch: %global python2_sitearch %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 
 Name:           convert2rhel
-Version:        0.11
+Version:        0.12
 Release:        1%{?dist}
 Summary:        Automates the conversion of RHEL derivative distributions to RHEL
 
@@ -96,6 +96,24 @@ install -p man/%{name}.8 %{buildroot}%{_mandir}/man8/
 %{_mandir}/man8/%{name}.8*
 
 %changelog
+* Wed Aug 19 2020 Michal Bocek <mbocek@redhat.com> 0.12-1
+- require --enablerepo with --disable-submgr
+- fix failing conversions if gpgcheck=1 not in used custom repos
+- always logging debug info to the log file
+- unnecessary backup of kernel packages is not being performed
+- add missing python-setuptools dependency on RHEL 6 to a spec file
+- unregister from RHN Classic if in use
+- change a temporary folder path from /tmp/convert2rhel/ to /var/lib/convert2rhel
+- add the ability to specify custom RHSM url
+- unsubscribe from RHSM during a rollback
+- drop the support for conversions of RHEL 5
+- make sure that RHEL kernel has been installed correctly during the conversion
+- fix parsing RHSM output due to its change in RHEL 7.8
+- fix stopping the convert2rhel execution when not running as root
+- the convert2rhel.log file is not being overwritten but appended
+- do not traceback when intentionally stopping the conversion
+- do not ask for subscription SKU pool IDs when activation key is used
+
 * Tue May 12 2020 Michal Bocek <mbocek@redhat.com> 0.11-1
 - updated license in spec files from GPLv3 to GPLv3+
 - set up automated pylint and unit test coverage checks in GitHub

--- a/packaging/epel/convert2rhel.spec
+++ b/packaging/epel/convert2rhel.spec
@@ -3,7 +3,7 @@
 %{!?python2_sitearch: %global python2_sitearch %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 
 Name:           convert2rhel
-Version:        0.11
+Version:        0.12
 Release:        1%{?dist}
 Summary:        Automates the conversion of RHEL derivative distributions to RHEL
 
@@ -94,6 +94,24 @@ install -p man/%{name}.8 %{buildroot}%{_mandir}/man8/
 %{_mandir}/man8/%{name}.8*
 
 %changelog
+* Wed Aug 19 2020 Michal Bocek <mbocek@redhat.com> 0.12-1
+- require --enablerepo with --disable-submgr
+- fix failing conversions if gpgcheck=1 not in used custom repos
+- always logging debug info to the log file
+- unnecessary backup of kernel packages is not being performed
+- add missing python-setuptools dependency on RHEL 6 to a spec file
+- unregister from RHN Classic if in use
+- change a temporary folder path from /tmp/convert2rhel/ to /var/lib/convert2rhel
+- add the ability to specify custom RHSM url
+- unsubscribe from RHSM during a rollback
+- drop the support for conversions of RHEL 5
+- make sure that RHEL kernel has been installed correctly during the conversion
+- fix parsing RHSM output due to its change in RHEL 7.8
+- fix stopping the convert2rhel execution when not running as root
+- the convert2rhel.log file is not being overwritten but appended
+- do not traceback when intentionally stopping the conversion
+- do not ask for subscription SKU pool IDs when activation key is used
+
 * Tue May 12 2020 Michal Bocek <mbocek@redhat.com> 0.11-1
 - updated license in spec files from GPLv3 to GPLv3+
 - set up automated pylint and unit test coverage checks in GitHub

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def read(fname):
 
 setup(
     name='convert2rhel',
-    version='0.11',
+    version='0.12',
     description='Automates the conversion of Red Hat Enterprise Linux'
                 ' derivative distributions to Red Hat Enterprise Linux.',
     long_description=read('README.md'),


### PR DESCRIPTION
Changes in the new version include:

- Fixes:
  - require --enablerepo with --disable-submgr (#45)
  - fix failing conversions if gpgcheck=1 not in used custom repos (#31)
  - add missing python-setuptools dependency on RHEL 6 to a spec file (#73)
  - fix parsing RHSM output due to its change in RHEL 7.8 (#72)
  - fix stopping the convert2rhel execution when not running as root (#81)
  - do not traceback when intentionally stopping the conversion (#87)
  - do not ask for subscription SKU pool IDs when activation key is used (#91)
- Enhancements:
  - always logging debug info to the log file (#41)
  - unnecessary backup of kernel packages is not being performed (#61)
  - unregister from RHN Classic if in use (#47)
  - change a temporary folder path from /tmp/convert2rhel/ to /var/lib/convert2rhel (#74)
  - add the ability to specify custom RHSM url (#64)
  - unsubscribe from RHSM during a rollback (#60)
  - drop the support for conversions of RHEL 5 (#75)
  - make sure that RHEL kernel has been installed correctly during the conversion (#58)
  - the convert2rhel.log file is not being overwritten but appended (#85)