### PR TITLE
Revert "Do not inhibit conversion on unsupported kmods"

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -100,10 +100,12 @@ def ensure_compatibility_of_kmods():
         )
         # TODO logger.critical("message %s, %s", "what should be under s")
         #  doesn't work. We have `%s` as output instead. Make it work
-        logger.warning(
+        logger.critical(
             (
                 "The following kernel modules are not "
-                "supported in RHEL:\n{kmods}"
+                "supported in RHEL:\n{kmods}\n"
+                "Uninstall or disable them and run convert2rhel "
+                "again to continue with the conversion."
             ).format(kmods=not_supported_kmods)
         )
     else:

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -151,7 +151,7 @@ def test_pre_ponr_checks(monkeypatch):
         ),
         (
             HOST_MODULES_STUB_BAD,
-            None,
+            SystemExit,
             None,
             "Kernel modules are compatible",
         ),


### PR DESCRIPTION
This reverts commit 5fb00030b4054dbb3c3cde9862eb2c2b12c0dce3 (https://github.com/oamg/convert2rhel/pull/229).