### PR TITLE
add: pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,25 @@ repos:
       - id: debug-statements
       - id: detect-private-key
       - id: end-of-file-fixer
+  - repo: "https://github.com/psf/black"
+    rev: "20.8b1"
+    hooks:
+      - id: "black"
+        name: "Format code (black)"
+        language_version: "python3"
+  - repo: "https://github.com/asottile/blacken-docs"
+    rev: "v1.9.2"
+    hooks:
+      - id: "blacken-docs"
+        name: "Format docs (blacken-docs)"
+        language_version: "python3"
+        args: [ "-l", "64" ]
+        additional_dependencies:
+          - "black==20.8b1"
+  - repo: "https://github.com/timothycrosley/isort"
+    rev: 5.7.0
+    hooks:
+      - id: isort
+        language_version: "python3"
+        additional_dependencies: [ toml ]
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+exclude: ^(src/blib2to3/|profiling/|unit_tests/data/)
+
+repos:
+  - repo: https://github.com/pycqa/pylint
+    rev: pylint-2.6.0
+    hooks:
+      - id: pylint
+  - repo: git://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-yaml
+        args: [--unsafe]
+      - id: debug-statements
+      - id: detect-private-key
+      - id: end-of-file-fixer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,47 @@
 1. All python code must be python 2.6/2.7/3.6 compatible
 1. The code should follow linting from pylint
 
+## Prerequisites
+
+### Install pre-commit
+
+We use `pre-commit` to run code formatting/linting tools on each commit. `pre-commit` operates only on **staged** files, and will only run checks that are applicable to files that have changes staged.
+
+```console
+# Ubuntu/Fedora
+# (installs pre-commit to $HOME/bin - make sure this is in your PATH)
+$ curl https://pre-commit.com/install-local.py | python -
+
+# macOS
+$ brew install pre-commit
+```
+
+If you want to format and verify your code passes on `git commit`, you can install pre-commit hooks using:
+
+```console
+$ pre-commit install
+```
+
+At anytime if you need to disable pre-commit hooks, run:
+
+```console
+$ pre-commit uninstall
+```
+
+> **Note:** You can also run these hooks manually at any time by running the following inside the repository:
+>
+> ```console
+> $ pre-commit run
+> ```
+
+> **Note:** It's usually a good idea to run the hooks against all of the files when adding new hooks (usually `pre-commit` will only run on the changed files during git hooks)
+>
+> ```console
+> $ pre-commit run --all-files
+> ```
+
+
+
 ## Unit tests
 Our unit tests are run within containers. To first create the container images, run:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.black]
+line-length=79
+target-version=["py38"]
+
+[tool.isort]
+atomic=true
+line_length = 79
+lines_after_imports=2
+lines_between_types=1
+use_parentheses = true
+balanced_wrapping = true
+include_trailing_comma = true
+multi_line_output = 3
+known_third_party=[
+    "pytest",
+]
+known_first_party=[
+    "convert2rhel",
+]
+


### PR DESCRIPTION
This PR will add pre-commit hook on our environment.

### Reason

Today we rely on developers to verify important settings and lines of code. Which is not very reliable, since we can forget some line and end up breaking the master branch.

With this PR, pre-commit will check:
* pylint
* merge-conflict
* large files
* symlinks
* debug statements
* some private keys
* end of file