### PR TITLE
Do not check deps when force replacing kernel

### DIFF
--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -620,7 +620,9 @@ def replace_non_rhel_installed_kernel(version):
 
     loggerinst.info("Replacing %s %s with RHEL kernel with the same NEVRA ... " % (system_info.name, pkg))
     output, ret_code = utils.run_subprocess(
-        'rpm -i --force --replacepkgs %s*' % os.path.join(utils.TMP_DIR, pkg),
+        # The --nodeps is needed as some kernels depend on system-release (alias for redhat-release) and that package
+        # is not installed at this stage.
+        'rpm -i --force --nodeps --replacepkgs %s*' % os.path.join(utils.TMP_DIR, pkg),
         print_output=False)
     if ret_code != 0:
         loggerinst.critical("Unable to replace the kernel package: %s" % output)

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -862,7 +862,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertEqual(utils.download_pkg.called, 1)
         self.assertEqual(utils.download_pkg.pkg, "kernel-4.7.4-200.fc24")
         self.assertEqual(utils.run_subprocess.cmd,
-                         "rpm -i --force --replacepkgs %skernel-4.7.4-200.fc24*" % utils.TMP_DIR)
+                         "rpm -i --force --nodeps --replacepkgs %skernel-4.7.4-200.fc24*" % utils.TMP_DIR)
 
     @unit_tests.mock(utils, "ask_to_continue", DumbCallableObject())
     @unit_tests.mock(utils, "download_pkg", DownloadPkgMocked())


### PR DESCRIPTION
Under typical circumstances, kernel is installed using yum and with that the system-release/redhat-release pkg is installed as a dependency. However when the original OR kernel and RHEL kernel have the same version, we install it through rpm which causes the "system-release is needed by kernel" error because system-release/redhat-release is not installed at that point.

Reported in https://github.com/oamg/convert2rhel/issues/166.