### PR TITLE
add: Check if /mnt /sys is read/write

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -149,6 +149,10 @@ def pre_ponr_conversion():
     # check if user pass some repo to both disablerepo and enablerepo options
     pkghandler.has_duplicate_repos_across_disablerepo_enablerepo_options()
 
+    # checking if /mnt and /sys are read-write
+    loggerinst.task("Convert: Checking /mnt and /sys are read-write")
+    utils.check_readonly_mounts()
+
     # package analysis
     loggerinst.task("Convert: List third-party packages")
     pkghandler.list_third_party_pkgs()

--- a/convert2rhel/unit_tests/__init__.py
+++ b/convert2rhel/unit_tests/__init__.py
@@ -218,3 +218,15 @@ class GetLoggerMocked(MockFunction):
 
     def debug(self, msg):
         self.debug_msgs.append(msg)
+
+
+class GetFileContentMocked(MockFunction):
+        def __init__(self, data, as_list=True):
+            self.data = data
+            self.as_list = as_list
+            self.called = 0
+
+        def __call__(self, filename, as_list):
+            self.called += 1
+            self.as_list = as_list
+            return [x.strip() for x in self.data] if self.as_list else self.data

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -19,7 +19,6 @@
 import os
 import unittest
 
-
 try:
     from collections import OrderedDict
 except ImportError:
@@ -35,7 +34,6 @@ from convert2rhel import (
     subscription,
     utils,
 )
-from convert2rhel.systeminfo import SystemInfo
 from convert2rhel.toolopts import tool_opts
 
 
@@ -54,6 +52,10 @@ class TestMain(unittest.TestCase):
     @unit_tests.mock(utils, "DATA_DIR", eula_dir)
     def test_show_eula(self):
         main.show_eula()
+
+    class GetFakeFunctionMocked(unit_tests.MockFunction):
+        def __call__(self, filename):
+            pass
 
     class GetFileContentMocked(unit_tests.MockFunction):
         def __call__(self, filename):
@@ -100,8 +102,6 @@ class TestMain(unittest.TestCase):
         @classmethod
         def reset(cls):
             cls.calls = OrderedDict()
-
-
 
     class CallYumCmdMocked(unit_tests.MockFunction):
         def __init__(self):
@@ -159,6 +159,7 @@ class TestMain(unittest.TestCase):
     @mock_calls(subscription, "disable_repos", CallOrderMocked)
     @mock_calls(subscription, "enable_repos", CallOrderMocked)
     @mock_calls(subscription, "download_rhsm_pkgs", CallOrderMocked)
+    @unit_tests.mock(utils, "check_readonly_mounts", GetFakeFunctionMocked)
     def test_pre_ponr_conversion_order_with_rhsm(self):
         self.CallOrderMocked.reset()
         main.pre_ponr_conversion()
@@ -200,6 +201,7 @@ class TestMain(unittest.TestCase):
     @mock_calls(subscription, "disable_repos", CallOrderMocked)
     @mock_calls(subscription, "enable_repos", CallOrderMocked)
     @mock_calls(subscription, "download_rhsm_pkgs", CallOrderMocked)
+    @unit_tests.mock(utils, "check_readonly_mounts", GetFakeFunctionMocked)
     def test_pre_ponr_conversion_order_without_rhsm(self):
         self.CallOrderMocked.reset()
         main.pre_ponr_conversion()


### PR DESCRIPTION
This commit will check if `/mnt` and `/sys` are read/write, if not, will abort the conversion.

Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1887513