### PR TITLE
Remove all things RHN

### DIFF
--- a/convert2rhel/data/6/x86_64/configs/centos-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/centos-6-x86_64.cfg
@@ -15,6 +15,8 @@ excluded_pkgs =
   redhat-release*
   libreport-centos
   libreport-plugin-mantisbt
+  rhn*
+  yum-rhn-plugin
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/6/x86_64/configs/oracle-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/oracle-6-x86_64.cfg
@@ -17,6 +17,8 @@ excluded_pkgs =
   oracleasm-support
   oracle-rdbms-server-*
   btrfs-progs-devel
+  rhn*
+  yum-rhn-plugin
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
@@ -17,6 +17,8 @@ excluded_pkgs =
   redhat-release*
   libreport-centos
   libreport-plugin-mantisbt
+  rhn*
+  yum-rhn-plugin
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
@@ -16,6 +16,8 @@ excluded_pkgs =
   akonadi-mysql
   oracleasm-support
   oracle-rdbms-server-*
+  rhn*
+  yum-rhn-plugin
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
@@ -12,6 +12,8 @@ excluded_pkgs =
   centos-indexhtml
   centos-release*
   redhat-release*
+  rhn*
+  python3-rhn*
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.
 # Delimited by any whitespace(s).

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -70,7 +70,6 @@ def main():
         loggerinst.task("Prepare: Backup System")
         redhatrelease.system_release_file.backup()
         redhatrelease.yum_conf.backup()
-        subscription.rhn_reg_file.backup()
 
         loggerinst.task("Prepare: Clear YUM/DNF version locks")
         pkghandler.clear_versionlock()
@@ -153,10 +152,6 @@ def pre_ponr_conversion():
     loggerinst.task("Convert: Remove excluded packages")
     pkghandler.remove_excluded_pkgs()
 
-    # checking RHN Classic
-    loggerinst.task("Checking RHN Classic")
-    subscription.unregister_from_rhn_classic()
-
     # install redhat release package
     loggerinst.task("Convert: Install Red Hat release package")
     redhatrelease.install_release_pkg()
@@ -218,7 +213,6 @@ def rollback_changes():
     subscription.rollback()
     utils.changed_pkgs_control.restore_pkgs()
     redhatrelease.system_release_file.restore()
-    subscription.rhn_reg_file.restore()
     redhatrelease.yum_conf.restore()
     pkghandler.versionlock_file.restore()
 

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -25,21 +25,6 @@ from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts
 from convert2rhel import utils
 
-_RHN_REGISTRATION_FILE = "/etc/sysconfig/rhn/systemid"
-rhn_reg_file = utils.RestorableFile(_RHN_REGISTRATION_FILE)  # pylint: disable=C0103
-
-
-def unregister_from_rhn_classic():
-    loggerinst = logging.getLogger(__name__)
-    if os.path.isfile(_RHN_REGISTRATION_FILE):
-        loggerinst.warning("The use of RHN Classic is not allowed during the conversion.\n"
-                           "The convert2rhel is going to unregister from RHN Classic.\n"
-                           "See https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/installation_guide/unregister-rhn for details.")
-        utils.ask_to_continue()
-        rhn_reg_file.remove()
-    else:
-        loggerinst.info("RHN Classic not detected.")
-
 
 def subscribe_system():
     """Register and attach a specific subscription to OS."""

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -123,7 +123,6 @@ class TestMain(unittest.TestCase):
     @unit_tests.mock(main.logging, "getLogger", GetLoggerMocked())
     @unit_tests.mock(tool_opts, "disable_submgr", False)
     @mock_calls(pkghandler, "remove_excluded_pkgs", CallOrderMocked)
-    @mock_calls(subscription, "unregister_from_rhn_classic", CallOrderMocked)
     @mock_calls(redhatrelease, "install_release_pkg", CallOrderMocked)
     @mock_calls(redhatrelease.YumConf, "patch", CallOrderMocked)
     @mock_calls(pkghandler, "list_third_party_pkgs", CallOrderMocked)
@@ -140,7 +139,6 @@ class TestMain(unittest.TestCase):
 
         intended_call_order = OrderedDict()
         intended_call_order["remove_excluded_pkgs"] = 1
-        intended_call_order["unregister_from_rhn_classic"] = 1
         intended_call_order["install_release_pkg"] = 1
         intended_call_order["patch"] = 1
         intended_call_order["list_third_party_pkgs"] = 1
@@ -163,7 +161,6 @@ class TestMain(unittest.TestCase):
     @unit_tests.mock(main.logging, "getLogger", GetLoggerMocked())
     @unit_tests.mock(tool_opts, "disable_submgr", False)
     @mock_calls(pkghandler, "remove_excluded_pkgs", CallOrderMocked)
-    @mock_calls(subscription, "unregister_from_rhn_classic", CallOrderMocked)
     @mock_calls(redhatrelease, "install_release_pkg", CallOrderMocked)
     @mock_calls(redhatrelease.YumConf, "patch", CallOrderMocked)
     @mock_calls(pkghandler, "list_third_party_pkgs", CallOrderMocked)
@@ -180,7 +177,6 @@ class TestMain(unittest.TestCase):
 
         intended_call_order = OrderedDict()
         intended_call_order["remove_excluded_pkgs"] = 1
-        intended_call_order["unregister_from_rhn_classic"] = 1
         intended_call_order["install_release_pkg"] = 1
         intended_call_order["patch"] = 1
         intended_call_order["list_third_party_pkgs"] = 1

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -145,21 +145,6 @@ class TestSubscription(unittest.TestCase):
     def setUp(self):
         tool_opts.__init__()
 
-    @unit_tests.mock(subscription.logging, "getLogger", GetLoggerMocked())
-    @unit_tests.mock(os.path, "isfile", IsFileMocked(is_file=False))
-    def test_rhn_classic_does_not_exist(self):
-        subscription.unregister_from_rhn_classic()
-        self.assertEqual(len(subscription.logging.getLogger.info_msgs), 1)
-
-    @unit_tests.mock(subscription.logging, "getLogger", GetLoggerMocked())
-    @unit_tests.mock(os.path, "isfile", IsFileMocked(is_file=True))
-    @unit_tests.mock(utils, "ask_to_continue", PromptUserMocked())
-    @unit_tests.mock(subscription.rhn_reg_file, "remove", RemoveFileMocked())
-    def test_rhn_classic_does_exist(self):
-        subscription.unregister_from_rhn_classic()
-        self.assertEqual(len(subscription.logging.getLogger.info_msgs), 0)
-        self.assertEqual(len(subscription.logging.getLogger.warning_msgs), 1)
-
     def test_get_registration_cmd(self):
         tool_opts.username = 'user'
         tool_opts.password = 'pass with space'


### PR DESCRIPTION
RHN has been shut down for good. And the RHN-related package rhn-client-tools started causing the conversion to fail on OL7.8.