### PR TITLE
Now tests*,lint* targets automatically installs required dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ system_tests/vmdefs/centos*/.vagrant/
 *.copr.conf
 .vscode/*
 .venv/*
+.install
+.images

--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,53 @@
+.PHONY: \
+	force-rebuild \
+	install \
+	tests-locally \
+	lint-locally \
+	clean \
+	images \
+	tests \
+	lint \
+	lint-errors \
+	tests8 \
+
 # Project constants
 IMAGE ?= convert2rhel
 PYTHON ?= python3
 PIP ?= pip3
 VENV ?= .venv3
 
-.PHONY: all
 all: clean images tests
 
-.PHONY: install
-install:
+install: .install
+
+.install:
 	virtualenv --system-site-packages --python $(PYTHON) $(VENV); \
 	. $(VENV)/bin/activate; \
 	$(PIP) install --upgrade -r ./requirements/local.centos8.requirements.txt; \
 	$(PIP) install -e .
+	touch $@
 
-.PHONY: tests-locally
-tests-locally:
+tests-locally: install
 	. $(VENV)/bin/activate; pytest
 
-.PHONY: lint-locally
-lint-locally:
+lint-locally: install
 	. $(VENV)/bin/activate; ./scripts/run_lint.sh
 
-
-.PHONY: clean
 clean:
 	@rm -rf build/ dist/ *.egg-info .pytest_cache/
 	@find . -name '__pycache__' -exec rm -fr {} +
 	@find . -name '*.pyc' -exec rm -f {} +
 	@find . -name '*.pyo' -exec rm -f {} +
 
-.PHONY: images
-images:
+images: .images
+
+.images:
 	@docker build -f Dockerfiles/centos6.Dockerfile -t $(IMAGE)/centos6 .
 	@docker build -f Dockerfiles/centos7.Dockerfile -t $(IMAGE)/centos7 .
 	@docker build -f Dockerfiles/centos8.Dockerfile -t $(IMAGE)/centos8 .
+	touch $@
 
-.PHONY: tests
-tests:
+tests: images
 	@echo 'CentOS 6 tests'
 	@docker run --rm -v $(shell pwd):/data:Z $(IMAGE)/centos6 pytest
 	@echo 'CentOS 7 tests'
@@ -45,14 +55,11 @@ tests:
 	@echo 'CentOS 8 tests'
 	@docker run --rm -v $(shell pwd):/data:Z $(IMAGE)/centos8 pytest
 
-.PHONY: lint
-lint:
+lint: images
 	@docker run --rm -v $(shell pwd):/data:Z $(IMAGE)/centos8 bash -c "scripts/run_lint.sh"
 
-.PHONY: lint-errors
-lint-errors:
+lint-errors: images
 	@docker run --rm -v $(shell pwd):/data:Z $(IMAGE)/centos8 bash -c "scripts/run_lint.sh --errors-only"
 
-.PHONY: tests8
-tests8:
+tests8: images
 	@docker run --rm -v $(shell pwd):/data:Z $(IMAGE)/centos8 pytest


### PR DESCRIPTION
Adding some Makefile good practices. Now targets have dependencies. For example, running:

- make tests, will automatically build images for you (only first time)
- make tests-locally, will create the venv (also only first time) 