### PR TITLE
Feature/integration tests of read only mnt sys

### DIFF
--- a/plans/integration/read-only-mnt-sys/container_centos7.fmf
+++ b/plans/integration/read-only-mnt-sys/container_centos7.fmf
@@ -1,0 +1,20 @@
+discover+:
+  filter+:
+    - 'tag: centos7'
+provision:
+    how: docker
+    image: convert2rhel_centos7int:latest
+    pull: false
+    develop: true
+
+/mnt:
+  discover+:
+    filter+:
+      - 'tag: mnt_ro'
+  provision+:
+    run_args: "-v /mnt:/mnt:ro -v /sys:/sys"
+
+/sys:
+  discover+:
+    filter+:
+      - 'tag: sys_ro'

--- a/plans/integration/read-only-mnt-sys/container_centos8.fmf
+++ b/plans/integration/read-only-mnt-sys/container_centos8.fmf
@@ -1,0 +1,20 @@
+discover+:
+  filter+:
+    - 'tag: centos8'
+provision:
+    how: docker
+    image: convert2rhel_centos8int:latest
+    pull: false
+    develop: true
+
+/mnt:
+  discover+:
+    filter+:
+      - 'tag: mnt_ro'
+  provision+:
+    run_args: "-v /mnt:/mnt:ro -v /sys:/sys"
+
+/sys:
+  discover+:
+    filter+:
+      - 'tag: sys_ro'

--- a/plans/integration/read-only-mnt-sys/main.fmf
+++ b/plans/integration/read-only-mnt-sys/main.fmf
@@ -1,0 +1,3 @@
+discover+:
+    filter:
+        - 'tag: read-only-mnt-sys'

--- a/tests/integration/read-only-mnt-sys/main.fmf
+++ b/tests/integration/read-only-mnt-sys/main.fmf
@@ -1,0 +1,17 @@
+summary: read-only-sys-mnt in container
+tag:
+  - centos7
+  - centos8
+  - read-only-mnt-sys
+
+/mnt_ro:
+  tag+:
+    - mnt_ro
+  test: |
+    pytest -svv --tb=no -m mnt_ro
+
+/sys_ro:
+  tag+:
+    - sys_ro
+  test: |
+    pytest -svv --tb=no -m sys_ro

--- a/tests/integration/read-only-mnt-sys/test_read_only_mnt_sys_test.py
+++ b/tests/integration/read-only-mnt-sys/test_read_only_mnt_sys_test.py
@@ -1,0 +1,53 @@
+import pytest
+
+from envparse import env
+
+
+@pytest.mark.sys_ro
+def test_readonly_sys(shell, capsys):
+    convertion = shell(
+        command=[
+            (
+                "convert2rhel -y "
+                "--serverurl {} --username {} "
+                "--password {} --pool {} "
+                "--debug"
+            ).format(
+                env.str("RHSM_SERVER_URL"),
+                env.str("RHSM_USERNAME"),
+                env.str("RHSM_PASSWORD"),
+                env.str("RHSM_POOL"),
+            )
+        ]
+    )
+    out, err = capsys.readouterr()
+    assert (
+        "Stopping conversion due to read-only mount to "
+        "/sys directory" in out
+    )
+    assert convertion.returncode == 1
+
+
+@pytest.mark.mnt_ro
+def test_readonly_mnt(shell, capsys):
+    convertion = shell(
+        command=[
+            (
+                "convert2rhel -y "
+                "--serverurl {} --username {} "
+                "--password {} --pool {} "
+                "--debug"
+            ).format(
+                env.str("RHSM_SERVER_URL"),
+                env.str("RHSM_USERNAME"),
+                env.str("RHSM_PASSWORD"),
+                env.str("RHSM_POOL"),
+            )
+        ]
+    )
+    out, err = capsys.readouterr()
+    assert (
+        "Stopping conversion due to read-only mount to "
+        "/mnt directory" in out
+    )
+    assert convertion.returncode == 1


### PR DESCRIPTION
Tests @fellipeh feature of inhibition of the conversion when /mnt or /sys are read only only #194
Currently tests checks the messages and inhibition on centos7 and 8 for /sys:ro  only