### PR TITLE
Enable repos enabled through RHSM in yum calls

### DIFF
--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -80,7 +80,11 @@ def call_yum_cmd(command, args="", print_output=True):
     for repo in tool_opts.disablerepo:
         cmd += " --disablerepo=%s" % repo
 
-    for repo in tool_opts.enablerepo:
+    # When using subscription-manager for the conversion, use those repos for the yum call that have been enabled
+    # through subscription-manager
+    repos_to_enable = system_info.submgr_enabled_repos if not tool_opts.disable_submgr else tool_opts.enablerepo
+
+    for repo in repos_to_enable:
         cmd += " --enablerepo=%s" % repo
 
     if args:

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -21,6 +21,7 @@ import re
 import shutil
 import logging
 
+from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts
 from convert2rhel import utils
 
@@ -317,16 +318,15 @@ def disable_repos():
     return
 
 
-def enable_repos(repos_needed):
-    """By default, enable just the repos identified by the tool as needed and
-    disable any other using subscription-manager. This can be overriden by the
-    --enablerepo option.
+def enable_repos(rhel_repoids):
+    """By default, enable the standard Red Hat CDN RHEL repository IDs using subscription-manager.
+    This can be overriden by the --enablerepo option.
     """
     loggerinst = logging.getLogger(__name__)
     if tool_opts.enablerepo:
         repos_to_enable = tool_opts.enablerepo
     else:
-        repos_to_enable = repos_needed
+        repos_to_enable = rhel_repoids
 
     enable_cmd = ""
     for repo in repos_to_enable:
@@ -337,7 +337,8 @@ def enable_repos(repos_needed):
         loggerinst.critical("Repos were not possible to enable through"
                             " subscription-manager:\n%s" % output)
     loggerinst.info("Repositories enabled through subscription-manager")
-    return
+
+    system_info.submgr_enabled_repos = repos_to_enable
 
 
 def rename_repo_files():

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -58,6 +58,8 @@ class SystemInfo(object):
         self.logger = None
         # ID of the default Red Hat CDN repository that corresponds to the current system
         self.default_repository_id = None
+        # List of repositories enabled through subscription-manager
+        self.submgr_enabled_repos = []
 
     def resolve_system_info(self):
         self.logger = logging.getLogger(__name__)

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -159,13 +159,23 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertEqual(pkghandler.call_yum_cmd.called, pkghandler.MAX_YUM_CMD_CALLS)
 
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
+    @unit_tests.mock(tool_opts, "disable_submgr", True)
     @unit_tests.mock(tool_opts, "disablerepo", ['*'])
     @unit_tests.mock(tool_opts, "enablerepo", ['rhel-7-extras-rpm'])
-    def test_call_yum_cmd_with_disablerepo(self):
+    def test_call_yum_cmd_with_disablerepo_and_enablerepo(self):
         pkghandler.call_yum_cmd("install")
 
         self.assertEqual(utils.run_subprocess.cmd,
                          "yum install -y --disablerepo=* --enablerepo=rhel-7-extras-rpm")
+
+    @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
+    @unit_tests.mock(system_info, "submgr_enabled_repos", ['rhel-7-extras-rpm'])
+    @unit_tests.mock(tool_opts, "enablerepo", ['not-to-be-used-in-the-yum-call'])
+    def test_call_yum_cmd_with_submgr_enabled_repos(self):
+        pkghandler.call_yum_cmd("install")
+
+        self.assertEqual(utils.run_subprocess.cmd,
+                         "yum install -y --enablerepo=rhel-7-extras-rpm")
         
     @unit_tests.mock(pkghandler, "get_installed_pkgs_by_fingerprint",
                      GetInstalledPkgsByFingerprintMocked())


### PR DESCRIPTION
There was a bug causing that when subscription-manager was used for the
conversions, no repository got enabled when calling yum. And because by
default convert2rhel disables all repos in yum calls except those to be
specifically enabled, the conversion could not proceed.

The issue got introduced in https://github.com/oamg/convert2rhel/pull/84.