### PR TITLE
Ignore kmods moved to kernel core

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -287,7 +287,11 @@ def get_rhel_kmods_keys(rhel_kmods_str):
 
 def get_unsupported_kmods(host_kmods, rhel_supported_kmods):
     """Return a set of those installed kernel modules that are not available in RHEL repositories.
-    
+
     Ignore certain kmods mentioned in the system configs. These kernel modules moved to kernel core, meaning that the
-    functionality is retained and we would be incorrectly saying that the modules are not supported in RHEL. """
-    return host_kmods - rhel_supported_kmods - set(system_info.kmods_to_ignore)
+    functionality is retained and we would be incorrectly saying that the modules are not supported in RHEL."""
+    return (
+        host_kmods
+        - rhel_supported_kmods
+        - set(system_info.kmods_to_ignore)
+    )

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -87,14 +87,15 @@ def ensure_compatibility_of_kmods():
     """Ensure if the host kernel modules are compatible with RHEL."""
     host_kmods = get_installed_kmods()
     rhel_supported_kmods = get_rhel_supported_kmods()
-    if is_unsupported_kmod_installed(host_kmods, rhel_supported_kmods):
+    unsupported_kmods = get_unsupported_kmods(host_kmods, rhel_supported_kmods)
+    if unsupported_kmods:
         kernel_version = run_subprocess("uname -r")[0].rstrip("\n")
         not_supported_kmods = "\n".join(
             map(
                 lambda kmod: "/lib/modules/{kver}/{kmod}".format(
                     kver=kernel_version, kmod=kmod
                 ),
-                host_kmods - rhel_supported_kmods,
+                unsupported_kmods,
             )
         )
         # TODO logger.critical("message %s, %s", "what should be under s")
@@ -284,6 +285,9 @@ def get_rhel_kmods_keys(rhel_kmods_str):
     )
 
 
-def is_unsupported_kmod_installed(host_kmods, rhel_supported_kmods):
-    """Return True if any of the installed kernel modules is not available in RHEL repositories."""
-    return not host_kmods.issubset(rhel_supported_kmods)
+def get_unsupported_kmods(host_kmods, rhel_supported_kmods):
+    """Return a set of those installed kernel modules that are not available in RHEL repositories.
+    
+    Ignore certain kmods mentioned in the system configs. These kernel modules moved to kernel core, meaning that the
+    functionality is retained and we would be incorrectly saying that the modules are not supported in RHEL. """
+    return host_kmods - rhel_supported_kmods - set(system_info.kmods_to_ignore)

--- a/convert2rhel/data/6/x86_64/configs/centos-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/centos-6-x86_64.cfg
@@ -26,3 +26,7 @@ repofile_pkgs =
 default_rhsm_repoids = rhel-6-server-rpms
 
 releasever=6.10
+
+# Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
+# that such a module is not available in RHEL and thus is unsupported, we ignore it.
+kmods_to_ignore = 

--- a/convert2rhel/data/6/x86_64/configs/oracle-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/oracle-6-x86_64.cfg
@@ -38,3 +38,7 @@ repofile_pkgs =
 default_rhsm_repoids = rhel-6-server-rpms
 
 releasever=6.10
+
+# Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
+# that such a module is not available in RHEL and thus is unsupported, we ignore it.
+kmods_to_ignore = 

--- a/convert2rhel/data/6/x86_64/configs/suse_es-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/suse_es-6-x86_64.cfg
@@ -19,3 +19,7 @@ repofile_pkgs =
 default_rhsm_repoids = rhel-6-server-rpms
 
 releasever=6.10
+
+# Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
+# that such a module is not available in RHEL and thus is unsupported, we ignore it.
+kmods_to_ignore = 

--- a/convert2rhel/data/7/ppc64/configs/centos-7-ppc64.cfg
+++ b/convert2rhel/data/7/ppc64/configs/centos-7-ppc64.cfg
@@ -27,3 +27,7 @@ repofile_pkgs =
 default_rhsm_repoids = rhel-7-server-rpms
 
 releasever=7Server
+
+# Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
+# that such a module is not available in RHEL and thus is unsupported, we ignore it.
+kmods_to_ignore = 

--- a/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
@@ -30,3 +30,8 @@ repofile_pkgs =
 default_rhsm_repoids = rhel-7-server-rpms
 
 releasever=7Server
+
+# Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
+# that such a module is not available in RHEL and thus is unsupported, we ignore it.
+kmods_to_ignore = 
+  kernel/drivers/input/ff-memless.ko.xz

--- a/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
@@ -36,3 +36,8 @@ repofile_pkgs =
 default_rhsm_repoids = rhel-7-server-rpms
 
 releasever=7Server
+
+# Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
+# that such a module is not available in RHEL and thus is unsupported, we ignore it.
+kmods_to_ignore = 
+  kernel/drivers/input/ff-memless.ko.xz

--- a/convert2rhel/data/7/x86_64/configs/suse_es-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/suse_es-7-x86_64.cfg
@@ -19,3 +19,7 @@ repofile_pkgs =
 default_rhsm_repoids = rhel-7-server-rpms
 
 releasever=7Server
+
+# Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
+# that such a module is not available in RHEL and thus is unsupported, we ignore it.
+kmods_to_ignore = 

--- a/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
@@ -31,3 +31,7 @@ default_rhsm_repoids =
   rhel-8-for-x86_64-appstream-rpms
 
 releasever=8
+
+# Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
+# that such a module is not available in RHEL and thus is unsupported, we ignore it.
+kmods_to_ignore = 

--- a/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
@@ -28,3 +28,7 @@ default_rhsm_repoids =
   rhel-8-for-x86_64-appstream-rpms
 
 releasever=8
+
+# Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
+# that such a module is not available in RHEL and thus is unsupported, we ignore it.
+kmods_to_ignore = 

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -180,7 +180,7 @@ class SystemInfo(object):
         return self._get_cfg_opt("releasever")
     
     def _get_kmods_to_ignore(self):
-        return self._get_cfg_opt("kmods_to_ignore")
+        return self._get_cfg_opt("kmods_to_ignore").split()
 
     def generate_rpm_va(self, log_filename=PRE_RPM_VA_LOG_FILENAME):
         """RPM is able to detect if any file installed as part of a package has been changed in any way after the

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -72,6 +72,8 @@ class SystemInfo(object):
         # List of repositories enabled through subscription-manager
         self.submgr_enabled_repos = []
         self.releasever = None
+        # List of kmods to not inhbit the conversion upon when detected as not available in RHEL
+        self.kmods_to_ignore = []
 
     def resolve_system_info(self):
         self.logger = logging.getLogger(__name__)
@@ -89,6 +91,7 @@ class SystemInfo(object):
         self.fingerprints_orig_os = self._get_gpg_key_fingerprints()
         self.generate_rpm_va()
         self.releasever = self._get_releasever()
+        self.kmods_to_ignore = self._get_kmods_to_ignore()
 
     @staticmethod
     def _get_system_release_file_content():
@@ -175,6 +178,9 @@ class SystemInfo(object):
 
     def _get_releasever(self):
         return self._get_cfg_opt("releasever")
+    
+    def _get_kmods_to_ignore(self):
+        return self._get_cfg_opt("kmods_to_ignore")
 
     def generate_rpm_va(self, log_filename=PRE_RPM_VA_LOG_FILENAME):
         """RPM is able to detect if any file installed as part of a package has been changed in any way after the

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -73,18 +73,29 @@ def setup_logger(tmpdir):
     initialize_logger(log_name="convert2rhel", log_dir=tmpdir)
 
 
-@pytest.fixture()
-def _replace_data_dir_for_centos8(monkeypatch, pkg_root):
-    monkeypatch.setattr(
-        utils,
-        "DATA_DIR",
-        value=str(pkg_root / "convert2rhel/data/8/x86_64/"),
-    )
+def _replace_data_dir_base(system_version_num):
+    """Factory function serves as a base to mokeypatch utils.DATA_DIR."""
+
+    def fixture(monkeypatch, pkg_root):
+        monkeypatch.setattr(
+            utils,
+            "DATA_DIR",
+            value=str(
+                pkg_root
+                / ("convert2rhel/data/%s/x86_64/" % system_version_num)
+            ),
+        )
+
+    return fixture
 
 
-@pytest.fixture()
-def pretend_centos8(monkeypatch, _replace_data_dir_for_centos8):
-    # TODO create similar for rest systems and document its usage
+_replace_data_dir_for_centos8 = pytest.fixture(_replace_data_dir_base("8"))
+_replace_data_dir_for_centos7 = pytest.fixture(_replace_data_dir_base("7"))
+
+
+def _pretend_fixture_base(monkeypatch, system_release_version):
+    """Apply common logic in pretend_{os_name} fixtures."""
+
     monkeypatch.setattr(
         redhatrelease,
         "get_system_release_filepath",
@@ -93,7 +104,34 @@ def pretend_centos8(monkeypatch, _replace_data_dir_for_centos8):
     monkeypatch.setattr(
         utils,
         "get_file_content",
-        value=lambda _: "CentOS Linux release 8.3.2011",
+        value=lambda _: "CentOS Linux release %s" % system_release_version,
     )
     tool_opts.no_rpm_va = True
     system_info.resolve_system_info()
+
+
+def _pretend_centos_base(system_release_version):
+    """Factory function serves as a base to pretend_{os} fixtures."""
+    def fixture_centos7(monkeypatch, _replace_data_dir_for_centos7):
+        _pretend_fixture_base(monkeypatch, system_release_version)
+
+    def fixture_centos8(monkeypatch, _replace_data_dir_for_centos8):
+        _pretend_fixture_base(monkeypatch, system_release_version)
+
+    release2data_dir_relations = {
+        "8.3.2011": fixture_centos8,
+        "7.9.2009": fixture_centos7,
+    }
+
+    try:
+        return release2data_dir_relations[system_release_version]
+    except KeyError:
+        raise KeyError(
+            "Unknown system release version %s.\n"
+            "Available are: %s"
+            % (system_release_version, " ".join(release2data_dir_relations)),
+        )
+
+
+pretend_centos8 = pytest.fixture(_pretend_centos_base("8.3.2011"))
+pretend_centos7 = pytest.fixture(_pretend_centos_base("7.9.2009"))


### PR DESCRIPTION
Some kernel modules move from kernel modules to kernel core. Instead of
inhibiting the conversion saying that such a module is not available in
RHEL and thus is unsupported, we ignore it.