### PR TITLE
Resolve yum errors with downgrades, not distro-sync

### DIFF
--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -189,7 +189,7 @@ def resolve_dep_errors(output, pkgs):
                         " resolve yum dependency errors.")
         return output
     problematic_pkgs['all'] += pkgs
-    cmd = "distro-sync"
+    cmd = "downgrade"
     loggerinst.info("\n\nTrying to resolve the following packages: %s"
                     % ", ".join(problematic_pkgs['all']))
     output, ret_code = call_yum_cmd(command=cmd, args=" %s" % " ".join(problematic_pkgs['all']))


### PR DESCRIPTION
Yum has a problematic resolution of dependencies in general. It
oftentimes ends up with a transaction error even though there's a way to
resolve the transaction, mainly when there are downgrades necessary.
Using yum downgrade instead of distro-sync should be more reliable in
this regards.