### PR TITLE
Download subscription-manager automatically

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -159,6 +159,8 @@ def pre_ponr_conversion():
     pkghandler.remove_excluded_pkgs()
 
     if not toolopts.tool_opts.disable_submgr:
+        loggerinst.task("Convert: Subscription Manager - Download packages")
+        subscription.download_subscription_manager_packages()
         loggerinst.task("Convert: Subscription Manager - Replace")
         subscription.replace_subscription_manager()
         loggerinst.task("Convert: Install RHEL certificates for RHSM")

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -160,7 +160,7 @@ def pre_ponr_conversion():
 
     if not toolopts.tool_opts.disable_submgr:
         loggerinst.task("Convert: Subscription Manager - Download packages")
-        subscription.download_subscription_manager_packages()
+        subscription.download_rhsm_pkgs()
         loggerinst.task("Convert: Subscription Manager - Replace")
         subscription.replace_subscription_manager()
         loggerinst.task("Convert: Install RHEL certificates for RHSM")

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -111,7 +111,8 @@ def call_yum_cmd(command, args="", print_output=True, enable_repos=None, disable
     else:
         # When using subscription-manager for the conversion, use those repos for the yum call that have been enabled
         # through subscription-manager
-        repos_to_enable = system_info.submgr_enabled_repos if not tool_opts.disable_submgr else tool_opts.enablerepo
+       repos_to_enable = system_info.submgr_enabled_repos if (
+               not tool_opts.disable_submgr and system_info.submgr_enabled_repos) else tool_opts.enablerepo
 
     for repo in repos_to_enable:
         cmd += " --enablerepo=%s" % repo

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -102,7 +102,7 @@ def call_yum_cmd(command, args="", print_output=True, enable_repos=None, disable
         cmd += " --releasever=%s" % system_info.releasever
 
     # Without the release package installed, dnf can't determine the modularity platform ID.
-    if int(system_info.version) == 8:
+    if system_info.version.major == 8:
         cmd += " --setopt=module_platform_id=platform:el8"
 
     repos_to_enable = []
@@ -111,8 +111,7 @@ def call_yum_cmd(command, args="", print_output=True, enable_repos=None, disable
     else:
         # When using subscription-manager for the conversion, use those repos for the yum call that have been enabled
         # through subscription-manager
-       repos_to_enable = system_info.submgr_enabled_repos if (
-               not tool_opts.disable_submgr and system_info.submgr_enabled_repos) else tool_opts.enablerepo
+        repos_to_enable = system_info.submgr_enabled_repos if not tool_opts.disable_submgr else tool_opts.enablerepo
 
     for repo in repos_to_enable:
         cmd += " --enablerepo=%s" % repo
@@ -599,9 +598,7 @@ def get_kernel(kernels_raw):
 
 
 def replace_non_rhel_installed_kernel(version):
-    """Replace the installed non-RHEL kernel with RHEL kernel with same
-    version.
-    """
+    """Replace the installed non-RHEL kernel with RHEL kernel with same version."""
     loggerinst = logging.getLogger(__name__)
     loggerinst.warning("The convert2rhel is going to force-replace the only"
                        " kernel installed, which has the same NEVRA as the"
@@ -616,8 +613,8 @@ def replace_non_rhel_installed_kernel(version):
     pkg = "kernel-%s" % version
 
     path = utils.download_pkg(
-        pkg=pkg, dest=utils.TMP_DIR, disablerepo=tool_opts.disablerepo,
-        enablerepo=tool_opts.enablerepo)
+        pkg=pkg, dest=utils.TMP_DIR, disable_repos=tool_opts.disablerepo,
+        enable_repos=tool_opts.enablerepo)
     if not path:
         loggerinst.critical("Unable to download the RHEL kernel package.")
 
@@ -626,7 +623,7 @@ def replace_non_rhel_installed_kernel(version):
         'rpm -i --force --replacepkgs %s*' % os.path.join(utils.TMP_DIR, pkg),
         print_output=False)
     if ret_code != 0:
-        loggerinst.critical("Unable to replace kernel package: %s" % output)
+        loggerinst.critical("Unable to replace the kernel package: %s" % output)
 
     loggerinst.info("\nRHEL %s installed.\n" % pkg)
 
@@ -673,7 +670,7 @@ def fix_invalid_grub2_entries():
     The solution handled by this function is to remove the non-functioning boot entries upon the removal of the original
     OS kernels, and setting the RHEL kernel as default.
     """
-    if int(system_info.version) < 8 or system_info.arch == "s390x":
+    if system_info.version.major < 8 or system_info.arch == "s390x":
         # Applicable only on systems derived from RHEL 8 and later, and systems using GRUB2 (s390x uses zipl)
         return
 

--- a/convert2rhel/redhatrelease.py
+++ b/convert2rhel/redhatrelease.py
@@ -30,9 +30,9 @@ def get_release_pkg_name():
 
     For RHEL 8, the name is redhat-release.
     """
-    if system_info.version in ["6", "7"]:
+    if system_info.version.major in [6, 7]:
         return "redhat-release-server"
-    elif system_info.version == "8":
+    elif system_info.version.major == 8:
         return "redhat-release"
 
 

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 from collections import namedtuple
 import os
 import re
@@ -29,6 +30,30 @@ from convert2rhel import pkghandler
 from convert2rhel.systeminfo import system_info
 
 SUBMGR_RPMS_DIR = os.path.join(utils.DATA_DIR, "subscription-manager")
+_RHSM_TMP_DIR = os.path.join(utils.TMP_DIR, "rhsm")
+_CENTOS_6_REPO_CONTENT = \
+        '[centos-6-contrib-convert2rhel]\n' \
+        'name=CentOS 6 - Contrib added by Convert2RHEL\n' \
+        'baseurl=https://vault.centos.org/centos/6/contrib/$basearch/\n' \
+        'gpgcheck=0\n' \
+        'enabled=1\n'
+_CENTOS_6_REPO_PATH = os.path.join(_RHSM_TMP_DIR, "centos_6.repo")
+_CENTOS_7_REPO_CONTENT = \
+        '[centos-7-convert2rhel]\n' \
+        'name=CentOS 7 added by Convert2RHEL\n' \
+        'mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=os\n' \
+        'gpgcheck=0\n' \
+        'enabled=1\n'
+_CENTOS_7_REPO_PATH = os.path.join(_RHSM_TMP_DIR, "centos_7.repo")
+# We are using UBI 8 instead of CentOS 8 because there's a bug in subscription-manager-rhsm-certificates on CentOS 8
+# https://bugs.centos.org/view.php?id=17907
+_UBI_8_REPO_CONTENT = \
+        '[ubi-8-baseos-convert2rhel]\n' \
+        'name=Red Hat Universal Base Image 8 - BaseOS added by Convert2RHEL\n' \
+        'baseurl=https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/os/\n' \
+        'gpgcheck=0\n' \
+        'enabled=1\n'
+_UBI_8_REPO_PATH = os.path.join(_RHSM_TMP_DIR, "ubi_8.repo")
 
 
 def subscribe_system():
@@ -412,45 +437,69 @@ def check_needed_repos_availability(repo_ids_needed):
         loggerinst.info("Needed RHEL repos are available.")
 
 
-def download_subscription_manager_packages():
+def download_rhsm_pkgs():
+    """Download all the packages necessary for a successful registration to the Red Hat Subscription Management.
+
+    The packages are available in non-standard repositories, so additional repofiles need to be used. The downloaded
+    RPMs are to be installed in a later stage of the conversion.
+    """
+    utils.mkdir_p(_RHSM_TMP_DIR)
+    pkgs_to_download = ["subscription-manager",
+                        "subscription-manager-rhsm-certificates"]
+
+    if system_info.version.major == 6:
+        pkgs_to_download.append("subscription-manager-rhsm")
+        _download_rhsm_pkgs(pkgs_to_download, _CENTOS_6_REPO_PATH, _CENTOS_6_REPO_CONTENT)
+
+    elif system_info.version.major == 7:
+        pkgs_to_download += ["subscription-manager-rhsm", "python-syspurpose"]
+        _download_rhsm_pkgs(pkgs_to_download, _CENTOS_7_REPO_PATH, _CENTOS_7_REPO_CONTENT)
+        _get_rhsm_cert_on_centos_7()
+
+    elif system_info.version.major == 8:
+        pkgs_to_download += ["python3-subscription-manager-rhsm", "dnf-plugin-subscription-manager",
+                             "python3-syspurpose"]
+        _download_rhsm_pkgs(pkgs_to_download, _UBI_8_REPO_PATH, _UBI_8_REPO_CONTENT)
+
+
+def _download_rhsm_pkgs(pkgs_to_download, repo_path, repo_content):
+    downloaddir = os.path.join(utils.DATA_DIR, "subscription-manager")
+    utils.store_content_to_file(filename=repo_path, content=repo_content)
+    paths = utils.download_pkgs(pkgs_to_download, dest=downloaddir, reposdir=_RHSM_TMP_DIR)
+    exit_on_failed_download(paths)
+
+
+def exit_on_failed_download(paths):
     loggerinst = logging.getLogger(__name__)
+    if None in paths:
+        loggerinst.critical("Unable to download the subscription-manager package or its dependencies. See details of"
+                            " the failed yumdownloader call above. These packages are necessary for the conversion"
+                            " unless you use the --disable-submgr option.")
 
-    _CENTOS_CONTRIB_REPO = '[contrib]\n' \
-                           'name=CentOS-$releasever - Contrib\n' \
-                           'mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib\n' \
-                           'gpgcheck=0\n' \
-                           'enabled=1\n' \
-                           'protect=0\n'
 
-    _TEMP_REPOFILE_DIR = '/tmp/convert2rhel/centos_contrib.repo'
+def _get_rhsm_cert_on_centos_7():
+    """There's a RHSM-related bug on CentOS 7: https://bugs.centos.org/view.php?id=14785
+    - The subscription-manager-rhsm-certificates is missing the necessary /etc/rhsm/ca/redhat-uep.pem.
+    - This cert is still available in the python-rhsm-certificates package which is not possible to install
+      (because it is obsoleted by the subscription-manager-rhsm-certificates).
+    The workaround is to download the python-rhsm-certificates and extract the certificate from it.
+    """
+    loggerinst = logging.getLogger(__name__)
+    cert_pkg_path = utils.download_pkg(pkg="python-rhsm-certificates", dest=_RHSM_TMP_DIR, reposdir=_RHSM_TMP_DIR)
+    exit_on_failed_download([cert_pkg_path])
 
-    version = utils.parse_version_number(system_info.system_release_file_content)
+    output, ret_code = utils.run_subprocess("rpm2cpio %s" % cert_pkg_path, print_output=False)
+    if ret_code != 0:
+        loggerinst.critical("Failed to extract cpio archive from the %s package." % cert_pkg_path)
 
-    if version['major'] <= 6 and (version['minor'] is None or ('minor' in version and version['minor'] <= 6)):
-        loggerinst.error(msg='Unable to download subscription-manager on CentOS/Oracle Linux 6.6 and older. '
-                             'Please use the --disable-submgr option or update to CentOS/Oracle Linux 6.7 or later')
-        sys.exit(1)
+    cpio_filepath = cert_pkg_path + ".cpio"
+    utils.store_content_to_file(filename=cpio_filepath, content=output)
 
-    if version['major'] == 6:
-        utils.store_content_to_file(filename=_TEMP_REPOFILE_DIR, content=_CENTOS_CONTRIB_REPO)
-        pkghandler.call_yum_cmd(command="install",
-                                args="subscription-manager "
-                                     "subscription-manager-rhsm "
-                                     "subscription-manager-rhsm-certificates"
-                                     " --setopt=reposdir=/tmp/convert2rhel/ --downloadonly"
-                                     " --downloaddir=/usr/share/convert2rhel/subscription-manager")
-
-    elif version['major'] == 7:
-        pkghandler.call_yum_cmd(command="install", args="subscription-manager subscription-manager-rhsm "
-                                                        "subscription-manager-rhsm-certificates "
-                                                        "--downloadonly "
-                                                        "--downloaddir=/usr/share/convert2rhel/subscription-manager")
-
-        utils.download_pkg(pkg='python-rhsm-certificates', dest='/tmp/')
-
-        utils.mkdir_p("/etc/rhsm/ca/")
-        rpm2cpio = subprocess.Popen("rpm2cpio /tmp/python-rhsm-certificates*.rpm", stdout=subprocess.PIPE, shell=True)
-        cpio = subprocess.Popen("cpio -iv --to-stdout ./etc/rhsm/ca/redhat-uep.pem > /etc/rhsm/ca/redhat-uep.pem",
-                                stdin=rpm2cpio.stdout, stdout=None, shell=True)
-        rpm2cpio.wait()
-        cpio.wait()
+    cert_path = "/etc/rhsm/ca/redhat-uep.pem"
+    utils.mkdir_p("/etc/rhsm/ca/")
+    output, ret_code = utils.run_subprocess("cpio --quiet -F %s -iv --to-stdout .%s" % (cpio_filepath, cert_path),
+                                            print_output=False)
+    # cpio return code 0 even if the requested file is not in the archive - but then the output is 0 chars
+    if ret_code != 0 or not output:
+        loggerinst.critical("Failed to extract the %s certificate from the %s archive." % (cert_path, cpio_filepath))
+    utils.store_content_to_file(cert_path, output)

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -35,14 +35,15 @@ from convert2rhel import (
     subscription,
     utils,
 )
+from convert2rhel.systeminfo import SystemInfo
 from convert2rhel.toolopts import tool_opts
 
 
 def mock_calls(class_or_module, method_name, mock_obj):
     return unit_tests.mock(class_or_module, method_name, mock_obj(method_name))
 
-class TestMain(unittest.TestCase):
 
+class TestMain(unittest.TestCase):
     class AskToContinueMocked(unit_tests.MockFunction):
         def __call__(self, *args, **kwargs):
             return
@@ -82,6 +83,7 @@ class TestMain(unittest.TestCase):
 
     class CallOrderMocked(unit_tests.MockFunction):
         calls = OrderedDict()
+
         def __init__(self, method_name):
             self.method_name = method_name
 
@@ -101,6 +103,25 @@ class TestMain(unittest.TestCase):
             cls.calls = OrderedDict()
 
 
+
+    class CallYumCmdMocked(unit_tests.MockFunction):
+        def __init__(self):
+            self.called = 0
+            self.return_code = 0
+            self.return_string = "Test output"
+            self.fail_once = False
+            self.command = None
+            self.args = None
+
+        def __call__(self, command, args):
+            if self.fail_once and self.called == 0:
+                self.return_code = 1
+            if self.fail_once and self.called > 0:
+                self.return_code = 0
+            self.called += 1
+            self.command = command
+            self.args = args
+            return self.return_string, self.return_code
 
     @unit_tests.mock(main.logging, "getLogger", GetLoggerMocked())
     @unit_tests.mock(utils, "ask_to_continue", AskToContinueMocked())
@@ -122,7 +143,6 @@ class TestMain(unittest.TestCase):
         self.assertEqual(subscription.rollback.called, 1)
         self.assertEqual(pkghandler.versionlock_file.restore.called, 1)
 
-
     @unit_tests.mock(main.logging, "getLogger", GetLoggerMocked())
     @unit_tests.mock(tool_opts, "disable_submgr", False)
     @unit_tests.mock(cert.SystemCert, "_get_cert_path", unit_tests.MockFunction)
@@ -137,6 +157,7 @@ class TestMain(unittest.TestCase):
     @mock_calls(subscription, "check_needed_repos_availability", CallOrderMocked)
     @mock_calls(subscription, "disable_repos", CallOrderMocked)
     @mock_calls(subscription, "enable_repos", CallOrderMocked)
+    @mock_calls(subscription, "download_subscription_manager_packages", CallOrderMocked)
     def test_pre_ponr_conversion_order_with_rhsm(self):
         self.CallOrderMocked.reset()
         main.pre_ponr_conversion()
@@ -144,6 +165,7 @@ class TestMain(unittest.TestCase):
         intended_call_order = OrderedDict()
         intended_call_order["list_third_party_pkgs"] = 1
         intended_call_order["remove_excluded_pkgs"] = 1
+        intended_call_order["download_subscription_manager_packages"] = 1
         intended_call_order["replace_subscription_manager"] = 1
         intended_call_order["install"] = 1
         intended_call_order["subscribe_system"] = 1
@@ -160,8 +182,6 @@ class TestMain(unittest.TestCase):
             if expected[1] > 0:
                 self.assertEqual(expected, actual)
 
-
-
     @unit_tests.mock(main.logging, "getLogger", GetLoggerMocked())
     @unit_tests.mock(tool_opts, "disable_submgr", False)
     @unit_tests.mock(cert.SystemCert, "_get_cert_path", unit_tests.MockFunction)
@@ -176,6 +196,7 @@ class TestMain(unittest.TestCase):
     @mock_calls(subscription, "check_needed_repos_availability", CallOrderMocked)
     @mock_calls(subscription, "disable_repos", CallOrderMocked)
     @mock_calls(subscription, "enable_repos", CallOrderMocked)
+    @mock_calls(subscription, "download_subscription_manager_packages", CallOrderMocked)
     def test_pre_ponr_conversion_order_without_rhsm(self):
         self.CallOrderMocked.reset()
         main.pre_ponr_conversion()
@@ -186,8 +207,9 @@ class TestMain(unittest.TestCase):
         intended_call_order["remove_excluded_pkgs"] = 1
 
         # Do not expect this one to be called - related to RHSM
+        intended_call_order["download_subscription_manager_packages"] = 1
         intended_call_order["replace_subscription_manager"] = 0
-        intended_call_order["install"] = 1
+        intended_call_order["install"] = 0
         intended_call_order["subscribe_system"] = 0
         intended_call_order["get_rhel_repoids"] = 0
         intended_call_order["check_needed_repos_availability"] = 0

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -157,7 +157,7 @@ class TestMain(unittest.TestCase):
     @mock_calls(subscription, "check_needed_repos_availability", CallOrderMocked)
     @mock_calls(subscription, "disable_repos", CallOrderMocked)
     @mock_calls(subscription, "enable_repos", CallOrderMocked)
-    @mock_calls(subscription, "download_subscription_manager_packages", CallOrderMocked)
+    @mock_calls(subscription, "download_rhsm_pkgs", CallOrderMocked)
     def test_pre_ponr_conversion_order_with_rhsm(self):
         self.CallOrderMocked.reset()
         main.pre_ponr_conversion()
@@ -165,7 +165,7 @@ class TestMain(unittest.TestCase):
         intended_call_order = OrderedDict()
         intended_call_order["list_third_party_pkgs"] = 1
         intended_call_order["remove_excluded_pkgs"] = 1
-        intended_call_order["download_subscription_manager_packages"] = 1
+        intended_call_order["download_rhsm_pkgs"] = 1
         intended_call_order["replace_subscription_manager"] = 1
         intended_call_order["install"] = 1
         intended_call_order["subscribe_system"] = 1
@@ -196,7 +196,7 @@ class TestMain(unittest.TestCase):
     @mock_calls(subscription, "check_needed_repos_availability", CallOrderMocked)
     @mock_calls(subscription, "disable_repos", CallOrderMocked)
     @mock_calls(subscription, "enable_repos", CallOrderMocked)
-    @mock_calls(subscription, "download_subscription_manager_packages", CallOrderMocked)
+    @mock_calls(subscription, "download_rhsm_pkgs", CallOrderMocked)
     def test_pre_ponr_conversion_order_without_rhsm(self):
         self.CallOrderMocked.reset()
         main.pre_ponr_conversion()
@@ -207,7 +207,7 @@ class TestMain(unittest.TestCase):
         intended_call_order["remove_excluded_pkgs"] = 1
 
         # Do not expect this one to be called - related to RHSM
-        intended_call_order["download_subscription_manager_packages"] = 1
+        intended_call_order["download_rhsm_pkgs"] = 0
         intended_call_order["replace_subscription_manager"] = 0
         intended_call_order["install"] = 0
         intended_call_order["subscribe_system"] = 0

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from collections import namedtuple
 import glob
 import os
 import re
@@ -161,7 +162,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertRaises(SystemExit, pkghandler.clear_versionlock)
         self.assertEqual(pkghandler.call_yum_cmd.called, 0)
 
-    @unit_tests.mock(system_info, "version", "8")
+    @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(8, 0))
     @unit_tests.mock(system_info, "releasever", "8")
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     def test_call_yum_cmd(self):
@@ -169,7 +170,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
 
         self.assertEqual(utils.run_subprocess.cmd, "yum install -y --releasever=8 --setopt=module_platform_id=platform:el8")
 
-    @unit_tests.mock(system_info, "version", "7")
+    @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     @unit_tests.mock(system_info, "releasever", "7Server")
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     def test_call_yum_cmd_not_setting_releasever(self):
@@ -185,7 +186,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertRaises(SystemExit, pkghandler.call_yum_cmd_w_downgrades, "test_cmd", ["fingerprint"])
         self.assertEqual(pkghandler.call_yum_cmd.called, pkghandler.MAX_YUM_CMD_CALLS)
 
-    @unit_tests.mock(system_info, "version", "7")
+    @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     @unit_tests.mock(tool_opts, "disable_submgr", True)
     @unit_tests.mock(tool_opts, "disablerepo", ['*'])
@@ -196,7 +197,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertEqual(utils.run_subprocess.cmd,
                          "yum install -y --disablerepo=* --enablerepo=rhel-7-extras-rpm")
 
-    @unit_tests.mock(system_info, "version", "7")
+    @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     @unit_tests.mock(system_info, "submgr_enabled_repos", ['rhel-7-extras-rpm'])
     @unit_tests.mock(tool_opts, "enablerepo", ['not-to-be-used-in-the-yum-call'])
@@ -206,7 +207,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertEqual(utils.run_subprocess.cmd,
                          "yum install -y --enablerepo=rhel-7-extras-rpm")
 
-    @unit_tests.mock(system_info, "version", "7")
+    @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     @unit_tests.mock(system_info, "submgr_enabled_repos", ['not-to-be-used-in-the-yum-call'])
     @unit_tests.mock(tool_opts, "enablerepo", ['not-to-be-used-in-the-yum-call'])
@@ -220,7 +221,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertEqual(utils.run_subprocess.cmd,
                          "yum install -y --disablerepo=disable-repo --enablerepo=enable-repo pkg")
 
-    @unit_tests.mock(system_info, "version", "7")
+    @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     @unit_tests.mock(pkghandler, "get_installed_pkgs_by_fingerprint",
                      GetInstalledPkgsByFingerprintMocked())
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
@@ -668,7 +669,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertTrue(pkghandler.call_yum_cmd_w_downgrades.cmd ==
                         output)
 
-    @unit_tests.mock(system_info, "version", "7")
+    @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     @unit_tests.mock(pkghandler, "install_rhel_kernel", lambda: True)
     @unit_tests.mock(pkghandler, "fix_invalid_grub2_entries", lambda: None)
     @unit_tests.mock(pkghandler, "remove_non_rhel_kernels", DumbCallableObject())
@@ -726,7 +727,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
                                                   arch="x86_64", packager="Oracle", from_repo="repoid")
                 ]
 
-    @unit_tests.mock(system_info, "version", "7")
+    @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     @unit_tests.mock(pkghandler, "handle_no_newer_rhel_kernel_available",
                      DumbCallableObject())
@@ -756,7 +757,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
 
         self.assertFalse(update_kernel)
 
-    @unit_tests.mock(system_info, "version", "7")
+    @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     @unit_tests.mock(pkghandler, "get_installed_pkgs_w_different_fingerprint",
                      GetInstalledPkgsWDifferentFingerprintMocked())
@@ -775,7 +776,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
 
         self.assertEqual(pkghandler.get_installed_pkgs_w_different_fingerprint.called, 2)
 
-    @unit_tests.mock(system_info, "version", "7")
+    @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     def test_get_kernel_availability(self):
         utils.run_subprocess.output = YUM_KERNEL_LIST_OLDER_AVAILABLE
@@ -793,7 +794,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertEqual(installed, ['4.7.2-201.fc24', '4.7.4-200.fc24'])
         self.assertEqual(available, ['4.7.4-200.fc24'])
 
-    @unit_tests.mock(system_info, "version", "7")
+    @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     def test_handle_older_rhel_kernel_available(self):
         utils.run_subprocess.output = YUM_KERNEL_LIST_OLDER_AVAILABLE
@@ -811,7 +812,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
             self.called += 1
             self.version = version
 
-    @unit_tests.mock(system_info, "version", "7")
+    @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     @unit_tests.mock(pkghandler,
                      "replace_non_rhel_installed_kernel",
@@ -823,7 +824,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
 
         self.assertEqual(pkghandler.replace_non_rhel_installed_kernel.called, 1)
 
-    @unit_tests.mock(system_info, "version", "7")
+    @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     @unit_tests.mock(utils, "remove_pkgs", RemovePkgsMocked())
     def test_handle_older_rhel_kernel_not_available_multiple_installed(self):
@@ -840,16 +841,16 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
             self.called = 0
             self.pkg = None
             self.dest = None
-            self.disablerepo = None
-            self.enablerepo = None
+            self.enable_repos = []
+            self.disable_repos = []
             self.to_return = "/path/to.rpm"
 
-        def __call__(self, pkg, dest, disablerepo, enablerepo):
+        def __call__(self, pkg, dest, enable_repos, disable_repos):
             self.called += 1
             self.pkg = pkg
             self.dest = dest
-            self.disablerepo = disablerepo
-            self.enablerepo = enablerepo
+            self.enable_repos = enable_repos
+            self.disable_repos = disable_repos
             return self.to_return
 
     @unit_tests.mock(utils, "ask_to_continue", DumbCallableObject())
@@ -915,19 +916,19 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
                                                           "kernel-firmware",
                                                           "kernel-uek-firmware"])
 
-    @unit_tests.mock(system_info, "version", "7")
+    @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     @unit_tests.mock(system_info, "arch", "x86_64")
     @unit_tests.mock(logger.CustomLogger, "info", LogMocked())
     def test_fix_invalid_grub2_entries_not_applicable(self):
         pkghandler.fix_invalid_grub2_entries()
         self.assertFalse(logger.CustomLogger.info.called)
 
-        system_info.version = "8"
+        system_info.version = namedtuple("Version", ["major", "minor"])(8, 0)
         system_info.arch = "s390x"
         pkghandler.fix_invalid_grub2_entries()
         self.assertFalse(logger.CustomLogger.info.called)
 
-    @unit_tests.mock(system_info, "version", "8")
+    @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(8, 0))
     @unit_tests.mock(system_info, "arch", "x86_64")
     @unit_tests.mock(utils, "get_file_content", lambda x: "1b11755afe1341d7a86383ca4944c324\n")
     @unit_tests.mock(glob, "glob", lambda x: [

--- a/convert2rhel/unit_tests/redhatrelease_test.py
+++ b/convert2rhel/unit_tests/redhatrelease_test.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from collections import namedtuple
 import glob
 import unittest
 
@@ -26,7 +27,7 @@ from convert2rhel.toolopts import tool_opts
 
 class TestRedHatRelease(unittest.TestCase):
 
-    supported_rhel_versions = ["6", "7", "8"]
+    supported_rhel_versions = [6, 7, 8]
 
     class DumbMocked(unit_tests.MockFunction):
         def __call__(self, *args, **kwargs):
@@ -74,8 +75,8 @@ class TestRedHatRelease(unittest.TestCase):
         yum_conf = redhatrelease.YumConf()
         yum_conf._yum_conf_content = YUM_CONF_WITH_DISTROVERPKG
 
-        for version in self.supported_rhel_versions:
-            system_info.version = version
+        for major in self.supported_rhel_versions:
+            system_info.version = namedtuple("Version", ["major", "minor"])(major, 0)
 
             # Call just this function to avoid unmockable built-in write func
             yum_conf._comment_out_distroverpkg_tag()

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -94,6 +94,7 @@ class TestSubscription(unittest.TestCase):
             self.info_msgs = []
             self.warning_msgs = []
             self.critical_msgs = []
+            self.error_msgs = []
 
         def __call__(self, msg):
             return self
@@ -101,6 +102,9 @@ class TestSubscription(unittest.TestCase):
         def critical(self, msg):
             self.critical_msgs.append(msg)
             raise SystemExit(1)
+
+        def error(self, msg):
+            self.error_msgs.append(msg)
 
         def task(self, msg):
             self.task_msgs.append(msg)
@@ -135,6 +139,25 @@ class TestSubscription(unittest.TestCase):
 
         def __call__(self, *args, **kwargs):
             return self.removed
+
+    class CallYumCmdMocked(unit_tests.MockFunction):
+        def __init__(self):
+            self.called = 0
+            self.return_code = 0
+            self.return_string = "Test output"
+            self.fail_once = False
+            self.command = None
+            self.args = None
+
+        def __call__(self, command, args):
+            if self.fail_once and self.called == 0:
+                self.return_code = 1
+            if self.fail_once and self.called > 0:
+                self.return_code = 0
+            self.called += 1
+            self.command = command
+            self.args = args
+            return self.return_string, self.return_code
 
     ##########################################################################
 
@@ -335,3 +358,79 @@ class TestSubscription(unittest.TestCase):
     @unit_tests.mock(pkghandler, "call_yum_cmd", lambda a, b, enable_repos, disable_repos, set_releasever: (None, 1))
     def test_install_rhel_subscription_manager_unable_to_install(self):
         self.assertRaises(SystemExit, subscription.install_rhel_subscription_manager)
+
+    class VersionMocked(unit_tests.MockFunction):
+        def __init__(self, version):
+            self.version = version
+
+        def __call__(self, version):
+            return self.version
+
+    @unit_tests.mock(subscription.logging, "getLogger", GetLoggerMocked())
+    @unit_tests.mock(utils, "parse_version_number",
+                     VersionMocked(version={'major': 1, 'minor': None, 'release': None}))
+    def test_download_subscription_manager_packages_rhel1(self):
+        self.assertRaises(SystemExit, subscription.download_subscription_manager_packages)
+        self.assertTrue(len(subscription.logging.getLogger.error_msgs), 1)
+        self.assertTrue("Unable to download subscription-manager" in subscription.logging.getLogger.error_msgs[0])
+
+    @unit_tests.mock(subscription.logging, "getLogger", GetLoggerMocked())
+    @unit_tests.mock(utils, "parse_version_number",
+                     VersionMocked(version={'major': 5, 'minor': None, 'release': None}))
+    def test_download_subscription_manager_packages_rhel5(self):
+        self.assertRaises(SystemExit, subscription.download_subscription_manager_packages)
+        self.assertTrue(len(subscription.logging.getLogger.error_msgs), 1)
+        self.assertTrue("Unable to download subscription-manager" in subscription.logging.getLogger.error_msgs[0])
+
+    @unit_tests.mock(subscription.logging, "getLogger", GetLoggerMocked())
+    @unit_tests.mock(utils, "parse_version_number",
+                     VersionMocked(version={'major': 6, 'minor': 6, 'release': None}))
+    def test_download_subscription_manager_packages_rhel66(self):
+        self.assertRaises(SystemExit, subscription.download_subscription_manager_packages)
+        self.assertTrue(len(subscription.logging.getLogger.error_msgs), 1)
+        self.assertTrue("Unable to download subscription-manager" in subscription.logging.getLogger.error_msgs[0])
+
+    class StoreContentMocked(unit_tests.MockFunction):
+        def __init__(self):
+            self.filename = None
+            self.content = None
+
+        def __call__(self, filename, content):
+            self.filename = filename
+            self.content = content
+            return True
+
+    @unit_tests.mock(utils, "store_content_to_file", StoreContentMocked())
+    @unit_tests.mock(utils, "parse_version_number",
+                     VersionMocked(version={'major': 6, 'minor': 7, 'release': None}))
+    @unit_tests.mock(pkghandler, "call_yum_cmd", CallYumCmdMocked())
+    def test_download_subscription_manager_packages_rhel67(self):
+        subscription.download_subscription_manager_packages()
+        self.assertTrue("centos_contrib.repo" in utils.store_content_to_file.filename)
+        self.assertEqual(pkghandler.call_yum_cmd.called, 1)
+        self.assertEqual("install", pkghandler.call_yum_cmd.command)
+        self.assertTrue("subscription-manager subscription-manager-rhsm" in pkghandler.call_yum_cmd.args)
+
+
+    class DownloadPkgMocked(unit_tests.MockFunction):
+        def __init__(self):
+            self.called = 0
+            self.pkg = None
+            self.dest = None
+
+        def __call__(self, pkg, dest):
+            self.called += 1
+            self.pkg = pkg
+            self.dest = dest
+
+    @unit_tests.mock(utils, "store_content_to_file", StoreContentMocked())
+    @unit_tests.mock(utils, "parse_version_number", VersionMocked(version={'major': 7, 'minor': 0, 'release': 1}))
+    @unit_tests.mock(pkghandler, "call_yum_cmd", CallYumCmdMocked())
+    @unit_tests.mock(utils, "download_pkg", DownloadPkgMocked())
+    def test_download_subscription_manager_packages_rhel7_or_above(self):
+        subscription.download_subscription_manager_packages()
+        self.assertEqual(pkghandler.call_yum_cmd.called, 1)
+        self.assertEqual("install", pkghandler.call_yum_cmd.command)
+        self.assertEqual(utils.download_pkg.called, 1)
+        self.assertEqual(utils.download_pkg.pkg, "python-rhsm-certificates")
+        self.assertEqual(utils.download_pkg.dest, "/tmp/")

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -24,6 +24,7 @@ import shutil
 import unittest
 
 import pytest
+from collections import namedtuple
 
 from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel import logger, utils
@@ -154,3 +155,18 @@ class TestSysteminfo(unittest.TestCase):
 
         self.assertEqual(utils.run_subprocess.called, 0)
         self.assertFalse(os.path.exists(self.rpmva_output_file))
+
+    def test_get_system_version(self):
+        Version = namedtuple("Version", ["major", "minor"])
+        versions = {"Oracle Linux Server release 6.10": Version(6, 10),
+                    "Oracle Linux Server release 7.8": Version(7, 8),
+                    "CentOS release 6.10 (Final)": Version(6, 10),
+                    "CentOS Linux release 7.6.1810 (Core)": Version(7, 6),
+                    "CentOS Linux release 8.1.1911 (Core)": Version(8, 1)}
+        for system_release in versions:
+            system_info.system_release_file_content = system_release
+            version = system_info._get_system_version()
+            self.assertEqual(version, versions[system_release])
+
+        system_info.system_release_file_content = "not containing the release"
+        self.assertRaises(SystemExit, system_info._get_system_version)

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -216,5 +216,14 @@ class TestUtils(unittest.TestCase):
 
             self.assertEqual(path, os.path.join(utils.TMP_DIR, self.DOWNLOADED_RPM_FILENAME))
 
+    def test_parse_version_number(self):
+        self.assertRaises(TypeError, utils.parse_version_number, 10)
+        self.assertRaises(Exception, utils.parse_version_number, "empty version string")
+        self.assertEqual(utils.parse_version_number('12'), {'major': 12, 'minor': None, 'release': None})
+        self.assertEqual(utils.parse_version_number('12.34'), {'major': 12, 'minor': 34, 'release': None})
+        self.assertEqual(utils.parse_version_number('12.34.56'), {'major': 12, 'minor': 34, 'release': 56})
+        self.assertEqual(utils.parse_version_number('test 1.2.3'), {'major': 1, 'minor': 2, 'release': 3})
+        self.assertEqual(utils.parse_version_number('test 1.2.3 test'), {'major': 1, 'minor': 2, 'release': 3})
+
     def test_is_rpm_based_os(self):
         assert is_rpm_based_os() in (True, False)

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -540,4 +540,24 @@ class RestorablePackage(object):
             loggerinst.warning("Can't access %s" % TMP_DIR)
 
 
+def parse_version_number(version_str):
+    """
+    Parses the version number from the version string in /etc/system-release.
+    Returns a dict with major, minor, and release keys where each key is a number or None
+    """
+    if not isinstance(version_str, str):
+        raise TypeError("Expected version_str to be a string")
+
+    version_number_regex = re.search(r"(?:^|\s)(\d+)(?:\.(\d+))?(?:\.(\d+))?", version_str)
+
+    if version_number_regex is None:
+        raise Exception("Could not find Operating System version number in \"" + version_str + "\"")
+
+    version_dict = {'major': int(version_number_regex.group(1)) if version_number_regex.group(1) else None,
+                    'minor': int(version_number_regex.group(2)) if version_number_regex.group(2) else None,
+                    'release': int(version_number_regex.group(3)) if version_number_regex.group(3) else None}
+
+    return version_dict
+
+
 changed_pkgs_control = ChangedRPMPackagesController()  # pylint: disable=C0103

--- a/packaging/convert2rhel.spec
+++ b/packaging/convert2rhel.spec
@@ -71,15 +71,20 @@ rm -rf build/lib/man
 
 rm -rf %{buildroot}%{python_sitelib}/%{name}/data
 
-# Move system version and architecture specific tool data to /usr/share/convert2rhel
-install -d %{buildroot}%{_datadir}/%{name}
+# Create the /usr/share/convert2rhel/ directory for storing data like GPG keys and config files
+install -d %{buildroot}%{_datadir}/%{name}/
 cp -a build/lib/%{name}/data/version-independent/. \
       %{buildroot}%{_datadir}/%{name}
 cp -a build/lib/%{name}/data/%{rhel}/%{_arch}/. \
       %{buildroot}%{_datadir}/%{name}
 
-# Temporary directory used mainly for backing up files during the conversion
-install -d %{buildroot}%{_sharedstatedir}/%{name}
+# Create a directory into which convert2rhel downloads RHSM-related packages
+install -d %{buildroot}%{_datadir}/%{name}/subscription-manager/
+
+# Create a temporary directory /var/lib/convert2rhel/ - used mainly for backing up files during the conversion
+install -d %{buildroot}%{_sharedstatedir}/%{name}/
+install -d %{buildroot}%{_sharedstatedir}/%{name}/backup/
+install -d %{buildroot}%{_sharedstatedir}/%{name}/rhsm/
 
 install -d -m 755 %{buildroot}%{_mandir}/man8
 install -p man/%{name}.8 %{buildroot}%{_mandir}/man8/
@@ -92,8 +97,8 @@ install -p man/%{name}.8 %{buildroot}%{_mandir}/man8/
 %endif
 
 %{_bindir}/%{name}
-%{_datadir}/%{name}
-%{_sharedstatedir}/%{name}
+%{_datadir}/%{name}/
+%{_sharedstatedir}/%{name}/
 %{python_sitelib}/%{name}*
 
 %{!?_licensedir:%global license %%doc}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 testpaths = "convert2rhel/unit_tests"
-addopts = --cov-fail-under=83 --tb=native
+addopts = --cov-fail-under=84 --tb=native
 ;log_cli = false
 ;log_cli_level = DEBUG
 ;log_cli_format = "| %(asctime)s | %(name)s | %(levelname)s | %(filename)s | %(message)s"


### PR DESCRIPTION
**Blocked by:** #107 

Download subscription-manager automatically, with workaround for CentOS 7, because of this bug: https://bugs.centos.org/view.php?id=14785

TODO:
- [x] Merge #107 first