### PR TITLE
Remove anaconda-dracut (in the optional repo)

### DIFF
--- a/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
@@ -8,18 +8,19 @@ gpg_fingerprints = 24c6a8a7f4a80eb5
 # List of packages to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
+  anaconda-dracut
   centos-bookmarks
-  centos-logos
   centos-indexhtml
+  centos-logos
+  cockpit-subscriptions
   geoipupdate
   kmod-kvdo
   libreport-centos
   libreport-plugin-mantisbt
-  rhn*
-  yum-rhn-plugin
   mod_ldap
   mod_proxy_html
-  cockpit-subscriptions
+  rhn*
+  yum-rhn-plugin
 
 # List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
@@ -9,18 +9,19 @@ gpg_fingerprints = 72f97b74ec551f03
 # List of packages to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
-  oracle-logos
-  yum-plugin-ulninfo
   akonadi-mysql
-  oracleasm-support
+  anaconda-dracut
+  oracle-logos
   oracle-rdbms-server-*
+  oracleasm-support
   rhn-check
+  rhn-client-tools
   rhn-setup
   rhn-setup-gnome
   rhnlib
   rhnsd
+  yum-plugin-ulninfo
   yum-rhn-plugin
-  rhn-client-tools
 
 # List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
 # The rhn-client-tools package contains repofiles on OL 7.6 and older, but when it's installed it's not possible to


### PR DESCRIPTION
The anaconda-dracut and anaconda-core rpms share by mistake 2 libexec
libraries on RHEL 7. As the anaconda-dracut rpm is present just inside
the optional repository on RHEL 7 which is by default disabled for
the conversion, the rpm transaction ends with conflicts between
anaconda-dracut and anaconda-core rpms. It do not even seems expected
that users could want to use the rpm at all. So just remove the rpm
during the conversion if installed.

The lists have been sorted for better orientation. Just the anaconda-dracut has been added.