### PR TITLE
Do not expect offline snapshot of RHEL repos

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -158,21 +158,23 @@ def pre_ponr_conversion():
     redhatrelease.YumConf().patch()
 
     # package analysis
-    loggerinst.task("Convert: Package analysis")
-    repos_needed = repo.package_analysis()
+    loggerinst.task("Convert: List third-party packages")
+    pkghandler.list_third_party_pkgs()
     if not toolopts.tool_opts.disable_submgr:
         loggerinst.task("Convert: Subscription Manager - Install")
         subscription.install_subscription_manager()
         loggerinst.task("Convert: Subscription Manager - Subscribe system")
         subscription.subscribe_system()
-        loggerinst.task("Convert: Subscription Manager - Check required repos")
-        repo.check_needed_repos_availability(repos_needed)
-        loggerinst.task("Convert: Subscription Manager - Disable all repos")
+        loggerinst.task("Convert: Get RHEL repository IDs")
+        rhel_repoids = repo.get_rhel_repoids()
+        loggerinst.task("Convert: Subscription Manager - Check required repositories")
+        repo.check_needed_repos_availability(rhel_repoids)
+        loggerinst.task("Convert: Subscription Manager - Disable all repositories")
         subscription.disable_repos()
-        loggerinst.task("Convert: Subscription Manager - Enable needed repos")
-        subscription.enable_repos(repos_needed)
+        loggerinst.task("Convert: Subscription Manager - Enable RHEL repositories")
+        subscription.enable_repos(rhel_repoids)
         # TODO: Replace renaming .repo files by using --enable for yum command
-        loggerinst.task("Convert: Subscription Manager - Rename repos")
+        loggerinst.task("Convert: Subscription Manager - Rename repositories")
         subscription.rename_repo_files()
 
 

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -225,6 +225,23 @@ def get_installed_pkgs_w_different_fingerprint(fingerprints, name=""):
             pkg.pkg_obj.name != "gpg-pubkey"]
 
 
+def list_third_party_pkgs():
+    """List packages not packaged by the original OS vendor or Red Hat and warn that these are not going
+    to be converted.
+    """
+    loggerinst = logging.getLogger(__name__)
+    third_party_pkgs = get_third_party_pkgs()
+    if third_party_pkgs:
+        loggerinst.warning("Only packages signed by %s are to be"
+                           " reinstalled. Red Hat support won't be provided"
+                           " for the following third party packages:\n"
+                           % system_info.name)
+        print_pkg_info(third_party_pkgs)
+        utils.ask_to_continue()
+    else:
+        loggerinst.info("No third party packages installed.")
+
+
 def print_pkg_info(pkgs):
     """Print package information."""
     for pkg in pkgs:

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -390,3 +390,26 @@ def rollback():
         unregister_system()
     except OSError:
         loggerinst.warn("subscription-manager not installed, skipping")
+
+
+def check_needed_repos_availability(repo_ids_needed):
+    """Check whether all the RHEL repositories needed for the system
+    conversion are available through subscription-manager.
+    """
+    loggerinst = logging.getLogger(__name__)
+    loggerinst.info("Verifying needed RHEL repositories are available ... ")
+    avail_repos = get_avail_repos()
+    loggerinst.info("Repositories available through RHSM:\n%s" %
+                    "\n".join(avail_repos) + "\n")
+
+    all_repos_avail = True
+    for repo_id in repo_ids_needed:
+        if repo_id not in avail_repos:
+            # TODO: List the packages that would be left untouched
+            loggerinst.warning("%s repository is not available - some packages"
+                               " may not be replaced and thus not supported."
+                               % repo_id)
+            utils.ask_to_continue()
+            all_repos_avail = False
+    if all_repos_avail:
+        loggerinst.info("Needed RHEL repos are available.")

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -53,6 +53,8 @@ class SystemInfo(object):
         self.cfg_content = None
         self.system_release_file_content = None
         self.logger = None
+        # ID of the default Red Hat CDN repository that corresponds to the current system
+        self.default_repository_id = None
 
     def resolve_system_info(self):
         self.logger = logging.getLogger(__name__)

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -593,6 +593,23 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
     def test_check_installed_rhel_kernel_returns_false(self):
         self.assertEqual(pkghandler.is_rhel_kernel_installed(), False)
 
+    @unit_tests.mock(pkghandler, "get_third_party_pkgs", lambda: [])
+    @unit_tests.mock(logger.CustomLogger, "info", LogMocked())
+    def test_list_third_party_pkgs_no_pkgs(self):
+        pkghandler.list_third_party_pkgs()
+
+        self.assertEqual(logger.CustomLogger.info.msg, "No third party packages installed.\n")
+
+    @unit_tests.mock(pkghandler, "get_third_party_pkgs", GetInstalledPkgsWFingerprintsMocked())
+    @unit_tests.mock(pkghandler, "print_pkg_info", PrintPkgInfoMocked())
+    @unit_tests.mock(logger.CustomLogger, "warning", LogMocked())
+    @unit_tests.mock(utils, "ask_to_continue", DumbCallableObject())
+    def test_list_third_party_pkgs(self):
+        pkghandler.list_third_party_pkgs()
+
+        self.assertEqual(len(pkghandler.print_pkg_info.pkgs), 3)
+        self.assertTrue("Only packages signed by" in logger.CustomLogger.warning.msg)
+        
 
 YUM_PROTECTED_ERROR = """Error: Trying to remove "systemd", which is protected
 Error: Trying to remove "yum", which is protected"""

--- a/convert2rhel/unit_tests/repo_test.py
+++ b/convert2rhel/unit_tests/repo_test.py
@@ -15,16 +15,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import logging
-
+from convert2rhel import repo
+from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel.systeminfo import system_info
 
 
-def get_rhel_repoids():
-    """Get IDs of the Red Hat CDN repositories that correspond to the current system."""
-    repos_needed = [system_info.default_repository_id]
+class TestRepo(unit_tests.ExtendedTestCase):
+    @unit_tests.mock(system_info, "default_repository_id", "rhel_server")
+    def test_get_rhel_repoids(self):
+        repos = repo.get_rhel_repoids()
 
-    loggerinst = logging.getLogger(__name__)
-    loggerinst.info("RHEL repository IDs: %s" % ', '.join(repos_needed))
-
-    return repos_needed
+        self.assertEqual(repos, ["rhel_server"])


### PR DESCRIPTION
The feature of consuming the offline snapshot of RHEL repos hasn't ever been used in upstream and it's not planned to be ever used. It used to provide information to the user prior the conversion about what packages *might* not be available in RHEL. Considering that we have no mechanism to get such snapshot publicly, the feature is being removed to make the code simpler.