### PR TITLE
Feature/make java opendjdk work

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -20,7 +20,7 @@ import os
 import sys
 
 from convert2rhel import cert
-from convert2rhel import logger
+from convert2rhel import logger, special_cases
 from convert2rhel import pkghandler
 from convert2rhel import redhatrelease
 from convert2rhel import repo
@@ -157,6 +157,11 @@ def pre_ponr_conversion():
     # remove excluded packages
     loggerinst.task("Convert: Remove excluded packages")
     pkghandler.remove_excluded_pkgs()
+
+
+    # handle special cases
+    loggerinst.task("Convert: resolve possible edge cases")
+    special_cases.check_and_resolve()
 
     if not toolopts.tool_opts.disable_submgr:
         loggerinst.task("Convert: Subscription Manager - Download packages")

--- a/convert2rhel/special_cases.py
+++ b/convert2rhel/special_cases.py
@@ -1,0 +1,29 @@
+import logging
+
+from convert2rhel.systeminfo import system_info
+from convert2rhel.utils import mkdir_p
+
+
+OPENJDK_RPM_STATE_DIR = "/var/lib/rpm-state/"
+
+logger = logging.getLogger(__name__)
+
+
+def perform_java_openjdk_workaround():
+    if system_info.is_rpm_installed(name="java-1.7.0-openjdk"):
+        logger.info(
+            "Package java-1.7.0-openjdk found. Applying workaround in"
+            "accordance with https://access.redhat.com/solutions/3573891"
+        )
+        try:
+            mkdir_p(OPENJDK_RPM_STATE_DIR)
+        except OSError:
+            logger.warning(
+                "Can't create %s directory." % OPENJDK_RPM_STATE_DIR
+            )
+        else:
+            logger.info("openjdk workaround applied successfully.")
+
+
+def check_and_resolve():
+    perform_java_openjdk_workaround()

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from convert2rhel.utils import run_subprocess
 
 from collections import namedtuple
 try:
@@ -211,6 +212,13 @@ class SystemInfo(object):
         if modified_rpm_files_diff:
             self.logger.info(
                 "Comparison of modified rpm files from before and after the conversion:\n%s" % modified_rpm_files_diff)
+
+    @staticmethod
+    def is_rpm_installed(name):
+        _, return_code = run_subprocess(
+            "rpm -q '%s'" % name, print_cmd=False, print_output=False
+        )
+        return return_code == 0
 
 
 # Code to be executed upon module import

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -146,6 +146,7 @@ class TestMain(unittest.TestCase):
     @unit_tests.mock(main.logging, "getLogger", GetLoggerMocked())
     @unit_tests.mock(tool_opts, "disable_submgr", False)
     @unit_tests.mock(cert.SystemCert, "_get_cert_path", unit_tests.MockFunction)
+    @mock_calls(main.special_cases, "check_and_resolve", CallOrderMocked)
     @mock_calls(pkghandler, "remove_excluded_pkgs", CallOrderMocked)
     @mock_calls(subscription, "replace_subscription_manager", CallOrderMocked)
     @mock_calls(pkghandler, "remove_repofile_pkgs", CallOrderMocked)
@@ -165,6 +166,7 @@ class TestMain(unittest.TestCase):
         intended_call_order = OrderedDict()
         intended_call_order["list_third_party_pkgs"] = 1
         intended_call_order["remove_excluded_pkgs"] = 1
+        intended_call_order["check_and_resolve"] = 1
         intended_call_order["download_rhsm_pkgs"] = 1
         intended_call_order["replace_subscription_manager"] = 1
         intended_call_order["install"] = 1
@@ -185,6 +187,7 @@ class TestMain(unittest.TestCase):
     @unit_tests.mock(main.logging, "getLogger", GetLoggerMocked())
     @unit_tests.mock(tool_opts, "disable_submgr", False)
     @unit_tests.mock(cert.SystemCert, "_get_cert_path", unit_tests.MockFunction)
+    @mock_calls(main.special_cases, "check_and_resolve", CallOrderMocked)
     @mock_calls(pkghandler, "remove_excluded_pkgs", CallOrderMocked)
     @mock_calls(subscription, "replace_subscription_manager", CallOrderMocked)
     @mock_calls(pkghandler, "remove_repofile_pkgs", CallOrderMocked)
@@ -205,6 +208,7 @@ class TestMain(unittest.TestCase):
 
         intended_call_order["list_third_party_pkgs"] = 1
         intended_call_order["remove_excluded_pkgs"] = 1
+        intended_call_order["check_and_resolve"] = 1
 
         # Do not expect this one to be called - related to RHSM
         intended_call_order["download_rhsm_pkgs"] = 0

--- a/convert2rhel/unit_tests/special_cases_test.py
+++ b/convert2rhel/unit_tests/special_cases_test.py
@@ -1,0 +1,98 @@
+import sys
+
+import pytest
+
+from convert2rhel import special_cases
+from convert2rhel.special_cases import (
+    OPENJDK_RPM_STATE_DIR,
+    check_and_resolve,
+    perform_java_openjdk_workaround,
+)
+
+
+if sys.version_info[:2] <= (2, 7):
+    import mock  # pylint: disable=import-error
+else:
+    from unittest import mock  # pylint: disable=no-name-in-module
+
+
+@pytest.mark.parametrize(
+    (
+        "has_openjdk",
+        "can_successfully_apply_workaround",
+        "mkdir_p_should_raise",
+        "check_message_in_log",
+        "check_message_not_in_log",
+    ),
+    [
+        # All is fine case
+        (
+            True,
+            True,
+            None,
+            "openjdk workaround applied successfully.",
+            "Can't create %s" % OPENJDK_RPM_STATE_DIR,
+        ),
+        # openjdk presented, but OSError when trying to apply workaround
+        (
+            True,
+            False,
+            OSError,
+            "Can't create %s" % OPENJDK_RPM_STATE_DIR,
+            "openjdk workaround applied successfully.",
+        ),
+        # No openjdk
+        (False, False, None, None, None),
+    ],
+)
+def test_perform_java_openjdk_workaround(
+    has_openjdk,
+    can_successfully_apply_workaround,
+    mkdir_p_should_raise,
+    check_message_in_log,
+    check_message_not_in_log,
+    monkeypatch,
+    caplog,
+):
+    mkdir_p_mocked = (
+        mock.Mock(side_effect=mkdir_p_should_raise())
+        if mkdir_p_should_raise
+        else mock.Mock()
+    )
+    has_rpm_mocked = mock.Mock(return_value=has_openjdk)
+
+    monkeypatch.setattr(
+        special_cases,
+        "mkdir_p",
+        value=mkdir_p_mocked,
+    )
+    monkeypatch.setattr(
+        special_cases.system_info,
+        "is_rpm_installed",
+        value=has_rpm_mocked,
+    )
+    perform_java_openjdk_workaround()
+
+    # check logs
+    if check_message_in_log:
+        assert check_message_in_log in caplog.text
+    if check_message_not_in_log:
+        assert check_message_not_in_log not in caplog.text
+
+    # check calls
+    if has_openjdk:
+        mkdir_p_mocked.assert_called()
+    else:
+        mkdir_p_mocked.assert_not_called()
+    has_rpm_mocked.assert_called()
+
+
+def test_check_and_resolve(monkeypatch):
+    perform_java_openjdk_workaround_mock = mock.Mock()
+    monkeypatch.setattr(
+        special_cases,
+        "perform_java_openjdk_workaround",
+        value=perform_java_openjdk_workaround_mock,
+    )
+    check_and_resolve()
+    perform_java_openjdk_workaround_mock.assert_called()


### PR DESCRIPTION
**Blocked by:** #179  **and contains its commits**

Ref https://issues.redhat.com/browse/OAMG-4245

In accordance with https://access.redhat.com/solutions/3573891
create a /var/lib/rpm-state/ dir when we see java package on host.

This MR also introduces a new module for handling such special cases

TODO:
- [x] fix failing tests due to blind caplog fixture
    - [x] use logger propagate True and fix tests [BLOCKED]