### PR TITLE
Do not require python-syspurpose in spec

### DIFF
--- a/packaging/convert2rhel.spec
+++ b/packaging/convert2rhel.spec
@@ -71,7 +71,6 @@ Requires:       m2crypto
 %if 0%{?rhel} && 0%{?rhel} >= 7
 Requires:       gobject-introspection
 Requires:       python%{python_pkgversion}-inotify
-Requires:       python%{python_pkgversion}-syspurpose
 %endif
 ### end of subscription-manager dependencies ###
 


### PR DESCRIPTION
The python-syspurpose and python3-syspurpose packages are the required dependencies of the RHEL 7 and 8 subscription-mananger package, respectively. However this syspurpose package is not available on Oracle Linux, so on OL 7 and 8, the installation of convert2rhel is not possible, unless one installs the syspurpose package from a non-standard repository manually beforehand.

Since the main and documented use of convert2rhel is currently with using custom repositories, and not RHSM, we are removing this dependency.

If anyone would like to use subscription-manager, they need to download the syspurpose package to the /usr/share/convert2rhel/subscription-manager/ upon installing convert2rhel, alongside the subscription-manager pkgs.

In the future:
- all the subscription-manager dependencies will be resolved by yum and not hardcoded in the convert2rhel spec: https://github.com/oamg/convert2rhel/pull/107.
- and the subscription-manager pkgs won't be necessary to pre-download as it is now: https://github.com/oamg/convert2rhel/pull/100