### PR TITLE
fix: Remove dependencies that isn't fixed

### DIFF
--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -66,6 +66,14 @@ def call_yum_cmd_w_downgrades(cmd, fingerprints):
         # handle error condition
         loggerinst.info("Resolving dependency errors ... ")
         resolve_dep_errors(output, [])
+        # if we have problematic packages, remove them
+        problematic_pkgs = get_problematic_pkgs(output, [])
+        if problematic_pkgs["errors"]:
+            loggerinst.warning(
+                "Removing problematic packages to continue with conversion:\n%s" %
+                "\n".join(problematic_pkgs["errors"])
+            )
+            utils.remove_pkgs(problematic_pkgs['errors'], critical=False)
     else:
         loggerinst.critical("Could not resolve yum errors.")
     return

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -138,6 +138,7 @@ def call_yum_cmd(command, args="", print_output=True, enable_repos=None, disable
 
 
 def get_problematic_pkgs(output, excluded_pkgs):
+    """Parse the YUM/DNF output to find what packages are causing a transaction failure."""
     loggerinst.info("Checking for problematic packages")
     problematic_pkgs = {
         "all": [],

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -232,20 +232,33 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
 
     def test_get_problematic_pkgs(self):
         error_pkgs = pkghandler.get_problematic_pkgs("", [])
-        self.assertEqual(error_pkgs, [])
+        self.assertEqual(error_pkgs, {
+            "all": [],
+            "protected": [],
+            "errors": [],
+            "multilib": [],
+            "required": [],
+        })
 
         error_pkgs = pkghandler.get_problematic_pkgs(YUM_PROTECTED_ERROR, [])
-        self.assertIn("systemd", error_pkgs)
-        self.assertIn("yum", error_pkgs)
+        self.assertIn("systemd", error_pkgs['all'])
+        self.assertIn("systemd", error_pkgs['protected'])
+        self.assertIn("yum", error_pkgs['all'])
+        self.assertIn("yum", error_pkgs['protected'])
 
         error_pkgs = pkghandler.get_problematic_pkgs(YUM_REQUIRES_ERROR, [])
-        self.assertIn("libreport-anaconda", error_pkgs)
-        self.assertIn("abrt-cli", error_pkgs)
-        self.assertIn("libreport-plugin-rhtsupport", error_pkgs)
+        self.assertIn("libreport-anaconda", error_pkgs['all'])
+        self.assertIn("libreport-anaconda", error_pkgs['errors'])
+        self.assertIn("abrt-cli", error_pkgs['all'])
+        self.assertIn("abrt-cli", error_pkgs['errors'])
+        self.assertIn("libreport-plugin-rhtsupport", error_pkgs['all'])
+        self.assertIn("libreport-plugin-rhtsupport", error_pkgs['required'])
 
         error_pkgs = pkghandler.get_problematic_pkgs(YUM_MULTILIB_ERROR, [])
-        self.assertIn("openldap", error_pkgs)
-        self.assertIn("p11-kit", error_pkgs)
+        self.assertIn("openldap", error_pkgs['all'])
+        self.assertIn("openldap", error_pkgs['multilib'])
+        self.assertIn("p11-kit", error_pkgs['all'])
+        self.assertIn("p11-kit", error_pkgs['multilib'])
 
     @unit_tests.mock(pkghandler, "call_yum_cmd", CallYumCmdMocked())
     def test_resolve_dep_errors_one_downgrade_fixes_the_error(self):


### PR DESCRIPTION
Fixes conversion failures due to packages like `abrt-cli` not resolving dependencies. We do this by taking all the errors we can find and removing them manually if the resolving of dependencies do not take care of them

`abrt-cli` caused conversion to fail due to dependency errors. A dependency `abrt-retrace-client` is in base CentOS repo but not in RHEL repo, only RHEL optional repo.

Since packages in RHEL optional repo is not supported we cannot enable this by default. For now we will simply remove the packages to ensure that the conversion goes smoothly

Closes #166, closes #200

# Todo:

- [x] Write tests