### PR TITLE
Feature/add integration tests setup based on tmt and implement test of kmods feature

### DIFF
--- a/plans/integration/inhibit-if-kmods-is-not-supported/container.fmf
+++ b/plans/integration/inhibit-if-kmods-is-not-supported/container.fmf
@@ -1,0 +1,5 @@
+provision:
+    how: docker
+    image: convert2rhel_centos8:latest
+    pull: false
+    develop: true

--- a/plans/integration/inhibit-if-kmods-is-not-supported/main.fmf
+++ b/plans/integration/inhibit-if-kmods-is-not-supported/main.fmf
@@ -1,0 +1,6 @@
+discover+:
+    filter:
+        - 'tag: inhibit-if-kmods-is-not-supported'
+prepare+:
+    playbook+:
+        - tests/integration/inhibit-if-kmods-is-not-supported/ansible/kmods.yml

--- a/plans/integration/inhibit-if-kmods-is-not-supported/vm_centos7.fmf
+++ b/plans/integration/inhibit-if-kmods-is-not-supported/vm_centos7.fmf
@@ -1,0 +1,20 @@
+discover+:
+    filter+:
+        - 'tag: centos7'
+provision:
+    how: libvirt
+    origin_vm_name: c2r_centos7_template
+    develop: true
+
+/good:
+    discover+:
+        filter+:
+            - 'tag: good_test'
+/bad:
+    discover+:
+        filter+:
+            - 'tag: bad_test'
+/skip_check:
+    discover+:
+        filter+:
+            - 'tag: ckip_check'

--- a/plans/integration/inhibit-if-kmods-is-not-supported/vm_centos8.fmf
+++ b/plans/integration/inhibit-if-kmods-is-not-supported/vm_centos8.fmf
@@ -1,0 +1,20 @@
+discover+:
+    filter+:
+        - 'tag: centos8'
+provision:
+    how: libvirt
+    origin_vm_name: c2r_centos8_template
+    develop: true
+
+/good:
+    discover+:
+        filter+:
+            - 'tag: good_test'
+/bad:
+    discover+:
+        filter+:
+            - 'tag: bad_test'
+/skip_check:
+    discover+:
+        filter+:
+            - 'tag: skip_check'

--- a/tests/integration/inhibit-if-kmods-is-not-supported/ansible/kmods.yml
+++ b/tests/integration/inhibit-if-kmods-is-not-supported/ansible/kmods.yml
@@ -1,0 +1,5 @@
+- hosts: all
+#  tasks:
+#    - name: Install convert2rhel deps
+#      pip:
+#        name: ["pytest", "pytest-cov"]

--- a/tests/integration/inhibit-if-kmods-is-not-supported/main.fmf
+++ b/tests/integration/inhibit-if-kmods-is-not-supported/main.fmf
@@ -1,0 +1,23 @@
+summary: kmods tests
+tag+:
+  - centos7
+  - centos8
+  - inhibit-if-kmods-is-not-supported
+
+/good:
+  tag+:
+    - good_test
+  test: |
+    pytest -svv --tb=no -m good_tests
+
+/bad:
+  tag+:
+    - bad_test
+  test: |
+    pytest -svv --tb=no -m bad_tests
+
+/skip_check:
+  tag+:
+    - skip_check
+  test: |
+    pytest -svv --tb=no -m skip_check

--- a/tests/integration/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
+++ b/tests/integration/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
@@ -26,6 +26,7 @@ def test_good_convertion(shell):
             )
         ]
     )
+    shell("subscription-manager unregister")
     assert convertion.returncode == 0
 
 
@@ -74,6 +75,7 @@ def test_bad_convertion(shell, insert_custom_kmod):
             )
         ]
     )
+    shell("subscription-manager unregister")
     assert convertion.returncode == 1
 
 
@@ -97,4 +99,5 @@ def test_skip_kmod_check(shell, insert_custom_kmod):
             )
         ]
     )
+    shell("subscription-manager unregister")
     assert convertion.returncode == 0

--- a/tests/integration/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
+++ b/tests/integration/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
@@ -78,6 +78,7 @@ def test_bad_convertion(shell, insert_custom_kmod):
 
 
 @pytest.mark.skip_check
+@pytest.mark.skip   # feature is not yet added - skipping
 def test_skip_kmod_check(shell, insert_custom_kmod):
     insert_custom_kmod()
     convertion = shell(

--- a/tests/integration/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
+++ b/tests/integration/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
@@ -1,0 +1,99 @@
+import pytest
+
+
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
+
+from envparse import env
+
+
+@pytest.mark.good_tests
+def test_good_convertion(shell):
+    convertion = shell(
+        command=[
+            (
+                "convert2rhel -y "
+                "--serverurl {} --username {} "
+                "--password {} --pool {} "
+                "--debug"
+            ).format(
+                env.str("RHSM_SERVER_URL"),
+                env.str("RHSM_USERNAME"),
+                env.str("RHSM_PASSWORD"),
+                env.str("RHSM_POOL"),
+            )
+        ]
+    )
+    assert convertion.returncode == 0
+
+
+@pytest.fixture()
+def insert_custom_kmod(shell):
+    def factory():
+        origin_kmod_loc = Path(
+            "/lib/modules/$(uname -r)/"
+            "kernel/drivers/net/bonding/bonding.ko.xz"
+        )
+        new_kmod_dir = origin_kmod_loc.parent / "custom_module_location"
+
+        shell(command=["mkdir {new_loc}".format(new_loc=str(new_kmod_dir))])
+        shell(
+            command=[
+                "mv {origin_kmod} {new_loc}".format(
+                    origin_kmod=str(origin_kmod_loc),
+                    new_loc=str(new_kmod_dir / origin_kmod_loc.name),
+                )
+            ]
+        )
+        shell(
+            command=[
+                "insmod {}".format(str(new_kmod_dir / origin_kmod_loc.name))
+            ]
+        )
+
+    return factory
+
+
+@pytest.mark.bad_tests
+def test_bad_convertion(shell, insert_custom_kmod):
+    insert_custom_kmod()
+    convertion = shell(
+        command=[
+            (
+                "convert2rhel -y "
+                "--serverurl {} --username {} "
+                "--password {} --pool {} "
+                "--debug"
+            ).format(
+                env.str("RHSM_SERVER_URL"),
+                env.str("RHSM_USERNAME"),
+                env.str("RHSM_PASSWORD"),
+                env.str("RHSM_POOL"),
+            )
+        ]
+    )
+    assert convertion.returncode == 1
+
+
+@pytest.mark.skip_check
+def test_skip_kmod_check(shell, insert_custom_kmod):
+    insert_custom_kmod()
+    convertion = shell(
+        command=[
+            (
+                "convert2rhel -y "
+                "--serverurl {} --username {} "
+                "--password {} --pool {} "
+                "--no-kmods-check "
+                "--debug"
+            ).format(
+                env.str("RHSM_SERVER_URL"),
+                env.str("RHSM_USERNAME"),
+                env.str("RHSM_PASSWORD"),
+                env.str("RHSM_POOL"),
+            )
+        ]
+    )
+    assert convertion.returncode == 0


### PR DESCRIPTION
**Blocked by:** #193 
**Blocked by:** #209 

A powerful feature that provides the framework of writing and running locally integration tests.

Uses:
- https://github.com/psss/tmt as tests and environment manager
- https://github.com/psss/fmf for defining the testing environment and execution used
- https://github.com/pytest-dev/pytest as framework for writing integration tests
- libvirt for providing VMs to test

Features:
- sends locally build rpms to the testing env and installs them
- together with tmt plan you can control weather to run the tests in one environment or in separate
- allows to use develop flag for further connecting to the test env machines for debugging purpose
- allows to choose which provisioned to use (available docker and libvirt)
- secrets management with help of .env and envparse

Additional training will be provided

ref #193 
