### PR TITLE
Do not check repoids with disabled RHSM

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -160,10 +160,7 @@ def pre_ponr_conversion():
     # package analysis
     loggerinst.task("Convert: Package analysis")
     repos_needed = repo.package_analysis()
-    if toolopts.tool_opts.disable_submgr:
-        loggerinst.task("Convert: Check required repos")
-        repo.check_needed_repos_availability(repos_needed)
-    else:
+    if not toolopts.tool_opts.disable_submgr:
         loggerinst.task("Convert: Subscription Manager - Install")
         subscription.install_subscription_manager()
         loggerinst.task("Convert: Subscription Manager - Subscribe system")


### PR DESCRIPTION
When using custom repos instead of RHSM, checking for expected repoids and warning when they're not available is confusing to customers as they fear something is wrong.
Related: OAMG-3144