### PR TITLE
Bump to version 0.17

### DIFF
--- a/packaging/convert2rhel.spec
+++ b/packaging/convert2rhel.spec
@@ -9,7 +9,7 @@
 %endif
 
 Name:           convert2rhel
-Version:        0.16
+Version:        0.17
 Release:        1%{?dist}
 Summary:        Automates the conversion of RHEL derivative distributions to RHEL
 
@@ -107,6 +107,11 @@ install -p man/%{name}.8 %{buildroot}%{_mandir}/man8/
 %attr(0644,root,root) %{_mandir}/man8/%{name}.8*
 
 %changelog
+* Thu Feb 10 2021 Michal Bocek <mbocek@redhat.com> 0.17-1
+- Fix broken package backup causing an incomplete rollback
+- Fix dependency issue when force replacing same-version kernel
+- Allow using RHSM repos when downloading same-version kernel
+
 * Thu Feb 4 2021 Michal Bocek <mbocek@redhat.com> 0.16-1
 - Not requiring users to download redhat-release and subscription-manager with
   its dependencies prior the conversion when using RHSM.

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def read(fname):
 
 setup(
     name='convert2rhel',
-    version='0.16',
+    version='0.17',
     description='Automates the conversion of Red Hat Enterprise Linux'
                 ' derivative distributions to Red Hat Enterprise Linux.',
     long_description=read('README.md'),


### PR DESCRIPTION
Changes in this version include:
- Fix broken package backup causing an incomplete rollback (#177)
- Fix dependency issue when force replacing same-version kernel (#182)
- Allow using RHSM repos when downloading same-version kernel (#178)