### PR TITLE
[WIP] Packit to build rpms in a custom epel-6-like chroot

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,19 +5,30 @@ upstream_project_url: https://github.com/oamg/convert2rhel
 
 jobs:
 - job: copr_build
+  trigger: pull_request
   metadata:
     owner: "@oamg"
     project: convert2rhel
     targets:
+    # The custom chroot is setup to behave the same as the removed epel-6-x86_64 chroot
+    - custom-1-x86_64
     - epel-7-x86_64
     - epel-8-x86_64
-  trigger: pull_request
   actions:
     # do not get the version from a tag (git describe) but from the spec file
     get-current-version:
     - grep -oP '^Version:\s+\K\S+' packaging/convert2rhel.spec
 - job: copr_build
   trigger: commit
+  metadata:
+    branch: main
+    owner: "@oamg"
+    project: convert2rhel
+    targets:
+    # The custom chroot is setup to behave the same as the removed epel-6-x86_64 chroot
+    - custom-1-x86_64
+    - epel-7-x86_64
+    - epel-8-x86_64
   actions:
     # bump spec so we get release starting with 2 and hence all the default branch builds will
     # have higher NVR than all the PR builds
@@ -26,13 +37,6 @@ jobs:
     # do not get the version from a tag (git describe) but from the spec file
     get-current-version:
     - grep -oP '^Version:\s+\K\S+' packaging/convert2rhel.spec
-  metadata:
-    branch: main
-    owner: "@oamg"
-    project: convert2rhel
-    targets:
-    - epel-7-x86_64
-    - epel-8-x86_64
 - job: tests
   metadata:
     targets:


### PR DESCRIPTION
Pavel Raiskup from the team behind Copr has suggested us to use the custom-1-x86_64 chroot available in Fedora Copr and set it up to behave the same as the original removed epel-6-x86_64 chroot.