### PR TITLE
Improve messaging around the obsoleted --variant option

### DIFF
--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -142,11 +142,11 @@ class CLI(object):
                                         " subscriptions. A list of the available"
                                         " subscriptions is possible to obtain by running"
                                         " 'subscription-manager list --available'.")
-        if any(x in sys.argv[1:] for x in ['--variant', '-v']):
-            group.add_option("-v", "--variant", help="The RHEL variant option is not processed anymore. In case of"
-                                                     " using subscription-manager, the system is converted to a Server"
-                                                     " variant. In case of using custom repositories, the system is"
-                                                     " converted to the variant provided by these repositories.")
+        group.add_option("-v", "--variant", help="This option is not supported anymore and has no effect. When"
+                                                 " converting a system to RHEL 6 or 7 using subscription-manager,"
+                                                 " the system is now always converted to the Server variant. In case"
+                                                 " of using custom repositories, the system is converted to the variant"
+                                                 " provided by these repositories.")
         group.add_option("--serverurl", help="Use a custom Red Hat Subscription"
                                              " Manager server URL to register the system with. If"
                                              " not provided, the subscription-manager defaults will be"
@@ -179,6 +179,8 @@ class CLI(object):
 
     def _process_cli_options(self):
         """Process command line options used with the tool."""
+        warn_on_unsupported_options()
+
         parsed_opts, _ = self._parser.parse_args()
 
         global tool_opts  # pylint: disable=C0103
@@ -220,10 +222,6 @@ class CLI(object):
         if parsed_opts.pool:
             tool_opts.pool = parsed_opts.pool
 
-        if any(x in sys.argv[1:] for x in ['--variant', '-v']):
-            loggerinst.warning("The --variant option is not supported anymore.")
-            utils.ask_to_continue()
-
         if parsed_opts.serverurl:
             if parsed_opts.disable_submgr:
                 loggerinst.warn("Ignoring the --serverurl option. It has no effect when --disable-submgr is used.")
@@ -242,6 +240,13 @@ class CLI(object):
 
         if tool_opts.username and tool_opts.password:
             tool_opts.credentials_thru_cli = True
+
+
+def warn_on_unsupported_options():
+    if any(x in sys.argv[1:] for x in ['--variant', '-v']):
+        loggerinst.warning("The -v|--variant option is not supported anymore and has no effect.\n"
+                            "See help (convert2rhel -h) for more information.")
+        utils.ask_to_continue()
 
 
 # Code to be executed upon module import

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -20,33 +20,43 @@
 
 import sys
 import unittest
+import pytest
 
 import convert2rhel.toolopts
+import convert2rhel.utils
 
 from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel.toolopts import tool_opts
 
 
-class TestToolopts(unittest.TestCase):
-    def _params(params):  # pylint: disable=E0213
-        return sys.argv[0:1] + params
+if sys.version_info[:2] <= (2, 7):
+    import mock  # pylint: disable=import-error
+else:
+    from unittest import mock  # pylint: disable=no-name-in-module
 
+
+def mock_cli_arguments(args):
+    """Return a list of cli arguments where the first one is always the name of the executable, followed by 'args'."""
+    return sys.argv[0:1] + args
+
+
+class TestToolopts(unittest.TestCase):
     def setUp(self):
         tool_opts.__init__()
 
-    @unit_tests.mock(sys, "argv", _params(["--username", "uname"]))
+    @unit_tests.mock(sys, "argv", mock_cli_arguments(["--username", "uname"]))
     def test_cmdline_interactive_username_without_passwd(self):
         convert2rhel.toolopts.CLI()
         self.assertEqual(tool_opts.username, "uname")
         self.assertFalse(tool_opts.credentials_thru_cli)
 
-    @unit_tests.mock(sys, "argv", _params(["--password", "passwd"]))
+    @unit_tests.mock(sys, "argv", mock_cli_arguments(["--password", "passwd"]))
     def test_cmdline_interactive_passwd_without_uname(self):
         convert2rhel.toolopts.CLI()
         self.assertEqual(tool_opts.password, "passwd")
         self.assertFalse(tool_opts.credentials_thru_cli)
 
-    @unit_tests.mock(sys, "argv", _params(["--username", "uname",
+    @unit_tests.mock(sys, "argv", mock_cli_arguments(["--username", "uname",
                                            "--password", "passwd"]))
     def test_cmdline_non_ineractive_with_credentials(self):
         convert2rhel.toolopts.CLI()
@@ -54,17 +64,41 @@ class TestToolopts(unittest.TestCase):
         self.assertEqual(tool_opts.password, "passwd")
         self.assertTrue(tool_opts.credentials_thru_cli)
 
-    @unit_tests.mock(sys, "argv", _params(["--serverurl", "url"]))
+    @unit_tests.mock(sys, "argv", mock_cli_arguments(["--serverurl", "url"]))
     def test_custom_serverurl(self):
         convert2rhel.toolopts.CLI()
         self.assertEqual(tool_opts.serverurl, "url")
 
-    @unit_tests.mock(sys, "argv", _params(["--enablerepo", "foo"]))
+    @unit_tests.mock(sys, "argv", mock_cli_arguments(["--enablerepo", "foo"]))
     def test_cmdline_disablerepo_defaults_to_asterisk(self):
         convert2rhel.toolopts.CLI()
         self.assertEqual(tool_opts.enablerepo, ["foo"])
         self.assertEqual(tool_opts.disablerepo, ["*"])
 
-    @unit_tests.mock(sys, "argv", _params(["--disable-submgr"]))
+    @unit_tests.mock(sys, "argv", mock_cli_arguments(["--disable-submgr"]))
     def test_cmdline_exits_on_empty_enablerepo_with_disable_submgr(self):
         self.assertRaises(SystemExit, convert2rhel.toolopts.CLI)
+
+
+@pytest.mark.parametrize(
+    ("argv", "warn", "ask_to_continue"), (
+        (mock_cli_arguments(["-v", "Server"]), True, True),
+        (mock_cli_arguments(["--variant", "Client"]), True, True),
+        (mock_cli_arguments(["-v"]), True, True),
+        (mock_cli_arguments(["--variant"]), True, True),
+        (mock_cli_arguments(["--version"]), False, False),
+        (mock_cli_arguments([]), False, False),
+    )
+)
+def test_cmdline_obsolete_variant_option(argv, warn, ask_to_continue, monkeypatch, caplog):
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setattr(convert2rhel.utils, "ask_to_continue", mock.Mock())
+    convert2rhel.toolopts.warn_on_unsupported_options()
+    if warn:
+        assert "variant option is not supported" in caplog.text
+    else:
+        assert "variant option is not supported" not in caplog.text
+    if ask_to_continue:
+        convert2rhel.utils.ask_to_continue.assert_called_once()
+    else:
+        convert2rhel.utils.ask_to_continue.assert_not_called()


### PR DESCRIPTION
- The option was basically now showing in the help message.
- The warning message was not shown when the -v or --variant was used without a value.
- The help message was missing the point that RHEL 8 comes with no variants.

Resolves: https://issues.redhat.com/browse/OAMG-4558