### PR TITLE
OL: ensure kernel.{arch} pkg to be installed

### DIFF
--- a/tests/ansible_collections/roles/oracle-linux-specific/tasks/boot_standard_kernel.yml
+++ b/tests/ansible_collections/roles/oracle-linux-specific/tasks/boot_standard_kernel.yml
@@ -1,8 +1,8 @@
 ---
 - name: Install standard kernel
   yum:
-    name: kernel
-    state: present
+    name: "kernel.*"
+    state: latest
 
 - name: Get installed kernel version
   shell: rpm -q --last kernel | head -1 |  gawk 'match($0, /kernel-(.+) \s+.+/, s) {print s[1]}'


### PR DESCRIPTION
For playbook which reboots the OL into RHCK:

The previous solution was unable to install kernel if there were present a kernel-.+ package name. This is fixed now

Resolves https://issues.redhat.com/browse/OAMG-4960.