### PR TITLE
Feature/add convenient convert2rhel fixture for int tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,9 +1,14 @@
-import click
 import subprocess
-
-import pytest
+import sys
 
 from collections import namedtuple
+from contextlib import contextmanager
+from typing import ContextManager
+
+import click
+import pexpect
+import pytest
+
 from envparse import env
 
 
@@ -32,5 +37,64 @@ def shell(tmp_path):
         returncode = process.wait()
         return namedtuple('Result', ['returncode', 'output'])(returncode, output)
 
+
+    return factory
+
+
+@pytest.fixture()
+def convert2rhel(shell):
+    """Context manager to run convert2rhel utility.
+
+    This fixture runs the convert2rhel with the specified options and
+    do automatic teardown for you. It yields pexpext.spawn object.
+
+    You can assert that some text is in stdout, by using:
+    c2r.expect("Sometext here") (see bellow example)
+
+    Or check the utility exit code:
+    assert c2r.exitcode == 0 (see bellow example)
+
+    Example:
+    >>> def test_good_conversion(convert2rhel):
+    >>> with convert2rhel(
+    >>>     (
+    >>>         "-y "
+    >>>         "--no-rpm-va "
+    >>>         "--serverurl {} --username {} "
+    >>>         "--password {} --pool {} "
+    >>>         "--debug"
+    >>>     ).format(
+    >>>         env.str("RHSM_SERVER_URL"),
+    >>>         env.str("RHSM_USERNAME"),
+    >>>         env.str("RHSM_PASSWORD"),
+    >>>         env.str("RHSM_POOL"),
+    >>>     )
+    >>> ) as c2r:
+    >>>     c2r.expect("Kernel is compatible with RHEL")
+    >>> assert c2r.exitstatus == 0
+
+    """
+
+    @contextmanager
+    def factory(
+        options: str,
+        timeout: int = 30 * 60,
+    ) -> ContextManager[pexpect.spawn]:
+        c2r_runtime = pexpect.spawn(
+            f"convert2rhel {options}",
+            encoding="utf-8",
+            timeout=timeout,
+        )
+        c2r_runtime.logfile_read = sys.stdout
+        try:
+            yield c2r_runtime
+        except Exception:
+            c2r_runtime.close()
+            raise
+        else:
+            c2r_runtime.expect(pexpect.EOF)
+            c2r_runtime.close()
+        finally:
+            shell("subscription-manager unsubscribe")
 
     return factory

--- a/tests/integration/inhibit-if-oracle-system-uses-not-standard-kernel/test_oracle_bad_kernel.py
+++ b/tests/integration/inhibit-if-oracle-system-uses-not-standard-kernel/test_oracle_bad_kernel.py
@@ -10,51 +10,40 @@ from envparse import env
 
 
 @pytest.mark.good_tests
-def test_good_conversion(shell, capsys):
-    convertion = shell(
-        command=[
-            (
-                "convert2rhel -y "
-                "--serverurl {} --username {} "
-                "--password {} --pool {} "
-                "--debug"
-            ).format(
-                env.str("RHSM_SERVER_URL"),
-                env.str("RHSM_USERNAME"),
-                env.str("RHSM_PASSWORD"),
-                env.str("RHSM_POOL"),
-            )
-        ]
-    )
-    # TODO make unregistering automatically, i.e. create a yield fixture to run
-    #   convert2rhel with the rhsm
-    shell("subscription-manager unregister")
-    assert convertion.returncode == 0
-    stdout, _ = capsys.readouterr()
-    assert "Kernel is compatible with RHEL" in stdout
+def test_good_conversion(convert2rhel):
+    with convert2rhel(
+        (
+            "-y "
+            "--no-rpm-va "
+            "--serverurl {} --username {} "
+            "--password {} --pool {} "
+            "--debug"
+        ).format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        c2r.expect("Kernel is compatible with RHEL")
+    assert c2r.exitstatus == 0
 
 
 @pytest.mark.bad_tests
-def test_bad_conversion(shell, capsys):
-    convertion = shell(
-        command=[
-            (
-                "convert2rhel -y "
-                "--serverurl {} --username {} "
-                "--password {} --pool {} "
-                "--debug"
-            ).format(
-                env.str("RHSM_SERVER_URL"),
-                env.str("RHSM_USERNAME"),
-                env.str("RHSM_PASSWORD"),
-                env.str("RHSM_POOL"),
-            )
-        ]
-    )
-    shell("subscription-manager unregister")
-    assert convertion.returncode == 1
-    stdout, _ = capsys.readouterr()
-    assert (
-        "The booted kernel version is incompatible"
-        in stdout
-    )
+def test_bad_conversion(convert2rhel):
+    with convert2rhel(
+        (
+            "-y "
+            "--no-rpm-va "
+            "--serverurl {} --username {} "
+            "--password {} --pool {} "
+            "--debug"
+        ).format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        c2r.expect("The booted kernel version is incompatible")
+    assert c2r.exitstatus == 1

--- a/tests/integration/remove_all_submgr_pkgs/test_remove_all_submgr_pkgs.py
+++ b/tests/integration/remove_all_submgr_pkgs/test_remove_all_submgr_pkgs.py
@@ -4,49 +4,54 @@ import pexpect
 
 from envparse import env
 
-def test_remove_all_submgr_pkgs(shell):
+
+def test_remove_all_submgr_pkgs(shell, convert2rhel):
     """Test that all subscription-manager pkgs (no matter the signature) get removed.
-    
+
     And that the system is unregistered before that.
     """
 
-    c2r = pexpect.spawn(
+    with open("/etc/system-release", "r") as file:
+        system_release = file.read()
+
+    with convert2rhel(
         (
-            "convert2rhel --no-rpm-va "
+            "-y "
+            "--no-rpm-va "
             "--serverurl {} --username {} "
             "--password {} --pool {} "
-            "--debug -y"
+            "--debug"
         ).format(
             env.str("RHSM_SERVER_URL"),
             env.str("RHSM_USERNAME"),
             env.str("RHSM_PASSWORD"),
             env.str("RHSM_POOL"),
-        ),
-        encoding="utf-8",
-        timeout=30 * 60, # The conversion can take a long time
-    )
+        )
+    ) as c2r:
+        if (
+            "Oracle Linux Server release 7" in system_release
+        ):  # We're not installing sub-mgr on OL 7
+            c2r.expect("The subscription-manager package is not installed.")
+        else:  # All other tests systems
+            # Check that the system is unregistered before removing the sub-mgr
+            c2r.expect("Calling command 'subscription-manager unregister'")
 
-    c2r.logfile_read = sys.stdout
+            # Check that the pre-installed sub-mgr gets removed
+            c2r.expect(
+                "Calling command 'rpm -e --nodeps subscription-manager'"
+            )
+        # Just to make sure the above output appeared before installing the
+        # subscription-manager pkgs
+        c2r.expect("Installing subscription-manager RPMs.")
 
-    with open('/etc/system-release', 'r') as file:
-        system_release = file.read()
-
-    if "Oracle Linux Server release 7" in system_release:  # We're not installing sub-mgr on OL 7
-        c2r.expect("The subscription-manager package is not installed.")
-    else:  # All other tests systems
-        # Check that the system is unregistered before removing the sub-mgr
-        c2r.expect("Calling command 'subscription-manager unregister'")
-        # Check that the pre-installed sub-mgr gets removed
-        c2r.expect("Calling command 'rpm -e --nodeps subscription-manager'")
-    # Just to make sure the above output appeared before installing the subscription-manager pkgs
-    c2r.expect("Installing subscription-manager RPMs.")
-
-    c2r.expect(pexpect.EOF)  # Wait for the conversion to finish
-    c2r.close()  # Per the pexpect API, this is necessary in order to get the return code
     assert c2r.exitstatus == 0
-    shell("subscription-manager unregister")
 
     # Check that the subscription-manager installed by c2r has the Red Hat signature
-    assert "199e2f91fd431d51" in shell("rpm -q --qf '%|DSAHEADER?{%{DSAHEADER:pgpsig}}:"
-                                       "{%|RSAHEADER?{%{RSAHEADER:pgpsig}}:{(none)}|}|' "
-                                       "subscription-manager").output
+    assert (
+        "199e2f91fd431d51"
+        in shell(
+            "rpm -q --qf '%|DSAHEADER?{%{DSAHEADER:pgpsig}}:"
+            "{%|RSAHEADER?{%{RSAHEADER:pgpsig}}:{(none)}|}|' "
+            "subscription-manager"
+        ).output
+    )

--- a/tests/integration/resolve-broken-ol8-rollback/test_resolve_broken_ol8_rollback.py
+++ b/tests/integration/resolve-broken-ol8-rollback/test_resolve_broken_ol8_rollback.py
@@ -5,18 +5,19 @@ import pexpect
 from envparse import env
 
 
-def test_proper_rhsm_clean_up(shell):
+def test_proper_rhsm_clean_up(shell, convert2rhel):
     """Test that c2r does not remove usermod and rhn-setup during rollback."""
 
     # Ensure usermode and rhn-setup packages are presented
     assert shell("yum install -y usermode rhn-setup").returncode == 0
 
     # run c2r until subscribing the system and then emulate pressing Ctrl + C
-    c2r = pexpect.spawn(
+    with convert2rhel(
         (
-            "convert2rhel "
-            "--serverurl {} --username {} "
-            "--password {} --pool {} "
+            "--serverurl {} "
+            "--username {} "
+            "--password {} "
+            "--pool {} "
             "--debug "
             "--no-rpm-va"
         ).format(
@@ -24,19 +25,15 @@ def test_proper_rhsm_clean_up(shell):
             env.str("RHSM_USERNAME"),
             env.str("RHSM_PASSWORD"),
             env.str("RHSM_POOL"),
-        ),
-        encoding="utf-8",
-        timeout=5 * 60,
-    )
-    c2r.logfile_read = sys.stdout
-    c2r.expect("Continue with the system conversion?")
-    c2r.sendline("y")
-    c2r.expect("Continue with the system conversion?")
-    c2r.sendline("y")
-    c2r.expect("Building subscription-manager command")
-    # send Ctrl-C
-    c2r.send(chr(3))
-    c2r.expect(pexpect.EOF)
+        )
+    ) as c2r:
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("y")
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("y")
+        c2r.expect("Building subscription-manager command")
+        # send Ctrl-C
+        c2r.send(chr(3))
 
     # check that packages still are in place
     assert shell("rpm -qi usermode").returncode == 0


### PR DESCRIPTION
~~blocked by: #271~~

This feature introduce more convinient way to write integration tests with the help of convert2rhel fixture. Which does automatic teardown for you. Example of test with this fixture is:
```python
def test_good_conversion(convert2rhel):
    with convert2rhel(
        (
            "-y "
            "--no-rpm-va "
            "--serverurl {} --username {} "
            "--password {} --pool {} "
            "--debug"
        ).format(
            env.str("RHSM_SERVER_URL"),
            env.str("RHSM_USERNAME"),
            env.str("RHSM_PASSWORD"),
            env.str("RHSM_POOL"),
        )
    ) as c2r:
        c2r.expect("Kernel is compatible with RHEL")
    assert c2r.exitstatus == 0
```