### PR TITLE
pkgs should be sorted for get_most_recent_unique_kernel_pkgs

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -126,7 +126,7 @@ def get_installed_kmods():
             'find /lib/modules/{kver} -name "*.ko*" -type f'.format(
                 kver=kernel_version.rstrip("\n")
             ),
-            print_output=False
+            print_output=False,
         )
         assert exit_code == 0
         assert kmod_str
@@ -243,7 +243,7 @@ def get_most_recent_unique_kernel_pkgs(pkgs):
     """
 
     pkgs_groups = itertools.groupby(
-        pkgs, lambda pkg_name: pkg_name.split(":")[0]
+        sorted(pkgs), lambda pkg_name: pkg_name.split(":")[0]
     )
     return (
         max(distinct_kernel_pkgs[1], key=_repos_version_key)

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -286,8 +286,8 @@ def test_get_rhel_supported_kmods(
         (
             (
                 "kernel-core-0:4.18.0-240.10.1.el8_3.x86_64",
-                "kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",
                 "kernel-debug-core-0:4.18.0-240.10.1.el8_3.x86_64",
+                "kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",
                 "kernel-debug-core-0:4.18.0-240.15.1.el8_3.x86_64",
             ),
             (


### PR DESCRIPTION
Otherwise the itertools.groupby doesn't work properly on python2