### PR TITLE
add: check function to validate custom repos

### DIFF
--- a/plans/integration/check-custom-repo/main.fmf
+++ b/plans/integration/check-custom-repo/main.fmf
@@ -1,0 +1,7 @@
+discover+:
+    filter:
+        - 'tag: check-custom-repo'
+
+provision:
+    how: libvirt
+    develop: true

--- a/plans/integration/check-custom-repo/vm_centos7.fmf
+++ b/plans/integration/check-custom-repo/vm_centos7.fmf
@@ -1,0 +1,14 @@
+discover+:
+    filter+:
+        - 'tag: centos7'
+provision+:
+    origin_vm_name: c2r_centos7_template
+
+/good:
+    discover+:
+        filter+:
+            - 'tag: good_test'
+/bad:
+    discover+:
+        filter+:
+            - 'tag: bad_test'

--- a/plans/integration/check-custom-repo/vm_centos8.fmf
+++ b/plans/integration/check-custom-repo/vm_centos8.fmf
@@ -1,0 +1,14 @@
+discover+:
+    filter+:
+        - 'tag: centos8'
+provision+:
+    origin_vm_name: c2r_centos8_template
+
+/good:
+    discover+:
+        filter+:
+            - 'tag: good_test'
+/bad:
+    discover+:
+        filter+:
+            - 'tag: bad_test'

--- a/plans/integration/check-custom-repo/vm_oracle7.fmf
+++ b/plans/integration/check-custom-repo/vm_oracle7.fmf
@@ -1,0 +1,14 @@
+discover+:
+    filter+:
+        - 'tag: oracle7'
+provision+:
+    origin_vm_name: c2r_oracle7_template
+
+/good:
+    discover+:
+        filter+:
+            - 'tag: good_test'
+/bad:
+    discover+:
+        filter+:
+            - 'tag: bad_test'

--- a/plans/integration/check-custom-repo/vm_oracle8.fmf
+++ b/plans/integration/check-custom-repo/vm_oracle8.fmf
@@ -1,0 +1,14 @@
+discover+:
+    filter+:
+        - 'tag: oracle8'
+provision+:
+    origin_vm_name: c2r_oracle8_template
+
+/good:
+    discover+:
+        filter+:
+            - 'tag: good_test'
+/bad:
+    discover+:
+        filter+:
+            - 'tag: bad_test'

--- a/tests/integration/check-custom-repo/main.fmf
+++ b/tests/integration/check-custom-repo/main.fmf
@@ -10,10 +10,10 @@ tag+:
   tag+:
     - good_test
   test: |
-    pytest -svv --tb=no -m good_tests
+    pytest -svv -m good_tests
 
 /bad:
   tag+:
     - bad_test
   test: |
-    pytest -svv --tb=no -m bad_tests
+    pytest -svv -m bad_tests

--- a/tests/integration/check-custom-repo/main.fmf
+++ b/tests/integration/check-custom-repo/main.fmf
@@ -1,0 +1,19 @@
+summary: check-custom-repo
+tag+:
+  - centos7
+  - centos8
+  - oracle7
+  - oracle8
+  - check-custom-repo
+
+/good:
+  tag+:
+    - good_test
+  test: |
+    pytest -svv --tb=no -m good_tests
+
+/bad:
+  tag+:
+    - bad_test
+  test: |
+    pytest -svv --tb=no -m bad_tests

--- a/tests/integration/check-custom-repo/test_custom-repos.py
+++ b/tests/integration/check-custom-repo/test_custom-repos.py
@@ -47,8 +47,6 @@ def test_good_convertion_without_rhsm(shell, convert2rhel):
         # send Ctrl-C
         c2r.send(chr(3))
 
-    assert c2r.exitstatus == 0
-
 
 @pytest.mark.bad_tests
 def test_bad_convertion_without_rhsm(shell, convert2rhel):
@@ -59,7 +57,7 @@ def test_bad_convertion_without_rhsm(shell, convert2rhel):
     with convert2rhel("-y --no-rpm-va --disable-submgr --enablerepo fake-rhel-8-for-x86_64-baseos-rpms --debug") as c2r:
         c2r.expect(
             "CRITICAL - Unable to access the repositories passed through the --enablerepo option. See the above "
-            "YUM/DNF output for more details. "
+            "YUM/DNF output for more details."
         )
 
     assert c2r.exitstatus == 1

--- a/tests/integration/check-custom-repo/test_custom-repos.py
+++ b/tests/integration/check-custom-repo/test_custom-repos.py
@@ -1,0 +1,65 @@
+import re
+
+from collections import namedtuple
+
+import pytest
+
+
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
+
+
+def get_system_version(system_release_content=None):
+    """Return a namedtuple with major and minor elements, both of an int type.
+
+    Examples:
+    Oracle Linux Server release 6.10
+    Oracle Linux Server release 7.8
+    CentOS release 6.10 (Final)
+    CentOS Linux release 7.6.1810 (Core)
+    CentOS Linux release 8.1.1911 (Core)
+    """
+    match = re.search(r".+?(\d+)\.(\d+)\D?", system_release_content)
+    if not match:
+        return "not match"
+    version = namedtuple("Version", ["major", "minor"])(int(match.group(1)), int(match.group(2)))
+
+    return version
+
+
+@pytest.mark.good_tests
+def test_good_convertion_without_rhsm(shell, convert2rhel):
+    """
+    Test if --enablerepo are not skipped when  subscription-manager are disabled and test if repo passed are valid.
+    """
+    with open("/etc/system-release", "r") as file:
+        system_release = file.read()
+        system_version = get_system_version(system_release_content=system_release)
+        if system_version.major == 7:
+            enable_repo_opt = "--enablerepo rhel-7-server-rpms"
+        elif system_version.major == 8:
+            enable_repo_opt = "--enablerepo rhel-8-for-x86_64-baseos-rpms --enablerepo rhel-8-for-x86_64-appstream-rpms"
+
+    with convert2rhel("-y --no-rpm-va --disable-submgr {} --debug".format(enable_repo_opt)) as c2r:
+        c2r.expect("The repositories passed through the --enablerepo option are all accessible.")
+        # send Ctrl-C
+        c2r.send(chr(3))
+
+    assert c2r.exitstatus == 0
+
+
+@pytest.mark.bad_tests
+def test_bad_convertion_without_rhsm(shell, convert2rhel):
+    """
+    Test if --enablerepo are not skipped when  subscription-manager are disabled and test the convertion will stop
+    with non-valid repo
+    """
+    with convert2rhel("-y --no-rpm-va --disable-submgr --enablerepo fake-rhel-8-for-x86_64-baseos-rpms --debug") as c2r:
+        c2r.expect(
+            "CRITICAL - Unable to access the repositories passed through the --enablerepo option. See the above "
+            "YUM/DNF output for more details. "
+        )
+
+    assert c2r.exitstatus == 1


### PR DESCRIPTION
When using custom repos but the repoid passed through --enablerepo is not valid (typo in the repoid, the baseurl not accessible, etc.), convert2rhel continues without a problem beyond the point of no return (PONR) and then it fails, leaving the user with a message that they need to fix their system manually.

This PR check the validity os repos before anything.