### PR TITLE
Allow running tests on non CentOS systems

### DIFF
--- a/convert2rhel/unit_tests/example_test.py
+++ b/convert2rhel/unit_tests/example_test.py
@@ -20,12 +20,7 @@ This is an example test file containing a simple test.
 """
 
 # Required imports:
-
-
-try:
-    import unittest2 as unittest  # Python 2.6 support
-except ImportError:
-    import unittest
+import unittest
 
 from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel import utils

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -15,19 +15,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from datetime import datetime
-
 import logging
 import os
 import shutil
+import unittest
 
-try:
-    import unittest2 as unittest  # Python 2.6 support
-except ImportError:
-    import unittest
+from datetime import datetime
 
-from convert2rhel import logger
 from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
+from convert2rhel import logger
 from convert2rhel.toolopts import tool_opts
 
 

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -112,12 +112,14 @@ class TestMain(unittest.TestCase):
     @unit_tests.mock(redhatrelease.system_release_file, "restore", unit_tests.CountableMockObject())
     @unit_tests.mock(redhatrelease.yum_conf, "restore", unit_tests.CountableMockObject())
     @unit_tests.mock(subscription, "rollback", unit_tests.CountableMockObject())
+    @unit_tests.mock(pkghandler.versionlock_file, "restore", unit_tests.CountableMockObject())
     def test_rollback_changes(self):
         main.rollback_changes()
         self.assertEqual(utils.changed_pkgs_control.restore_pkgs.called, 1)
         self.assertEqual(redhatrelease.system_release_file.restore.called, 1)
         self.assertEqual(redhatrelease.yum_conf.restore.called, 1)
         self.assertEqual(subscription.rollback.called, 1)
+        self.assertEqual(pkghandler.versionlock_file.restore.called, 1)
 
 
     @unit_tests.mock(main.logging, "getLogger", GetLoggerMocked())

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -17,25 +17,25 @@
 
 
 import os
+import unittest
 
-try:
-    import unittest2 as unittest  # Python 2.6 support
-except ImportError:
-    import unittest
 
 try:
     from collections import OrderedDict
 except ImportError:
     from ordereddict import OrderedDict
 
-from convert2rhel import main
 from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
-from convert2rhel import redhatrelease
-from convert2rhel import repo
-from convert2rhel import subscription
-from convert2rhel import utils
-from convert2rhel import pkghandler
+from convert2rhel import (
+    main,
+    pkghandler,
+    redhatrelease,
+    repo,
+    subscription,
+    utils,
+)
 from convert2rhel.toolopts import tool_opts
+
 
 def mock_calls(class_or_module, method_name, mock_obj):
     return unit_tests.mock(class_or_module, method_name, mock_obj(method_name))

--- a/convert2rhel/unit_tests/other_test.py
+++ b/convert2rhel/unit_tests/other_test.py
@@ -15,14 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-try:
-    import unittest2 as unittest  # Python 2.6 support
-except ImportError:
-    import unittest
+import unittest
 
-from convert2rhel import pkghandler
-from convert2rhel import utils
-from convert2rhel import logger
+from convert2rhel import logger, pkghandler, utils
 
 
 class TestOther(unittest.TestCase):

--- a/convert2rhel/unit_tests/redhatrelease_test.py
+++ b/convert2rhel/unit_tests/redhatrelease_test.py
@@ -16,16 +16,12 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import glob
+import unittest
 
 from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel import redhatrelease, utils
 from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts
-
-try:
-    import unittest2 as unittest  # Python 2.6 support
-except ImportError:
-    import unittest
 
 
 class TestRedHatRelease(unittest.TestCase):

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -14,20 +14,15 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Required imports:
+
+
+import unittest
+
 from collections import namedtuple
 
-# Required imports:
-import os
 from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
-
-try:
-    import unittest2 as unittest  # Python 2.6 support
-except ImportError:
-    import unittest
-
-from convert2rhel import logger
-from convert2rhel import subscription
-from convert2rhel import utils
+from convert2rhel import logger, subscription, utils
 from convert2rhel.toolopts import tool_opts
 
 

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -22,6 +22,9 @@ import logging
 import os
 import shutil
 
+from convert2rhel.unit_tests import skipIf
+from convert2rhel.utils import is_rpm_based_os
+
 try:
     import unittest2 as unittest  # Python 2.6 support
 except ImportError:
@@ -131,6 +134,7 @@ class TestSysteminfo(unittest.TestCase):
         data=[['.M.......  g /etc/pki/ca-trust/extracted/java/cacerts'],
               ['.M.......  g /etc/pki/ca-trust/extracted/java/cacerts',
                'S.5....T.  c /etc/yum.conf']]))
+    @skipIf(not is_rpm_based_os(), reason="Current test runs only on rpm based systems.")
     def test_modified_rpm_files_diff_with_differences_after_conversion(self):
         system_info.modified_rpm_files_diff()
         self.assertTrue(any('S.5....T.  c /etc/yum.conf' in elem for elem in system_info.logger.info_msgs))

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -21,20 +21,14 @@
 import logging
 import os
 import shutil
+import unittest
 
+from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
+from convert2rhel import logger, utils
+from convert2rhel.systeminfo import system_info
+from convert2rhel.toolopts import tool_opts
 from convert2rhel.unit_tests import skipIf
 from convert2rhel.utils import is_rpm_based_os
-
-try:
-    import unittest2 as unittest  # Python 2.6 support
-except ImportError:
-    import unittest
-
-from convert2rhel import logger
-from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
-from convert2rhel import utils
-from convert2rhel.toolopts import tool_opts
-from convert2rhel.systeminfo import system_info
 
 
 class TestSysteminfo(unittest.TestCase):

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -19,14 +19,11 @@
 
 
 import sys
+import unittest
 
-try:
-    import unittest2 as unittest  # Python 2.6 support
-except ImportError:
-    import unittest
+import convert2rhel.toolopts
 
 from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
-import convert2rhel.toolopts
 from convert2rhel.toolopts import tool_opts
 
 

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -19,6 +19,8 @@
 import re
 import os
 
+from convert2rhel.utils import is_rpm_based_os
+
 try:
     import unittest2 as unittest  # Python 2.6 support
 except ImportError:
@@ -212,3 +214,6 @@ class TestUtils(unittest.TestCase):
             path = utils.get_rpm_path_from_yumdownloader_output("cmd not important", output, utils.TMP_DIR)
 
             self.assertEqual(path, os.path.join(utils.TMP_DIR, self.DOWNLOADED_RPM_FILENAME))
+
+    def test_is_rpm_based_os(self):
+        assert is_rpm_based_os() in (True, False)

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -16,18 +16,13 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-import re
 import os
-
-from convert2rhel.utils import is_rpm_based_os
-
-try:
-    import unittest2 as unittest  # Python 2.6 support
-except ImportError:
-    import unittest
+import re
+import unittest
 
 from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel import utils
+from convert2rhel.utils import is_rpm_based_os
 
 
 class TestUtils(unittest.TestCase):

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -127,7 +127,7 @@ def run_subprocess(cmd="", print_cmd=True, print_output=True):
     if print_cmd:
         loggerinst.debug("Calling command '%s'" % cmd)
 
-    # Python 2.6 has a bug in shlex that interprets certain characters in a string as 
+    # Python 2.6 has a bug in shlex that interprets certain characters in a string as
     # a NULL character. This is a workaround that encodes the string to avoid the issue.
     if sys.version_info[0] == 2 and sys.version_info[1] == 6:
         cmd = cmd.encode("ascii")
@@ -533,3 +533,13 @@ class RestorablePackage(object):
 
 
 changed_pkgs_control = ChangedRPMPackagesController()  # pylint: disable=C0103
+
+
+def is_rpm_based_os():
+    """Check if the OS is rpm based."""
+    try:
+        run_subprocess("rpm")
+    except EnvironmentError:
+        return False
+    else:
+        return True


### PR DESCRIPTION
After this MR it will be possible to run tests locally on non-CentOS systems.
Also, python2.6, 2.7, 3 compatible `skipIf` decorator is introduced, that allows to skip tests on condition. API is similar to https://docs.python.org/2/library/unittest.html#unittest.skipIf 

Skipped tests are reported in the testing session log:
```
centos6_1  | ............/data/convert2rhel/unit_tests/__init__.py:182: UserWarning: Test <function test_call_yum_cmd_w_downgrades_continuous_fail at 0x1fba7d0> skipped. Reason: Current test runs only on rpm based systems.
centos6_1  |   warn("Test %r skipped. Reason: %s" % (test_item, reason))
centos6_1  | ...................../data/convert2rhel/unit_tests/__init__.py:182: UserWarning: Test <function test_get_rpm_header at 0x1fc41b8> skipped. Reason: Current test runs only on rpm based systems.
centos6_1  |   warn("Test %r skipped. Reason: %s" % (test_item, reason))
centos6_1  | ..................................................../data/convert2rhel/unit_tests/__init__.py:182: UserWarning: Test <function test_modified_rpm_files_diff_with_differences_after_conversion at 0x2034410> skipped. Reason: Current test runs only on rpm based systems.
centos6_1  |   warn("Test %r skipped. Reason: %s" % (test_item, reason))
centos6_1  | .........................
centos6_1  | ----------------------------------------------------------------------
centos6_1  | Ran 110 tests in 0.284s
centos6_1  | 
centos6_1  | OK
convert2rhel_centos6_1 exited with code 0
centos7_1  | ..............................................................................................................
centos7_1  | ----------------------------------------------------------------------
centos7_1  | Ran 110 tests in 1.970s
centos7_1  | 
centos7_1  | OK
centos8_1  | ..............................................................................................................
centos8_1  | ----------------------------------------------------------------------
centos8_1  | Ran 110 tests in 2.061s
centos8_1  | 
centos8_1  | OK
convert2rhel_centos7_1 exited with code 0
convert2rhel_centos8_1 exited with code 0
```