### PR TITLE
Inhibit the system conversion on UEFI

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2016 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+import logging
+import os
+
+from convert2rhel.pkghandler import call_yum_cmd
+
+logger = logging.getLogger(__name__)
+
+def check_uefi():
+    """Inhibit the conversion when UEFI detected."""
+    logger.task("Prepare: Checking the firmware interface type")
+    if os.path.exists("/sys/firmware/efi"):
+        # NOTE(pstodulk): the check doesn't have to be valid for hybrid boot
+        # (e.g. AWS, Azure, OSP, ..)
+        logger.critical(
+            "Conversion of UEFI systems is currently not supported, see"
+            " https://bugzilla.redhat.com/show_bug.cgi?id=1898314"
+            " for more information."
+        )
+    logger.debug("Converting BIOS system")
+
+
+def perform_pre_checks():
+    """Perform all 'registered' checks
+
+    Every check function in this file should be performed from here.
+    This is the entry-point for this module.
+    """
+    check_uefi()

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -21,6 +21,7 @@ import sys
 
 from convert2rhel import (
     cert,
+    checks,
     logger,
     pkghandler,
     redhatrelease,
@@ -68,6 +69,10 @@ def main():
         # gather system information
         loggerinst.task("Prepare: Gather system information")
         systeminfo.system_info.resolve_system_info()
+
+        # check the system prior the conversion (possible inhibit)
+        loggerinst.task("Prepare: Running pre-conversion checks")
+        checks.perform_pre_checks()
 
         # backup system release file before starting conversion process
         loggerinst.task("Prepare: Backup System")

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+try:
+    import unittest2 as unittest  # Python 2.6 support
+except ImportError:
+    import unittest
+
+from convert2rhel import checks, unit_tests
+from convert2rhel.unit_tests import GetLoggerMocked
+
+
+class TestChecks(unittest.TestCase):
+
+    @unit_tests.mock(os.path, "exists", lambda x: x == "/sys/firmware/efi")
+    @unit_tests.mock(checks, "logger", GetLoggerMocked())
+    def test_check_uefi_efi_detected(self):
+        self.assertRaises(SystemExit, checks.check_uefi)
+        self.assertEqual(len(checks.logger.critical_msgs), 1)
+        self.assertTrue("Conversion of UEFI systems is currently not supported" in checks.logger.critical_msgs[0])
+        if checks.logger.debug_msgs:
+            self.assertFalse("Converting BIOS system" in checks.logger.debug_msgs[0])
+
+
+    @unit_tests.mock(os.path, "exists", lambda x: not x == "/sys/firmware/efi")
+    @unit_tests.mock(checks, "logger", GetLoggerMocked())
+    def test_check_uefi_bios_detected(self):
+        checks.check_uefi()
+        self.assertFalse(checks.logger.critical_msgs)
+        self.assertTrue("Converting BIOS system" in checks.logger.debug_msgs[0])


### PR DESCRIPTION
In case the system is booted using the UEFI firmware, the bootloader
is broken (user ends with the grub prompt). Inhibit the conversion
in case the UEFI is detected to prevent users from the broken
bootloader state.

Note: The current UEFI detection solution is not handling hybrid boot
(e.g. used on AWS, Azure, ...). It's possible that in case of hybrid
boot an additional checks will be needed. But such systems are not
supported for conversions right now so using just the simple detection.

Relates:  https://bugzilla.redhat.com/show_bug.cgi?id=1898314

Co-author: Fellipe Henrique <fellipeh@gmail.com>


## Outputs:
On BIOS:
```
[03/15/2021 18:26:50] TASK - [Prepare: Gather system information] *******************************
Name:                CentOS Linux
OS version:          7.9
Architecture:        x86_64
Config filename:     centos-7-x86_64.cfg
Running the 'rpm -Va' command which can take several minutes. It can be disabled by using the --no-rpm-va option.
The 'rpm -Va' output has been stored in the /var/log/convert2rhel/rpm_va.log file

[03/15/2021 18:27:05] TASK - [Prepare: Running pre-conversion checks] ***************************

[03/15/2021 18:27:05] TASK - [Prepare: Checking the firmware interface type] ********************

[03/15/2021 18:27:05] TASK - [Prepare: Backup System] *******************************************
....
```

On UEFI:
```
[03/15/2021 18:44:36] TASK - [Prepare: Gather system information] *******************************
Name:                CentOS Linux
OS version:          7.9
Architecture:        x86_64
Config filename:     centos-7-x86_64.cfg
Running the 'rpm -Va' command which can take several minutes. It can be disabled by using the --no-rpm-va option.
The 'rpm -Va' output has been stored in the /var/log/convert2rhel/rpm_va.log file

[03/15/2021 18:44:47] TASK - [Prepare: Running pre-conversion checks] ***************************

[03/15/2021 18:44:47] TASK - [Prepare: Checking the firmware interface type] ********************
CRITICAL - The UEFI has been used for the boot. The conversition with UEFI is not currently supported because of the following bug: https://bugzilla.redhat.com/show_bug.cgi?id=1898314
No changes were made to the system.
...
```