### PR TITLE
Remove cockpit-subscriptions not available in RHEL

### DIFF
--- a/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
@@ -19,6 +19,7 @@ excluded_pkgs =
   yum-rhn-plugin
   mod_ldap
   mod_proxy_html
+  cockpit-subscriptions
 
 # List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
 # Delimited by any whitespace(s).


### PR DESCRIPTION
Leaving this package on the system leads to a transaction failure. It conflicts with files of the RHEL package cockpit-system that is being installed during the conversion.