### PR TITLE
Fix: RHSM repo availibility method not found 

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -168,7 +168,7 @@ def pre_ponr_conversion():
         loggerinst.task("Convert: Get RHEL repository IDs")
         rhel_repoids = repo.get_rhel_repoids()
         loggerinst.task("Convert: Subscription Manager - Check required repositories")
-        repo.check_needed_repos_availability(rhel_repoids)
+        subscription.check_needed_repos_availability(rhel_repoids)
         loggerinst.task("Convert: Subscription Manager - Disable all repositories")
         subscription.disable_repos()
         loggerinst.task("Convert: Subscription Manager - Enable RHEL repositories")

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -23,7 +23,11 @@ try:
 except ImportError:
     import unittest
 
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
+
 from convert2rhel import main
 from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel import redhatrelease


### PR DESCRIPTION
Tests makes sure call order is what we expect, as a benefit it also catches the error introduced in #99