### PR TITLE
Feature/use logger instead of custom logger

### DIFF
--- a/Dockerfiles/centos6.Dockerfile
+++ b/Dockerfiles/centos6.Dockerfile
@@ -24,7 +24,8 @@ COPY $APP_DEV_DEPS $APP_DEV_DEPS
 RUN $PIP install -r $APP_DEV_DEPS
 
 FROM install_dev_deps as install_application
-RUN useradd -u 5000 app
+RUN groupadd --gid=1000 -r app && \
+    useradd -r --uid=1000 --gid=1000 app
 RUN chown -R app:app .
-COPY . .
+COPY --chown=app:app . .
 USER app:app

--- a/Dockerfiles/centos7.Dockerfile
+++ b/Dockerfiles/centos7.Dockerfile
@@ -21,7 +21,8 @@ COPY $APP_DEV_DEPS $APP_DEV_DEPS
 RUN $PIP install -r $APP_DEV_DEPS
 
 FROM install_dev_deps as install_application
-RUN useradd -u 5000 app
+RUN groupadd --gid=1000 -r app && \
+    useradd -r --uid=1000 --gid=1000 app
 RUN chown -R app:app .
-COPY . .
+COPY --chown=app:app . .
 USER app:app

--- a/Dockerfiles/centos8.Dockerfile
+++ b/Dockerfiles/centos8.Dockerfile
@@ -22,7 +22,8 @@ COPY $APP_DEV_DEPS $APP_DEV_DEPS
 RUN $PIP install -r $APP_DEV_DEPS
 
 FROM install_dev_deps as install_application
-RUN useradd -u 5000 app
+RUN groupadd --gid=1000 -r app && \
+    useradd -r --uid=1000 --gid=1000 app
 RUN chown -R app:app .
-COPY . .
+COPY --chown=app:app . .
 USER app:app

--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,11 @@ images: .images
 
 tests: images
 	@echo 'CentOS 6 tests'
-	@docker run --rm -v $(shell pwd):/data:Z $(IMAGE)/centos6 pytest
+	@docker run --user=$(id -ur):$(id -gr) --rm -v $(shell pwd):/data:Z $(IMAGE)/centos6 pytest
 	@echo 'CentOS 7 tests'
-	@docker run --rm -v $(shell pwd):/data:Z $(IMAGE)/centos7 pytest
+	@docker run --user=$(id -ur):$(id -gr) --rm -v $(shell pwd):/data:Z $(IMAGE)/centos7 pytest
 	@echo 'CentOS 8 tests'
-	@docker run --rm -v $(shell pwd):/data:Z $(IMAGE)/centos8 pytest
+	@docker run --user=$(id -ur):$(id -gr) --rm -v $(shell pwd):/data:Z $(IMAGE)/centos8 pytest
 
 lint: images
 	@docker run --rm -v $(shell pwd):/data:Z $(IMAGE)/centos8 bash -c "scripts/run_lint.sh"

--- a/convert2rhel/cert.py
+++ b/convert2rhel/cert.py
@@ -18,11 +18,11 @@
 import logging
 import os
 import shutil
-import sys
 
-from convert2rhel.systeminfo import system_info
-from convert2rhel.toolopts import tool_opts
 from convert2rhel import utils
+
+
+loggerinst = logging.getLogger(__name__)
 
 
 class SystemCert(object):
@@ -33,7 +33,6 @@ class SystemCert(object):
 
     @staticmethod
     def _get_cert_path():
-        loggerinst = logging.getLogger(__name__)
         cert_dir = os.path.join(utils.DATA_DIR, "rhel-certs")
         if not os.access(cert_dir, os.R_OK | os.W_OK):
             loggerinst.critical("Error: Could not access %s." % cert_dir)
@@ -50,7 +49,6 @@ class SystemCert(object):
         """RHEL certificate (.pem) is used by subscription-manager to
         determine the running system type/version.
         """
-        loggerinst = logging.getLogger(__name__)
         loggerinst.info("Installing RHEL certificate to the system.")
 
         try:

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -19,15 +19,21 @@ import logging
 import os
 import sys
 
-from convert2rhel import cert
-from convert2rhel import logger, special_cases
-from convert2rhel import pkghandler
-from convert2rhel import redhatrelease
-from convert2rhel import repo
-from convert2rhel import subscription
-from convert2rhel import systeminfo
-from convert2rhel import toolopts
-from convert2rhel import utils
+from convert2rhel import (
+    cert,
+    logger,
+    pkghandler,
+    redhatrelease,
+    repo,
+    special_cases,
+    subscription,
+    systeminfo,
+    toolopts,
+    utils,
+)
+
+
+loggerinst = logging.getLogger(__name__)
 
 
 class ConversionPhase(object):
@@ -51,7 +57,6 @@ def main():
     # initialize logging
     logger.initialize_logger("convert2rhel.log")
     # get module level logger (inherits from root logger)
-    loggerinst = logging.getLogger(__name__)
 
     try:
         process_phase = ConversionPhase.POST_CLI
@@ -130,7 +135,6 @@ def user_to_accept_eula():
     """Request user to accept EULA license agreement. This is required
     otherwise the conversion process stops and fails with error.
     """
-    loggerinst = logging.getLogger(__name__)
 
     eula_filename = "GLOBAL_EULA_RHEL"
     eula_filepath = os.path.join(utils.DATA_DIR, eula_filename)
@@ -146,7 +150,6 @@ def user_to_accept_eula():
 
 def pre_ponr_conversion():
     """Perform steps and checks to guarantee system is ready for conversion."""
-    loggerinst = logging.getLogger(__name__)
 
     # check if user pass some repo to both disablerepo and enablerepo options
     pkghandler.has_duplicate_repos_across_disablerepo_enablerepo_options()
@@ -194,7 +197,6 @@ def pre_ponr_conversion():
 
 def post_ponr_conversion():
     """Perform main steps for system conversion."""
-    loggerinst = logging.getLogger(__name__)
 
     loggerinst.task("Convert: Import Red Hat GPG keys")
     pkghandler.install_gpg_keys()
@@ -219,7 +221,6 @@ def is_help_msg_exit(process_phase, err):
 
 def rollback_changes():
     """Perform a rollback of changes made during conversion."""
-    loggerinst = logging.getLogger(__name__)
 
     loggerinst.warn("Abnormal exit! Performing rollback ...")
     subscription.rollback()

--- a/convert2rhel/redhatrelease.py
+++ b/convert2rhel/redhatrelease.py
@@ -24,6 +24,8 @@ from convert2rhel import utils
 from convert2rhel.toolopts import tool_opts
 from convert2rhel.systeminfo import system_info
 
+loggerinst = logging.getLogger(__name__)
+
 
 def get_release_pkg_name():
     """For RHEL 6 and 7 the release package name is redhat-release-server.
@@ -41,7 +43,6 @@ def get_system_release_filepath():
     release_filepath = "/etc/system-release"  # RHEL 6/7/8 based OSes
     if os.path.isfile(release_filepath):
         return release_filepath
-    loggerinst = logging.getLogger(__name__)
     loggerinst.critical("Error: Unable to find the /etc/system-release file containing the OS name and version")
 
 
@@ -49,7 +50,6 @@ def get_system_release_content():
     """Return content of the file containing name of the operating
     system and its version.
     """
-    loggerinst = logging.getLogger(__name__)
     filepath = get_system_release_filepath()
     try:
         return utils.get_file_content(filepath)
@@ -63,7 +63,6 @@ class YumConf(object):
 
     def __init__(self):
         self._yum_conf_content = utils.get_file_content(self._yum_conf_path)
-        self.loggerinst = logging.getLogger(__name__)
 
     def patch(self):
         """Comment out the distroverpkg variable in yum.conf so yum can determine
@@ -72,7 +71,7 @@ class YumConf(object):
         """
         self._comment_out_distroverpkg_tag()
         self._write_altered_yum_conf()
-        self.loggerinst.debug("%s patched." % self._yum_conf_path)
+        loggerinst.debug("%s patched." % self._yum_conf_path)
         return
 
     def _comment_out_distroverpkg_tag(self):

--- a/convert2rhel/repo.py
+++ b/convert2rhel/repo.py
@@ -23,11 +23,13 @@ from convert2rhel.systeminfo import system_info
 from convert2rhel.utils import BACKUP_DIR
 
 
+loggerinst = logging.getLogger(__name__)
+
+
 def get_rhel_repoids():
     """Get IDs of the Red Hat CDN repositories that correspond to the current system."""
     repos_needed = system_info.default_rhsm_repoids
 
-    loggerinst = logging.getLogger(__name__)
     loggerinst.info("RHEL repository IDs to enable: %s" % ', '.join(repos_needed))
 
     return repos_needed
@@ -36,7 +38,6 @@ def backup_yum_repos():
     """Backup .repo files in /etc/yum.repos.d/ so the repositories
     can be restored on rollback.
     """
-    loggerinst = logging.getLogger(__name__)
     loggerinst.info("Backing up repositories")
     repo_files_backed_up = False
     for repo in os.listdir("/etc/yum.repos.d/"):
@@ -53,7 +54,6 @@ def restore_yum_repos():
     """Rollback all .repo files in /etc/yum.repos.d/ that were
     backed up.
     """
-    loggerinst = logging.getLogger(__name__)
     loggerinst.task("Rollback: Restore .repo files to /etc/yum.repos.d/")
     repo_has_restored = False
     for repo in os.listdir(BACKUP_DIR):

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -19,7 +19,10 @@ import logging
 import optparse
 import sys
 
-from convert2rhel import utils, __version__
+from convert2rhel import __version__, utils
+
+
+loggerinst = logging.getLogger(__name__)
 
 
 class ToolOpts(object):
@@ -85,7 +88,10 @@ class CLI(object):
                                 " messages that could help find an issue.")
         self._parser.add_option("--disable-colors", action="store_true", help="Disable color output")
         # Importing here instead of on top of the file to avoid cyclic dependency
-        from convert2rhel.systeminfo import PRE_RPM_VA_LOG_FILENAME, POST_RPM_VA_LOG_FILENAME
+        from convert2rhel.systeminfo import (
+            POST_RPM_VA_LOG_FILENAME,
+            PRE_RPM_VA_LOG_FILENAME,
+        )
         self._parser.add_option("--no-rpm-va", action="store_true", help="Skip gathering changed rpm files using"
                                                                          " 'rpm -Va'. By default it's performed before and after the conversion with the output"
                                                                          " stored in log files %s and %s. At the end of the conversion, these logs are compared"
@@ -173,7 +179,6 @@ class CLI(object):
 
     def _process_cli_options(self):
         """Process command line options used with the tool."""
-        loggerinst = logging.getLogger(__name__)
         parsed_opts, _ = self._parser.parse_args()
 
         global tool_opts  # pylint: disable=C0103
@@ -248,7 +253,6 @@ def print_non_interactive_opts():
     """Print command line options to be used for the next run of the tool
     to avoid the need of any interactive input during the system conversion.
     """
-    loggerinst = logging.getLogger(__name__)
     loggerinst.info("For the non-interactive use of the tool, run the"
                     " following command:")
     global tool_opts  # pylint: disable=C0103

--- a/convert2rhel/unit_tests/cert_test.py
+++ b/convert2rhel/unit_tests/cert_test.py
@@ -59,7 +59,7 @@ class TestCert(unittest.TestCase):
                 self.assertEqual(cert_path, "{0}/rhel-certs/{1}"
                                     .format(utils.DATA_DIR, pem))
 
-    @unit_tests.mock(cert.logging, "getLogger", unit_tests.GetLoggerMocked())
+    @unit_tests.mock(cert, "loggerinst", unit_tests.GetLoggerMocked())
     @unit_tests.mock(utils, "DATA_DIR", unit_tests.TMP_DIR)
     @unit_tests.mock(system_info, "arch", "arch")
     def test_get_cert_path_missing_cert(self):
@@ -69,16 +69,16 @@ class TestCert(unittest.TestCase):
         utils.mkdir_p(cert_dir)
         # Check response for the non-existing certificate in the temporary dir
         self.assertRaises(SystemExit, cert.SystemCert._get_cert_path)
-        self.assertEqual(len(cert.logging.getLogger.critical_msgs), 1)
+        self.assertEqual(len(cert.loggerinst.critical_msgs), 1)
         # Remove the temporary directory tree
         shutil.rmtree(os.path.join(utils.DATA_DIR, "rhel-certs"))
 
-    @unit_tests.mock(cert.logging, "getLogger", unit_tests.GetLoggerMocked())
+    @unit_tests.mock(cert, "loggerinst", unit_tests.GetLoggerMocked())
     @unit_tests.mock(utils, "DATA_DIR", unit_tests.NONEXISTING_DIR)
     @unit_tests.mock(system_info, "arch", "nonexisting_arch")
     def test_get_cert_path_nonexisting_dir(self):
         self.assertRaises(SystemExit, cert.SystemCert._get_cert_path)
-        self.assertEqual(len(cert.logging.getLogger.critical_msgs), 1)
+        self.assertEqual(len(cert.loggerinst.critical_msgs), 1)
 
     @unit_tests.mock(cert.SystemCert, "_system_cert_dir", unit_tests.TMP_DIR)
     @unit_tests.mock(tool_opts, "arch", "x86_64")

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -2,6 +2,8 @@ import sys
 
 import pytest
 
+from convert2rhel.logger import initialize_logger
+
 
 @pytest.fixture(scope="session")
 def is_py26():
@@ -59,5 +61,10 @@ def pkg_root(is_py2):
     if is_py2:
         import pathlib2 as pathlib  # pylint: disable=import-error
     else:
-        import pathlib    # pylint: disable=import-error
+        import pathlib  # pylint: disable=import-error
     return pathlib.Path(__file__).parents[2]
+
+
+@pytest.fixture(autouse=True)
+def setup_logger(tmpdir):
+    initialize_logger(log_name="convert2rhel", log_dir=tmpdir)

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -21,7 +21,6 @@ import os
 import pytest
 
 from convert2rhel import logger as logger_module
-from convert2rhel.logger import CustomLogger
 from convert2rhel.toolopts import tool_opts
 
 
@@ -76,7 +75,6 @@ def test_logger_custom_logger(tmpdir, caplog):
     log_fname = "convert2rhel.log"
     logger_module.initialize_logger(log_name=log_fname, log_dir=tmpdir)
     logger = logging.getLogger(__name__)
-    assert isinstance(logger, CustomLogger)
     logger.task("Some task")
     logger.file("Some task write to file")
     with pytest.raises(SystemExit):

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -123,12 +123,12 @@ class TestMain(unittest.TestCase):
             self.args = args
             return self.return_string, self.return_code
 
-    @unit_tests.mock(main.logging, "getLogger", GetLoggerMocked())
+    @unit_tests.mock(main, "loggerinst", GetLoggerMocked())
     @unit_tests.mock(utils, "ask_to_continue", AskToContinueMocked())
     @unit_tests.mock(utils, "get_file_content", GetFileContentMocked())
     def test_user_to_accept_eula_nonexisting_file(self):
         self.assertRaises(SystemExit, main.user_to_accept_eula)
-        self.assertEqual(len(main.logging.getLogger.critical_msgs), 1)
+        self.assertEqual(len(main.loggerinst.critical_msgs), 1)
 
     @unit_tests.mock(utils.changed_pkgs_control, "restore_pkgs", unit_tests.CountableMockObject())
     @unit_tests.mock(redhatrelease.system_release_file, "restore", unit_tests.CountableMockObject())

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -15,8 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # Required imports:
-
-
+import logging
 import os
 import unittest
 
@@ -286,23 +285,23 @@ class TestSubscription(unittest.TestCase):
         def __call__(self, msg):
             self.msg += "%s\n" % msg
 
-    @unit_tests.mock(logger.CustomLogger, "info", LogMocked())
-    @unit_tests.mock(logger.CustomLogger, "warning", LogMocked())
+    @unit_tests.mock(logging.Logger, "info", LogMocked())
+    @unit_tests.mock(logging.Logger, "warning", LogMocked())
     @unit_tests.mock(utils, "ask_to_continue", PromptUserMocked())
     @unit_tests.mock(subscription, "get_avail_repos", lambda: ["rhel_x", "rhel_y"])
     def test_check_needed_repos_availability(self):
         subscription.check_needed_repos_availability(["rhel_x"])
-        self.assertTrue("Needed RHEL repos are available" in logger.CustomLogger.info.msg)
+        self.assertTrue("Needed RHEL repos are available" in logging.Logger.info.msg)
 
         subscription.check_needed_repos_availability(["rhel_z"])
-        self.assertTrue("rhel_z repository is not available" in logger.CustomLogger.warning.msg)
+        self.assertTrue("rhel_z repository is not available" in logging.Logger.warning.msg)
 
-    @unit_tests.mock(logger.CustomLogger, "warning", LogMocked())
+    @unit_tests.mock(logging.Logger, "warning", LogMocked())
     @unit_tests.mock(utils, "ask_to_continue", PromptUserMocked())
     @unit_tests.mock(subscription, "get_avail_repos", lambda: [])
     def test_check_needed_repos_availability_no_repo_available(self):
         subscription.check_needed_repos_availability(["rhel"])
-        self.assertTrue("rhel repository is not available" in logger.CustomLogger.warning.msg)
+        self.assertTrue("rhel repository is not available" in logging.Logger.warning.msg)
 
     @unit_tests.mock(os.path, "isdir", lambda x: True)
     @unit_tests.mock(os, "listdir", lambda x: [])

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -149,10 +149,10 @@ class TestSubscription(unittest.TestCase):
     @unit_tests.mock(utils, "let_user_choose_item", LetUserChooseItemMocked())
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     @unit_tests.mock(tool_opts, "activation_key", "dummy_activate_key")
-    @unit_tests.mock(subscription.logging, "getLogger", GetLoggerMocked())
+    @unit_tests.mock(subscription, "loggerinst", GetLoggerMocked())
     def test_attach_subscription_available_with_activation_key(self):
         self.assertEqual(subscription.attach_subscription(), True)
-        self.assertEqual(len(subscription.logging.getLogger.info_msgs), 1)
+        self.assertEqual(len(subscription.loggerinst.info_msgs), 1)
 
     @unit_tests.mock(subscription, "get_avail_subs", GetNoAvailSubsMocked())
     def test_attach_subscription_none_available(self):
@@ -178,7 +178,7 @@ class TestSubscription(unittest.TestCase):
         subscription.subscribe_system()
         self.assertEqual(subscription.register_system.called, 2)
 
-    @unit_tests.mock(subscription.logging, "getLogger", GetLoggerMocked())
+    @unit_tests.mock(subscription, "loggerinst", GetLoggerMocked())
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked([("nope", 1)]))
     def test_register_system_fail_non_interactive(self):
         # Check the critical severity is logged when the credentials are given
@@ -187,7 +187,7 @@ class TestSubscription(unittest.TestCase):
         tool_opts.password = 'pass'
         tool_opts.credentials_thru_cli = True
         self.assertRaises(SystemExit, subscription.register_system)
-        self.assertEqual(len(subscription.logging.getLogger.critical_msgs), 1)
+        self.assertEqual(len(subscription.loggerinst.critical_msgs), 1)
 
     @unit_tests.mock(utils,
                      "run_subprocess",
@@ -249,27 +249,27 @@ class TestSubscription(unittest.TestCase):
         "System Type:       Virtual\n\n"  # this has changed to Entitlement Type since RHEL 7.8
     )
 
-    @unit_tests.mock(subscription.logging, "getLogger", GetLoggerMocked())
+    @unit_tests.mock(subscription, "loggerinst", GetLoggerMocked())
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     def test_unregister_system_successfully(self):
         unregistration_cmd = "subscription-manager unregister"
         subscription.unregister_system()
         self.assertEqual(utils.run_subprocess.called, 1)
         self.assertEqual(utils.run_subprocess.cmd, unregistration_cmd)
-        self.assertEqual(len(subscription.logging.getLogger.info_msgs), 1)
-        self.assertEqual(len(subscription.logging.getLogger.task_msgs), 1)
-        self.assertEqual(len(subscription.logging.getLogger.warning_msgs), 0)
+        self.assertEqual(len(subscription.loggerinst.info_msgs), 1)
+        self.assertEqual(len(subscription.loggerinst.task_msgs), 1)
+        self.assertEqual(len(subscription.loggerinst.warning_msgs), 0)
 
-    @unit_tests.mock(subscription.logging, "getLogger", GetLoggerMocked())
+    @unit_tests.mock(subscription, "loggerinst", GetLoggerMocked())
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked([('output', 1)]))
     def test_unregister_system_fails(self):
         unregistration_cmd = "subscription-manager unregister"
         subscription.unregister_system()
         self.assertEqual(utils.run_subprocess.called, 1)
         self.assertEqual(utils.run_subprocess.cmd, unregistration_cmd)
-        self.assertEqual(len(subscription.logging.getLogger.info_msgs), 0)
-        self.assertEqual(len(subscription.logging.getLogger.task_msgs), 1)
-        self.assertEqual(len(subscription.logging.getLogger.warning_msgs), 1)
+        self.assertEqual(len(subscription.loggerinst.info_msgs), 0)
+        self.assertEqual(len(subscription.loggerinst.task_msgs), 1)
+        self.assertEqual(len(subscription.loggerinst.warning_msgs), 1)
 
     @unit_tests.mock(subscription, "unregister_system", unit_tests.CountableMockObject())
     @unit_tests.mock(subscription, "remove_subscription_manager", unit_tests.CountableMockObject())


### PR DESCRIPTION
This merge request introduces a set of fixes and improvements to the app logger facility.

Fixes:

1. Testing session logger was different from the logger during the app run (not an instance of CustomLogger etc.). This makes invisible CustomLogger functionality (i.e.  not expected sys.exit during logger.critical call during the test run). In this MR this issue is solved and the same logger is used for the app and testing session

Improvements:

1. Now there is no difference whether you get logger at the module level or inside the functions, due to the singleton pattern used in getting the logger and  auto propogating the handlers from the convert2rhel logger.
2. The setup of the logger performed before each testing unit and logs are available in the tmpdir (fixture) with automatic teardown at the end of the testing session
3. Provide write access to the app root dir within the docker

TODO
- [x] fix existing places where the logger was called from inside each function