### PR TITLE
Do not print the output of finding kmods

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -125,7 +125,8 @@ def get_installed_kmods():
         kmod_str, exit_code = run_subprocess(
             'find /lib/modules/{kver} -name "*.ko*"'.format(
                 kver=kernel_version.rstrip("\n")
-            )
+            ),
+            print_output=False
         )
         assert exit_code == 0
         assert kmod_str


### PR DESCRIPTION
We call the `find` command to get the list of installed kernel modules.
We unintentionaly print the output of this command as a debug information. But it's of little value and adds hundreds or thousands lines to the log file.

Implements this missed review suggestion: https://github.com/oamg/convert2rhel/pull/193/files#r599911927.