### PR TITLE
fix: add abrt to excluded pkgs

### DIFF
--- a/convert2rhel/data/6/x86_64/configs/centos-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/centos-6-x86_64.cfg
@@ -8,6 +8,7 @@ gpg_fingerprints = 0946fca2c105b9de
 # List of packages to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
+  abrt*
   centos-bookmarks
   centos-logos
   centos-indexhtml

--- a/convert2rhel/data/7/ppc64/configs/centos-7-ppc64.cfg
+++ b/convert2rhel/data/7/ppc64/configs/centos-7-ppc64.cfg
@@ -10,6 +10,7 @@ gpg_fingerprints =
 # List of packages to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
+  abrt*
   centos-bookmarks
   centos-logos
   centos-indexhtml


### PR DESCRIPTION
abrt-cli caused conversion to fail due to dependency errors. A dependency abrt-retrace-client is in base CentOS repo but not in RHEL repo, only RHEL optional repo.

Since packages in RHEL optional repo is not supported we cannot enable this by default. For now we will simply remove the packages to ensure that the conversion goes smoothly
 
Closes #166, closes #200