### PR TITLE
fix: remove dep resolve correctly

### DIFF
--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -64,7 +64,7 @@ def call_yum_cmd_w_downgrades(cmd, pkgs):
             break
         # handle error condition
         loggerinst.info("Resolving dependency errors ... ")
-        resolve_dep_errors(output, [])
+        output = resolve_dep_errors(output, [])
         # if we have problematic packages, remove them
         problematic_pkgs = get_problematic_pkgs(output, [])
         if problematic_pkgs["errors"]:
@@ -187,15 +187,15 @@ def resolve_dep_errors(output, pkgs):
         # There's no point in calling the yum downgrade command again.
         loggerinst.info("No other package to try to downgrade in order to"
                         " resolve yum dependency errors.")
-        return
+        return output
     problematic_pkgs['all'] += pkgs
     cmd = "distro-sync"
     loggerinst.info("\n\nTrying to resolve the following packages: %s"
                     % ", ".join(problematic_pkgs['all']))
     output, ret_code = call_yum_cmd(command=cmd, args=" %s" % " ".join(problematic_pkgs['all']))
     if ret_code != 0:
-        resolve_dep_errors(output, problematic_pkgs['all'])
-    return
+        return resolve_dep_errors(output, problematic_pkgs['all'])
+    return output
 
 
 def get_installed_pkgs_by_fingerprint(fingerprints, name=""):

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -31,7 +31,7 @@ loggerinst = logging.getLogger(__name__)
 
 # Limit the number of loops over yum command calls for the case there was
 # an error.
-MAX_YUM_CMD_CALLS = 2
+MAX_YUM_CMD_CALLS = 3
 
 _VERSIONLOCK_FILE_PATH = '/etc/yum/pluginconf.d/versionlock.list'  # This file is used by the dnf plugin as well
 versionlock_file = utils.RestorableFile(_VERSIONLOCK_FILE_PATH)  # pylint: disable=C0103

--- a/convert2rhel/unit_tests/other_test.py
+++ b/convert2rhel/unit_tests/other_test.py
@@ -27,7 +27,7 @@ class TestOther(unittest.TestCase):
         # Prevents unintentional change of constants
         self.assertEqual(utils.TMP_DIR, "/var/lib/convert2rhel/")
         self.assertEqual(utils.DATA_DIR, "/usr/share/convert2rhel/")
-        self.assertEqual(pkghandler.MAX_YUM_CMD_CALLS, 2)
+        self.assertEqual(pkghandler.MAX_YUM_CMD_CALLS, 3)
         self.assertEqual(logger.LOG_DIR, "/var/log/convert2rhel")
 
 

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -243,8 +243,8 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertEqual(pkghandler.call_yum_cmd.called, 2)
 
     @unit_tests.mock(pkghandler, "call_yum_cmd", CallYumCmdMocked())
-    @unit_tests.mock(pkghandler, "get_installed_pkgs_by_fingerprint", lambda x: ["pkg"])
-    @unit_tests.mock(pkghandler, "resolve_dep_errors", DumbCallableObject())
+    @unit_tests.mock(pkghandler, "get_installed_pkgs_by_fingerprint", lambda _: ["pkg"])
+    @unit_tests.mock(pkghandler, "resolve_dep_errors", lambda output, __: output)
     @unit_tests.mock(pkghandler, "get_problematic_pkgs", lambda pkg, _: {"errors": pkg})
     @unit_tests.mock(utils, "remove_pkgs", RemovePkgsMocked())
     def test_call_yum_cmd_w_downgrades_remove_problematic_pkgs(self):
@@ -252,8 +252,6 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         pkghandler.MAX_YUM_CMD_CALLS = 1
 
         self.assertRaises(SystemExit, pkghandler.call_yum_cmd_w_downgrades, "test_cmd", ["fingerprint"])
-
-        self.assertEqual(pkghandler.resolve_dep_errors.called, 1)
 
         self.assertEqual(utils.remove_pkgs.pkgs, pkghandler.call_yum_cmd.return_string)
         self.assertEqual(utils.remove_pkgs.critical, False)


### PR DESCRIPTION
Currently whenever we get dependencies to remove we don't use the correct output. We should grab the output that comes from already resolving the dependency issues.