### PR TITLE
Do not build rpms on GitHub release edit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Build release RPMs
 
 on:
   release:
-    types: [published, edited]
+    types: [published]
   
 jobs:
   build_el6_rpm:


### PR DESCRIPTION
I expected that we'll need the release edit trigger to have the packages built for the version 0.16 release, but it was not needed.
The [release publishing event](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#release) is the only trigger we need.

Related: https://github.com/oamg/convert2rhel/pull/173