### PR TITLE
Remove obsolete TODO comment about activation keys

### DIFF
--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -250,8 +250,6 @@ def attach_subscription():
     interactively choose one.
     """
     # TODO: Support attaching multiple pool IDs.
-    # TODO: Support the scenario when the passed activation key attaches
-    #       all the appropriate subscriptions during registration already.
 
     if tool_opts.activation_key:
         loggerinst.info("Using the activation key provided through the command line...")


### PR DESCRIPTION
Convert2RHEL no longer tries to attach a subscription when an activation key
is used. It was resolved under https://github.com/oamg/convert2rhel/pull/91.