### PR TITLE
Allow caplog see logger entries

### DIFF
--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -44,10 +44,11 @@ class LogLevelFile(object):
     label = "FILE"
 
 
-def initialize_logger(log_name):
+def initialize_logger(log_name, log_dir=LOG_DIR):
     """Initialize custom logging levels, handlers, and so on. Call this method
     from your application's main start point.
         log_name = the name for the log file
+        log_dir = path to the dir where log file will be presented
     """
     # check if already initialized with custom class
     if logging.getLoggerClass() == CustomLogger:
@@ -62,7 +63,7 @@ def initialize_logger(log_name):
     # get root logger
     logger = logging.getLogger("convert2rhel")
     # propagate
-    logger.propagate = False
+    logger.propagate = True
     # set default logging level
     logger.setLevel(LogLevelFile.level)
 
@@ -75,9 +76,9 @@ def initialize_logger(log_name):
     logger.addHandler(stdout_handler)
 
     # create file handler
-    if not os.path.isdir(LOG_DIR):
-        os.makedirs(LOG_DIR)
-    handler = logging.FileHandler(os.path.join(LOG_DIR, log_name), "a")
+    if not os.path.isdir(log_dir):
+        os.makedirs(log_dir)    # pragma: no cover
+    handler = logging.FileHandler(os.path.join(log_dir, log_name), "a")
     formatter = CustomFormatter("%(message)s")
     formatter.disable_colors(True)
     handler.setFormatter(formatter)

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -1,0 +1,53 @@
+import sys
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def is_py26():
+    return sys.version_info[:2] == (2, 6)
+
+
+@pytest.fixture(scope="session")
+def is_py2():
+    return sys.version_info[:2] <= (2, 7)
+
+
+@pytest.fixture()
+def tmpdir(tmpdir, is_py2):
+    """Make tmpdir type str for py26.
+
+    Origin LocalPath object is not supported in python26 for os.path.isdir.
+    We're using this method when do a logger setup.
+    """
+    if is_py2:
+        return str(tmpdir)
+    else:
+        return tmpdir
+
+
+@pytest.fixture()
+def read_std(capsys, is_py2):
+    """Multipython compatible, modified version of capsys.
+
+    Example:
+    >>> def test_example(read_std):
+    >>>     import sys
+    >>>     sys.stdout.write("stdout")
+    >>>     sys.stderr.write("stderr")
+    >>>     std_out, std_err = read_std()
+    >>>     assert "stdout" in std_out
+    >>>     assert "stderr" in std_err
+
+    :returns: Callable[Tuple[str, str]] Factory that reads the stdouterr and
+        returns captured stdout and stderr strings
+    """
+
+    def factory():
+        stdouterr = capsys.readouterr()
+        if is_py2:
+            return stdouterr
+        else:
+            return stdouterr.out, stdouterr.err
+
+    return factory

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -16,109 +16,63 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
-import os
-import shutil
-import unittest
 
-from datetime import datetime
+import pytest
 
-from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
-from convert2rhel import logger
+from convert2rhel import logger as logger_module
+from convert2rhel.logger import CustomLogger
 from convert2rhel.toolopts import tool_opts
 
 
-class TestLogger(unittest.TestCase):
+def test_logger_handlers(tmp_path, caplog, capsys):
+    """Test if the logger handlers emmits the events to the file and stdout."""
+    # initializing the logger first
+    log_fname = "convert2rhel.log"
+    tool_opts.debug = True  # debug entries > stdout if True
+    logger_module.initialize_logger(log_name=log_fname, log_dir=tmp_path)
+    logger = logging.getLogger(__name__)
 
-    @unit_tests.mock(logger, "LOG_DIR", unit_tests.TMP_DIR)
-    def setUp(self):
-        # initialize class variables
-        self.log_dir = logger.LOG_DIR
-        self.log_file = "convert2rhel.log"
-        self.test_msg = "testmsg"
+    # emitting some log entries
+    logger.info("Test info")
+    logger.debug("Test debug")
 
-        # remove the directory to ensure the content is clean
-        if os.path.exists(logger.LOG_DIR):
-            shutil.rmtree(logger.LOG_DIR)
-        # initialize logger
-        logger.initialize_logger(self.log_file)
+    # Test if logs were emmited to the file
+    with open(tmp_path / log_fname) as log_f:
+        assert "Test info" in log_f.readline().rstrip()
+        assert "Test debug" in log_f.readline().rstrip()
 
-    def test_set_logger(self):
-        loggerinst = logging.getLogger("convert2rhel.unittests")
-        handlers = loggerinst.handlers
+    # Test if logs were emmited to the stdout
+    stdouterr = capsys.readouterr()
+    assert "Test info" in stdouterr.out
+    assert "Test debug" in stdouterr.out
 
-        # find parent logger instances where our handlers exist
-        while len(handlers) == 0:
-            loggerinst = loggerinst.parent
-            handlers = loggerinst.handlers
 
-        # verify both StreamHandler and FileHandler have been created
-        has_stream_handler_instance = False
-        has_file_handler_instance = False
-        for handler in handlers:
-            if isinstance(handler, logging.StreamHandler):
-                has_stream_handler_instance = True
-            if isinstance(handler, logging.FileHandler):
-                has_file_handler_instance = True
+def test_tools_opts_debug_(tmp_path, capsys):
+    log_fname = "convert2rhel.log"
+    logger_module.initialize_logger(log_name=log_fname, log_dir=tmp_path)
+    logger = logging.getLogger(__name__)
+    tool_opts.debug = True
+    logger.debug("debug entry 1")
+    stdouterr = capsys.readouterr()
+    # TODO should be in stdout, but this only works when running this test
+    #   alone (see https://github.com/pytest-dev/pytest/issues/5502)
+    try:
+        assert "debug entry 1" in stdouterr.out
+    except AssertionError:
+        assert "debug entry 1" in stdouterr.err
+    tool_opts.debug = False
+    logger.debug("debug entry 2")
+    stdouterr = capsys.readouterr()
+    assert "debug entry 2" not in stdouterr.out
 
-        self.assertTrue(has_stream_handler_instance)
-        self.assertTrue(has_file_handler_instance)
 
-        # verify log file name
-        for handler in handlers:
-            if type(handler) is logging.FileHandler:
-                log_path = os.path.join(self.log_dir, self.log_file)
-                self.assertEqual(log_path, handler.baseFilename)
-
-    def test_log_format(self):
-        self.dummy_handler = logging.StreamHandler()
-
-        custom_formatter = logger.CustomFormatter("%(message)s")
-
-        self.dummy_handler.setFormatter(custom_formatter)
-        dt_strformat = '[%m/%d/%Y %H:%M:%S] DEBUG - '
-        tempstr = datetime.now().strftime(dt_strformat) + self.test_msg
-        self.check_formatter_result(
-            logging.DEBUG, tempstr)
-        self.check_formatter_result(
-            logging.INFO, self.test_msg)
-        tempstr = "\033[93mWARNING - %s\033[0m" % self.test_msg
-        self.check_formatter_result(logging.WARNING, tempstr)
-
-        custom_formatter.disable_colors(True)
-        tempstr = "WARNING - %s" % self.test_msg
-        self.check_formatter_result(logging.WARNING, tempstr)
-
-    def check_formatter_result(self, log_level, expected_result):
-        rec = logging.LogRecord("", log_level, "", 0, self.test_msg, (), None)
-        formatted_msg = self.dummy_handler.format(rec)
-        self.assertEqual(formatted_msg, expected_result)
-
-    class HandlerHandleMocked(unit_tests.MockFunction):
-        def __init__(self):
-            self.called = 0
-
-        def __call__(self, rec):
-            self.called += 1
-
-    @unit_tests.mock(logging.Handler, "handle", HandlerHandleMocked())
-    def test_log_to_file(self):
-        loggerinst = logging.getLogger(__name__)
-        loggerinst.file(self.test_msg)
-
-        # Handler is a base class for all log handlers (incl. FileHandler)
-        self.assertEqual(logging.Handler.handle.called, 1)
-
-    @unit_tests.mock(logging.Handler, "handle", HandlerHandleMocked())
-    @unit_tests.mock(tool_opts, "debug", True)
-    def test_log(self):
-        loggerinst = logging.getLogger(__name__)
-        loggerinst.debug("debugmsg1")
-        loggerinst.info("infomsg")
-        loggerinst.warning("warningmsg")
-
-        # generic handler called (2 handlers called for each function above)
-        # except debug level which is logged only with --debug option
-        self.assertEqual(logging.Handler.handle.called, 6)
-        tool_opts.debug = False
-        loggerinst.debug("debugmsg2")
-        self.assertEqual(logging.Handler.handle.called, 7)
+def test_logger_custom_logger(tmp_path, caplog):
+    """Test CustomLogger."""
+    log_fname = "convert2rhel.log"
+    logger_module.initialize_logger(log_name=log_fname, log_dir=tmp_path)
+    logger = logging.getLogger(__name__)
+    assert isinstance(logger, CustomLogger)
+    logger.task("Some task")
+    logger.file("Some task write to file")
+    with pytest.raises(SystemExit):
+        logger.critical("Critical error")

--- a/requirements/centos6.requirements.txt
+++ b/requirements/centos6.requirements.txt
@@ -3,3 +3,5 @@ astroid==1.2
 unittest2==0.5.1
 pytest==3.2.5
 pytest-cov==2.5.1
+mock==2.0.0
+pytest-catchlog==1.2.2

--- a/requirements/centos7.requirements.txt
+++ b/requirements/centos7.requirements.txt
@@ -2,3 +2,4 @@ pylint==1.9.5
 astroid==1.6.6
 pytest==4.6.11
 pytest-cov==2.11.0
+mock==2.0.0


### PR DESCRIPTION
Caplog adds its own handler to the root logger to track the records, however
our logger setup blocks the handler from being propagated to all child loggers.
This makes the caplog blind to the emitted entries.

Also, tests are rewritten in pytest because the old way was tested the logger
indirectly, switching to propagate=True led to inconsistent results across
different Python versions, which makes it hard to test.

The logger module coverage increased from 93 -> 100%

Also added helper fixtures to capture stdout and stderr