### PR TITLE
Forbid python to create pycache in containers

### DIFF
--- a/Dockerfiles/centos6.Dockerfile
+++ b/Dockerfiles/centos6.Dockerfile
@@ -2,6 +2,7 @@ FROM centos:6 as base
 
 ENV PYTHON python2
 ENV PIP pip2
+ENV PYTHONDONTWRITEBYTECODE 1
 
 ENV URL_GET_PIP "https://bootstrap.pypa.io/2.6/get-pip.py"
 ENV APP_DEV_DEPS "requirements/centos6.requirements.txt"

--- a/Dockerfiles/centos7.Dockerfile
+++ b/Dockerfiles/centos7.Dockerfile
@@ -2,6 +2,7 @@ FROM centos:7 as base
 
 ENV PYTHON python2
 ENV PIP pip
+ENV PYTHONDONTWRITEBYTECODE 1
 
 ENV URL_GET_PIP "https://bootstrap.pypa.io/2.7/get-pip.py"
 ENV APP_DEV_DEPS "requirements/centos7.requirements.txt"

--- a/Dockerfiles/centos8.Dockerfile
+++ b/Dockerfiles/centos8.Dockerfile
@@ -2,6 +2,7 @@ FROM centos:8 as base
 
 ENV PYTHON python3
 ENV PIP pip3
+ENV PYTHONDONTWRITEBYTECODE 1
 
 ENV URL_GET_PIP "https://bootstrap.pypa.io/get-pip.py"
 ENV APP_DEV_DEPS "requirements/centos8.requirements.txt"


### PR DESCRIPTION
Due to running the tests inside the containers, there is no sense to cache pyc files, forever this creates additional overhead for the user to remove them before next tests.

This is fixed now