### PR TITLE
Feature/inhibit if kmods are not supported

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -101,8 +101,10 @@ def ensure_compatibility_of_kmods():
         #  doesn't work. We have `%s` as output instead. Make it work
         logger.critical(
             (
-                "The following kernel module(s) are not "
-                "supported in RHEL:\n{kmods}"
+                "The following kernel modules are not "
+                "supported in RHEL:\n{kmods}\n"
+                "Uninstall or disable them and run convert2rhel "
+                "again to continue with the conversion."
             ).format(kmods=not_supported_kmods)
         )
     else:

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -16,12 +16,28 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
+import itertools
 import logging
 import os
+import re
+import subprocess
 
-from convert2rhel.pkghandler import call_yum_cmd
+from convert2rhel.systeminfo import system_info
+from convert2rhel.utils import run_subprocess
+
 
 logger = logging.getLogger(__name__)
+
+KERNEL_REPO_RE = re.compile("^.+:(?P<version>.+).el.+$")
+KERNEL_REPO_VER_SPLIT_RE = re.compile("\W+")
+LINK_KMODS_RH_POLICY = "https://access.redhat.com/third-party-software-support"
+
+
+def perform_pre_checks():
+    """Early checks after system facts should be added here."""
+    check_uefi()
+    check_tainted_kmods()
+
 
 def check_uefi():
     """Inhibit the conversion when UEFI detected."""
@@ -37,10 +53,236 @@ def check_uefi():
     logger.debug("Converting BIOS system")
 
 
-def perform_pre_checks():
-    """Perform all 'registered' checks
+def check_tainted_kmods():
+    """Stop the conversion when a loaded tainted kernel module is detected.
 
-    Every check function in this file should be performed from here.
-    This is the entry-point for this module.
+    Tainted kmods ends with (...) in /proc/modules, for example:
+        multipath 20480 0 - Live 0x0000000000000000
+        linear 20480 0 - Live 0x0000000000000000
+        system76_io 16384 0 - Live 0x0000000000000000 (OE)  <<<<<< Tainted
+        system76_acpi 16384 0 - Live 0x0000000000000000 (OE) <<<<< Tainted
     """
-    check_uefi()
+    unsigned_modules, _ = run_subprocess("grep '(' /proc/modules")
+    module_names = "\n  ".join(
+        [mod.split(" ")[0] for mod in unsigned_modules.splitlines()]
+    )
+    if unsigned_modules:
+        logger.critical(
+            "Tainted kernel module(s) detected. "
+            "Third-party components are not supported per our "
+            "software support policy\n%s\n\n"
+            "Uninstall or disable the following module(s) and run convert2rhel "
+            "again to continue with the conversion:\n  %s",
+            LINK_KMODS_RH_POLICY,
+            module_names,
+        )
+
+
+def perform_pre_ponr_checks():
+    """Late checks before ponr should be added here."""
+    ensure_compatibility_of_kmods()
+
+
+def ensure_compatibility_of_kmods():
+    """Ensure if the host kernel modules are compatible with RHEL."""
+    host_kmods = get_installed_kmods()
+    rhel_supported_kmods = get_rhel_supported_kmods()
+    if is_unsupported_kmod_installed(host_kmods, rhel_supported_kmods):
+        kernel_version = run_subprocess("uname -r")[0].rstrip("\n")
+        not_supported_kmods = "\n".join(
+            map(
+                lambda kmod: "/lib/modules/{kver}/{kmod}".format(
+                    kver=kernel_version, kmod=kmod
+                ),
+                host_kmods - rhel_supported_kmods,
+            )
+        )
+        # TODO logger.critical("message %s, %s", "what should be under s")
+        #  doesn't work. We have `%s` as output instead. Make it work
+        logger.critical(
+            (
+                "The following kernel module(s) are not "
+                "supported in RHEL:\n{kmods}"
+            ).format(kmods=not_supported_kmods)
+        )
+    else:
+        logger.debug("Kernel modules are compatible.")
+
+
+def get_installed_kmods():
+    """Get a set of kernel modules.
+
+    Each module we cut part of the path until the kernel release
+    (i.e. /lib/modules/5.8.0-7642-generic/kernel/lib/a.ko.xz ->
+    kernel/lib/a.ko.xz) in order to be able to compare with RHEL
+    kernel modules in case of different kernel release
+    """
+    try:
+        kernel_version, exit_code = run_subprocess("uname -r")
+        assert exit_code == 0
+        kmod_str, exit_code = run_subprocess(
+            'find /lib/modules/{kver} -name "*.ko*"'.format(
+                kver=kernel_version.rstrip("\n")
+            )
+        )
+        assert exit_code == 0
+        assert kmod_str
+    except (subprocess.CalledProcessError, AssertionError):
+        logger.critical("Can't get list of kernel modules.")
+    else:
+        return set(
+            _get_kmod_comparison_key(path)
+            for path in kmod_str.rstrip("\n").split()
+        )
+
+
+def _get_kmod_comparison_key(path):
+    """Create a comparison key from the kernel module abs path.
+
+    Converts /lib/modules/5.8.0-7642-generic/kernel/lib/a.ko.xz ->
+    kernel/lib/a.ko.xz
+
+    Why:
+        The standard kernel modules are located under
+        /lib/modules/{some kernel release}/.
+        If we want to make sure that the kernel package is present
+        on RHEL, we need to compare the full path, but because kernel release
+        might be different, we compare the relative paths after kernel release.
+    """
+    return "/".join(path.split("/")[4:])
+
+
+def get_rhel_supported_kmods():
+    """Return set of target RHEL supported kernel modules."""
+    repoquery_repoids_args = " ".join(
+        "--repoid " + repoid for repoid in system_info.get_enabled_rhel_repos()
+    )
+    # Without the release package installed, dnf can't determine the modularity
+    #   platform ID.
+    setopt_arg = (
+        "--setopt=module_platform_id=platform:el8"
+        if system_info.version.major == 8
+        else ""
+    )
+    # get output of a command to get all packages which are the source
+    # of kmods
+    kmod_pkgs_str, _ = run_subprocess(
+        (
+            "repoquery "
+            "--releasever={releasever} "
+            "{setopt_arg} "
+            "{repoids_args} "
+            "-f /lib/modules/*.ko*"
+        ).format(
+            releasever=system_info.releasever,
+            setopt_arg=setopt_arg,
+            repoids_args=repoquery_repoids_args,
+        ),
+        print_output=False,
+    )
+    # from these packages we select only the latest one
+    kmod_pkgs = get_most_recent_unique_kernel_pkgs(
+        kmod_pkgs_str.rstrip("\n").split()
+    )
+    # querying obtained packages for files they produces
+    rhel_kmods_str, _ = run_subprocess(
+        (
+            "repoquery "
+            "--releasever={releasever} "
+            "{setopt_arg} "
+            "{repoids_args} "
+            "-l {pkgs}"
+        ).format(
+            releasever=system_info.releasever,
+            setopt_arg=setopt_arg,
+            repoids_args=repoquery_repoids_args,
+            pkgs=" ".join(kmod_pkgs),
+        ),
+        print_output=False,
+    )
+    return get_rhel_kmods_keys(rhel_kmods_str)
+
+
+def get_most_recent_unique_kernel_pkgs(pkgs):
+    """Return the most recent versions of all kernel packages.
+
+    When we scan kernel modules provided by kernel packages
+    it is expensive to check each kernel pkg. Since each new
+    kernel pkg do not deprecate kernel modules we only select
+    the most recent ones.
+
+    All RHEL kmods packages starts with kernel* or kmod*
+
+    For example, we have the following packages list:
+        kernel-core-0:4.18.0-240.10.1.el8_3.x86_64
+        kernel-core-0:4.19.0-240.10.1.el8_3.x86_64
+        kmod-debug-core-0:4.18.0-240.10.1.el8_3.x86_64
+        kmod-debug-core-0:4.18.0-245.10.1.el8_3.x86_64
+    ==> (output of this function will be)
+        kernel-core-0:4.19.0-240.10.1.el8_3.x86_64
+        kmod-debug-core-0:4.18.0-245.10.1.el8_3.x86_64
+
+    _repos_version_key extract the version of a package
+        into the tuple, i.e.
+        kernel-core-0:4.18.0-240.10.1.el8_3.x86_64 ==>
+        (4, 15, 0, 240, 10, 1)
+
+
+    :type pkgs: Iterable[str]
+    :type pkgs_groups:
+        Iterator[
+            Tuple[
+                package_name_without_version,
+                Iterator[package_name, ...],
+                ...,
+            ]
+        ]
+    """
+
+    pkgs_groups = itertools.groupby(
+        pkgs, lambda pkg_name: pkg_name.split(":")[0]
+    )
+    return (
+        max(distinct_kernel_pkgs[1], key=_repos_version_key)
+        for distinct_kernel_pkgs in pkgs_groups
+        if distinct_kernel_pkgs[0].startswith(("kernel", "kmod"))
+    )
+
+
+def _repos_version_key(pkg_name):
+    try:
+        rpm_version = KERNEL_REPO_RE.search(pkg_name).group("version")
+    except AttributeError:
+        logger.critical(
+            "Unexpected package:\n%s\n is a source of kernel modules.",
+            pkg_name,
+        )
+    else:
+        return tuple(
+            map(
+                _convert_to_int_or_zero,
+                KERNEL_REPO_VER_SPLIT_RE.split(rpm_version),
+            )
+        )
+
+
+def _convert_to_int_or_zero(s):
+    try:
+        return int(s)
+    except ValueError:
+        return 0
+
+
+def get_rhel_kmods_keys(rhel_kmods_str):
+    return set(
+        _get_kmod_comparison_key(kmod_path)
+        for kmod_path in filter(
+            lambda path: path.endswith(("ko.xz", "ko")),
+            rhel_kmods_str.rstrip("\n").split(),
+        )
+    )
+
+
+def is_unsupported_kmod_installed(host_kmods, rhel_supported_kmods):
+    """Return True if any of the installed kernel modules is not available in RHEL repositories."""
+    return not host_kmods.issubset(rhel_supported_kmods)

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -71,7 +71,7 @@ def main():
         systeminfo.system_info.resolve_system_info()
 
         # check the system prior the conversion (possible inhibit)
-        loggerinst.task("Prepare: Running pre-conversion checks")
+        loggerinst.task("Prepare: Initial system checks before conversion")
         checks.perform_pre_checks()
 
         # backup system release file before starting conversion process
@@ -197,6 +197,10 @@ def pre_ponr_conversion():
     # comment out the distroverpkg variable in yum.conf
     loggerinst.task("Convert: Patch yum configuration file")
     redhatrelease.YumConf().patch()
+
+    # perform final checks before the conversion
+    loggerinst.task("Convert: Final system checks before main conversion")
+    checks.perform_pre_ponr_checks()
 
 
 def post_ponr_conversion():

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -119,7 +119,7 @@ def call_yum_cmd(command, args="", print_output=True, enable_repos=None, disable
     else:
         # When using subscription-manager for the conversion, use those repos for the yum call that have been enabled
         # through subscription-manager
-        repos_to_enable = system_info.submgr_enabled_repos if not tool_opts.disable_submgr else tool_opts.enablerepo
+        repos_to_enable = system_info.get_enabled_rhel_repos()
 
     for repo in repos_to_enable:
         cmd += " --enablerepo=%s" % repo
@@ -632,9 +632,8 @@ def replace_non_rhel_installed_kernel(version):
 
     pkg = "kernel-%s" % version
 
-    # For downloading the RHEL kernel we need to use the RHEL repositories. Those are available either through the
-    # attached subscription (submgr_enabled_repos) or through custom repositories (tool_opts.enablerepo).
-    repos_to_enable = system_info.submgr_enabled_repos if not tool_opts.disable_submgr else tool_opts.enablerepo
+    # For downloading the RHEL kernel we need to use the RHEL repositories.
+    repos_to_enable = system_info.get_enabled_rhel_repos()
     path = utils.download_pkg(
         pkg=pkg, dest=utils.TMP_DIR, disable_repos=tool_opts.disablerepo,
         enable_repos=repos_to_enable)

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -17,6 +17,7 @@
 from convert2rhel.utils import run_subprocess
 
 from collections import namedtuple
+
 try:
     import ConfigParser as configparser
 except ImportError:
@@ -102,7 +103,7 @@ class SystemInfo(object):
 
     def _get_system_version(self):
         """Return a namedtuple with major and minor elements, both of an int type.
-        
+
         Examples:
         Oracle Linux Server release 6.10
         Oracle Linux Server release 7.8
@@ -219,6 +220,25 @@ class SystemInfo(object):
             "rpm -q '%s'" % name, print_cmd=False, print_output=False
         )
         return return_code == 0
+
+    # TODO write unit tests
+    def get_enabled_rhel_repos(self):
+        """Return a tuple of repoids containing RHEL packages.
+
+        These are either the repos enabled through RHSM or the custom
+        repositories passed though CLI.
+        """
+        # TODO:
+        # if not self.submgr_enabled_repos:
+        #     raise ValueError(
+        #         "system_info.get_enabled_rhel_repos is not "
+        #          "to be consumed before registering the system with RHSM."
+        #     )
+        return (
+            self.submgr_enabled_repos
+            if not tool_opts.disable_submgr
+            else tool_opts.enablerepo
+        )
 
 
 # Code to be executed upon module import

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -16,30 +16,402 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
+import subprocess
+import sys
+
+import pytest
+
+from convert2rhel import checks, unit_tests
+from convert2rhel.checks import (
+    check_tainted_kmods,
+    ensure_compatibility_of_kmods,
+    get_installed_kmods,
+    get_most_recent_unique_kernel_pkgs,
+    get_rhel_supported_kmods,
+    perform_pre_checks,
+    perform_pre_ponr_checks,
+)
+from convert2rhel.unit_tests import GetLoggerMocked
+from convert2rhel.utils import run_subprocess
+
+
 try:
     import unittest2 as unittest  # Python 2.6 support
 except ImportError:
     import unittest
 
-from convert2rhel import checks, unit_tests
-from convert2rhel.unit_tests import GetLoggerMocked
+
+try:
+    import unittest2 as unittest  # Python 2.6 support
+except ImportError:
+    import unittest
 
 
-class TestChecks(unittest.TestCase):
+if sys.version_info[:2] <= (2, 7):
+    import mock  # pylint: disable=import-error
+else:
+    from unittest import mock  # pylint: disable=no-name-in-module
 
+
+HOST_MODULES_STUB_GOOD = (
+    "/lib/modules/5.8.0-7642-generic/kernel/lib/a.ko.xz\n"
+    "/lib/modules/5.8.0-7642-generic/kernel/lib/b.ko.xz\n"
+    "/lib/modules/5.8.0-7642-generic/kernel/lib/c.ko.xz\n"
+)
+HOST_MODULES_STUB_BAD = (
+    "/lib/modules/5.8.0-7642-generic/kernel/lib/d.ko.xz\n"
+    "/lib/modules/5.8.0-7642-generic/kernel/lib/e.ko.xz\n"
+    "/lib/modules/5.8.0-7642-generic/kernel/lib/f.ko.xz\n"
+)
+REPOQUERY_F_STUB_GOOD = (
+    "kernel-core-0:4.18.0-240.10.1.el8_3.x86_64\n"
+    "kernel-core-0:4.18.0-240.15.1.el8_3.x86_64\n"
+    "kernel-debug-core-0:4.18.0-240.10.1.el8_3.x86_64\n"
+    "kernel-debug-core-0:4.18.0-240.15.1.el8_3.x86_64\n"
+)
+REPOQUERY_F_STUB_BAD = (
+    "kernel-idontexpectyou-core-sdsdsd.ell8_3.x86_64\n"
+    "kernel-core-0:4.18.0-240.15.1.el8_3.x86_64\n"
+    "kernel-debug-core-0:4.18.0-240.10.1.el8_3.x86_64\n"
+    "kernel-debug-core-0:4.18.0-240.15.1.el8_3.x86_64\n"
+)
+REPOQUERY_L_STUB_GOOD = (
+    "/lib/modules/5.8.0-7642-generic/kernel/lib/a.ko.xz\n"
+    "/lib/modules/5.8.0-7642-generic/kernel/lib/a.ko\n"
+    "/lib/modules/5.8.0-7642-generic/kernel/lib/b.ko.xz\n"
+    "/lib/modules/5.8.0-7642-generic/kernel/lib/c.ko.xz\n"
+    "/lib/modules/5.8.0-7642-generic/kernel/lib/c.ko\n"
+)
+REPOQUERY_L_STUB_BAD = (
+    "/lib/modules/5.8.0-7642-generic/kernel/lib/d.ko.xz\n"
+    "/lib/modules/5.8.0-7642-generic/kernel/lib/d.ko\n"
+    "/lib/modules/5.8.0-7642-generic/kernel/lib/e.ko.xz\n"
+    "/lib/modules/5.8.0-7642-generic/kernel/lib/f.ko.xz\n"
+    "/lib/modules/5.8.0-7642-generic/kernel/lib/f.ko\n"
+)
+
+
+def _run_subprocess_side_effect(*stubs):
+    def factory(*args, **kwargs):
+        for kws, result in stubs:
+            if all(kw in args[0] for kw in kws):
+                return result
+        else:
+            return run_subprocess(*args, **kwargs)
+
+    return factory
+
+
+def test_perform_pre_checks(monkeypatch):
+    check_thirdparty_kmods_mock = mock.Mock()
+    check_uefi_mock = mock.Mock()
+    monkeypatch.setattr(
+        checks,
+        "check_uefi",
+        value=check_uefi_mock,
+    )
+    monkeypatch.setattr(
+        checks,
+        "check_tainted_kmods",
+        value=check_thirdparty_kmods_mock,
+    )
+
+    perform_pre_checks()
+
+    check_thirdparty_kmods_mock.assert_called_once()
+    check_uefi_mock.assert_called_once()
+
+
+def test_pre_ponr_checks(monkeypatch):
+    ensure_compatibility_of_kmods_mock = mock.Mock()
+    monkeypatch.setattr(
+        checks,
+        "ensure_compatibility_of_kmods",
+        value=ensure_compatibility_of_kmods_mock,
+    )
+    perform_pre_ponr_checks()
+    ensure_compatibility_of_kmods_mock.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    (
+        "host_kmods",
+        "exception",
+        "should_be_in_logs",
+        "shouldnt_be_in_logs",
+    ),
+    (
+        (
+            HOST_MODULES_STUB_GOOD,
+            None,
+            "Kernel modules are compatible",
+            None,
+        ),
+        (
+            HOST_MODULES_STUB_BAD,
+            SystemExit,
+            None,
+            "Kernel modules are compatible",
+        ),
+    ),
+)
+def test_ensure_compatibility_of_kmods(
+    monkeypatch,
+    pretend_centos8,
+    caplog,
+    host_kmods,
+    exception,
+    should_be_in_logs,
+    shouldnt_be_in_logs,
+):
+    run_subprocess_mock = mock.Mock(
+        side_effect=_run_subprocess_side_effect(
+            (("uname",), ("5.8.0-7642-generic\n", 0)),
+            (("find",), (host_kmods, 0)),
+            (("repoquery", " -f "), (REPOQUERY_F_STUB_GOOD, 0)),
+            (("repoquery", " -l "), (REPOQUERY_L_STUB_GOOD, 0)),
+        )
+    )
+    monkeypatch.setattr(
+        checks,
+        "run_subprocess",
+        value=run_subprocess_mock,
+    )
+
+    if exception:
+        with pytest.raises(exception):
+            ensure_compatibility_of_kmods()
+    else:
+        ensure_compatibility_of_kmods()
+
+    if should_be_in_logs:
+        assert should_be_in_logs in caplog.records[-1].message
+    if shouldnt_be_in_logs:
+        assert shouldnt_be_in_logs not in caplog.records[-1].message
+
+
+@pytest.mark.parametrize(
+    ("run_subprocess_mock", "exp_res"),
+    (
+        (
+            mock.Mock(return_value=(HOST_MODULES_STUB_GOOD, 0)),
+            set(
+                (
+                    "kernel/lib/a.ko.xz",
+                    "kernel/lib/b.ko.xz",
+                    "kernel/lib/c.ko.xz",
+                )
+            ),
+        ),
+        (
+            mock.Mock(return_value=("", 1)),
+            None,
+        ),
+        (
+            mock.Mock(
+                side_effect=subprocess.CalledProcessError(returncode=1, cmd="")
+            ),
+            None,
+        ),
+    ),
+)
+def test_get_installed_kmods(
+    tmpdir, monkeypatch, caplog, run_subprocess_mock, exp_res
+):
+    monkeypatch.setattr(
+        checks,
+        "run_subprocess",
+        value=run_subprocess_mock,
+    )
+    if exp_res:
+        assert exp_res == get_installed_kmods()
+    else:
+        with pytest.raises(SystemExit):
+            get_installed_kmods()
+        assert (
+            "Can't get list of kernel modules." in caplog.records[-1].message
+        )
+
+
+@pytest.mark.parametrize(
+    ("repoquery_f_stub", "repoquery_l_stub", "exception"),
+    (
+        (REPOQUERY_F_STUB_GOOD, REPOQUERY_L_STUB_GOOD, None),
+        (REPOQUERY_F_STUB_BAD, REPOQUERY_L_STUB_GOOD, SystemExit),
+    ),
+)
+def test_get_rhel_supported_kmods(
+    monkeypatch,
+    pretend_centos8,
+    repoquery_f_stub,
+    repoquery_l_stub,
+    exception,
+):
+    run_subprocess_mock = mock.Mock(
+        side_effect=_run_subprocess_side_effect(
+            (
+                ("repoquery", " -f "),
+                (repoquery_f_stub, 0),
+            ),
+            (
+                ("repoquery", " -l "),
+                (repoquery_l_stub, 0),
+            ),
+        )
+    )
+    monkeypatch.setattr(
+        checks,
+        "run_subprocess",
+        value=run_subprocess_mock,
+    )
+    if exception:
+        with pytest.raises(exception):
+            get_rhel_supported_kmods()
+    else:
+        res = get_rhel_supported_kmods()
+        assert res == set(
+            (
+                "kernel/lib/a.ko",
+                "kernel/lib/a.ko.xz",
+                "kernel/lib/b.ko.xz",
+                "kernel/lib/c.ko.xz",
+                "kernel/lib/c.ko",
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("pkgs", "exp_res", "exception"),
+    (
+        (
+            (
+                "kernel-core-0:4.18.0-240.10.1.el8_3.x86_64",
+                "kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",
+                "kernel-debug-core-0:4.18.0-240.10.1.el8_3.x86_64",
+                "kernel-debug-core-0:4.18.0-240.15.1.el8_3.x86_64",
+            ),
+            (
+                "kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",
+                "kernel-debug-core-0:4.18.0-240.15.1.el8_3.x86_64",
+            ),
+            None,
+        ),
+        (
+            (
+                "kmod-core-0:4.18.0-240.10.1.el8_3.x86_64",
+                "kmod-core-0:4.18.0-240.15.1.el8_3.x86_64",
+            ),
+            ("kmod-core-0:4.18.0-240.15.1.el8_3.x86_64",),
+            None,
+        ),
+        (
+            (
+                "not-expected-core-0:4.18.0-240.10.1.el8_3.x86_64",
+                "kmod-core-0:4.18.0-240.15.1.el8_3.x86_64",
+            ),
+            ("kmod-core-0:4.18.0-240.15.1.el8_3.x86_64",),
+            None,
+        ),
+        (
+            (
+                "kernel-core-0:4.18.0-240.beta5.1.el8_3.x86_64",
+                "kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",
+            ),
+            ("kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",),
+            None,
+        ),
+        (
+            (
+                "kernel-core-0:4.18.0-240.15.beta5.1.el8_3.x86_64",
+                "kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",
+            ),
+            ("kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",),
+            None,
+        ),
+        (
+            (
+                "kernel-core-0:4.18.0-240.16.beta5.1.el8_3.x86_64",
+                "kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",
+            ),
+            ("kernel-core-0:4.18.0-240.16.beta5.1.el8_3.x86_64",),
+            None,
+        ),
+        (("kernel_bad_package:111111",), (), SystemExit),
+        (
+            (
+                "kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",
+                "kernel_bad_package:111111",
+                "kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",
+            ),
+            (),
+            SystemExit,
+        ),
+    ),
+)
+def test_get_most_recent_unique_kernel_pkgs(pkgs, exp_res, exception):
+    if not exception:
+        most_recent_pkgs = tuple(get_most_recent_unique_kernel_pkgs(pkgs))
+        assert exp_res == most_recent_pkgs
+    else:
+        with pytest.raises(exception):
+            tuple(get_most_recent_unique_kernel_pkgs(pkgs))
+
+
+@pytest.mark.parametrize(
+    ("command_return", "expected_exception"),
+    (
+        (
+            ("", 0),
+            None,
+        ),
+        (
+            (
+                (
+                    "system76_io 16384 0 - Live 0x0000000000000000 (OE)\n"
+                    "system76_acpi 16384 0 - Live 0x0000000000000000 (OE)"
+                ),
+                0,
+            ),
+            SystemExit,
+        ),
+    ),
+)
+def test_check_tainted_kmods(
+    monkeypatch, command_return, expected_exception
+):
+    run_subprocess_mock = mock.Mock(return_value=command_return)
+    monkeypatch.setattr(
+        checks,
+        "run_subprocess",
+        value=run_subprocess_mock,
+    )
+    if expected_exception:
+        with pytest.raises(expected_exception):
+            check_tainted_kmods()
+    else:
+        check_tainted_kmods()
+
+
+class TestUEFIChecks(unittest.TestCase):
     @unit_tests.mock(os.path, "exists", lambda x: x == "/sys/firmware/efi")
     @unit_tests.mock(checks, "logger", GetLoggerMocked())
     def test_check_uefi_efi_detected(self):
         self.assertRaises(SystemExit, checks.check_uefi)
         self.assertEqual(len(checks.logger.critical_msgs), 1)
-        self.assertTrue("Conversion of UEFI systems is currently not supported" in checks.logger.critical_msgs[0])
+        self.assertTrue(
+            "Conversion of UEFI systems is currently not supported"
+            in checks.logger.critical_msgs[0]
+        )
         if checks.logger.debug_msgs:
-            self.assertFalse("Converting BIOS system" in checks.logger.debug_msgs[0])
-
+            self.assertFalse(
+                "Converting BIOS system" in checks.logger.debug_msgs[0]
+            )
 
     @unit_tests.mock(os.path, "exists", lambda x: not x == "/sys/firmware/efi")
     @unit_tests.mock(checks, "logger", GetLoggerMocked())
     def test_check_uefi_bios_detected(self):
         checks.check_uefi()
         self.assertFalse(checks.logger.critical_msgs)
-        self.assertTrue("Converting BIOS system" in checks.logger.debug_msgs[0])
+        self.assertTrue(
+            "Converting BIOS system" in checks.logger.debug_msgs[0]
+        )

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 
 from convert2rhel import redhatrelease, utils
 from convert2rhel.logger import initialize_logger
+from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts
 
 
@@ -73,8 +74,7 @@ def setup_logger(tmpdir):
 
 
 @pytest.fixture()
-def replace_data_dir_for_centos8(monkeypatch, pkg_root):
-    """Use our """
+def _replace_data_dir_for_centos8(monkeypatch, pkg_root):
     monkeypatch.setattr(
         utils,
         "DATA_DIR",
@@ -83,7 +83,7 @@ def replace_data_dir_for_centos8(monkeypatch, pkg_root):
 
 
 @pytest.fixture()
-def pretend_centos8(monkeypatch, replace_data_dir_for_centos8):
+def pretend_centos8(monkeypatch, _replace_data_dir_for_centos8):
     # TODO create similar for rest systems and document its usage
     monkeypatch.setattr(
         redhatrelease,
@@ -96,3 +96,4 @@ def pretend_centos8(monkeypatch, replace_data_dir_for_centos8):
         value=lambda _: "CentOS Linux release 8.3.2011",
     )
     tool_opts.no_rpm_va = True
+    system_info.resolve_system_info()

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -2,7 +2,9 @@ import sys
 
 import pytest
 
+from convert2rhel import redhatrelease, utils
 from convert2rhel.logger import initialize_logger
+from convert2rhel.toolopts import tool_opts
 
 
 @pytest.fixture(scope="session")
@@ -68,3 +70,29 @@ def pkg_root(is_py2):
 @pytest.fixture(autouse=True)
 def setup_logger(tmpdir):
     initialize_logger(log_name="convert2rhel", log_dir=tmpdir)
+
+
+@pytest.fixture()
+def replace_data_dir_for_centos8(monkeypatch, pkg_root):
+    """Use our """
+    monkeypatch.setattr(
+        utils,
+        "DATA_DIR",
+        value=str(pkg_root / "convert2rhel/data/8/x86_64/"),
+    )
+
+
+@pytest.fixture()
+def pretend_centos8(monkeypatch, replace_data_dir_for_centos8):
+    # TODO create similar for rest systems and document its usage
+    monkeypatch.setattr(
+        redhatrelease,
+        "get_system_release_filepath",
+        value=lambda: "/etc/system-release",
+    )
+    monkeypatch.setattr(
+        utils,
+        "get_file_content",
+        value=lambda _: "CentOS Linux release 8.3.2011",
+    )
+    tool_opts.no_rpm_va = True

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -147,6 +147,8 @@ class TestMain(unittest.TestCase):
     @unit_tests.mock(tool_opts, "disable_submgr", False)
     @unit_tests.mock(cert.SystemCert, "_get_cert_path", unit_tests.MockFunction)
     @mock_calls(main.special_cases, "check_and_resolve", CallOrderMocked)
+    @mock_calls(main.checks, "perform_pre_checks", CallOrderMocked)
+    @mock_calls(main.checks, "perform_pre_ponr_checks", CallOrderMocked)
     @mock_calls(pkghandler, "remove_excluded_pkgs", CallOrderMocked)
     @mock_calls(subscription, "replace_subscription_manager", CallOrderMocked)
     @mock_calls(pkghandler, "remove_repofile_pkgs", CallOrderMocked)
@@ -178,6 +180,8 @@ class TestMain(unittest.TestCase):
         intended_call_order["enable_repos"] = 1
         intended_call_order["remove_repofile_pkgs"] = 1
         intended_call_order["patch"] = 1
+        intended_call_order["perform_pre_ponr_checks"] = 1
+        intended_call_order["perform_pre_checks"] = 1
 
         # Merge the two together like a zipper, creates a tuple which we can assert with - including method call order!
         zipped_call_order = zip(intended_call_order.items(), self.CallOrderMocked.calls.items())
@@ -189,6 +193,8 @@ class TestMain(unittest.TestCase):
     @unit_tests.mock(tool_opts, "disable_submgr", False)
     @unit_tests.mock(cert.SystemCert, "_get_cert_path", unit_tests.MockFunction)
     @mock_calls(main.special_cases, "check_and_resolve", CallOrderMocked)
+    @mock_calls(main.checks, "perform_pre_checks", CallOrderMocked)
+    @mock_calls(main.checks, "perform_pre_ponr_checks", CallOrderMocked)
     @mock_calls(pkghandler, "remove_excluded_pkgs", CallOrderMocked)
     @mock_calls(subscription, "replace_subscription_manager", CallOrderMocked)
     @mock_calls(pkghandler, "remove_repofile_pkgs", CallOrderMocked)
@@ -224,6 +230,7 @@ class TestMain(unittest.TestCase):
 
         intended_call_order["remove_repofile_pkgs"] = 1
         intended_call_order["patch"] = 1
+        intended_call_order["perform_pre_ponr_checks"] = 1
 
         # Merge the two together like a zipper, creates a tuple which we can assert with - including method call order!
         zipped_call_order = zip(intended_call_order.items(), self.CallOrderMocked.calls.items())

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -189,6 +189,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertEqual(pkghandler.call_yum_cmd.called, pkghandler.MAX_YUM_CMD_CALLS)
 
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
+    @unit_tests.mock(system_info, "releasever", None)
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     @unit_tests.mock(tool_opts, "disable_submgr", True)
     @unit_tests.mock(tool_opts, "disablerepo", ['*'])
@@ -200,6 +201,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
                          "yum install -y --disablerepo=* --enablerepo=rhel-7-extras-rpm")
 
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
+    @unit_tests.mock(system_info, "releasever", None)
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     @unit_tests.mock(system_info, "submgr_enabled_repos", ['rhel-7-extras-rpm'])
     @unit_tests.mock(tool_opts, "enablerepo", ['not-to-be-used-in-the-yum-call'])
@@ -210,6 +212,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
                          "yum install -y --enablerepo=rhel-7-extras-rpm")
 
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
+    @unit_tests.mock(system_info, "releasever", None)
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     @unit_tests.mock(system_info, "submgr_enabled_repos", ['not-to-be-used-in-the-yum-call'])
     @unit_tests.mock(tool_opts, "enablerepo", ['not-to-be-used-in-the-yum-call'])
@@ -224,6 +227,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
                          "yum install -y --disablerepo=disable-repo --enablerepo=enable-repo pkg")
 
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
+    @unit_tests.mock(system_info, "releasever", None)
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     def test_call_yum_cmd_w_downgrades_correct_cmd(self):
         pkghandler.call_yum_cmd_w_downgrades("update", ["pkg1 pkg2"])
@@ -693,6 +697,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
             self.assertEqual(["pkg", "subscription-manager*"], pkghandler.call_yum_cmd_w_downgrades.pkgs[i])
 
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
+    @unit_tests.mock(system_info, "releasever", None)
     @unit_tests.mock(pkghandler, "install_rhel_kernel", lambda: True)
     @unit_tests.mock(pkghandler, "fix_invalid_grub2_entries", lambda: None)
     @unit_tests.mock(pkghandler, "remove_non_rhel_kernels", DumbCallableObject())
@@ -821,6 +826,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertEqual(available, ['4.7.4-200.fc24'])
 
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
+    @unit_tests.mock(system_info, "releasever", None)
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     def test_handle_older_rhel_kernel_available(self):
         utils.run_subprocess.output = YUM_KERNEL_LIST_OLDER_AVAILABLE
@@ -851,6 +857,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertEqual(pkghandler.replace_non_rhel_installed_kernel.called, 1)
 
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
+    @unit_tests.mock(system_info, "releasever", None)
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
     @unit_tests.mock(utils, "remove_pkgs", RemovePkgsMocked())
     def test_handle_older_rhel_kernel_not_available_multiple_installed(self):


### PR DESCRIPTION
~~**blocked by:** #191 (rebased on top)~~

This MR introduces a check of host kernel modules against available kernel modules on rhel

TODO:
- [x] verify 
- [x] Move 3rd party kmods check right after system facts check
- [x] Use repoqery -l {pkgs} instead of loop for each package