### PR TITLE
Try the system to subscribe finite number of times

### DIFF
--- a/convert2rhel/unit_tests/__init__.py
+++ b/convert2rhel/unit_tests/__init__.py
@@ -197,17 +197,17 @@ class GetLoggerMocked(MockFunction):
     def __call__(self, msg):
         return self
 
-    def critical(self, msg):
+    def critical(self, msg, *args):
         self.critical_msgs.append(msg)
         raise SystemExit(1)
 
-    def error(self, msg):
+    def error(self, msg, *args):
         self.error_msgs.append(msg)
 
-    def task(self, msg):
+    def task(self, msg, *args):
         self.task_msgs.append(msg)
 
-    def info(self, msg):
+    def info(self, msg, *args):
         self.info_msgs.append(msg)
 
     def warn(self, msg, *args):
@@ -216,7 +216,7 @@ class GetLoggerMocked(MockFunction):
     def warning(self, msg, *args):
         self.warn(msg, *args)
 
-    def debug(self, msg):
+    def debug(self, msg, *args):
         self.debug_msgs.append(msg)
 
 

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -186,7 +186,7 @@ class TestSubscription(unittest.TestCase):
         self.assertEqual(subscription.register_system.called, 2)
 
     @unit_tests.mock(subscription, "loggerinst", GetLoggerMocked())
-    @unit_tests.mock(subscription, "MAX_NUM_OF_TRIALS_TO_SUBSCRIBE", 1)
+    @unit_tests.mock(subscription, "MAX_NUM_OF_ATTEMPTS_TO_SUBSCRIBE", 1)
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked([("nope", 1)]))
     @unit_tests.mock(subscription, "sleep", mock.Mock())
     def test_register_system_fail_non_interactive(self):


### PR DESCRIPTION
Previously utility tried an infinite number of times, asking the user for the credentials.
And only one time if credentials were provided through cli.

New solution provides fixed number of trials for both options
(may be adjusted via subscription.MAX_NUM_OF_TRIALS_TO_SUBSCRIBE)

and then inhibit the conversion.

The call for this feature comes from the experience of running integration tests when sometimes the system is unable to subscribe through the credentials provided by cli options.