### PR TITLE
Improvement of UX registration

### DIFF
--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -89,8 +89,12 @@ def register_system():
     attempt = 0
     while True and attempt < MAX_NUM_OF_ATTEMPTS_TO_SUBSCRIBE:
         registration_cmd = get_registration_cmd()
-        loggerinst.info("Attempt %s of %s: Registering system by running subscription-manager"
-                        " command ... ", attempt+1, MAX_NUM_OF_ATTEMPTS_TO_SUBSCRIBE)
+
+        attempt_msg = ""
+        if attempt > 0:
+            attempt_msg = "Attempt %d of %d: " % (attempt + 1, MAX_NUM_OF_ATTEMPTS_TO_SUBSCRIBE)
+        loggerinst.info("%sRegistering the system using subscription-manager ...", attempt_msg)
+
         ret_code = call_registration_cmd(registration_cmd)
         if ret_code == 0:
             return
@@ -122,8 +126,11 @@ def get_registration_cmd():
         registration_cmd += " --activationkey=%s" % tool_opts.activation_key
     else:
         # No activation key -> username/password required
-        loggerinst.info("    ... activation key not found, username and"
-                        " password required")
+        if tool_opts.username and tool_opts.password:
+            loggerinst.info("    ... activation key not found, using given username and password")
+        else:
+            loggerinst.info("    ... activation key not found, username and password required")
+
         if tool_opts.username:
             loggerinst.info("    ... username detected")
             username = tool_opts.username


### PR DESCRIPTION
The piece of message "provide username and password" is not printed - it does not make sense when using RHSM with activation key + org ID
The message "Attempt x of 3..." is printed only if registration unsuccessful to not scare people as most of the time it's successful

Looks like many changes, but from me are just two: added if+else from line [99](https://github.com/oamg/convert2rhel/pull/247/commits/0df8b4902a08d4871d82a8e98e7de3f2ec54c5bc#diff-51e9ff11d39778d3b26778b293fc350430a82e2feed0dab2938da7c0069ffdc6R99) and if+else from line [147](https://github.com/oamg/convert2rhel/pull/247/commits/0df8b4902a08d4871d82a8e98e7de3f2ec54c5bc#diff-51e9ff11d39778d3b26778b293fc350430a82e2feed0dab2938da7c0069ffdc6R147). The rest of the changes is made by Black code formatter.