### PR TITLE
Fix backing up packages

### DIFF
--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -170,9 +170,10 @@ class TestUtils(unittest.TestCase):
         "[SKIPPED] %s: Already downloaded" % DOWNLOADED_RPM_FILENAME
     ]
 
-    @unit_tests.mock(utils, "download_pkg", lambda pkg, dest, reposdir, enable_repos, disable_repos: "/filepath/")
+    @unit_tests.mock(utils, "download_pkg",
+                     lambda pkg, dest, reposdir, enable_repos, disable_repos, set_releasever: "/filepath/")
     def test_download_pkgs(self):
-        paths = utils.download_pkgs(["pkg1", "pkg2"], "/dest/", "/reposdir/", ["repo1"], ["repo2"])
+        paths = utils.download_pkgs(["pkg1", "pkg2"], "/dest/", "/reposdir/", ["repo1"], ["repo2"], False)
 
         self.assertEqual(paths, ["/filepath/", "/filepath/"])
 
@@ -187,7 +188,8 @@ class TestUtils(unittest.TestCase):
         disable_repos = ["*"]
         
         path = utils.download_pkg(
-            "kernel", dest=dest, reposdir=reposdir, enable_repos=enable_repos, disable_repos=disable_repos)
+            "kernel", dest=dest, reposdir=reposdir, enable_repos=enable_repos,
+            disable_repos=disable_repos, set_releasever=True)
 
         self.assertEqual('yumdownloader -v --destdir="%s" --setopt=reposdir="%s" --disablerepo="*" --enablerepo="repo1"'
                          ' --enablerepo="repo2" --releasever=8 --setopt=module_platform_id=platform:el8 kernel'

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -407,12 +407,12 @@ def install_pkgs(pkgs_to_install, replace=False, critical=True):
     return True
 
 
-def download_pkgs(pkgs, dest=TMP_DIR, reposdir=None, enable_repos=None, disable_repos=None):
+def download_pkgs(pkgs, dest=TMP_DIR, reposdir=None, enable_repos=None, disable_repos=None, set_releasever=True):
     """A wrapper for the download_pkg function allowing to download multiple packages."""
-    return [download_pkg(pkg, dest, reposdir, enable_repos, disable_repos) for pkg in pkgs]
+    return [download_pkg(pkg, dest, reposdir, enable_repos, disable_repos, set_releasever) for pkg in pkgs]
     
 
-def download_pkg(pkg, dest=TMP_DIR, reposdir=None, enable_repos=None, disable_repos=None):
+def download_pkg(pkg, dest=TMP_DIR, reposdir=None, enable_repos=None, disable_repos=None, set_releasever=True):
     """Download an rpm using yumdownloader and return its filepath. If not successful, return None.
 
     The enable_repos and disable_repos function parameters accept lists. If used, the repos are passed to the
@@ -437,7 +437,7 @@ def download_pkg(pkg, dest=TMP_DIR, reposdir=None, enable_repos=None, disable_re
         for repo in enable_repos:
             cmd += ' --enablerepo="%s"' % repo
 
-    if system_info.releasever:
+    if set_releasever and system_info.releasever:
         cmd += " --releasever=%s" % system_info.releasever
 
     if system_info.version.major == 8:
@@ -553,7 +553,9 @@ class RestorablePackage(object):
         loggerinst = logging.getLogger(__name__)
         loggerinst.info("Backing up %s" % self.name)
         if os.path.isdir(BACKUP_DIR):
-            self.path = download_pkg(self.name, dest=BACKUP_DIR)
+            # When backing up the packages, the original system repofiles are still available and for them we can't
+            # use the releasever for RHEL repositories
+            self.path = download_pkg(self.name, dest=BACKUP_DIR, set_releasever=False)
         else:
             loggerinst.warning("Can't access %s" % TMP_DIR)
 


### PR DESCRIPTION
We were passing incorrect --releasever to the yumdownloader call. This releasever is to be used with RHEL repositories, not with the original system repositories.
It caused the pkg download to not be able to access the original system repositories and thus to not download the packages for the rollback.