### PR TITLE
test: disable fail-fast for CI & enable CentOS 6

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -10,8 +10,9 @@ jobs:
   linting:
     name: linting-centos${{ matrix.centos_ver }}
     strategy:
+      fail-fast: false
       matrix:
-        centos_ver: [7, 8]
+        centos_ver: [6, 7, 8]
 
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,9 @@ jobs:
   testing:
     name: testing-centos${{ matrix.centos_ver }}
     strategy:
+      fail-fast: false
       matrix:
-        centos_ver: [7, 8]
+        centos_ver: [6, 7, 8]
 
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast

Allows matrix-runs to continue running if a run fails

---

Re-enables CentOS 6 runs