### PR TITLE
Do not inhibit conversion on unsupported kmods

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -99,12 +99,10 @@ def ensure_compatibility_of_kmods():
         )
         # TODO logger.critical("message %s, %s", "what should be under s")
         #  doesn't work. We have `%s` as output instead. Make it work
-        logger.critical(
+        logger.warning(
             (
                 "The following kernel modules are not "
-                "supported in RHEL:\n{kmods}\n"
-                "Uninstall or disable them and run convert2rhel "
-                "again to continue with the conversion."
+                "supported in RHEL:\n{kmods}"
             ).format(kmods=not_supported_kmods)
         )
     else:

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -149,7 +149,7 @@ def test_pre_ponr_checks(monkeypatch):
         ),
         (
             HOST_MODULES_STUB_BAD,
-            SystemExit,
+            None,
             None,
             "Kernel modules are compatible",
         ),


### PR DESCRIPTION
There might be false positives so we don't want to inhibit in those
cases.