### PR TITLE
Disable centos6 jobs until resolving the issue with ssl

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -11,7 +11,7 @@ jobs:
     name: linting-centos${{ matrix.centos_ver }}
     strategy:
       matrix:
-        centos_ver: [6, 7, 8]
+        centos_ver: [7, 8]
 
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: testing-centos${{ matrix.centos_ver }}
     strategy:
       matrix:
-        centos_ver: [6, 7, 8]
+        centos_ver: [7, 8]
 
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
Currently, container can't be build due to inability to install pip. We need to disable centos6 pipelines until finishing the investigation, in order do not block other MRs