### PR TITLE
fix: remove mod_ldap and mod_proxy_html

### DIFF
--- a/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
@@ -17,6 +17,8 @@ excluded_pkgs =
   libreport-plugin-mantisbt
   rhn*
   yum-rhn-plugin
+  mod_ldap
+  mod_proxy_html
 
 # List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
 # Delimited by any whitespace(s).


### PR DESCRIPTION
Adds `mod_ldap` and `mod_proxy_html` to `excluded_pkgs`. Only happens on CentOS 7