### PR TITLE
Feature: inhibit if non-standard kernel is used

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -22,14 +22,27 @@ import os
 import re
 import subprocess
 
+from convert2rhel.pkghandler import (
+    get_installed_pkg_objects,
+    get_pkg_fingerprint,
+)
 from convert2rhel.systeminfo import system_info
-from convert2rhel.utils import run_subprocess, get_file_content
+from convert2rhel.utils import get_file_content, run_subprocess
+
 
 logger = logging.getLogger(__name__)
 
-KERNEL_REPO_RE = re.compile("^.+:(?P<version>.+).el.+$")
-KERNEL_REPO_VER_SPLIT_RE = re.compile("\W+")
+KERNEL_REPO_RE = re.compile(r"^.+:(?P<version>.+).el.+$")
+KERNEL_REPO_VER_SPLIT_RE = re.compile(r"\W+")
+BAD_KERNEL_RELEASE_SUBSTRINGS = ("uek", "rt", "linode")
+
 LINK_KMODS_RH_POLICY = "https://access.redhat.com/third-party-software-support"
+# The kernel version stays the same throughout a RHEL major version
+COMPATIBLE_KERNELS_VERS = {
+    6: "2.6.32",
+    7: "3.10.0",
+    8: "4.18.0",
+}
 
 
 def perform_pre_checks():
@@ -37,6 +50,7 @@ def perform_pre_checks():
     check_uefi()
     check_tainted_kmods()
     check_readonly_mounts()
+    check_rhel_compatible_kernel_is_used()
 
 
 def check_uefi():
@@ -163,7 +177,8 @@ def get_installed_kmods():
         logger.critical("Can't get list of kernel modules.")
     else:
         return set(
-            _get_kmod_comparison_key(path) for path in kmod_str.rstrip("\n").split()
+            _get_kmod_comparison_key(path)
+            for path in kmod_str.rstrip("\n").split()
         )
 
 
@@ -212,7 +227,9 @@ def get_rhel_supported_kmods():
         print_output=False,
     )
     # from these packages we select only the latest one
-    kmod_pkgs = get_most_recent_unique_kernel_pkgs(kmod_pkgs_str.rstrip("\n").split())
+    kmod_pkgs = get_most_recent_unique_kernel_pkgs(
+        kmod_pkgs_str.rstrip("\n").split()
+    )
     # querying obtained packages for files they produces
     rhel_kmods_str, _ = run_subprocess(
         (
@@ -318,3 +335,116 @@ def get_unsupported_kmods(host_kmods, rhel_supported_kmods):
     Ignore certain kmods mentioned in the system configs. These kernel modules moved to kernel core, meaning that the
     functionality is retained and we would be incorrectly saying that the modules are not supported in RHEL."""
     return host_kmods - rhel_supported_kmods - set(system_info.kmods_to_ignore)
+
+
+def check_rhel_compatible_kernel_is_used():
+    """Ensure the booted kernel is signed, is standard (not UEK, realtime, ...), and has the same version as in RHEL.
+
+    By requesting that, we can be confident that the RHEL kernel will provide the same capabilities as on the
+    original system.
+    """
+    logger.task("Prepare: Check kernel compatibility with RHEL")
+    kernel_release = run_subprocess("uname -r", print_output=False)[0].rstrip()
+    logger.debug(
+        "Booted kernel VRA (version, release, architecture): {0}".format(
+            kernel_release
+        )
+    )
+    if any(
+        (
+            _bad_kernel_version(kernel_release),
+            _bad_kernel_package_signature(kernel_release),
+            _bad_kernel_substring(kernel_release),
+        )
+    ):
+        logger.critical(
+            "The booted kernel version is incompatible with the standard RHEL kernel. "
+            "To proceed with the conversion, boot into a kernel that is available in the {0} {1} base repository"
+            " by executing the following steps:\n\n"
+            "1. Ensure that the {0} {1} base repository is enabled\n"
+            "2. Run: yum install kernel\n"
+            "3. (optional) Run: grubby --set-default "
+            '/boot/vmlinuz-`rpm -q --qf "%{{EVR}}.%{{ARCH}}\\n" kernel | sort -r | head -n 1`\n'
+            "4. Reboot the machine and if step 3 was not applied choose the kernel"
+            " installed in step 2 manually".format(
+                system_info.name, system_info.version.major
+            )
+        )
+    else:
+        logger.debug("Kernel is compatible with RHEL")
+
+
+def _bad_kernel_version(kernel_release):
+    """Return True if the booted kernel version does not correspond to the kernel version available in RHEL."""
+    kernel_version = kernel_release.split("-")[0]
+    try:
+        incompatible_version = (
+            COMPATIBLE_KERNELS_VERS[system_info.version.major]
+            != kernel_version
+        )
+        if incompatible_version:
+            logger.warning(
+                "Booted kernel version '%s' does not correspond to the version "
+                "'%s' available in RHEL %d"
+                % (
+                    kernel_version,
+                    COMPATIBLE_KERNELS_VERS[system_info.version.major],
+                    system_info.version.major,
+                )
+            )
+        else:
+            logger.debug(
+                "Booted kernel version '%s' corresponds to the version available in RHEL %d"
+                % (kernel_version, system_info.version.major)
+            )
+        return incompatible_version
+    except KeyError:
+        logger.debug(
+            "Unexpected OS major version. Expected: %r"
+            % COMPATIBLE_KERNELS_VERS.keys()
+        )
+        return True
+
+
+def _bad_kernel_package_signature(kernel_release):
+    """Return True if the booted kernel is not signed by the original OS vendor, i.e. it's a custom kernel."""
+    kernel_pkg = run_subprocess(
+        'rpm -qf --qf "%{{NAME}}" /boot/vmlinuz-{kernel_release}'.format(
+            kernel_release=kernel_release
+        ),
+        print_output=False,
+    )[0]
+    logger.debug("Booted kernel package name: {0}".format(kernel_pkg))
+    kernel_pkg_obj = get_installed_pkg_objects(kernel_pkg)[0]
+    kernel_pkg_gpg_fingerprint = get_pkg_fingerprint(kernel_pkg_obj)
+    bad_signature = (
+        system_info.cfg_content["gpg_fingerprints"]
+        != kernel_pkg_gpg_fingerprint
+    )
+    # e.g. Oracle Linux Server -> Oracle
+    os_vendor = system_info.name.split()[0]
+    if bad_signature:
+        logger.warning(
+            "Custom kernel detected. "
+            "The booted kernel needs to be signed by %s." % os_vendor
+        )
+        return True
+    logger.debug("The booted kernel is signed by %s." % os_vendor)
+    return False
+
+
+def _bad_kernel_substring(kernel_release):
+    """Return True if the booted kernel release contains one of the strings that identify it as non-standard kernel."""
+    bad_substring = any(
+        bad_substring in kernel_release
+        for bad_substring in BAD_KERNEL_RELEASE_SUBSTRINGS
+    )
+    if bad_substring:
+        logger.debug(
+            "The booted kernel '{0}' contains one of the disallowed "
+            "substrings: {1}".format(
+                kernel_release, BAD_KERNEL_RELEASE_SUBSTRINGS
+            )
+        )
+        return True
+    return False

--- a/plans/integration/inhibit-if-oracle-system-uses-not-standard-kernel/main.fmf
+++ b/plans/integration/inhibit-if-oracle-system-uses-not-standard-kernel/main.fmf
@@ -1,0 +1,3 @@
+discover+:
+    filter:
+        - 'tag: inhibit-if-oracle-system-uses-not-standard-kernel'

--- a/plans/integration/inhibit-if-oracle-system-uses-not-standard-kernel/vm_oracle7.fmf
+++ b/plans/integration/inhibit-if-oracle-system-uses-not-standard-kernel/vm_oracle7.fmf
@@ -1,0 +1,19 @@
+discover+:
+    filter+:
+        - 'tag: oracle7'
+provision:
+    how: libvirt
+    origin_vm_name: c2r_oracle7_template
+    develop: true
+
+/good:
+    discover+:
+        filter+:
+            - 'tag: good_test'
+    prepare+:
+        playbook+:
+            - tests/integration/inhibit-if-oracle-system-uses-not-standard-kernel/ansible/replace_oracle_kernel.yml
+/bad:
+    discover+:
+        filter+:
+            - 'tag: bad_test'

--- a/plans/integration/inhibit-if-oracle-system-uses-not-standard-kernel/vm_oracle8.fmf
+++ b/plans/integration/inhibit-if-oracle-system-uses-not-standard-kernel/vm_oracle8.fmf
@@ -1,0 +1,19 @@
+discover+:
+    filter+:
+        - 'tag: oracle8'
+provision:
+    how: libvirt
+    origin_vm_name: c2r_oracle8_template
+    develop: true
+
+/good:
+    discover+:
+        filter+:
+            - 'tag: good_test'
+    prepare+:
+        playbook+:
+            - tests/integration/inhibit-if-oracle-system-uses-not-standard-kernel/ansible/replace_oracle_kernel.yml
+/bad:
+    discover+:
+        filter+:
+            - 'tag: bad_test'

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,5 @@
 import subprocess
 import click
-import sys
 
 import pytest
 

--- a/tests/integration/inhibit-if-oracle-system-uses-not-standard-kernel/ansible/replace_oracle_kernel.yml
+++ b/tests/integration/inhibit-if-oracle-system-uses-not-standard-kernel/ansible/replace_oracle_kernel.yml
@@ -1,0 +1,19 @@
+- hosts: all
+  vars:
+    # to be overridden by the tmt
+    repo_root:
+  tasks:
+    - name: Install standard kernel
+      yum:
+        name: kernel
+        state: present
+
+    - name: Get installed kernel version
+      shell: rpm -q --last kernel | head -1 |  gawk 'match($0, /kernel-(.+) \s+.+/, s) {print s[1]}'
+      register: kernel_ver
+
+    - name: Set default kernel to Red Hat compatible kernel
+      shell: "grubby --set-default /boot/vmlinuz-{{ kernel_ver.stdout }}"
+
+    - name: Reboot
+      reboot:

--- a/tests/integration/inhibit-if-oracle-system-uses-not-standard-kernel/main.fmf
+++ b/tests/integration/inhibit-if-oracle-system-uses-not-standard-kernel/main.fmf
@@ -1,0 +1,17 @@
+summary: inhibit-if-oracle-system-uses-not-standard-kernel
+tag+:
+  - oracle7
+  - oracle8
+  - inhibit-if-oracle-system-uses-not-standard-kernel
+
+/good:
+  tag+:
+    - good_test
+  test: |
+    pytest -svv --tb=no -m good_tests
+
+/bad:
+  tag+:
+    - bad_test
+  test: |
+    pytest -svv --tb=no -m bad_tests

--- a/tests/integration/inhibit-if-oracle-system-uses-not-standard-kernel/test_oracle_bad_kernel.py
+++ b/tests/integration/inhibit-if-oracle-system-uses-not-standard-kernel/test_oracle_bad_kernel.py
@@ -1,0 +1,60 @@
+import pytest
+
+
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
+
+from envparse import env
+
+
+@pytest.mark.good_tests
+def test_good_conversion(shell, capsys):
+    convertion = shell(
+        command=[
+            (
+                "convert2rhel -y "
+                "--serverurl {} --username {} "
+                "--password {} --pool {} "
+                "--debug"
+            ).format(
+                env.str("RHSM_SERVER_URL"),
+                env.str("RHSM_USERNAME"),
+                env.str("RHSM_PASSWORD"),
+                env.str("RHSM_POOL"),
+            )
+        ]
+    )
+    # TODO make unregistering automatically, i.e. create a yield fixture to run
+    #   convert2rhel with the rhsm
+    shell("subscription-manager unregister")
+    assert convertion.returncode == 0
+    stdout, _ = capsys.readouterr()
+    assert "Kernel is compatible with RHEL" in stdout
+
+
+@pytest.mark.bad_tests
+def test_bad_conversion(shell, capsys):
+    convertion = shell(
+        command=[
+            (
+                "convert2rhel -y "
+                "--serverurl {} --username {} "
+                "--password {} --pool {} "
+                "--debug"
+            ).format(
+                env.str("RHSM_SERVER_URL"),
+                env.str("RHSM_USERNAME"),
+                env.str("RHSM_PASSWORD"),
+                env.str("RHSM_POOL"),
+            )
+        ]
+    )
+    shell("subscription-manager unregister")
+    assert convertion.returncode == 1
+    stdout, _ = capsys.readouterr()
+    assert (
+        "The booted kernel version is incompatible"
+        in stdout
+    )


### PR DESCRIPTION
We can't guarantee the fully functional state of the OS after the conversion if a kernel that is not available in RHEL is being used before the conversion. This change inhibits the conversion in an early conversion stage. Example of the message:
```
SystemExit: The booted kernel is not compatible with the target RHEL system.
To proceed with the conversion, boot a RHEL-compatible kernel (RHCK) by 
executing the following steps:

1. yum install kernel
2. (optional step) grubby --set-default /boot/vmlinuz-{{ installed_kernel_version_from_step_1 }}
3. reboot the machine and if step 2 was not applied choose RHCK (installed in step 1) manually.
```

TODO:
- [x] add playbook to replace the kernel
- [x] add more integration tests
- [x] implement the feature:)
- [x] fix failing integration test on ol7 (the kernel is not replaced)