### PR TITLE
fix: Change URL for pip in containerfiles

### DIFF
--- a/Dockerfiles/centos6.Dockerfile
+++ b/Dockerfiles/centos6.Dockerfile
@@ -4,7 +4,7 @@ ENV PYTHON python2
 ENV PIP pip2
 ENV PYTHONDONTWRITEBYTECODE 1
 
-ENV URL_GET_PIP "https://bootstrap.pypa.io/2.6/get-pip.py"
+ENV URL_GET_PIP "https://bootstrap.pypa.io/pip/2.6/get-pip.py"
 ENV APP_DEV_DEPS "requirements/centos6.requirements.txt"
 ENV APP_MAIN_DEPS \
     python-six \

--- a/Dockerfiles/centos7.Dockerfile
+++ b/Dockerfiles/centos7.Dockerfile
@@ -4,7 +4,7 @@ ENV PYTHON python2
 ENV PIP pip
 ENV PYTHONDONTWRITEBYTECODE 1
 
-ENV URL_GET_PIP "https://bootstrap.pypa.io/2.7/get-pip.py"
+ENV URL_GET_PIP "https://bootstrap.pypa.io/pip/2.7/get-pip.py"
 ENV APP_DEV_DEPS "requirements/centos7.requirements.txt"
 ENV APP_MAIN_DEPS \
     python-six \

--- a/Dockerfiles/centos8.Dockerfile
+++ b/Dockerfiles/centos8.Dockerfile
@@ -4,7 +4,7 @@ ENV PYTHON python3
 ENV PIP pip3
 ENV PYTHONDONTWRITEBYTECODE 1
 
-ENV URL_GET_PIP "https://bootstrap.pypa.io/get-pip.py"
+ENV URL_GET_PIP "https://bootstrap.pypa.io/pip/get-pip.py"
 ENV APP_DEV_DEPS "requirements/centos8.requirements.txt"
 ENV APP_MAIN_DEPS \
     python3 \


### PR DESCRIPTION
URL for pip was moved, this uses the new URL as mentioned in their notice

> Hi there!
> 
> The URL you are using to fetch this script has changed, and this one will no
> longer work. Please use get-pip.py from the following URL instead:
> 
>     https://bootstrap.pypa.io/pip/2.7/get-pip.py
> 
> Sorry if this change causes any inconvenience for you!
> 
> We don't have a good mechanism to make more gradual changes here, and this
> renaming is a part of an effort to make it easier to us to update these
> scripts, when there's a pip release. It's also essential for improving how we
> handle the `get-pip.py` scripts, when pip drops support for a Python minor
> version.
> 
> There are no more renames/URL changes planned, and we don't expect that a need
> would arise to do this again in the near future.
> 
> Thanks for understanding!
> 
> - Pradyun, on behalf of the volunteers who maintain pip.