### PR TITLE
add: check/warn user if same repo in both enable / disable repo options

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -148,6 +148,9 @@ def pre_ponr_conversion():
     """Perform steps and checks to guarantee system is ready for conversion."""
     loggerinst = logging.getLogger(__name__)
 
+    # check if user pass some repo to both disablerepo and enablerepo options
+    pkghandler.has_duplicate_repos_across_disablerepo_enablerepo_options()
+
     # remove excluded packages
     loggerinst.task("Convert: Remove excluded packages")
     pkghandler.remove_excluded_pkgs()

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -222,6 +222,7 @@ def get_installed_pkg_objects(name=""):
         return _get_installed_pkg_objects_dnf(name)
 
 
+
 def _get_installed_pkg_objects_yum(name):
     yum_base = pkgmanager.YumBase()
     # Disable plugins (when kept enabled yum outputs useless text every call)
@@ -676,3 +677,15 @@ def clear_versionlock():
         call_yum_cmd("versionlock clear", print_output=False)
     else:
         loggerinst.info("Usage of YUM/DNF versionlock plugin not detected.")
+
+
+def has_duplicate_repos_across_disablerepo_enablerepo_options():
+    loggerinst = logging.getLogger(__name__)
+
+    duplicate_repos = set(tool_opts.disablerepo) & set(tool_opts.enablerepo)
+    if duplicate_repos:
+        message = "Duplicate repositories was found across disablerepo and enablerepo options:"
+        for repo in duplicate_repos:
+            message += "\n%s" % repo
+        message += "\nThis ambiguity may have unintended consequences."
+        loggerinst.warning(message)

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -863,8 +863,10 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
 
     @unit_tests.mock(tool_opts, "disablerepo", ['*'])
     @unit_tests.mock(tool_opts, "enablerepo", ['rhel-7-extras-rpm'])
+    @unit_tests.mock(logger.CustomLogger, "warning", LogMocked())
     def test_is_disable_and_enable_repos_doesnt_thas_same_repo(self):
-        self.assertEqual(None, pkghandler.has_duplicate_repos_across_disablerepo_enablerepo_options())
+        pkghandler.has_duplicate_repos_across_disablerepo_enablerepo_options()
+        self.assertEqual(logger.CustomLogger.warning.called, 0)
 
 
 YUM_PROTECTED_ERROR = """Error: Trying to remove "systemd", which is protected

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -853,6 +853,19 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertEqual(len(pkghandler.print_pkg_info.pkgs), 3)
         self.assertTrue("Only packages signed by" in logger.CustomLogger.warning.msg)
 
+    @unit_tests.mock(tool_opts, "disablerepo", ['*', 'rhel-7-extras-rpm'])
+    @unit_tests.mock(tool_opts, "enablerepo", ['rhel-7-extras-rpm'])
+    @unit_tests.mock(logger.CustomLogger, "warning", LogMocked())
+    def test_is_disable_and_enable_repos_has_same_repo(self):
+        pkghandler.has_duplicate_repos_across_disablerepo_enablerepo_options()
+        self.assertTrue("Duplicate repositories was found" in logger.CustomLogger.warning.msg)
+
+
+    @unit_tests.mock(tool_opts, "disablerepo", ['*'])
+    @unit_tests.mock(tool_opts, "enablerepo", ['rhel-7-extras-rpm'])
+    def test_is_disable_and_enable_repos_doesnt_thas_same_repo(self):
+        self.assertEqual(None, pkghandler.has_duplicate_repos_across_disablerepo_enablerepo_options())
+
 
 YUM_PROTECTED_ERROR = """Error: Trying to remove "systemd", which is protected
 Error: Trying to remove "yum", which is protected"""


### PR DESCRIPTION
Warn the user when they provide the same repo in both the --disablerereo and --enablerepo option.