### PR TITLE
feat: install subscription-manager through yum, not rpm and spec file

### DIFF
--- a/convert2rhel/data/6/x86_64/configs/centos-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/centos-6-x86_64.cfg
@@ -5,7 +5,7 @@
 # Delimited by whitespace(s).
 gpg_fingerprints = 0946fca2c105b9de
 
-# List of packages that have to be removed before the system conversion starts.
+# List of packages to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
   centos-bookmarks
@@ -13,11 +13,13 @@ excluded_pkgs =
   centos-indexhtml
   libreport-centos
   libreport-plugin-mantisbt
-  rhn*
+  rhnlib
   yum-rhn-plugin
 
-release_pkgs =
-  centos-release*
+# List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
+# Delimited by any whitespace(s).
+repofile_pkgs =
+  centos-release
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/6/x86_64/configs/centos-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/centos-6-x86_64.cfg
@@ -11,12 +11,13 @@ excluded_pkgs =
   centos-bookmarks
   centos-logos
   centos-indexhtml
-  centos-release*
-  redhat-release*
   libreport-centos
   libreport-plugin-mantisbt
   rhn*
   yum-rhn-plugin
+
+release_pkgs =
+  centos-release*
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/6/x86_64/configs/oracle-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/oracle-6-x86_64.cfg
@@ -6,7 +6,7 @@
 # Delimited by whitespace(s).
 gpg_fingerprints = 72f97b74ec551f03
 
-# List of packages that have to be removed before the system conversion starts.
+# List of packages to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
   oracle-logos
@@ -15,11 +15,23 @@ excluded_pkgs =
   oracleasm-support
   oracle-rdbms-server-*
   btrfs-progs-devel
-  rhn*
+  oraclelinux-release-notes
   yum-rhn-plugin
+  rhn-check
+  rhn-setup
+  rhn-setup-gnome
+  rhnlib
+  rhnsd
 
-release_pkgs =
-  oracle*release*
+# List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
+# Delimited by any whitespace(s).
+repofile_pkgs =
+  rhn-client-tools
+  oraclelinux-release-el6
+  oraclelinux-developer-release-el6
+  oracle-release-el6
+  oraclelinux-release
+  redhat-release*
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/6/x86_64/configs/oracle-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/oracle-6-x86_64.cfg
@@ -9,8 +9,6 @@ gpg_fingerprints = 72f97b74ec551f03
 # List of packages that have to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
-  redhat-release-*
-  oracle*release*
   oracle-logos
   yum-plugin-ulninfo
   linux-firmware
@@ -19,6 +17,9 @@ excluded_pkgs =
   btrfs-progs-devel
   rhn*
   yum-rhn-plugin
+
+release_pkgs =
+  oracle*release*
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/6/x86_64/configs/suse_es-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/suse_es-6-x86_64.cfg
@@ -2,12 +2,17 @@
 
 # SUSE ES packages are not signed
 gpg_fingerprints =
-# List of packages that have to be removed before the system conversion starts.
+
+# List of packages to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
   - sles_es-indexhtml
   - suseRegisterInfo
   - suseRegisterRES
+
+# List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
+# Delimited by any whitespace(s).
+repofile_pkgs =
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/7/ppc64/configs/centos-7-ppc64.cfg
+++ b/convert2rhel/data/7/ppc64/configs/centos-7-ppc64.cfg
@@ -7,16 +7,20 @@ gpg_fingerprints =
   24c6a8a7f4a80eb5
   a963bbdbf533f4fa
 
-# List of packages that have to be removed before the system conversion starts.
+# List of packages to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
   centos-bookmarks
   centos-logos
   centos-indexhtml
-  centos-release*
-  redhat-release*
   libreport-centos
   libreport-plugin-mantisbt
+
+# List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
+# Delimited by any whitespace(s).
+repofile_pkgs =
+  centos-release
+  redhat-release*
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
@@ -5,7 +5,7 @@
 # Delimited by whitespace(s).
 gpg_fingerprints = 24c6a8a7f4a80eb5
 
-# List of packages that have to be removed before the system conversion starts.
+# List of packages to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
   centos-bookmarks
@@ -18,8 +18,10 @@ excluded_pkgs =
   rhn*
   yum-rhn-plugin
 
-release_pkgs =
-  centos-release*
+# List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
+# Delimited by any whitespace(s).
+repofile_pkgs =
+  centos-release
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
@@ -11,14 +11,15 @@ excluded_pkgs =
   centos-bookmarks
   centos-logos
   centos-indexhtml
-  centos-release*
   geoipupdate
   kmod-kvdo
-  redhat-release*
   libreport-centos
   libreport-plugin-mantisbt
   rhn*
   yum-rhn-plugin
+
+release_pkgs =
+  centos-release*
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
@@ -9,8 +9,6 @@ gpg_fingerprints = 72f97b74ec551f03
 # List of packages that have to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
-  redhat-release-*
-  oracle*release*
   oracle-logos
   yum-plugin-ulninfo
   akonadi-mysql
@@ -18,6 +16,9 @@ excluded_pkgs =
   oracle-rdbms-server-*
   rhn*
   yum-rhn-plugin
+
+release_pkgs =
+  oracle*release*
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
@@ -6,7 +6,7 @@
 # Delimited by whitespace(s).
 gpg_fingerprints = 72f97b74ec551f03
 
-# List of packages that have to be removed before the system conversion starts.
+# List of packages to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
   oracle-logos
@@ -14,11 +14,22 @@ excluded_pkgs =
   akonadi-mysql
   oracleasm-support
   oracle-rdbms-server-*
-  rhn*
+  rhn-check
+  rhn-setup
+  rhn-setup-gnome
+  rhnlib
+  rhnsd
   yum-rhn-plugin
+  rhn-client-tools
 
-release_pkgs =
-  oracle*release*
+# List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
+# The rhn-client-tools package contains repofiles on OL 7.6 and older, but when it's installed it's not possible to
+# install subscription-manager. That means that the conversion using RHSM is not possible on OL 7.6 and older.
+# Delimited by any whitespace(s).
+repofile_pkgs =
+  oracle*-release-el7
+  oraclelinux-release
+  redhat-release*
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/7/x86_64/configs/suse_es-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/suse_es-7-x86_64.cfg
@@ -2,12 +2,17 @@
 
 # SUSE ES packages are not signed
 gpg_fingerprints =
-# List of packages that have to be removed before the system conversion starts.
+
+# List of packages to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
   - sles_es-indexhtml
   - suseRegisterInfo
   - suseRegisterRES
+
+# List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
+# Delimited by any whitespace(s).
+repofile_pkgs =
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
@@ -10,12 +10,11 @@ gpg_fingerprints = 05b555b38483c65d
 excluded_pkgs =
   centos-logos*
   centos-indexhtml
-  centos*-release
-  centos*-repos
-  centos-obsolete-packages
-  redhat-release*
   rhn*
   python3-rhn*
+
+release_pkgs =
+  centos-release*
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
@@ -5,16 +5,24 @@
 # Delimited by whitespace(s).
 gpg_fingerprints = 05b555b38483c65d
 
-# List of packages that have to be removed before the system conversion starts.
+# List of packages to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
   centos-logos*
   centos-indexhtml
+  centos-obsolete-packages
   rhn*
   python3-rhn*
 
-release_pkgs =
+# List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
+# Delimited by any whitespace(s).
+repofile_pkgs =
   centos-release*
+  centos-repos
+  centos-linux-repos
+  centos-stream-repos
+  centos-linux-release
+  centos-stream-release
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
@@ -5,16 +5,21 @@
 # Delimited by whitespace(s).
 gpg_fingerprints = 82562ea9ad986da3
 
-# List of packages that have to be removed before the system conversion starts.
+# List of packages to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
   oracle-logos*
   oracle-indexhtml
   oracle-backgrounds
-  *subscription-manager*
+  rhn*
+  python3-rhn*
 
-release_pkgs =
-  oracle*release*
+# List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
+# Delimited by any whitespace(s).
+repofile_pkgs =
+  oracle*-release-el8
+  oraclelinux-release
+  redhat-release
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
@@ -11,8 +11,10 @@ excluded_pkgs =
   oracle-logos*
   oracle-indexhtml
   oracle-backgrounds
-  oracle*-release*
-  redhat-release*
+  *subscription-manager*
+
+release_pkgs =
+  oracle*release*
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -150,15 +150,17 @@ def pre_ponr_conversion():
     # check if user pass some repo to both disablerepo and enablerepo options
     pkghandler.has_duplicate_repos_across_disablerepo_enablerepo_options()
 
-    if not toolopts.tool_opts.disable_submgr:
-        # It's necessary to install subscription-manager before removing the excluded packages to have access to the
-        # standard system repositories provided by excluded packages like centos-release or oraclelinux-release.
-        loggerinst.task("Convert: Subscription Manager - Replace")
-        subscription.replace_subscription_manager()
-
     # remove excluded packages
     loggerinst.task("Convert: Remove excluded packages")
     pkghandler.remove_excluded_pkgs()
+
+    if not toolopts.tool_opts.disable_submgr:
+        loggerinst.task("Convert: Subscription Manager - Replace")
+        subscription.replace_subscription_manager()
+
+    # remove non-RHEL release packages
+    loggerinst.task("Convert: Remove existing OS-release packages")
+    pkghandler.remove_non_rhel_release_pkgs()
 
     # install RHEL certificates depending on variant and arch
     # this allows us to skip installing redhat-release pkg to get certs as 

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -150,6 +150,12 @@ def pre_ponr_conversion():
     # check if user pass some repo to both disablerepo and enablerepo options
     pkghandler.has_duplicate_repos_across_disablerepo_enablerepo_options()
 
+    if not toolopts.tool_opts.disable_submgr:
+        # It's necessary to install subscription-manager before removing the excluded packages to have access to the
+        # standard system repositories provided by excluded packages like centos-release or oraclelinux-release.
+        loggerinst.task("Convert: Subscription Manager - Replace")
+        subscription.replace_subscription_manager()
+
     # remove excluded packages
     loggerinst.task("Convert: Remove excluded packages")
     pkghandler.remove_excluded_pkgs()
@@ -169,8 +175,6 @@ def pre_ponr_conversion():
     loggerinst.task("Convert: List third-party packages")
     pkghandler.list_third_party_pkgs()
     if not toolopts.tool_opts.disable_submgr:
-        loggerinst.task("Convert: Subscription Manager - Install")
-        subscription.install_subscription_manager()
         loggerinst.task("Convert: Subscription Manager - Subscribe system")
         subscription.subscribe_system()
         loggerinst.task("Convert: Get RHEL repository IDs")

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -204,7 +204,6 @@ def get_installed_pkgs_w_fingerprints(name=""):
 
 def get_pkg_fingerprint(pkg_obj):
     """Get fingerprint of the key used to sign a package"""
-    loggerinst = logging.getLogger(__name__)
     if pkgmanager.TYPE == 'yum':
         hdr = pkg_obj.hdr
     elif pkgmanager.TYPE == 'dnf':
@@ -547,7 +546,7 @@ def handle_no_newer_rhel_kernel_available():
             # of them - the one that has the same version as the available RHEL
             # kernel
             older = available[-1]
-            utils.remove_pkgs(pkgs_to_remove=["kernel-%s" % older], should_backup=False)
+            utils.remove_pkgs(pkgs_to_remove=["kernel-%s" % older], backup=False)
             call_yum_cmd(command="install", args="kernel-%s" % older)
         else:
             replace_non_rhel_installed_kernel(installed[0])
@@ -631,7 +630,7 @@ def remove_non_rhel_kernels():
     if non_rhel_kernels:
         loggerinst.info("Removing non-RHEL kernels")
         print_pkg_info(non_rhel_kernels)
-        utils.remove_pkgs(pkgs_to_remove=[get_pkg_nvra(pkg) for pkg in non_rhel_kernels], should_backup=False)
+        utils.remove_pkgs(pkgs_to_remove=[get_pkg_nvra(pkg) for pkg in non_rhel_kernels], backup=False)
     else:
         loggerinst.info("None found.")
     return non_rhel_kernels

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -190,7 +190,9 @@ def install_rhel_subscription_manager():
         # When installing subscription-manager packages, the RHEL repos are not available yet => we need to use
         # the repos that are available on the system
         enable_repos=[],
-        disable_repos=[]
+        disable_repos=[],
+        # When using the original system repos, we need YUM/DNF to expand the $releasever by itself
+        set_releasever=False
     )
     if ret_code:
         loggerinst.critical("Failed to install subscription-manager packages."

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -26,6 +26,8 @@ from convert2rhel.toolopts import tool_opts
 from convert2rhel import pkghandler
 from convert2rhel import utils
 
+SUBMGR_RPMS_DIR = os.path.join(utils.DATA_DIR, "subscription-manager")
+
 
 def subscribe_system():
     """Register and attach a specific subscription to OS."""
@@ -139,21 +141,46 @@ def hide_password(cmd):
     return re.sub("--password=\".*?\"", "--password=\"*****\"", cmd)
 
 
-def install_subscription_manager():
-    """Install subscription-manager RPM and its dependencies."""
+def replace_subscription_manager():
+    """Remove the original and install the RHEL subscription-manager packages."""
     loggerinst = logging.getLogger(__name__)
-    sm_dir = os.path.join(utils.DATA_DIR, "subscription-manager")
-    if not os.path.isdir(sm_dir) or not os.listdir(sm_dir):
+    if not os.path.isdir(SUBMGR_RPMS_DIR) or not os.listdir(SUBMGR_RPMS_DIR):
         loggerinst.critical("The %s directory does not exist or is empty."
                             " Using the subscription-manager is not documented"
                             " yet. Please use the --disable-submgr option."
                             " Read more about the tool usage in the article"
                             " https://access.redhat.com/articles/2360841."
-                            % sm_dir)
+                            % SUBMGR_RPMS_DIR)
         return
-    rpms_to_install = [os.path.join(sm_dir, filename) for filename in os.listdir(sm_dir)]
+
+    remove_original_subscription_manager()
+    install_rhel_subscription_manager()
+
+
+def remove_original_subscription_manager():
+    loggerinst = logging.getLogger(__name__)
+    loggerinst.info("Removing non-RHEL subscription-manager packages.")
+    # python3-subscription-manager-rhsm, dnf-plugin-subscription-manager, subscription-manager-rhsm-certificates, etc.
+    submgr_pkgs = pkghandler.get_installed_pkgs_w_different_fingerprint(
+        system_info.fingerprints_rhel, "*subscription-manager*")
+    if not submgr_pkgs:
+        loggerinst.info("No packages related to subscription-manager installed.")
+        return
+    loggerinst.info("Upon continuing, we will uninstall the following subscription-manager pkgs:\n")
+    pkghandler.print_pkg_info(submgr_pkgs)
+    utils.ask_to_continue()
+    submgr_pkg_names = [pkg.name for pkg in submgr_pkgs]
+    utils.remove_pkgs(submgr_pkg_names, critical=False)
+
+
+def install_rhel_subscription_manager():
+    loggerinst = logging.getLogger(__name__)
+    loggerinst.info("Installing subscription-manager RPMs.")
+    rpms_to_install = [os.path.join(SUBMGR_RPMS_DIR, filename) for filename in os.listdir(SUBMGR_RPMS_DIR)]
     if rpms_to_install:
         _, ret_code = pkghandler.call_yum_cmd(
+            # We're using distro-sync as there might be various versions of the subscription-manager pkgs installed
+            # and we need these packages to be replaced with the provided RPMs from RHEL.
             "install",
             " ".join(rpms_to_install),
             # When installing subscription-manager packages, the RHEL repos are not available yet => we need to use

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -59,7 +59,7 @@ class SystemInfo(object):
         # Packages to be removed before the system conversion
         self.excluded_pkgs = []
         # Release packages to be removed before the system conversion
-        self.release_pkgs = []
+        self.repofile_pkgs = []
         self.cfg_filename = None
         self.cfg_content = None
         self.system_release_file_content = None
@@ -81,7 +81,7 @@ class SystemInfo(object):
         self.cfg_filename = self._get_cfg_filename()
         self.cfg_content = self._get_cfg_content()
         self.excluded_pkgs = self._get_excluded_pkgs()
-        self.release_pkgs = self._get_release_pkgs()
+        self.repofile_pkgs = self._get_repofile_pkgs()
         self.default_rhsm_repoids = self._get_default_rhsm_repoids()
         self.fingerprints_orig_os = self._get_gpg_key_fingerprints()
         self.generate_rpm_va()
@@ -155,8 +155,8 @@ class SystemInfo(object):
     def _get_excluded_pkgs(self):
         return self._get_cfg_opt("excluded_pkgs").split()
 
-    def _get_release_pkgs(self):
-        return self._get_cfg_opt("release_pkgs").split()
+    def _get_repofile_pkgs(self):
+        return self._get_cfg_opt("repofile_pkgs").split()
 
     def _get_releasever(self):
         return self._get_cfg_opt("releasever")

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -58,6 +58,8 @@ class SystemInfo(object):
             "219180cddb42a60e"]
         # Packages to be removed before the system conversion
         self.excluded_pkgs = []
+        # Release packages to be removed before the system conversion
+        self.release_pkgs = []
         self.cfg_filename = None
         self.cfg_content = None
         self.system_release_file_content = None
@@ -79,6 +81,7 @@ class SystemInfo(object):
         self.cfg_filename = self._get_cfg_filename()
         self.cfg_content = self._get_cfg_content()
         self.excluded_pkgs = self._get_excluded_pkgs()
+        self.release_pkgs = self._get_release_pkgs()
         self.default_rhsm_repoids = self._get_default_rhsm_repoids()
         self.fingerprints_orig_os = self._get_gpg_key_fingerprints()
         self.generate_rpm_va()
@@ -151,6 +154,9 @@ class SystemInfo(object):
 
     def _get_excluded_pkgs(self):
         return self._get_cfg_opt("excluded_pkgs").split()
+
+    def _get_release_pkgs(self):
+        return self._get_cfg_opt("release_pkgs").split()
 
     def _get_releasever(self):
         return self._get_cfg_opt("releasever")

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -130,7 +130,7 @@ class TestMain(unittest.TestCase):
     @mock_calls(cert.SystemCert, "install", CallOrderMocked)
     @mock_calls(redhatrelease.YumConf, "patch", CallOrderMocked)
     @mock_calls(pkghandler, "list_third_party_pkgs", CallOrderMocked)
-    @mock_calls(subscription, "install_subscription_manager", CallOrderMocked)
+    @mock_calls(subscription, "replace_subscription_manager", CallOrderMocked)
     @mock_calls(subscription, "subscribe_system", CallOrderMocked)
     @mock_calls(repo, "get_rhel_repoids", CallOrderMocked)
     @mock_calls(subscription, "check_needed_repos_availability", CallOrderMocked)
@@ -141,11 +141,11 @@ class TestMain(unittest.TestCase):
         main.pre_ponr_conversion()
 
         intended_call_order = OrderedDict()
+        intended_call_order["replace_subscription_manager"] = 1
         intended_call_order["remove_excluded_pkgs"] = 1
         intended_call_order["install"] = 1
         intended_call_order["patch"] = 1
         intended_call_order["list_third_party_pkgs"] = 1
-        intended_call_order["install_subscription_manager"] = 1
         intended_call_order["subscribe_system"] = 1
         intended_call_order["get_rhel_repoids"] = 1
         intended_call_order["check_needed_repos_availability"] = 1
@@ -167,7 +167,7 @@ class TestMain(unittest.TestCase):
     @mock_calls(cert.SystemCert, "install", CallOrderMocked)
     @mock_calls(redhatrelease.YumConf, "patch", CallOrderMocked)
     @mock_calls(pkghandler, "list_third_party_pkgs", CallOrderMocked)
-    @mock_calls(subscription, "install_subscription_manager", CallOrderMocked)
+    @mock_calls(subscription, "replace_subscription_manager", CallOrderMocked)
     @mock_calls(subscription, "subscribe_system", CallOrderMocked)
     @mock_calls(repo, "get_rhel_repoids", CallOrderMocked)
     @mock_calls(subscription, "check_needed_repos_availability", CallOrderMocked)
@@ -178,13 +178,16 @@ class TestMain(unittest.TestCase):
         main.pre_ponr_conversion()
 
         intended_call_order = OrderedDict()
+
+        # Do not expect this one to be called - related to RHSM
+        intended_call_order["replace_subscription_manager"] = 0
+
         intended_call_order["remove_excluded_pkgs"] = 1
         intended_call_order["install"] = 1
         intended_call_order["patch"] = 1
         intended_call_order["list_third_party_pkgs"] = 1
 
         # Do not expect these to be called - related to RHSM
-        intended_call_order["install_subscription_manager"] = 0
         intended_call_order["subscribe_system"] = 0
         intended_call_order["get_rhel_repoids"] = 0
         intended_call_order["check_needed_repos_availability"] = 0

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -127,6 +127,7 @@ class TestMain(unittest.TestCase):
     @unit_tests.mock(tool_opts, "disable_submgr", False)
     @unit_tests.mock(cert.SystemCert, "_get_cert_path", unit_tests.MockFunction)
     @mock_calls(pkghandler, "remove_excluded_pkgs", CallOrderMocked)
+    @mock_calls(pkghandler, "remove_non_rhel_release_pkgs", CallOrderMocked)
     @mock_calls(cert.SystemCert, "install", CallOrderMocked)
     @mock_calls(redhatrelease.YumConf, "patch", CallOrderMocked)
     @mock_calls(pkghandler, "list_third_party_pkgs", CallOrderMocked)
@@ -141,8 +142,9 @@ class TestMain(unittest.TestCase):
         main.pre_ponr_conversion()
 
         intended_call_order = OrderedDict()
-        intended_call_order["replace_subscription_manager"] = 1
         intended_call_order["remove_excluded_pkgs"] = 1
+        intended_call_order["replace_subscription_manager"] = 1
+        intended_call_order["remove_non_rhel_release_pkgs"] = 1
         intended_call_order["install"] = 1
         intended_call_order["patch"] = 1
         intended_call_order["list_third_party_pkgs"] = 1
@@ -164,6 +166,7 @@ class TestMain(unittest.TestCase):
     @unit_tests.mock(tool_opts, "disable_submgr", False)
     @unit_tests.mock(cert.SystemCert, "_get_cert_path", unit_tests.MockFunction)
     @mock_calls(pkghandler, "remove_excluded_pkgs", CallOrderMocked)
+    @mock_calls(pkghandler, "remove_non_rhel_release_pkgs", CallOrderMocked)
     @mock_calls(cert.SystemCert, "install", CallOrderMocked)
     @mock_calls(redhatrelease.YumConf, "patch", CallOrderMocked)
     @mock_calls(pkghandler, "list_third_party_pkgs", CallOrderMocked)
@@ -179,10 +182,12 @@ class TestMain(unittest.TestCase):
 
         intended_call_order = OrderedDict()
 
+        intended_call_order["remove_excluded_pkgs"] = 1
+
         # Do not expect this one to be called - related to RHSM
         intended_call_order["replace_subscription_manager"] = 0
 
-        intended_call_order["remove_excluded_pkgs"] = 1
+        intended_call_order["remove_non_rhel_release_pkgs"] = 1
         intended_call_order["install"] = 1
         intended_call_order["patch"] = 1
         intended_call_order["list_third_party_pkgs"] = 1

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -127,11 +127,11 @@ class TestMain(unittest.TestCase):
     @unit_tests.mock(tool_opts, "disable_submgr", False)
     @unit_tests.mock(cert.SystemCert, "_get_cert_path", unit_tests.MockFunction)
     @mock_calls(pkghandler, "remove_excluded_pkgs", CallOrderMocked)
-    @mock_calls(pkghandler, "remove_non_rhel_release_pkgs", CallOrderMocked)
+    @mock_calls(subscription, "replace_subscription_manager", CallOrderMocked)
+    @mock_calls(pkghandler, "remove_repofile_pkgs", CallOrderMocked)
     @mock_calls(cert.SystemCert, "install", CallOrderMocked)
     @mock_calls(redhatrelease.YumConf, "patch", CallOrderMocked)
     @mock_calls(pkghandler, "list_third_party_pkgs", CallOrderMocked)
-    @mock_calls(subscription, "replace_subscription_manager", CallOrderMocked)
     @mock_calls(subscription, "subscribe_system", CallOrderMocked)
     @mock_calls(repo, "get_rhel_repoids", CallOrderMocked)
     @mock_calls(subscription, "check_needed_repos_availability", CallOrderMocked)
@@ -142,17 +142,17 @@ class TestMain(unittest.TestCase):
         main.pre_ponr_conversion()
 
         intended_call_order = OrderedDict()
+        intended_call_order["list_third_party_pkgs"] = 1
         intended_call_order["remove_excluded_pkgs"] = 1
         intended_call_order["replace_subscription_manager"] = 1
-        intended_call_order["remove_non_rhel_release_pkgs"] = 1
         intended_call_order["install"] = 1
-        intended_call_order["patch"] = 1
-        intended_call_order["list_third_party_pkgs"] = 1
         intended_call_order["subscribe_system"] = 1
         intended_call_order["get_rhel_repoids"] = 1
         intended_call_order["check_needed_repos_availability"] = 1
         intended_call_order["disable_repos"] = 1
         intended_call_order["enable_repos"] = 1
+        intended_call_order["remove_repofile_pkgs"] = 1
+        intended_call_order["patch"] = 1
 
         # Merge the two together like a zipper, creates a tuple which we can assert with - including method call order!
         zipped_call_order = zip(intended_call_order.items(), self.CallOrderMocked.calls.items())
@@ -166,11 +166,11 @@ class TestMain(unittest.TestCase):
     @unit_tests.mock(tool_opts, "disable_submgr", False)
     @unit_tests.mock(cert.SystemCert, "_get_cert_path", unit_tests.MockFunction)
     @mock_calls(pkghandler, "remove_excluded_pkgs", CallOrderMocked)
-    @mock_calls(pkghandler, "remove_non_rhel_release_pkgs", CallOrderMocked)
+    @mock_calls(subscription, "replace_subscription_manager", CallOrderMocked)
+    @mock_calls(pkghandler, "remove_repofile_pkgs", CallOrderMocked)
     @mock_calls(cert.SystemCert, "install", CallOrderMocked)
     @mock_calls(redhatrelease.YumConf, "patch", CallOrderMocked)
     @mock_calls(pkghandler, "list_third_party_pkgs", CallOrderMocked)
-    @mock_calls(subscription, "replace_subscription_manager", CallOrderMocked)
     @mock_calls(subscription, "subscribe_system", CallOrderMocked)
     @mock_calls(repo, "get_rhel_repoids", CallOrderMocked)
     @mock_calls(subscription, "check_needed_repos_availability", CallOrderMocked)
@@ -182,22 +182,20 @@ class TestMain(unittest.TestCase):
 
         intended_call_order = OrderedDict()
 
+        intended_call_order["list_third_party_pkgs"] = 1
         intended_call_order["remove_excluded_pkgs"] = 1
 
         # Do not expect this one to be called - related to RHSM
         intended_call_order["replace_subscription_manager"] = 0
-
-        intended_call_order["remove_non_rhel_release_pkgs"] = 1
         intended_call_order["install"] = 1
-        intended_call_order["patch"] = 1
-        intended_call_order["list_third_party_pkgs"] = 1
-
-        # Do not expect these to be called - related to RHSM
         intended_call_order["subscribe_system"] = 0
         intended_call_order["get_rhel_repoids"] = 0
         intended_call_order["check_needed_repos_availability"] = 0
         intended_call_order["disable_repos"] = 0
         intended_call_order["enable_repos"] = 0
+
+        intended_call_order["remove_repofile_pkgs"] = 1
+        intended_call_order["patch"] = 1
 
         # Merge the two together like a zipper, creates a tuple which we can assert with - including method call order!
         zipped_call_order = zip(intended_call_order.items(), self.CallOrderMocked.calls.items())

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -188,6 +188,19 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertEqual(utils.run_subprocess.cmd,
                          "yum install -y --enablerepo=rhel-7-extras-rpm")
 
+    @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
+    @unit_tests.mock(system_info, "submgr_enabled_repos", ['not-to-be-used-in-the-yum-call'])
+    @unit_tests.mock(tool_opts, "enablerepo", ['not-to-be-used-in-the-yum-call'])
+    def test_call_yum_cmd_with_repo_overrides(self):
+        pkghandler.call_yum_cmd("install", "pkg", enable_repos=[], disable_repos=[])
+
+        self.assertEqual(utils.run_subprocess.cmd, "yum install -y pkg")
+
+        pkghandler.call_yum_cmd("install", "pkg", enable_repos=["enable-repo"], disable_repos=["disable-repo"])
+
+        self.assertEqual(utils.run_subprocess.cmd,
+                         "yum install -y --disablerepo=disable-repo --enablerepo=enable-repo pkg")
+
     @unit_tests.mock(system_info, "version", "7")
     @unit_tests.mock(pkghandler, "get_installed_pkgs_by_fingerprint",
                      GetInstalledPkgsByFingerprintMocked())

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -584,9 +584,9 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
             self.pkgs = None
             self.should_bkp = False
 
-        def __call__(self, pkgs_to_remove, should_backup=False):
+        def __call__(self, pkgs_to_remove, backup=False):
             self.pkgs = pkgs_to_remove
-            self.should_bkp = should_backup
+            self.should_bkp = backup
 
     @unit_tests.mock(system_info, "excluded_pkgs", ["installed_pkg",
                                                     "not_installed_pkg"])

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -17,6 +17,7 @@
 # Required imports:
 
 
+import os
 import unittest
 
 from collections import namedtuple
@@ -278,9 +279,11 @@ class TestSubscription(unittest.TestCase):
         self.assertEqual(len(subscription.logging.getLogger.warning_msgs), 1)
 
     @unit_tests.mock(subscription, "unregister_system", unit_tests.CountableMockObject())
+    @unit_tests.mock(subscription, "remove_subscription_manager", unit_tests.CountableMockObject())
     def test_rollback(self):
         subscription.rollback()
         self.assertEqual(subscription.unregister_system.called, 1)
+        self.assertEqual(subscription.remove_subscription_manager.called, 1)
 
     class LogMocked(unit_tests.MockFunction):
         def __init__(self):

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -332,6 +332,6 @@ class TestSubscription(unittest.TestCase):
 
     @unit_tests.mock(os.path, "isdir", lambda x: True)
     @unit_tests.mock(os, "listdir", lambda x: ["filename"])
-    @unit_tests.mock(pkghandler, "call_yum_cmd", lambda a, b, enable_repos, disable_repos: (None, 1))
+    @unit_tests.mock(pkghandler, "call_yum_cmd", lambda a, b, enable_repos, disable_repos, set_releasever: (None, 1))
     def test_install_rhel_subscription_manager_unable_to_install(self):
         self.assertRaises(SystemExit, subscription.install_rhel_subscription_manager)

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -138,14 +138,14 @@ class TestUtils(unittest.TestCase):
                      "track_installed_pkg",
                      DummyFuncMocked())
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
-    def test_install_pkgs_with_replace_and_force(self):
+    def test_install_pkgs_with_replace(self):
         pkgs = ['pkg1', 'pkg2', 'pkg3']
-        utils.install_pkgs(pkgs, replace=True, force=True)
+        utils.install_pkgs(pkgs, replace=True)
         self.assertEqual(
             utils.ChangedRPMPackagesController.track_installed_pkg.called, len(pkgs))
 
         self.assertEqual(utils.run_subprocess.called, 1)
-        self.assertEqual("rpm -i --replacepkgs --force pkg1 pkg2 pkg3", utils.run_subprocess.cmd)
+        self.assertEqual("rpm -i --replacepkgs pkg1 pkg2 pkg3", utils.run_subprocess.cmd)
 
     def test_run_subprocess(self):
         output, code = utils.run_subprocess("echo foobar")

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -138,14 +138,14 @@ class TestUtils(unittest.TestCase):
                      "track_installed_pkg",
                      DummyFuncMocked())
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
-    def test_install_pkgs_with_replace(self):
+    def test_install_pkgs_with_replace_and_force(self):
         pkgs = ['pkg1', 'pkg2', 'pkg3']
-        utils.install_pkgs(pkgs, True)
+        utils.install_pkgs(pkgs, replace=True, force=True)
         self.assertEqual(
             utils.ChangedRPMPackagesController.track_installed_pkg.called, len(pkgs))
 
         self.assertEqual(utils.run_subprocess.called, 1)
-        self.assertEqual("rpm -i --replacepkgs pkg1 pkg2 pkg3", utils.run_subprocess.cmd)
+        self.assertEqual("rpm -i --replacepkgs --force pkg1 pkg2 pkg3", utils.run_subprocess.cmd)
 
     def test_run_subprocess(self):
         output, code = utils.run_subprocess("echo foobar")

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -364,7 +364,7 @@ def remove_pkgs(pkgs_to_remove, backup=True, critical=True):
                 loggerinst.warning("Couldn't remove %s." % nvra)
 
 
-def install_pkgs(pkgs_to_install, replace=False, critical=True, force=False):
+def install_pkgs(pkgs_to_install, replace=False, critical=True):
     """Install packages locally available."""
     loggerinst = logging.getLogger(__name__)
 
@@ -375,8 +375,6 @@ def install_pkgs(pkgs_to_install, replace=False, critical=True, force=False):
     cmd_param = ["rpm", "-i"]
     if replace:
         cmd_param.append("--replacepkgs")
-    if force:
-        cmd_param.append("--force")
 
     cmd = " ".join(cmd_param)
     pkgs = " ".join(pkgs_to_install)

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -343,6 +343,13 @@ def remove_pkgs(pkgs_to_remove, backup=True, critical=True):
     """Remove packages not heeding to their dependencies."""
     loggerinst = logging.getLogger(__name__)
 
+    if backup:
+        # Some packages, when removed, will also remove repo files, making it
+        # impossible to access the repositories to download a backup. For this
+        # reason we first backup all packages and only after that we remove
+        for nvra in pkgs_to_remove:
+            changed_pkgs_control.backup_and_track_removed_pkg(nvra)
+
     if not pkgs_to_remove:
         loggerinst.info("No package to remove")
         return
@@ -356,15 +363,8 @@ def remove_pkgs(pkgs_to_remove, backup=True, critical=True):
             else:
                 loggerinst.warning("Couldn't remove %s." % nvra)
 
-    if backup:
-        # Some packages, when removed, will also remove repo files, making it
-        # impossible to access the repositories to download a backup. For this
-        # reason we first backup all packages and only after that we remove
-        for nvra in pkgs_to_remove:
-            changed_pkgs_control.backup_and_track_removed_pkg(nvra)
 
-
-def install_pkgs(pkgs_to_install, replace=False, critical=True):
+def install_pkgs(pkgs_to_install, replace=False, critical=True, force=False):
     """Install packages locally available."""
     loggerinst = logging.getLogger(__name__)
 
@@ -375,6 +375,8 @@ def install_pkgs(pkgs_to_install, replace=False, critical=True):
     cmd_param = ["rpm", "-i"]
     if replace:
         cmd_param.append("--replacepkgs")
+    if force:
+        cmd_param.append("--force")
 
     cmd = " ".join(cmd_param)
     pkgs = " ".join(pkgs_to_install)

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -300,7 +300,7 @@ class ChangedRPMPackagesController(object):
         """For each package installed during conversion remove it."""
         loggerinst = logging.getLogger(__name__)
         loggerinst.task("Rollback: Removing installed packages")
-        remove_pkgs(self.installed_pkgs, should_backup=False, critical=False)
+        remove_pkgs(self.installed_pkgs, backup=False, critical=False)
 
     def _install_removed_pkgs(self):
         """For each package removed during conversion install it."""
@@ -314,7 +314,7 @@ class ChangedRPMPackagesController(object):
                 continue
             pkgs_to_install.append(restorable_pkg.path)
 
-        install_pkgs(pkgs_to_install, critical=False)
+        install_pkgs(pkgs_to_install, replace=True, critical=False)
 
     def restore_pkgs(self):
         """Restore system to the original state."""
@@ -339,15 +339,9 @@ def remove_orphan_folders():
             os.rmdir(path)
 
 
-def remove_pkgs(pkgs_to_remove, should_backup=True, critical=True):
+def remove_pkgs(pkgs_to_remove, backup=True, critical=True):
     """Remove packages not heeding to their dependencies."""
     loggerinst = logging.getLogger(__name__)
-    if should_backup:
-        # Some packages, when removed, will also remove repo files, making it
-        # impossible to access the repositories to download a backup. For this
-        # reason we first backup all packages and only after that we remove
-        for nvra in pkgs_to_remove:
-            changed_pkgs_control.backup_and_track_removed_pkg(nvra)
 
     if not pkgs_to_remove:
         loggerinst.info("No package to remove")
@@ -361,6 +355,13 @@ def remove_pkgs(pkgs_to_remove, should_backup=True, critical=True):
                 loggerinst.critical("Error: Couldn't remove %s." % nvra)
             else:
                 loggerinst.warning("Couldn't remove %s." % nvra)
+
+    if backup:
+        # Some packages, when removed, will also remove repo files, making it
+        # impossible to access the repositories to download a backup. For this
+        # reason we first backup all packages and only after that we remove
+        for nvra in pkgs_to_remove:
+            changed_pkgs_control.backup_and_track_removed_pkg(nvra)
 
 
 def install_pkgs(pkgs_to_install, replace=False, critical=True):

--- a/packaging/convert2rhel.spec
+++ b/packaging/convert2rhel.spec
@@ -46,34 +46,6 @@ Requires:       yum-utils
 Requires:       pexpect
 %endif
 
-### subscription-manager dependencies ###
-Requires:       usermode
-Requires:       virt-what
-Requires:       python%{python_pkgversion}-decorator
-Requires:       python%{python_pkgversion}-dateutil
-Requires:       python%{python_pkgversion}-dmidecode
-Requires:       python%{python_pkgversion}-iniparse
-Requires:       python%{python_pkgversion}-ethtool
-%if 0%{?el6} && 0%{?rhel}
-Requires:       pygobject2
-%endif
-%if 0%{?el7} && 0%{?rhel}
-Requires:       pygobject3-base
-%endif
-%if 0%{?el8} && 0%{?rhel}
-Requires:       python3-gobject-base
-Requires:       python3-dbus
-%endif
-%if 0%{?rhel} && 0%{?rhel} <= 7
-Requires:       dbus-python
-Requires:       m2crypto
-%endif
-%if 0%{?rhel} && 0%{?rhel} >= 7
-Requires:       gobject-introspection
-Requires:       python%{python_pkgversion}-inotify
-%endif
-### end of subscription-manager dependencies ###
-
 
 %description
 The purpose of the convert2rhel tool is to provide an automated way of


### PR DESCRIPTION
We currently install dependencies for RHSM through spec files so we can install it through RPM. Instead we should utilize yum to resolve the dependencies for us.

See https://github.com/oamg/convert2rhel/pull/82#issuecomment-680937882 

OAMG-3843

TODO:

- [x] Merge https://github.com/oamg/convert2rhel/pull/105 first.