### PR TITLE
Add back pylint 2.6 check

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -22,7 +22,32 @@ on:
     branches: [ main ]
 
 jobs:        
+  pylint_check_2_6:
+    name: py2.6 check
+    runs-on: ubuntu-latest
+    container: centos:centos6
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v1
+
+    - name: Fix unavailable CentOS 6 repos
+      run: |
+        sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Base.repo
+        sed -i 's/^#baseurl.*$/baseurl=http:\/\/vault.centos.org\/6.10\/os\/x86_64/g' /etc/yum.repos.d/CentOS-Base.repo
+
+    - name: Install Requirements
+      run: |
+        yum install -y python-six pexpect
+        curl https://bootstrap.pypa.io/2.6/get-pip.py -o get-pip.py
+        python get-pip.py
+        pip install pylint==1.1.0
+        pip install astroid==1.2
+    - name: Run Pylint Checks
+      run: ${{ env.interpreted_pylint }}
+
   pylint_check_2_7:
+    name: py2.7 check
     runs-on: ubuntu-latest
     container: centos:centos7
 
@@ -38,6 +63,7 @@ jobs:
       run: ${{ env.interpreted_pylint }}
 
   pylint_check_3:
+    name: py3 check
     runs-on: ubuntu-latest
     container: centos:centos8
 


### PR DESCRIPTION
There was an issue with unavailable CentOS 6 repos. They have moved to Vault.

Reverts the removal from https://github.com/oamg/convert2rhel/pull/126.