### PR TITLE
Use Vault in CentOS 6 Docker image

### DIFF
--- a/Dockerfiles/centos6
+++ b/Dockerfiles/centos6
@@ -4,6 +4,8 @@ VOLUME /data
 
 WORKDIR /data
 
-RUN yum update -y &&\
+RUN sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Base.repo &&\
+    sed -i 's/^#baseurl.*$/baseurl=http:\/\/vault.centos.org\/6.10\/os\/x86_64/g' /etc/yum.repos.d/CentOS-Base.repo &&\
+    yum update -y &&\
     yum install -y python-nose python-six python-wheel pexpect &&\
     yum clean all


### PR DESCRIPTION
CentOS 6 has been retired and its repos moved to the Vault. We use CentOS 6 Docker image for unit testing, so we need to point the yum repos to the Vault now.

Related: #136 