### PR TITLE
Do not rename repofiles

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -178,9 +178,6 @@ def pre_ponr_conversion():
         subscription.disable_repos()
         loggerinst.task("Convert: Subscription Manager - Enable RHEL repositories")
         subscription.enable_repos(rhel_repoids)
-        # TODO: Replace renaming .repo files by using --enable for yum command
-        loggerinst.task("Convert: Subscription Manager - Rename repositories")
-        subscription.rename_repo_files()
 
 
 def post_ponr_conversion():

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -326,52 +326,9 @@ def enable_repos(rhel_repoids):
     system_info.submgr_enabled_repos = repos_to_enable
 
 
-def rename_repo_files():
-    """Rename non-Red Hat .repo files in /etc/yum.repos.d/ so the repositories
-    in them are not used by yum command.
-    """
-    loggerinst = logging.getLogger(__name__)
-    repo_files_renamed = False
-    exe_name = utils.get_executable_name()
-    for filename in os.listdir("/etc/yum.repos.d/"):
-        if filename.endswith(".repo") and filename != "redhat.repo":
-            filepath_old = os.path.join("/etc/yum.repos.d/", filename)
-            filepath_new = "%s.%s_renamed" % (filepath_old, exe_name)
-            shutil.move(filepath_old, filepath_new)
-            loggerinst.info("Renamed: %s -> %s"
-                            % (filepath_old, filepath_new))
-            repo_files_renamed = True
-    if not repo_files_renamed:
-        loggerinst.info("No .repo file renamed.")
-    return
-
-
-def rollback_renamed_repo_files():
-    """Rollback all non-Red Hat .repo files in /etc/yum.repos.d/ that were
-    renamed.
-    """
-    loggerinst = logging.getLogger(__name__)
-    loggerinst.task("Rollback: Rollback all non-Red Hat .repo files renamed in"
-                    " /etc/yum.repos.d/")
-    exe_name = utils.get_executable_name()
-    file_restored = False
-    for filename in os.listdir("/etc/yum.repos.d/"):
-        if filename.endswith(".%s_renamed" % exe_name):
-            filepath_old = os.path.join("/etc/yum.repos.d/", filename)
-            filepath_new = os.path.splitext(filepath_old)[0]
-            shutil.move(filepath_old, filepath_new)
-            loggerinst.info("Renamed: %s -> %s"
-                            % (filepath_old, filepath_new))
-            file_restored = True
-
-    if not file_restored:
-        loggerinst.info("No .repo files to rollback")
-
-
 def rollback():
     """Rollback all subscription related changes"""
     loggerinst = logging.getLogger(__name__)
-    rollback_renamed_repo_files()
     try:
         unregister_system()
     except OSError:

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -132,7 +132,6 @@ class TestMain(unittest.TestCase):
     @mock_calls(subscription, "check_needed_repos_availability", CallOrderMocked)
     @mock_calls(subscription, "disable_repos", CallOrderMocked)
     @mock_calls(subscription, "enable_repos", CallOrderMocked)
-    @mock_calls(subscription, "rename_repo_files", CallOrderMocked)
     def test_pre_ponr_conversion_order_with_rhsm(self):
         self.CallOrderMocked.reset()
         main.pre_ponr_conversion()
@@ -148,7 +147,6 @@ class TestMain(unittest.TestCase):
         intended_call_order["check_needed_repos_availability"] = 1
         intended_call_order["disable_repos"] = 1
         intended_call_order["enable_repos"] = 1
-        intended_call_order["rename_repo_files"] = 1
 
         # Merge the two together like a zipper, creates a tuple which we can assert with - including method call order!
         zipped_call_order = zip(intended_call_order.items(), self.CallOrderMocked.calls.items())
@@ -170,7 +168,6 @@ class TestMain(unittest.TestCase):
     @mock_calls(subscription, "check_needed_repos_availability", CallOrderMocked)
     @mock_calls(subscription, "disable_repos", CallOrderMocked)
     @mock_calls(subscription, "enable_repos", CallOrderMocked)
-    @mock_calls(subscription, "rename_repo_files", CallOrderMocked)
     def test_pre_ponr_conversion_order_without_rhsm(self):
         self.CallOrderMocked.reset()
         main.pre_ponr_conversion()
@@ -188,7 +185,6 @@ class TestMain(unittest.TestCase):
         intended_call_order["check_needed_repos_availability"] = 0
         intended_call_order["disable_repos"] = 0
         intended_call_order["enable_repos"] = 0
-        intended_call_order["rename_repo_files"] = 0
 
         # Merge the two together like a zipper, creates a tuple which we can assert with - including method call order!
         zipped_call_order = zip(intended_call_order.items(), self.CallOrderMocked.calls.items())

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -282,11 +282,9 @@ class TestSubscription(unittest.TestCase):
         self.assertEqual(len(subscription.logging.getLogger.task_msgs), 1)
         self.assertEqual(len(subscription.logging.getLogger.warning_msgs), 1)
 
-    @unit_tests.mock(subscription, "rollback_renamed_repo_files", unit_tests.CountableMockObject())
     @unit_tests.mock(subscription, "unregister_system", unit_tests.CountableMockObject())
     def test_rollback(self):
         subscription.rollback()
-        self.assertEqual(subscription.rollback_renamed_repo_files.called, 1)
         self.assertEqual(subscription.unregister_system.called, 1)
 
     class LogMocked(unit_tests.MockFunction):


### PR DESCRIPTION
When using RHSM, we currently rename all repofiles not coming from Red Hat during the conversion so that they are not used for the conversion in any way. That causes a problem when somebody passes --enablerepo together with using RHSM, and this repo is in some other repofile than /etc/yum.repos.d/redhat.repo. Because of the repofile renaming, this repository is then unexpectedly not used during the conversion.

The repofile renaming is not needed if we call yum with the right parameters (--enablerepo and --disablerepo) and that's what we've managed under https://github.com/oamg/convert2rhel/pull/109/.