### PR TITLE
Add missing CentOS 8 packages - to be removed prior the conversion

### DIFF
--- a/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
@@ -8,10 +8,10 @@ gpg_fingerprints = 05b555b38483c65d
 # List of packages that have to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
-  centos-logos{,-httpd}
+  centos-logos*
   centos-indexhtml
-  centos-{,linux-}release
-  centos-{,linux-}repos
+  centos*-release
+  centos*-repos
   centos-obsolete-packages
   redhat-release*
   rhn*

--- a/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
@@ -8,9 +8,11 @@ gpg_fingerprints = 05b555b38483c65d
 # List of packages that have to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
-  centos-logos
+  centos-logos{,-httpd}
   centos-indexhtml
-  centos-release*
+  centos-{,linux-}release
+  centos-{,linux-}repos
+  centos-obsolete-packages
   redhat-release*
   rhn*
   python3-rhn*

--- a/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
@@ -8,10 +8,10 @@ gpg_fingerprints = 82562ea9ad986da3
 # List of packages that have to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
-  oracle-logos{,-httpd,-ipa}
+  oracle-logos*
   oracle-indexhtml
   oracle-backgrounds
-  oracle{,linux}-release{,-el8}
+  oracle*-release*
   redhat-release*
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.

--- a/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
@@ -8,10 +8,10 @@ gpg_fingerprints = 82562ea9ad986da3
 # List of packages that have to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
-  oracle-logos*
+  oracle-logos{,-httpd,-ipa}
   oracle-indexhtml
   oracle-backgrounds
-  oracle*release*
+  oracle{,linux}-release{,-el8}
   redhat-release*
 
 # List of repoids to enable through subscription-manager when the --enablerepo option is not used.


### PR DESCRIPTION
In CentOS 8.3 the package that used to be named `centos-release` in CentOS 8.2 was renamed to `centos-linux-release`.
Also, the `centos-repos`/`centos-linux-repos` and `centos-obsolete-packages` were missing in the list of pkgs to remove thus not being removed during the conversion.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1913008