### PR TITLE
fix(Utils): Avoid NULL byte error by ASCII-encoding subprocess command

### DIFF
--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -150,9 +150,9 @@ class TestUtils(unittest.TestCase):
         self.assertEqual("rpm -i --replacepkgs pkg1 pkg2 pkg3", utils.run_subprocess.cmd)
 
     def test_run_subprocess(self):
-        output, code = utils.run_subprocess("echo ahoj")
+        output, code = utils.run_subprocess("echo foobar")
 
-        self.assertEqual(output, "ahoj\n")
+        self.assertEqual(output, "foobar\n")
         self.assertEqual(code, 0)
 
         output, code = utils.run_subprocess("sh -c 'exit 56'")  # a command that just returns 56

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -126,6 +126,11 @@ def run_subprocess(cmd="", **kwargs):
     loggerinst = logging.getLogger(__name__)
     if print_cmd:
         loggerinst.debug("Calling command '%s'" % cmd)
+
+    # Python 2.6 has a bug in shlex that interprets certain characters in a string as 
+    # a NULL character. This is a workaround that encodes the string to avoid the issue.
+    if sys.version_info[0] == 2 and sys.version_info[1] == 6:
+        cmd = cmd.encode("ascii")
     cmd = shlex.split(cmd, False)
     process = subprocess.Popen(cmd,
                                stdout=subprocess.PIPE,


### PR DESCRIPTION
Fixes `TypeError: execve() argument 1 must be encoded string without NULL bytes, not str` error with `subprocess` and `shlex` for python 2.6 with OL6/CentOS 6

Gotten the bugfix to work but be wary in testing as the error it fixes may not happen every time