### PR TITLE
Remove gpg-pubkey

### DIFF
--- a/convert2rhel/data/6/x86_64/configs/centos-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/centos-6-x86_64.cfg
@@ -15,6 +15,7 @@ excluded_pkgs =
   libreport-plugin-mantisbt
   rhnlib
   yum-rhn-plugin
+  gpg-pubkey
 
 # List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/6/x86_64/configs/oracle-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/oracle-6-x86_64.cfg
@@ -22,6 +22,7 @@ excluded_pkgs =
   rhn-setup-gnome
   rhnlib
   rhnsd
+  gpg-pubkey
 
 # List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/6/x86_64/configs/suse_es-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/suse_es-6-x86_64.cfg
@@ -6,9 +6,10 @@ gpg_fingerprints =
 # List of packages to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
-  - sles_es-indexhtml
-  - suseRegisterInfo
-  - suseRegisterRES
+  sles_es-indexhtml
+  suseRegisterInfo
+  suseRegisterRES
+  gpg-pubkey
 
 # List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/7/ppc64/configs/centos-7-ppc64.cfg
+++ b/convert2rhel/data/7/ppc64/configs/centos-7-ppc64.cfg
@@ -15,6 +15,7 @@ excluded_pkgs =
   centos-indexhtml
   libreport-centos
   libreport-plugin-mantisbt
+  gpg-pubkey
 
 # List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
@@ -21,6 +21,7 @@ excluded_pkgs =
   mod_proxy_html
   rhn*
   yum-rhn-plugin
+  gpg-pubkey
 
 # List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
@@ -22,6 +22,7 @@ excluded_pkgs =
   rhnsd
   yum-plugin-ulninfo
   yum-rhn-plugin
+  gpg-pubkey
 
 # List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
 # The rhn-client-tools package contains repofiles on OL 7.6 and older, but when it's installed it's not possible to

--- a/convert2rhel/data/7/x86_64/configs/suse_es-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/suse_es-7-x86_64.cfg
@@ -6,9 +6,10 @@ gpg_fingerprints =
 # List of packages to be removed before the system conversion starts.
 # Delimited by any whitespace(s).
 excluded_pkgs =
-  - sles_es-indexhtml
-  - suseRegisterInfo
-  - suseRegisterRES
+  sles_es-indexhtml
+  suseRegisterInfo
+  suseRegisterRES
+  gpg-pubkey
 
 # List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
@@ -13,6 +13,7 @@ excluded_pkgs =
   centos-obsolete-packages
   rhn*
   python3-rhn*
+  gpg-pubkey
 
 # List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
@@ -13,6 +13,7 @@ excluded_pkgs =
   oracle-backgrounds
   rhn*
   python3-rhn*
+  gpg-pubkey
 
 # List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
 # Delimited by any whitespace(s).


### PR DESCRIPTION
Remove gpg-pubkey packages of the original system to convert. They contain the CentOS/Oracle/Suse GPG keys that won't be needed on the converted system anymore.