### PR TITLE
Remove CentOS/EPEL 6 from CI/CD

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -22,26 +22,6 @@ on:
     branches: [ main ]
 
 jobs:        
-  pylint_check_2_6:
-    runs-on: ubuntu-latest
-    container: centos:centos6
-
-    steps:
-    - name: Checkout Code
-      uses: actions/checkout@v1
-
-
-    - name: Install Requirements
-      run: |
-        yum install -y python-six pexpect
-        curl https://bootstrap.pypa.io/2.6/get-pip.py -o get-pip.py
-        python get-pip.py
-        pip install pylint==1.1.0
-        pip install astroid==1.2
-
-    - name: Run Pylint Checks
-      run: ${{ env.interpreted_pylint }}
-
   pylint_check_2_7:
     runs-on: ubuntu-latest
     container: centos:centos7

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,7 +9,6 @@ jobs:
     owner: "@oamg"
     project: convert2rhel
     targets:
-    - epel-6-x86_64
     - epel-7-x86_64
     - epel-8-x86_64
   trigger: pull_request
@@ -32,13 +31,11 @@ jobs:
     owner: "@oamg"
     project: convert2rhel
     targets:
-    - epel-6-x86_64
     - epel-7-x86_64
     - epel-8-x86_64
 - job: tests
   metadata:
     targets:
-    - epel-6-x86_64
     - epel-7-x86_64
     - epel-8-x86_64
   trigger: pull_request
@@ -46,6 +43,5 @@ jobs:
   trigger: release
   metadata:
     dist_git_branches:
-    - el6
     - epel7
     - epel8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ $ kinit <your_FAS_user_name>@FEDORAPROJECT.ORG  # see [1] on setting up Kerberos
 $ fedpkg clone convert2rhel convert2rhel-distgit  # to get the fedpkg utility, see [2]
 $ cd convert2rhel-distgit
 
-$ fedpkg switch-branch el6  # for EPEL 6
+$ fedpkg switch-branch epel7  # for EPEL 7
 $ fedpkg pull  # make sure you work with the latest branch content
 $ rm -rf convert2rhel*  # remove all the files related to the previous release
 $ wget https://raw.githubusercontent.com/oamg/convert2rhel/main/packaging/convert2rhel.spec
@@ -70,10 +70,8 @@ $ # wait for the above command to finish
 $ fedpkg build  # create the official build
 $ fedpkg update  # -> this creates a Bodhi request; read [3] and play it by your ear
  
-$ fedpkg switch-branch epel7  # for EPEL 7
-$ # all the steps as for the branch 'el6' above
 $ fedpkg switch-branch epel8  # for EPEL 8
-$ # all the steps as for the branch 'el6' above
+$ # all the steps as for the branch 'epel7' above
 ```
 
 Related resources:


### PR DESCRIPTION
EPEL 6 is not available anymore, that is - not available in Fedora Copr as chroot, not available as a repository.

As well, CentOS 6 repos are not available anymore (except Vault which is an archive of old and not updated versions of CentOS).

That impacts our pylint tests, package building, unit testing. We'll be looking for another ways to have the packages for CentOS/OL 6 built and the code tested with py2.6.