### PR TITLE
Improve logging of single-user mode check

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -66,6 +66,7 @@ def main():
         # We check for the single-user mode only after the resolve_system_info() call because that function stops
         # the conversion in case the system vendor/major version is not supported and we don't want users to go
         # through booting into single-user mode to just find this out.
+        loggerinst.task("Prepare: Require single-user mode")
         utils.require_single_user_mode()
         
         # backup system release file before starting conversion process

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -533,8 +533,10 @@ class RestorablePackage(object):
 
 
 def require_single_user_mode():
-    """
-    Make sure that the system is running in single-user mode and exit if it is not.
+    """Make sure that the system is running in single-user mode and exit if it is not.
+
+    If booted into multi-user mode, a different logged in user than the one executing the conversion may be interfering
+    with the system during the conversion, potentially leaving the system in an undefined state.
     """
     loggerinst = logging.getLogger(__name__)
 


### PR DESCRIPTION
The single-user mode check was kind of hidden:
- the check itself was not announced by the tool (TASK),
- ~~executing of the `runlevel` command was not logged,~~ (fixed in https://github.com/oamg/convert2rhel/pull/149)
- ~~the output of the `runlevel` command was always printed to the standard output - that was very mysterious (suddenly seeing `N 3` on the output)~~ (fixed in https://github.com/oamg/convert2rhel/pull/149)

Before:
```
[01/14/2021 22:52:25] TASK - [Prepare: Gather system information] *******************************
Name:                CentOS Linux
OS major version:    7
[01/14/2021 22:52:25] DEBUG - Calling command 'uname -i'
Architecture:        x86_64
Config filename:     centos-7-x86_64.cfg
Skipping the execution of 'rpm -Va'.
N 3
CRITICAL - Convert2RHEL requires the system to run in single-user mode.
[01/14/2021 22:52:25] DEBUG - Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/convert2rhel/main.py", line 69, in main
    utils.require_single_user_mode()
  File "/usr/lib/python2.7/site-packages/convert2rhel/utils.py", line 548, in require_single_user_mode
    loggerinst.critical("Convert2RHEL requires the system to run in single-user mode.")
  File "/usr/lib/python2.7/site-packages/convert2rhel/logger.py", line 106, in critical
    sys.exit(msg)
SystemExit: Convert2RHEL requires the system to run in single-user mode.
```

After:
```
[01/14/2021 22:53:52] TASK - [Prepare: Gather system information] *******************************
Name:                CentOS Linux
OS major version:    7
[01/14/2021 22:53:52] DEBUG - Calling command 'uname -i'
Architecture:        x86_64
Config filename:     centos-7-x86_64.cfg
Skipping the execution of 'rpm -Va'.

[01/14/2021 22:53:52] TASK - [Prepare: Require single-user mode] ********************************
[01/14/2021 22:53:52] DEBUG - Calling command 'runlevel'
CRITICAL - Convert2RHEL requires the system to run in single-user mode.
[01/14/2021 22:53:52] DEBUG - Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/convert2rhel/main.py", line 70, in main
    utils.require_single_user_mode()
  File "/usr/lib/python2.7/site-packages/convert2rhel/utils.py", line 546, in require_single_user_mode
    loggerinst.critical("Convert2RHEL requires the system to run in single-user mode.")
  File "/usr/lib/python2.7/site-packages/convert2rhel/logger.py", line 106, in critical
    sys.exit(msg)
SystemExit: Convert2RHEL requires the system to run in single-user mode.
```