### PR TITLE
Delete temp folder

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -103,6 +103,9 @@ def main():
         loggerinst.task("Final: rpm files modified by the conversion")
         systeminfo.system_info.modified_rpm_files_diff()
 
+        loggerinst.task("Final: Remove temporary folder %s" % utils.TMP_DIR)
+        utils.remove_tmp_dir()
+
         loggerinst.info("\nConversion successful!\n")
 
         # restart system if required

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -274,6 +274,17 @@ def get_traceback_str():
     return "".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
 
 
+def remove_tmp_dir():
+    """Remove temporary folder (TMP_DIR), not needed post-conversion."""
+    try:
+        shutil.rmtree(TMP_DIR)
+        loggerinst.info("Temporary folder %s removed" % TMP_DIR)
+    except OSError as err:
+        loggerinst.warn("Failed removing temporary folder %s\nError (%s): %s" % (TMP_DIR, err.errno, err.strerror))
+    except TypeError:
+        loggerinst.warn("TypeError error while removing temporary folder %s" % TMP_DIR)
+
+
 class DictWListValues(dict):
     """Python 2.4 replacement for Python 2.5+ collections.defaultdict(list)."""
 

--- a/plans/integration/conversion/delete-temp-folder/main.fmf
+++ b/plans/integration/conversion/delete-temp-folder/main.fmf
@@ -1,8 +1,13 @@
 discover+:
     filter+:
         - 'tag: delete-temp-folder'
-        - 'tag: centos7'
 provision:
     how: libvirt
     develop: true
-    origin_vm_name: c2r_centos7_template
+
+/centos7:
+    discover+:
+        filter+:
+            - 'tag: centos7'
+    provision+:
+        origin_vm_name: c2r_centos7_template

--- a/plans/integration/conversion/delete-temp-folder/main.fmf
+++ b/plans/integration/conversion/delete-temp-folder/main.fmf
@@ -1,0 +1,8 @@
+discover+:
+    filter+:
+        - 'tag: delete-temp-folder'
+        - 'tag: centos7'
+provision:
+    how: libvirt
+    develop: true
+    origin_vm_name: c2r_centos7_template

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -6,4 +6,5 @@ prepare:
     - name: main preparation step
       how: ansible
       playbook: tests/ansible_collections/main.yml
-environment_from: .env
+environment-file:
+  - .env

--- a/tests/integration/conversion/delete-temp-folder/main.fmf
+++ b/tests/integration/conversion/delete-temp-folder/main.fmf
@@ -1,0 +1,10 @@
+summary: delete-temporary-folder
+tag+:
+  - centos7
+  - delete-temp-folder
+adjust:
+  enabled: false
+  when: >
+    distro != centos-7
+test: |
+  pytest -svv

--- a/tests/integration/conversion/delete-temp-folder/test_delete_temp_folder.py
+++ b/tests/integration/conversion/delete-temp-folder/test_delete_temp_folder.py
@@ -1,0 +1,7 @@
+import os
+
+
+def test_temp_folder():
+    """Testing, if the temporary folder was sucessfully removed after conversion"""
+    tmp_folder = "/var/lib/convert2rhel/"
+    assert not os.path.exists(tmp_folder)


### PR DESCRIPTION
The utility copies bunch of files to /var/lib/convert2rhel/ (mainly backup for the rollback) and they are not being removed upon uninstalling the rpm. Then it's just a junk data.

I've added the remove of data as the absolutely last step of conversion.