### PR TITLE
Rename CentOS -> CentOS Linux

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ If you want to become a member of that group, [let us know](https://github.com/o
 
 Q: When are we supposed to do that?
 
-A: Whenever we decide that users of CentOS and Oracle Linux should be able to take advantage of the new fixes and features we introduce in upstream/GitHub.
+A: Whenever we decide that users of CentOS Linux and Oracle Linux should be able to take advantage of the new fixes and features we introduce in upstream/GitHub.
 
 
 The procedure below expects that [a new upstream GitHub release](https://github.com/oamg/convert2rhel/releases) has been created already.

--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,11 @@ images: .images
 	touch $@
 
 tests: images
-	@echo 'CentOS 6 tests'
+	@echo 'CentOS Linux 6 tests'
 	@docker run --user=$(id -ur):$(id -gr) --rm -v $(shell pwd):/data:Z $(IMAGE)/centos6 pytest
-	@echo 'CentOS 7 tests'
+	@echo 'CentOS Linux 7 tests'
 	@docker run --user=$(id -ur):$(id -gr) --rm -v $(shell pwd):/data:Z $(IMAGE)/centos7 pytest
-	@echo 'CentOS 8 tests'
+	@echo 'CentOS Linux 8 tests'
 	@docker run --user=$(id -ur):$(id -gr) --rm -v $(shell pwd):/data:Z $(IMAGE)/centos8 pytest
 
 lint: images

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -682,7 +682,7 @@ def remove_non_rhel_kernels():
 
 def fix_default_kernel():
     """
-    Systems converted from Oracle Linux or CentOS Plus may have leftover kernel-uek or kernel-plus in
+    Systems converted from Oracle Linux or CentOS Linux may have leftover kernel-uek or kernel-plus in
     /etc/sysconfig/kernel as DEFAULTKERNEL.
     This function fixes that by replacing the DEFAULTKERNEL setting from kernel-uek or kernel-plus to kernel for RHEL 6,7 and kernel-core for RHEL 8
     """

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -32,7 +32,7 @@ SUBMGR_RPMS_DIR = os.path.join(utils.DATA_DIR, "subscription-manager")
 _RHSM_TMP_DIR = os.path.join(utils.TMP_DIR, "rhsm")
 _CENTOS_6_REPO_CONTENT = \
         '[centos-6-contrib-convert2rhel]\n' \
-        'name=CentOS 6 - Contrib added by Convert2RHEL\n' \
+        'name=CentOS Linux 6 - Contrib added by Convert2RHEL\n' \
         'baseurl=https://vault.centos.org/centos/6/contrib/$basearch/\n' \
         'gpgcheck=0\n' \
         'enabled=1\n'
@@ -44,7 +44,7 @@ _UBI_7_REPO_CONTENT = \
         'gpgcheck=0\n' \
         'enabled=1\n'
 _UBI_7_REPO_PATH = os.path.join(_RHSM_TMP_DIR, "ubi_7.repo")
-# We are using UBI 8 instead of CentOS 8 because there's a bug in subscription-manager-rhsm-certificates on CentOS 8
+# We are using UBI 8 instead of CentOS Linux 8 because there's a bug in subscription-manager-rhsm-certificates on CentOS Linux 8
 # https://bugs.centos.org/view.php?id=17907
 _UBI_8_REPO_CONTENT = \
         '[ubi-8-baseos-convert2rhel]\n' \

--- a/packaging/build_locally.sh
+++ b/packaging/build_locally.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Run this script on CentOS/OL/RHEL 6/7/8
+# Run this script on CentOS Linux/OL/RHEL 6/7/8
 pushd $(dirname "$0")/../
 
 echo "Creating a tarball for building the RPM ..."

--- a/packaging/convert2rhel.spec
+++ b/packaging/convert2rhel.spec
@@ -51,8 +51,8 @@ Requires:       pexpect
 The purpose of the convert2rhel tool is to provide an automated way of
 converting the installed other-than-RHEL OS distribution to Red Hat Enterprise
 Linux (RHEL). The tool replaces all the original OS-signed packages with the
-RHEL ones. Available are conversions of CentOS 6/7/8 and Oracle Linux 6/7/8 to
-the respective major version of RHEL.
+RHEL ones. Available are conversions of CentOS Linux 6/7/8 and 
+Oracle Linux 6/7/8 to the respective major version of RHEL.
 
 %prep
 %setup -q
@@ -92,7 +92,7 @@ install -p man/%{name}.8 %{buildroot}%{_mandir}/man8/
 %files
 
 %if 0%{?el6} && 0%{?rhel}
-# without this on CentOS/OL 6, rpmlint gives an error "E: files-attr-not-set"
+# without this on CentOS Linux/OL 6, rpmlint gives an error "E: files-attr-not-set"
 %defattr(-,root,root,-)
 %endif
 


### PR DESCRIPTION
All occurrences of CentOS X, or just CentOS are replaced with CentOS Linux X, or CentOS Linux