### PR TITLE
Add support for converting OL 8

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Install Requirements
       run: |
-        yum install -y python-coverage python-nose python-six
+        yum install -y python-coverage python-nose python-six pexpect
         
     - name: Check test coverage
       run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Install Requirements
       run: |
-        yum install -y python-six
+        yum install -y python-six pexpect
         curl https://bootstrap.pypa.io/2.6/get-pip.py -o get-pip.py
         python get-pip.py
         pip install pylint==1.1.0
@@ -52,7 +52,7 @@ jobs:
     - name: Install Requirements
       run: |
         yum --enablerepo=extras install -y epel-release  # to get pylint
-        yum install -y python-six pylint
+        yum install -y python-six pylint pexpect
 
     - name: Run Pylint Checks
       run: ${{ env.interpreted_pylint }}
@@ -67,7 +67,7 @@ jobs:
     - name: Install Requirements
       run: |
         yum --enablerepo=extras install -y epel-release  # to get pylint
-        yum install -y pylint
+        yum install -y pylint python3-pexpect
         
     - name: Run Pylint Checks
       run: ${{ env.interpreted_pylint }}

--- a/Dockerfiles/centos6
+++ b/Dockerfiles/centos6
@@ -5,5 +5,5 @@ VOLUME /data
 WORKDIR /data
 
 RUN yum update -y &&\
-    yum install -y python-nose python-six python-wheel &&\
+    yum install -y python-nose python-six python-wheel pexpect &&\
     yum clean all

--- a/Dockerfiles/centos7
+++ b/Dockerfiles/centos7
@@ -5,5 +5,5 @@ VOLUME /data
 WORKDIR /data
 
 RUN yum update -y &&\
-    yum install -y python-nose python-six python-wheel &&\
+    yum install -y python-nose python-six python-wheel pexpect &&\
     yum clean all

--- a/Dockerfiles/centos8
+++ b/Dockerfiles/centos8
@@ -5,6 +5,6 @@ VOLUME /data
 WORKDIR /data
 
 RUN dnf update -y &&\
-    dnf install -y python3-nose python3-six &&\
+    dnf install -y python3-nose python3-six python3-pexpect &&\
     dnf clean all
 

--- a/convert2rhel/data/6/x86_64/configs/oracle-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/oracle-6-x86_64.cfg
@@ -1,8 +1,8 @@
 [system_info]
 
 # Fingerprints of GPG keys used for signing packages of the OS to be converted.
-# The GPG keys are available at:
-#   https://docs.oracle.com/cd/E37670_01/E39381/html/ol_import_gpg.html
+# The GPG key is available at:
+#   http://public-yum.oracle.com/RPM-GPG-KEY-oracle-ol6
 # Delimited by whitespace(s).
 gpg_fingerprints = 72f97b74ec551f03
 
@@ -10,7 +10,7 @@ gpg_fingerprints = 72f97b74ec551f03
 # Delimited by any whitespace(s).
 excluded_pkgs =
   redhat-release-*
-  oraclelinux-release*
+  oracle*release*
   oracle-logos
   yum-plugin-ulninfo
   linux-firmware

--- a/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
@@ -1,24 +1,21 @@
 [system_info]
 
 # Fingerprints of GPG keys used for signing packages of the OS to be converted.
-# The GPG key is available at:
-#   http://public-yum.oracle.com/RPM-GPG-KEY-oracle-ol7
+# The GPG key is available at http://public-yum.oracle.com/RPM-GPG-KEY-oracle-ol8
 # Delimited by whitespace(s).
-gpg_fingerprints = 72f97b74ec551f03
+gpg_fingerprints = 82562ea9ad986da3
 
 # List of packages that have to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
-  redhat-release-*
+  oracle-logos*
+  oracle-indexhtml
+  oracle-backgrounds
   oracle*release*
-  oracle-logos
-  yum-plugin-ulninfo
-  akonadi-mysql
-  oracleasm-support
-  oracle-rdbms-server-*
-  rhn*
-  yum-rhn-plugin
+  redhat-release*
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).
-default_rhsm_repoids = rhel-7-server-rpms
+default_rhsm_repoids =
+  rhel-8-for-x86_64-baseos-rpms
+  rhel-8-for-x86_64-appstream-rpms

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -179,7 +179,7 @@ def get_pkg_fingerprint(pkg_obj):
     loggerinst = logging.getLogger(__name__)
     if pkgmanager.TYPE == 'yum':
         hdr = pkg_obj.hdr
-    else:
+    elif pkgmanager.TYPE == 'dnf':
         hdr = get_rpm_header(pkg_obj)
 
     pkg_sig = hdr.sprintf(
@@ -217,7 +217,8 @@ def get_installed_pkg_objects(name=""):
     """
     if pkgmanager.TYPE == 'yum':
         return _get_installed_pkg_objects_yum(name)
-    return _get_installed_pkg_objects_dnf(name)
+    elif pkgmanager.TYPE == 'dnf':
+        return _get_installed_pkg_objects_dnf(name)
 
 
 def _get_installed_pkg_objects_yum(name):
@@ -327,12 +328,12 @@ def get_pkg_nevra(pkg_obj):
                                   pkg_obj.version,
                                   pkg_obj.release,
                                   pkg_obj.arch)
-    # DNF
-    return "%s-%s%s-%s.%s" % (pkg_obj.name,
-                              "" if pkg_obj.epoch == 0 else str(pkg_obj.epoch) + ":",
-                              pkg_obj.version,
-                              pkg_obj.release,
-                              pkg_obj.arch)
+    elif pkgmanager.TYPE == 'dnf':
+        return "%s-%s%s-%s.%s" % (pkg_obj.name,
+                                  "" if pkg_obj.epoch == 0 else str(pkg_obj.epoch) + ":",
+                                  pkg_obj.version,
+                                  pkg_obj.release,
+                                  pkg_obj.arch)
 
 
 def get_packager(pkg_obj):

--- a/convert2rhel/redhatrelease.py
+++ b/convert2rhel/redhatrelease.py
@@ -22,6 +22,7 @@ from re import sub
 
 from convert2rhel import utils
 from convert2rhel.toolopts import tool_opts
+from convert2rhel.systeminfo import system_info
 
 
 def install_release_pkg():
@@ -51,10 +52,15 @@ def install_release_pkg():
 
 
 def get_release_pkg_name():
-    """Starting with RHEL 6 the release package name follows this schema: redhat-release-<lowercase variant>, e.g.
+    """For RHEL 6 and 7 the release package name follows this schema: redhat-release-<lowercase variant>, e.g.
     redhat-release-server.
+
+    For RHEL 8, the name is just redhat-release.
     """
-    return "redhat-release-" + tool_opts.variant.lower()
+    if system_info.version in ["6", "7"]:
+        return "redhat-release-" + tool_opts.variant.lower()
+    elif system_info.version == "8":
+        return "redhat-release"
 
 
 def get_system_release_filepath():

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -485,7 +485,6 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
                                              arch="x86_64", from_repo="test")
         return [obj1, obj2, obj3]
 
-    @unit_tests.mock(pkgmanager, "TYPE", "dnf")
     def test_print_pkg_info(self):
         pkgs = TestPkgHandler.prepare_pkg_obj_for_print()
         result = pkghandler.print_pkg_info(pkgs)
@@ -493,7 +492,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
                                   result, re.MULTILINE))
         self.assertTrue(re.search(r"^pkg1-0\.1-1\.x86_64\s+Oracle\s+anaconda$",
                                   result, re.MULTILINE))
-        self.assertTrue(re.search(r"^pkg2-1:0\.1-1\.x86_64\s+N/A\s+N/A$",
+        self.assertTrue(re.search(r"^pkg2-0\.1-1\.x86_64\s+N/A\s+N/A$",
                                   result, re.MULTILINE))
         self.assertTrue(re.search(r"^gpg-pubkey-0\.1-1\.x86_64\s+N/A\s+test$",
                                   result, re.MULTILINE))

--- a/convert2rhel/unit_tests/redhatrelease_test.py
+++ b/convert2rhel/unit_tests/redhatrelease_test.py
@@ -30,7 +30,7 @@ except ImportError:
 
 class TestRedHatRelease(unittest.TestCase):
 
-    supported_rhel_versions = ["5", "6", "7"]
+    supported_rhel_versions = ["6", "7", "8"]
 
     class DumbMocked(unit_tests.MockFunction):
         def __call__(self, *args, **kwargs):
@@ -94,10 +94,8 @@ class TestRedHatRelease(unittest.TestCase):
             # Call just this function to avoid unmockable built-in write func
             yum_conf._insert_distroverpkg_tag()
 
-            self.assertTrue("\ndistroverpkg=redhat-release" in
-                            yum_conf._yum_conf_content)
-            self.assertEqual(yum_conf._yum_conf_content.count(
-                                "\ndistroverpkg="), 1)
+            self.assertTrue("\ndistroverpkg=redhat-release" in yum_conf._yum_conf_content)
+            self.assertEqual(yum_conf._yum_conf_content.count("\ndistroverpkg="), 1)
 
 
 YUM_CONF_WITHOUT_DISTROVERPKG = """[main]

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -325,7 +325,7 @@ class ChangedRPMPackagesController(object):
 
 def remove_orphan_folders():
     """Even after removing redhat-release-* package, some of its folders are
-    stil present, are empty, and that blocks us from installing centos-release
+    still present, are empty, and that blocks us from installing centos-release
     pkg back. So, by now, we are removing them manually.
     """
     rh_release_paths = ['/usr/share/redhat-release',

--- a/packaging/convert2rhel.spec
+++ b/packaging/convert2rhel.spec
@@ -36,6 +36,7 @@ Requires:       python%{python_pkgversion}-six
 Requires:       dnf
 # dnf-utils includes yumdownloader we use
 Requires:       dnf-utils
+Requires:       grubby
 Requires:       python3-pexpect
 %endif
 %if 0%{?rhel} && 0%{?rhel} <= 7

--- a/packaging/convert2rhel.spec
+++ b/packaging/convert2rhel.spec
@@ -28,6 +28,8 @@ Requires:       python%{python_pkgversion}-six
 
 %if 0%{?el8} && 0%{?rhel}
 Requires:       dnf
+# dnf-utils includes yumdownloader we use
+Requires:       dnf-utils
 %endif
 
 %if 0%{?rhel} && 0%{?rhel} <= 7

--- a/packaging/convert2rhel.spec
+++ b/packaging/convert2rhel.spec
@@ -19,23 +19,30 @@ Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
 BuildRequires:  python%{python_pkgversion}-devel
-BuildRequires:  python%{python_pkgversion}-six
 BuildRequires:  python%{python_pkgversion}-setuptools
+BuildRequires:  python%{python_pkgversion}-six
+%if 0%{?rhel} && 0%{?el8}
+BuildRequires:  python3-pexpect
+%endif
+%if 0%{?rhel} && 0%{?rhel} <= 7
+BuildRequires:  pexpect
+%endif
+
 Requires:       rpm
 Requires:       python%{python_pkgversion}
 Requires:       python%{python_pkgversion}-setuptools
 Requires:       python%{python_pkgversion}-six
-
-%if 0%{?el8} && 0%{?rhel}
+%if 0%{?rhel} && 0%{?el8}
 Requires:       dnf
 # dnf-utils includes yumdownloader we use
 Requires:       dnf-utils
+Requires:       python3-pexpect
 %endif
-
 %if 0%{?rhel} && 0%{?rhel} <= 7
 Requires:       yum
 # yum-utils includes yumdownloader we use
 Requires:       yum-utils
+Requires:       pexpect
 %endif
 
 ### subscription-manager dependencies ###

--- a/plans/unittests.fmf
+++ b/plans/unittests.fmf
@@ -9,4 +9,4 @@ prepare:
     script:
     # We can't use a simple `command -v dnf` test because the testing farm executes `ln -fs $(which yum) /usr/bin/dnf`
     #  on the epel-8 target.
-    - if [ -e "/usr/bin/dnf-3" ]; then dnf install -y python3-nose; else yum install -y python-nose; fi
+    - if [ -e "/usr/bin/dnf-3" ]; then dnf install -y python3-nose python3-pexpect; else yum install -y python-nose pexpect; fi


### PR DESCRIPTION
- Added missing dnf-utils dependency for yumdownloader.
- Replaced function getting package NVRA with getting NEVRA as that's what yum/dnf is printing.
- Improved function for downloading packages that uses yumdownloader to be more robust.
- The get_installed_pkgs_w_different_fingerprint function, when using DNF, filters packages by name only, not by package NEVRA as with YUM.
- Fixed getting the redhat-release package name, it's different on RHEL 8 than on RHEL 6 and 7.

To convert OL 8, run the following under root:
```
dnf install -y http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/python3-syspurpose-1.26.20-1.el8_2.x86_64.rpm # temporary before we fix deps
curl https://copr.fedorainfracloud.org/coprs/g/oamg/convert2rhel/repo/epel-8/group_oamg-convert2rhel-epel-8.repo -o /etc/yum.repos.d/copr_convert2rhel.repo
yum install -y convert2rhel*pr112*

mkdir -p /usr/share/convert2rhel/redhat-release/Server/
curl http://<pulp_mirror_hostname>/content/dist/rhel8/8.2/x86_64/baseos/os/Packages/r/redhat-release-8.2-1.0.el8.x86_64.rpm -o /usr/share/convert2rhel/redhat-release/Server/redhat-release-8.2-1.0.el8.x86_64.rpm 

cat >/etc/yum.repos.d/rhel8.repo <<EOFE
[rhel-8-for-x86_64-baseos-rpms]
name=RHEL 8.2 BaseOS for x86_64
baseurl=http://<pulp_mirror_hostname>/content/dist/rhel8/8.2/x86_64/baseos/os/
enabled=0
gpgcheck=0

[rhel-8-for-x86_64-appstream-rpms]
name=RHEL 8.2 AppStream for x86_64
baseurl=http://<pulp_mirror_hostname>/content/dist/rhel8/8.2/x86_64/appstream/os/
enabled=0
gpgcheck=0
EOFE

convert2rhel --debug -y --no-rpm-va --disable-submgr --enablerepo rhel-8-for-x86_64-baseos-rpms --enablerepo rhel-8-for-x86_64-appstream-rpms
```

Notes:
- It won't be needed to install the python3-syspurpose package manually after merging https://github.com/oamg/convert2rhel/pull/107.
- It won't be needed to download the redhat-release package after merging https://github.com/oamg/convert2rhel/pull/105.
- Unfortunately, the `packager` field of Oracle Linux package dnf objects is empty. We used to print a vendor, not a packager, but a package vendor is not available through dnf due to a bug: https://bugzilla.redhat.com/show_bug.cgi?id=1876561. The outcome:
```
WARNING - The following packages will be removed...
Package                                     Packager  Repository
-------                                     --------  ----------
oraclelinux-release-8:8.2-1.0.8.el8.x86_64  N/A       N/A
oraclelinux-release-el8-1.0-11.el8.x86_64   N/A       N/A
redhat-release-2:8.2-1.0.0.1.el8.x86_64     N/A       N/A
```