### PR TITLE
add: check single-user mode

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -66,6 +66,11 @@ def main():
         loggerinst.task("Prepare: Determine RHEL variant")
         rhelvariant.determine_rhel_variant()
 
+        # We check for the single-user mode only after the resolve_system_info() call because that function stops
+        # the conversion in case the system vendor/major version is not supported and we don't want users to go
+        # through booting into single-user mode to just find this out.
+        utils.require_single_user_mode()
+        
         # backup system release file before starting conversion process
         loggerinst.task("Prepare: Backup System")
         redhatrelease.system_release_file.backup()

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -212,3 +212,54 @@ class TestUtils(unittest.TestCase):
 
     def test_is_rpm_based_os(self):
         assert is_rpm_based_os() in (True, False)
+
+    class GetLoggerMocked(unit_tests.MockFunction):
+        def __init__(self):
+            self.task_msgs = []
+            self.info_msgs = []
+            self.warning_msgs = []
+            self.critical_msgs = []
+
+        def __call__(self, msg):
+            return self
+
+        def critical(self, msg):
+            self.critical_msgs.append(msg)
+            raise SystemExit(1)
+
+        def task(self, msg):
+            self.task_msgs.append(msg)
+
+        def info(self, msg):
+            self.info_msgs.append(msg)
+
+        def warn(self, msg, *args):
+            self.warning_msgs.append(msg)
+
+        def warning(self, msg, *args):
+            self.warn(msg, *args)
+
+        def debug(self, msg):
+            pass
+
+    @unit_tests.mock(utils, "run_cmd_in_pty", RunSubprocessMocked(ret_code=0, output='0\r\n 1\r\n'))
+    @unit_tests.mock(utils.logging, "getLogger", GetLoggerMocked())
+    def test_when_single_user_mode_check_is_true(self):
+        utils.require_single_user_mode()
+        self.assertEqual(len(utils.logging.getLogger.critical_msgs), 0)
+
+    @unit_tests.mock(utils, "run_cmd_in_pty", RunSubprocessMocked(ret_code=0, output='0\r\n 3\r\n'))
+    @unit_tests.mock(utils.logging, "getLogger", GetLoggerMocked())
+    def test_when_single_user_mode_check_is_false(self):
+        self.assertRaises(SystemExit, utils.require_single_user_mode)
+        self.assertEqual(len(utils.logging.getLogger.critical_msgs), 1)
+        self.assertTrue(
+            "Convert2RHEL requires the system to run in single-user mode" in utils.logging.getLogger.critical_msgs[0])
+
+    @unit_tests.mock(utils, "run_cmd_in_pty", RunSubprocessMocked(ret_code=1, output='0\r\n 3\r\n'))
+    @unit_tests.mock(utils.logging, "getLogger", GetLoggerMocked())
+    def test_when_single_user_mode_check_fails(self):
+        self.assertRaises(SystemExit, utils.require_single_user_mode)
+        self.assertEqual(len(utils.logging.getLogger.critical_msgs), 1)
+        self.assertTrue(
+            "Unable to determine if the system runs in single-user mode" in utils.logging.getLogger.critical_msgs[0])

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -532,6 +532,21 @@ class RestorablePackage(object):
             loggerinst.warning("Can't access %s" % TMP_DIR)
 
 
+def require_single_user_mode():
+    """
+    Make sure that the system is running in single-user mode and exit if it is not.
+    """
+    loggerinst = logging.getLogger(__name__)
+
+    output, ret_code = run_cmd_in_pty("runlevel", print_cmd=False)
+    runlevel = output.replace("\r\n", "")[-1]
+
+    if ret_code != 0:
+        loggerinst.critical("Unable to determine if the system runs in single-user mode.")
+    elif runlevel != '1':
+        loggerinst.critical("Convert2RHEL requires the system to run in single-user mode.")
+
+
 changed_pkgs_control = ChangedRPMPackagesController()  # pylint: disable=C0103
 
 


### PR DESCRIPTION
Require the system-to-be-converted to be booted in a single-user mode.
That would prevent other user sessions from doing changes to the system during the conversion.

WARNING:
- Need to update the vagrant test box after merge this PR.
- Need to update the Red Hat Knowledgebase article (https://access.redhat.com/articles/2360841)
