### PR TITLE
Add proper coverage config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+omit=
+    convert2rhel/unit_tests/*
+source=convert2rhel

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 testpaths = "convert2rhel/unit_tests"
-addopts = --cov-fail-under=84 --tb=native
+addopts = --cov-fail-under=73 --tb=native
 ;log_cli = false
 ;log_cli_level = DEBUG
 ;log_cli_format = "| %(asctime)s | %(name)s | %(levelname)s | %(filename)s | %(message)s"


### PR DESCRIPTION
Previously the coverage included the scope of tests itself. This is fixed now. Also, the min coverage margin to make the coverage job was adjusted to reflect the current state