### PR TITLE
Fix not replacing same version kernel

### DIFF
--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -548,11 +548,11 @@ def replace_non_rhel_installed_kernel(version):
 
     pkg = "kernel-%s" % version
 
-    ret_code = utils.download_pkg(
+    path = utils.download_pkg(
         pkg=pkg, dest=utils.TMP_DIR, disablerepo=tool_opts.disablerepo,
         enablerepo=tool_opts.enablerepo)
-    if ret_code != 0:
-        return
+    if not path:
+        loggerinst.critical("Unable to download the RHEL kernel package.")
 
     loggerinst.info("Replacing %s %s with RHEL kernel with the same NEVRA ... " % (system_info.name, pkg))
     output, ret_code = utils.run_subprocess(
@@ -560,7 +560,6 @@ def replace_non_rhel_installed_kernel(version):
         print_output=False)
     if ret_code != 0:
         loggerinst.critical("Unable to replace kernel package: %s" % output)
-        return
 
     loggerinst.info("\nRHEL %s installed.\n" % pkg)
 


### PR DESCRIPTION
Without this fix the original kernel silently remains not replaced with the RHEL one in case the kernel version on the original system is the same as the version available for RHEL.

Related change that caused this bug: https://github.com/oamg/convert2rhel/pull/112/files#diff-ed1ca2e4a8b27f1bee13d608562d4e94eceb2972790eccf4d84f366b750f221dR433