### PR TITLE
Remove misleading --variant related messages

### DIFF
--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -222,11 +222,6 @@ class CLI(object):
 
         if any(x in sys.argv[1:] for x in ['--variant', '-v']):
             loggerinst.warning("The --variant option is not supported anymore.")
-            if parsed_opts.disable_submgr:
-                loggerinst.warning("The system will be converted to the RHEL variant provided by the repositories you"
-                                   " have enabled through the --enablerepo option.")
-            else:
-                loggerinst.warning("The system will be converted to the Server variant of RHEL.")
             utils.ask_to_continue()
 
         if parsed_opts.serverurl:


### PR DESCRIPTION
The warning messages are giving incorrect information when converting to RHEL 8 which comes with no variants.

This follows up on https://github.com/oamg/convert2rhel/pull/246.