### PR TITLE
use more universal reboot command

### DIFF
--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -114,7 +114,7 @@ def store_content_to_file(filename, content):
 def restart_system():
     from convert2rhel.toolopts import tool_opts
     if tool_opts.restart:
-        run_subprocess("reboot")
+        run_subprocess("shutdown -r now")
     else:
         loggerinst.warning("In order to boot the RHEL kernel,"
                            " restart of the system is needed.")


### PR DESCRIPTION
fixes #241

reboot command might be missing on CentOS 6. Using a more universal alternative
