### PR TITLE
Print confirmation of a successful conversion

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -100,6 +100,8 @@ def main():
         loggerinst.task("Final: rpm files modified by the conversion")
         systeminfo.system_info.modified_rpm_files_diff()
 
+        loggerinst.info("\nConversion successful!\n")
+
         # restart system if required
         utils.restart_system()
 


### PR DESCRIPTION
Without this it may not be obvious that the conversion finished successfully. See:
```
[05/11/2021 14:24:05] TASK - [Final: rpm files modified by the conversion] **********************
Skipping the execution of 'rpm -Va'.
Skipping comparison of the 'rpm -Va' output from before and after the conversion.
WARNING - In order to boot the RHEL kernel, restart of the system is needed.
```