### PR TITLE
Remove non-interactive command suggestion

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -101,10 +101,6 @@ def main():
         loggerinst.task("Final: rpm files modified by the conversion")
         systeminfo.system_info.modified_rpm_files_diff()
 
-        # recommend non-interactive command
-        loggerinst.task("Final: Non-interactive mode")
-        toolopts.print_non_interactive_opts()
-
         # restart system if required
         utils.restart_system()
 

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -249,37 +249,5 @@ class CLI(object):
             tool_opts.credentials_thru_cli = True
 
 
-def print_non_interactive_opts():
-    """Print command line options to be used for the next run of the tool
-    to avoid the need of any interactive input during the system conversion.
-    """
-    loggerinst.info("For the non-interactive use of the tool, run the"
-                    " following command:")
-    global tool_opts  # pylint: disable=C0103
-    cmd = utils.get_executable_name()
-
-    if tool_opts.disable_submgr:
-        cmd += " --disable-submgr "
-        for repo in tool_opts.disablerepo:
-            cmd += " --disablerepo=%s " % repo
-        for repo in tool_opts.enablerepo:
-            cmd += " --enablerepo=%s " % repo
-    else:
-        if tool_opts.username:
-            cmd += " -u %s" % tool_opts.username
-            if tool_opts.password_file:
-                pswd_opt = " -f %s" % tool_opts.password_file
-            else:
-                pswd_opt = " -p *****"
-            cmd += pswd_opt
-        if tool_opts.activation_key:
-            cmd += " -k %s" % tool_opts.activation_key
-        if tool_opts.org:
-            cmd += " -o %s" % tool_opts.org
-        cmd += " %s" % tool_opts.pool
-    cmd += " -y"
-    loggerinst.info(cmd + "\n\n")
-
-
 # Code to be executed upon module import
 tool_opts = ToolOpts()  # pylint: disable=C0103


### PR DESCRIPTION
Currently the feature of suggesting a convert2rhel command to run on other systems to convert in a non-interactive fashion is not working properly. For example, it is missing couple of switches (e.g. --no-rpm-va and --debug) and does not handle well the situation with enabled repoids when RHSM is used.

To reduce the codebase to maintain and for the lack of feedback on this feature, we decided to remove it.

An example of the output being removed:
```
[03/29/2021 19:55:12] TASK - [Final: Non-interactive mode] **************************************
For the non-interactive use of the tool, run the following command:
convert2rhel --disable-submgr  --disablerepo=*  --enablerepo=rhel-7-server-rpms  -y
```

Related: https://issues.redhat.com/browse/OAMG-3141