### PR TITLE
fix: Moving check_readonly_mounts function from utils.py to checks.py

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -150,10 +150,6 @@ def pre_ponr_conversion():
     # check if user pass some repo to both disablerepo and enablerepo options
     pkghandler.has_duplicate_repos_across_disablerepo_enablerepo_options()
 
-    # checking if /mnt and /sys are read-write
-    loggerinst.task("Convert: Checking /mnt and /sys are read-write")
-    utils.check_readonly_mounts()
-
     # package analysis
     loggerinst.task("Convert: List third-party packages")
     pkghandler.list_third_party_pkgs()

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -24,7 +24,7 @@ try:
 except ImportError:
     from ordereddict import OrderedDict
 
-from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
+from convert2rhel import unit_tests, checks  # Imports unit_tests/__init__.py
 from convert2rhel import (
     cert,
     main,
@@ -161,7 +161,7 @@ class TestMain(unittest.TestCase):
     @mock_calls(subscription, "disable_repos", CallOrderMocked)
     @mock_calls(subscription, "enable_repos", CallOrderMocked)
     @mock_calls(subscription, "download_rhsm_pkgs", CallOrderMocked)
-    @unit_tests.mock(utils, "check_readonly_mounts", GetFakeFunctionMocked)
+    @unit_tests.mock(checks, "check_readonly_mounts", GetFakeFunctionMocked)
     def test_pre_ponr_conversion_order_with_rhsm(self):
         self.CallOrderMocked.reset()
         main.pre_ponr_conversion()
@@ -207,7 +207,7 @@ class TestMain(unittest.TestCase):
     @mock_calls(subscription, "disable_repos", CallOrderMocked)
     @mock_calls(subscription, "enable_repos", CallOrderMocked)
     @mock_calls(subscription, "download_rhsm_pkgs", CallOrderMocked)
-    @unit_tests.mock(utils, "check_readonly_mounts", GetFakeFunctionMocked)
+    @unit_tests.mock(checks, "check_readonly_mounts", GetFakeFunctionMocked)
     def test_pre_ponr_conversion_order_without_rhsm(self):
         self.CallOrderMocked.reset()
         main.pre_ponr_conversion()

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -23,7 +23,7 @@ import unittest
 from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel import utils
 from convert2rhel.systeminfo import system_info
-from convert2rhel.unit_tests import is_rpm_based_os, GetLoggerMocked, GetFileContentMocked
+from convert2rhel.unit_tests import is_rpm_based_os
 
 
 class TestUtils(unittest.TestCase):
@@ -229,28 +229,3 @@ class TestUtils(unittest.TestCase):
 
     def test_is_rpm_based_os(self):
         assert is_rpm_based_os() in (True, False)
-
-    @unit_tests.mock(utils, "loggerinst", GetLoggerMocked())
-    @unit_tests.mock(utils, "get_file_content",
-                     GetFileContentMocked(data=['sysfs /sys sysfs rw,seclabel,nosuid,nodev,noexec,relatime 0 0',
-                                                'mnt /mnt sysfs rw,seclabel,nosuid,nodev,noexec,relatime 0 0',
-                                                'cgroup /sys/fs/cgroup/cpuset cgroup rw,seclabel,nosuid,nodev,noexec,relatime,cpuset 0 0']))
-    def test_mounted_are_readwrite(self):
-        utils.check_readonly_mounts()
-        self.assertEqual(len(utils.loggerinst.critical_msgs), 0)
-        self.assertEqual(len(utils.loggerinst.debug_msgs), 2)
-        self.assertTrue("/mnt mount point is not read-only." in utils.loggerinst.debug_msgs)
-        self.assertTrue("/sys mount point is not read-only." in utils.loggerinst.debug_msgs)
-
-    @unit_tests.mock(utils, "loggerinst", GetLoggerMocked())
-    @unit_tests.mock(utils, "get_file_content",
-                     GetFileContentMocked(data=['sysfs /sys sysfs rw,seclabel,nosuid,nodev,noexec,relatime 0 0',
-                                                'mnt /mnt sysfs ro,seclabel,nosuid,nodev,noexec,relatime 0 0',
-                                                'cgroup /sys/fs/cgroup/cpuset cgroup rw,seclabel,nosuid,nodev,noexec,relatime,cpuset 0 0']))
-    def test_mounted_are_readonly(self):
-        self.assertRaises(SystemExit, utils.check_readonly_mounts)
-        self.assertEqual(len(utils.loggerinst.critical_msgs), 1)
-        self.assertTrue(
-            "Stopping conversion due to read-only mount to /mnt directory" in utils.loggerinst.critical_msgs[0])
-        self.assertTrue(
-            "Stopping conversion due to read-only mount to /sys directory" not in utils.loggerinst.critical_msgs[0])

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -267,8 +267,7 @@ def log_traceback(debug):
 def get_traceback_str():
     """Get a traceback of an exception as a string."""
     exc_type, exc_value, exc_traceback = sys.exc_info()
-    return "".join(traceback.format_exception(exc_type, exc_value,
-                                              exc_traceback))
+    return "".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
 
 
 class DictWListValues(dict):
@@ -480,7 +479,6 @@ def get_rpm_path_from_yumdownloader_output(cmd, output, dest):
 
 
 class RestorableFile(object):
-
     def __init__(self, filepath):
         self.filepath = filepath
 
@@ -529,7 +527,6 @@ class RestorableFile(object):
 
 
 class RestorablePackage(object):
-
     def __init__(self, pkgname):
         self.name = pkgname
         self.path = None
@@ -543,28 +540,6 @@ class RestorablePackage(object):
             self.path = download_pkg(self.name, dest=BACKUP_DIR, set_releasever=False)
         else:
             loggerinst.warning("Can't access %s" % TMP_DIR)
-
-
-def check_readonly_mounts():
-    """
-    Mounting directly to /mnt/ is not in line with Unix FS (https://en.wikipedia.org/wiki/Unix_filesystem).
-    Having /mnt/ and /sys/ read-only causes the installation of the filesystem package to
-    fail (https://bugzilla.redhat.com/show_bug.cgi?id=1887513, https://github.com/oamg/convert2rhel/issues/123).
-    """
-    mounts = get_file_content('/proc/mounts', as_list=True)
-    for line in mounts:
-        _, mount_point, _, flags, _, _ = line.split()
-        flags = flags.split(',')
-        if mount_point not in ('/mnt', '/sys'):
-            continue
-        if 'ro' in flags:
-            if mount_point == '/mnt':
-                loggerinst.critical("Stopping conversion due to read-only mount to /mnt directory.\n"
-                                    "Mount at a subdirectory of /mnt to have /mnt writeable.")
-            else:  # /sys
-                loggerinst.critical("Stopping conversion due to read-only mount to /sys directory.\n"
-                                    "Ensure mount point is writable before executing convert2rhel.")
-        loggerinst.debug("%s mount point is not read-only." % mount_point)
 
 
 changed_pkgs_control = ChangedRPMPackagesController()  # pylint: disable=C0103


### PR DESCRIPTION
Related ticket: OAMG-4697

Moving check_readonly_mounts function from `utils.py` to `checks.py`, since we defined one place for checks in checks.py. This will allow us easier to manage those checks.