### PR TITLE
Created rpms on publishing a new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Build release RPMs
 
 on:
   release:
-    types: [created]
+    types: [published, edited]
   
 jobs:
   build_el6_rpm:


### PR DESCRIPTION
The trigger on "created" was incorrect as that means the rpm-building GitHub Action is triggered even when a release **draft** is created. And then upon publishing the draft the GitHub Action is not triggered again, leaving the release without built rpms.
Release trigger types: https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#release

I've added "edit" type as well - that is just temporary to be able to trigger the action for the already [released version 0.16](https://github.com/oamg/convert2rhel/releases/tag/v0.16). After triggering it, I'll create a new PR removing the "edit" type.