### PR TITLE
Rework patching yum.conf

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -217,6 +217,13 @@ def post_ponr_conversion():
     pkghandler.replace_non_red_hat_packages()
     loggerinst.task("Convert: List remaining non-Red Hat packages")
     pkghandler.list_non_red_hat_pkgs_left()
+    
+    # if user modified /etc/yum.conf, then comment out the distroverpkg variable in yum.conf
+    output, return_code = utils.run_subprocess("rpm -V yum", False, False)
+    if return_code != 0:
+        loggerinst.task("Convert: Patch yum configuration file")
+        redhatrelease.YumConf().patch()
+
     return
 
 

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -78,7 +78,6 @@ def main():
         # backup system release file before starting conversion process
         loggerinst.task("Prepare: Backup System")
         redhatrelease.system_release_file.backup()
-        redhatrelease.yum_conf.backup()
         repo.backup_yum_repos()
 
         loggerinst.task("Prepare: Clear YUM/DNF version locks")
@@ -197,10 +196,6 @@ def pre_ponr_conversion():
         loggerinst.task("Convert: Subscription Manager - Enable RHEL repositories")
         subscription.enable_repos(rhel_repoids)
 
-    # comment out the distroverpkg variable in yum.conf
-    loggerinst.task("Convert: Patch yum configuration file")
-    redhatrelease.YumConf().patch()
-
     # perform final checks before the conversion
     loggerinst.task("Convert: Final system checks before main conversion")
     checks.perform_pre_ponr_checks()
@@ -217,12 +212,9 @@ def post_ponr_conversion():
     pkghandler.replace_non_red_hat_packages()
     loggerinst.task("Convert: List remaining non-Red Hat packages")
     pkghandler.list_non_red_hat_pkgs_left()
-    
-    # if user modified /etc/yum.conf, then comment out the distroverpkg variable in yum.conf
-    output, return_code = utils.run_subprocess("rpm -V yum", False, False)
-    if return_code != 0:
-        loggerinst.task("Convert: Patch yum configuration file")
-        redhatrelease.YumConf().patch()
+
+    loggerinst.task("Convert: Patch yum configuration file")
+    redhatrelease.YumConf().patch()
 
     return
 
@@ -244,7 +236,6 @@ def rollback_changes():
     utils.changed_pkgs_control.restore_pkgs()
     repo.restore_yum_repos()
     redhatrelease.system_release_file.restore()
-    redhatrelease.yum_conf.restore()
     pkghandler.versionlock_file.restore()
     system_cert = cert.SystemCert()
     system_cert.remove()

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -130,7 +130,6 @@ class TestMain(unittest.TestCase):
         unit_tests.CountableMockObject(),
     )
     @unit_tests.mock(repo, "restore_yum_repos", unit_tests.CountableMockObject())
-    @unit_tests.mock(redhatrelease.yum_conf, "restore", unit_tests.CountableMockObject())
     @unit_tests.mock(subscription, "rollback", unit_tests.CountableMockObject())
     @unit_tests.mock(
         pkghandler.versionlock_file,
@@ -144,7 +143,6 @@ class TestMain(unittest.TestCase):
         self.assertEqual(utils.changed_pkgs_control.restore_pkgs.called, 1)
         self.assertEqual(repo.restore_yum_repos.called, 1)
         self.assertEqual(redhatrelease.system_release_file.restore.called, 1)
-        self.assertEqual(redhatrelease.yum_conf.restore.called, 1)
         self.assertEqual(subscription.rollback.called, 1)
         self.assertEqual(pkghandler.versionlock_file.restore.called, 1)
         self.assertEqual(cert.SystemCert.remove.called, 1)
@@ -160,7 +158,6 @@ class TestMain(unittest.TestCase):
     @mock_calls(subscription, "verify_rhsm_installed", CallOrderMocked)
     @mock_calls(pkghandler, "remove_repofile_pkgs", CallOrderMocked)
     @mock_calls(cert.SystemCert, "install", CallOrderMocked)
-    @mock_calls(redhatrelease.YumConf, "patch", CallOrderMocked)
     @mock_calls(pkghandler, "list_third_party_pkgs", CallOrderMocked)
     @mock_calls(subscription, "subscribe_system", CallOrderMocked)
     @mock_calls(repo, "get_rhel_repoids", CallOrderMocked)
@@ -187,7 +184,6 @@ class TestMain(unittest.TestCase):
         intended_call_order["disable_repos"] = 1
         intended_call_order["remove_repofile_pkgs"] = 1
         intended_call_order["enable_repos"] = 1
-        intended_call_order["patch"] = 1
         intended_call_order["perform_pre_ponr_checks"] = 1
         intended_call_order["perform_pre_checks"] = 1
 
@@ -208,7 +204,6 @@ class TestMain(unittest.TestCase):
     @mock_calls(subscription, "verify_rhsm_installed", CallOrderMocked)
     @mock_calls(pkghandler, "remove_repofile_pkgs", CallOrderMocked)
     @mock_calls(cert.SystemCert, "install", CallOrderMocked)
-    @mock_calls(redhatrelease.YumConf, "patch", CallOrderMocked)
     @mock_calls(pkghandler, "list_third_party_pkgs", CallOrderMocked)
     @mock_calls(subscription, "subscribe_system", CallOrderMocked)
     @mock_calls(repo, "get_rhel_repoids", CallOrderMocked)
@@ -241,7 +236,6 @@ class TestMain(unittest.TestCase):
 
         intended_call_order["enable_repos"] = 0
 
-        intended_call_order["patch"] = 1
         intended_call_order["perform_pre_ponr_checks"] = 1
 
         # Merge the two together like a zipper, creates a tuple which we can assert with - including method call order!

--- a/plans/integration/changed-yum-conf/main.fmf
+++ b/plans/integration/changed-yum-conf/main.fmf
@@ -1,0 +1,8 @@
+discover+:
+    filter:
+        - 'tag: changed-yum-conf'
+
+provision:
+    how: libvirt
+    origin_vm_name: c2r_centos7_template
+    develop: true

--- a/tests/integration/changed-yum-conf/main.fmf
+++ b/tests/integration/changed-yum-conf/main.fmf
@@ -1,0 +1,5 @@
+summary: changed-yum-conf
+
+tag+:
+    - changed-yum-conf
+test: pytest -svv

--- a/tests/integration/changed-yum-conf/test_patch_yum_conf.py
+++ b/tests/integration/changed-yum-conf/test_patch_yum_conf.py
@@ -1,0 +1,32 @@
+import pytest
+
+
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
+
+from envparse import env
+
+
+def test_yum_patch(convert2rhel, shell):
+    """Test the scenario in which the user modifies /etc/yum.conf before the conversion.
+    In that case during the conversion the config file does not get replaced with the config file from the RHEL package
+    (%config(noreplace)) and we need to make sure that we patch the config file to get rid of the distroverpkg config
+    key. Leaving the distroverpkg key there would lead to errors when calling yum after the conversion for not
+    expanding the $releasever variable properly.
+    """
+    shell("echo '#random text' >> /etc/yum.conf")
+
+    with convert2rhel(
+        ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        c2r.expect("/etc/yum.conf patched.")
+    assert c2r.exitstatus == 0
+
+    assert shell("yum update -y").returncode == 0


### PR DESCRIPTION
Since https://github.com/oamg/convert2rhel/pull/105 we do no longer install the redhat-release package but instead we copy the RHSM certificates to the system.

Yet currently we are commenting out the distroverpkg variable from the /etc/yum.conf. For example on CentOS 7 it's distroverpkg=centos-release. This variable tells yum at which package to look at to be able to expand the $releasever variable. But in https://github.com/oamg/convert2rhel/pull/105 we've started using the --releasever yum option for every yum call.

The conf patching is not necessary anymore, except one use case - when user touches the yum.conf prior executing the conversion (`rpm -V yum`). Then during the conversion yum is replaced but not this config file, so it keeps the distroverpkg variable. If we don't patch the conf in this case, after the conversion every yum call would fail to expand the releasever var.

The above case can be safely done as one of the last steps of the conversion. We don't need to do that at the beginning as we do that now. Leaving it up to the end has the advantage of not needing to backup and restore the file in case of conversion failure.
