### PR TITLE
Use RHSM repos for downloading same version kernel

### DIFF
--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -612,9 +612,12 @@ def replace_non_rhel_installed_kernel(version):
 
     pkg = "kernel-%s" % version
 
+    # For downloading the RHEL kernel we need to use the RHEL repositories. Those are available either through the
+    # attached subscription (submgr_enabled_repos) or through custom repositories (tool_opts.enablerepo).
+    repos_to_enable = system_info.submgr_enabled_repos if not tool_opts.disable_submgr else tool_opts.enablerepo
     path = utils.download_pkg(
         pkg=pkg, dest=utils.TMP_DIR, disable_repos=tool_opts.disablerepo,
-        enable_repos=tool_opts.enablerepo)
+        enable_repos=repos_to_enable)
     if not path:
         loggerinst.critical("Unable to download the RHEL kernel package.")
 


### PR DESCRIPTION
For the case when the all installed kernels have the same version as those available in RHEL repos, we need to download one of the RHEL kernels and force replace the already installed one. However for the download we were using only the RHEL repos passed through the --enablerepo option. That would cause the download to fail if the tool uses RHSM and not custom repos (--enablerepo).

TODO:

- [x] Cover by unit tests