### PR TITLE
[RHELC-676] Allow conversions of CentOS Stream 8 to RHEL 8

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -44,6 +44,6 @@ jobs:
     epel-7-x86_64:
       distros: [centos-7, oraclelinux-7]
     epel-8-x86_64:
-      distros: [centos-8.4, centos-8, oraclelinux-8.4, oraclelinux-8.6]
+      distros: [centos-8.4, centos-8, oraclelinux-8.4, oraclelinux-8.6, centos-stream-8]
   use_internal_tf: True
   trigger: pull_request

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -283,7 +283,7 @@ def ensure_compatibility_of_kmods():
                 unsupported_kmods,
             )
         )
-        logger.critical(
+        logger.warning(
             (
                 "The following kernel modules are not supported in RHEL:\n{kmods}\n"
                 "Make sure you have updated the kernel to the latest available version and rebooted the system. "

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -151,9 +151,11 @@ class SystemInfo(object):
         minor_version = int(match.group(2)) if match.group(2) else MINOR_VERSION_UNAVAILABLE
         version = Version(int(match.group(1)), minor_version)
 
-        version_to_log = ("%d.%d" % (version.major, version.minor)
-                          if version.minor is not MINOR_VERSION_UNAVAILABLE
-                          else str(version.major))
+        version_to_log = (
+            "%d.%d" % (version.major, version.minor)
+            if version.minor is not MINOR_VERSION_UNAVAILABLE
+            else str(version.major)
+        )
         self.logger.info("%-20s %s" % ("OS version:", version_to_log))
         return version
 

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -188,6 +188,7 @@ class TestSysteminfo(unittest.TestCase):
             "CentOS release 6.10 (Final)": Version(6, 10),
             "CentOS Linux release 7.6.1810 (Core)": Version(7, 6),
             "CentOS Linux release 8.1.1911 (Core)": Version(8, 1),
+            "CentOS Stream release 8": Version(8, systeminfo.MINOR_VERSION_UNAVAILABLE),
         }
         for system_release in versions:
             system_info.system_release_file_content = system_release


### PR DESCRIPTION
There were two things holding back the Stream conversions:
- incorrect parsing of the system version
- kernel modules compatibility check

The latter is to stay. We are yet to add an option to disable the check. In the meantime, here we change the check to not block the conversion for the sake of testing.

This is just a proof of concept with low priority for the brave to try it out.

Resolves: https://issues.redhat.com/browse/RHELC-676