### PR TITLE
refactor: move away from blacklist

### DIFF
--- a/convert2rhel/data/6/x86_64/configs/centos-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/centos-6-x86_64.cfg
@@ -7,7 +7,7 @@ gpg_fingerprints = 0946fca2c105b9de
 
 # List of packages that have to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
-pkg_blacklist =
+excluded_pkgs =
   centos-bookmarks
   centos-logos
   centos-indexhtml

--- a/convert2rhel/data/6/x86_64/configs/oracle-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/oracle-6-x86_64.cfg
@@ -8,7 +8,7 @@ gpg_fingerprints = 72f97b74ec551f03
 
 # List of packages that have to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
-pkg_blacklist =
+excluded_pkgs =
   redhat-release-*
   oraclelinux-release*
   oracle-logos

--- a/convert2rhel/data/6/x86_64/configs/suse_es-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/suse_es-6-x86_64.cfg
@@ -4,7 +4,7 @@
 gpg_fingerprints =
 # List of packages that have to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
-pkg_blacklist =
+excluded_pkgs =
   - sles_es-indexhtml
   - suseRegisterInfo
   - suseRegisterRES

--- a/convert2rhel/data/7/ppc64/configs/centos-7-ppc64.cfg
+++ b/convert2rhel/data/7/ppc64/configs/centos-7-ppc64.cfg
@@ -9,7 +9,7 @@ gpg_fingerprints =
 
 # List of packages that have to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
-pkg_blacklist =
+excluded_pkgs =
   centos-bookmarks
   centos-logos
   centos-indexhtml

--- a/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
@@ -7,7 +7,7 @@ gpg_fingerprints = 24c6a8a7f4a80eb5
 
 # List of packages that have to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
-pkg_blacklist =
+excluded_pkgs =
   centos-bookmarks
   centos-logos
   centos-indexhtml

--- a/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
@@ -8,7 +8,7 @@ gpg_fingerprints = 72f97b74ec551f03
 
 # List of packages that have to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
-pkg_blacklist =
+excluded_pkgs =
   redhat-release-*
   oraclelinux-release*
   oracle-logos

--- a/convert2rhel/data/7/x86_64/configs/suse_es-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/suse_es-7-x86_64.cfg
@@ -4,7 +4,7 @@
 gpg_fingerprints =
 # List of packages that have to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
-pkg_blacklist =
+excluded_pkgs =
   - sles_es-indexhtml
   - suseRegisterInfo
   - suseRegisterRES

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -148,9 +148,9 @@ def pre_ponr_conversion():
     """Perform steps and checks to guarantee system is ready for conversion."""
     loggerinst = logging.getLogger(__name__)
 
-    # remove blacklisted packages
-    loggerinst.task("Convert: Remove blacklisted packages")
-    pkghandler.remove_blacklisted_pkgs()
+    # remove excluded packages
+    loggerinst.task("Convert: Remove excluded packages")
+    pkghandler.remove_excluded_pkgs()
 
     # checking RHN Classic
     loggerinst.task("Checking RHN Classic")

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -306,30 +306,30 @@ def list_non_red_hat_pkgs_left():
         loggerinst.info("All packages are now signed by Red Hat.")
 
 
-def remove_blacklisted_pkgs():
+def remove_excluded_pkgs():
     """Certain packages need to be removed before the system conversion,
     depending on the system to be converted. At least removing <os>-release
     package is a must.
     """
     loggerinst = logging.getLogger(__name__)
-    installed_blacklisted_pkgs = []
-    loggerinst.info("Searching for the following blacklisted packages:\n")
-    for blacklisted_pkg in system_info.pkg_blacklist:
-        temp = '.' * (50 - len(blacklisted_pkg) - 2)
-        pkg_objects = get_installed_pkg_objects(blacklisted_pkg)
-        installed_blacklisted_pkgs.extend(pkg_objects)
+    installed_excluded_pkgs = []
+    loggerinst.info("Searching for the following excluded packages:\n")
+    for excluded_pkg in system_info.excluded_pkgs:
+        temp = '.' * (50 - len(excluded_pkg) - 2)
+        pkg_objects = get_installed_pkg_objects(excluded_pkg)
+        installed_excluded_pkgs.extend(pkg_objects)
         loggerinst.info("%s %s %s" %
-                        (blacklisted_pkg, temp, str(len(pkg_objects))))
+                        (excluded_pkg, temp, str(len(pkg_objects))))
 
-    if not installed_blacklisted_pkgs:
+    if not installed_excluded_pkgs:
         loggerinst.info("\nNothing to do.")
         return
     loggerinst.info("\n")
     loggerinst.warning("The following packages will be removed...")
     loggerinst.info("\n")
-    print_pkg_info(installed_blacklisted_pkgs)
+    print_pkg_info(installed_excluded_pkgs)
     utils.ask_to_continue()
-    utils.remove_pkgs([get_pkg_nvra(pkg) for pkg in installed_blacklisted_pkgs])
+    utils.remove_pkgs([get_pkg_nvra(pkg) for pkg in installed_excluded_pkgs])
 
 
 def replace_non_red_hat_packages():

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -51,7 +51,7 @@ class SystemInfo(object):
             # RHEL 6/7: RPM-GPG-KEY-redhat-legacy-former
             "219180cddb42a60e"]
         # Packages to be removed before the system conversion
-        self.pkg_blacklist = []
+        self.excluded_pkgs = []
         self.cfg_filename = None
         self.cfg_content = None
         self.system_release_file_content = None
@@ -69,7 +69,7 @@ class SystemInfo(object):
 
         self.cfg_filename = self._get_cfg_filename()
         self.cfg_content = self._get_cfg_content()
-        self.pkg_blacklist = self._get_pkg_blacklist()
+        self.excluded_pkgs = self._get_excluded_pkgs()
         self.default_repository_id = self._get_default_repository_id()
         self.fingerprints_orig_os = self._get_gpg_key_fingerprints()
         self._generate_rpm_va()
@@ -140,8 +140,8 @@ class SystemInfo(object):
     def _get_gpg_key_fingerprints(self):
         return self._get_cfg_opt("gpg_fingerprints").split()
 
-    def _get_pkg_blacklist(self):
-        return self._get_cfg_opt("pkg_blacklist").split()
+    def _get_excluded_pkgs(self):
+        return self._get_cfg_opt("excluded_pkgs").split()
 
     def _generate_rpm_va(self, log_filename=DEFAULT_RPM_VA_LOG_FILENAME):
         """Let the rpm command to list all those rpm files that have been modified after the the rpm installation.

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -122,7 +122,7 @@ class TestMain(unittest.TestCase):
 
     @unit_tests.mock(main.logging, "getLogger", GetLoggerMocked())
     @unit_tests.mock(tool_opts, "disable_submgr", False)
-    @mock_calls(pkghandler, "remove_blacklisted_pkgs", CallOrderMocked)
+    @mock_calls(pkghandler, "remove_excluded_pkgs", CallOrderMocked)
     @mock_calls(subscription, "unregister_from_rhn_classic", CallOrderMocked)
     @mock_calls(redhatrelease, "install_release_pkg", CallOrderMocked)
     @mock_calls(redhatrelease.YumConf, "patch", CallOrderMocked)
@@ -139,7 +139,7 @@ class TestMain(unittest.TestCase):
         main.pre_ponr_conversion()
 
         intended_call_order = OrderedDict()
-        intended_call_order["remove_blacklisted_pkgs"] = 1
+        intended_call_order["remove_excluded_pkgs"] = 1
         intended_call_order["unregister_from_rhn_classic"] = 1
         intended_call_order["install_release_pkg"] = 1
         intended_call_order["patch"] = 1
@@ -162,7 +162,7 @@ class TestMain(unittest.TestCase):
 
     @unit_tests.mock(main.logging, "getLogger", GetLoggerMocked())
     @unit_tests.mock(tool_opts, "disable_submgr", False)
-    @mock_calls(pkghandler, "remove_blacklisted_pkgs", CallOrderMocked)
+    @mock_calls(pkghandler, "remove_excluded_pkgs", CallOrderMocked)
     @mock_calls(subscription, "unregister_from_rhn_classic", CallOrderMocked)
     @mock_calls(redhatrelease, "install_release_pkg", CallOrderMocked)
     @mock_calls(redhatrelease.YumConf, "patch", CallOrderMocked)
@@ -179,7 +179,7 @@ class TestMain(unittest.TestCase):
         main.pre_ponr_conversion()
 
         intended_call_order = OrderedDict()
-        intended_call_order["remove_blacklisted_pkgs"] = 1
+        intended_call_order["remove_excluded_pkgs"] = 1
         intended_call_order["unregister_from_rhn_classic"] = 1
         intended_call_order["install_release_pkg"] = 1
         intended_call_order["patch"] = 1

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -405,15 +405,15 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
             self.pkgs = pkgs_to_remove
             self.should_bkp = should_backup
 
-    @unit_tests.mock(system_info, "pkg_blacklist", ["installed_pkg",
+    @unit_tests.mock(system_info, "excluded_pkgs", ["installed_pkg",
                                                     "not_installed_pkg"])
     @unit_tests.mock(utils, "ask_to_continue", DumbCallableObject())
     @unit_tests.mock(pkghandler, "print_pkg_info", DumbCallableObject())
     @unit_tests.mock(utils, "remove_pkgs", RemovePkgsMocked())
     @unit_tests.mock(pkghandler, "get_installed_pkg_objects",
                      GetInstalledPkgObjectsMocked())
-    def test_remove_blacklisted_pkgs(self):
-        pkghandler.remove_blacklisted_pkgs()
+    def test_remove_excluded_pkgs(self):
+        pkghandler.remove_excluded_pkgs()
 
         self.assertEqual(len(utils.remove_pkgs.pkgs), 1)
         self.assertEqual(utils.remove_pkgs.pkgs[0], "installed_pkg-0.1-1.x86_64")


### PR DESCRIPTION
Everything blacklist is now renamed to excluded. Such as `blacklisted_pkgs` to `excluded_pkgs`. Spec files with changelog entries have not been changed