### PR TITLE
Feature/add possibility to skip function execution

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -24,7 +24,7 @@ import subprocess
 
 from convert2rhel.pkghandler import get_installed_pkg_objects, get_pkg_fingerprint
 from convert2rhel.systeminfo import system_info
-from convert2rhel.utils import get_file_content, run_subprocess
+from convert2rhel.utils import ask_to_continue, get_file_content, run_subprocess
 
 
 logger = logging.getLogger(__name__)
@@ -44,6 +44,7 @@ COMPATIBLE_KERNELS_VERS = {
 
 def perform_pre_checks():
     """Early checks after system facts should be added here."""
+    check_environment()
     check_uefi()
     check_tainted_kmods()
     check_readonly_mounts()
@@ -393,3 +394,9 @@ def _bad_kernel_substring(kernel_release):
         )
         return True
     return False
+
+
+def check_environment():
+    if "CONVERT2RHEL_NOT_SUPPORTED" in os.environ:
+        logger.warning("Variable CONVERT2RHEL_UNSUPPORTED has been detected. Proceed at your own risk.")
+        ask_to_continue()

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -24,7 +24,7 @@ import subprocess
 
 from convert2rhel.pkghandler import get_installed_pkg_objects, get_pkg_fingerprint
 from convert2rhel.systeminfo import system_info
-from convert2rhel.utils import ask_to_continue, get_file_content, run_subprocess
+from convert2rhel.utils import ask_to_continue, available_for_skipping, get_file_content, run_subprocess
 
 
 logger = logging.getLogger(__name__)
@@ -65,6 +65,7 @@ def check_uefi():
     logger.debug("Converting BIOS system")
 
 
+@available_for_skipping(aliases=("tainted", "tainted_kernel", "tainted_kmods"))
 def check_tainted_kmods():
     """Stop the conversion when a loaded tainted kernel module is detected.
 
@@ -88,6 +89,7 @@ def check_tainted_kmods():
         )
 
 
+@available_for_skipping(aliases=("readonly", "readonly_mounts"))
 def check_readonly_mounts():
     """
     Mounting directly to /mnt/ is not in line with Unix FS (https://en.wikipedia.org/wiki/Unix_filesystem).
@@ -121,6 +123,7 @@ def perform_pre_ponr_checks():
     ensure_compatibility_of_kmods()
 
 
+@available_for_skipping(aliases=("kmods_check", "supported_kmods"))
 def ensure_compatibility_of_kmods():
     """Ensure if the host kernel modules are compatible with RHEL."""
     host_kmods = get_installed_kmods()
@@ -397,6 +400,6 @@ def _bad_kernel_substring(kernel_release):
 
 
 def check_environment():
-    if "CONVERT2RHEL_NOT_SUPPORTED" in os.environ:
+    if "CONVERT2RHEL_UNSUPPORTED" in os.environ:
         logger.warning("Variable CONVERT2RHEL_UNSUPPORTED has been detected. Proceed at your own risk.")
         ask_to_continue()

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -656,7 +656,7 @@ class TestReadOnlyMountsChecks(unittest.TestCase):
 
 
 def test_check_environment(monkeypatch, caplog):
-    monkeypatch.setenv("CONVERT2RHEL_NOT_SUPPORTED", "1")
+    monkeypatch.setenv("CONVERT2RHEL_UNSUPPORTED", "1")
     monkeypatch.setattr(checks, "ask_to_continue", mock.Mock())
     check_environment()
     checks.ask_to_continue.assert_called_once()

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -29,6 +29,7 @@ from convert2rhel.checks import (
     _bad_kernel_substring,
     _bad_kernel_version,
     _get_kmod_comparison_key,
+    check_environment,
     check_rhel_compatible_kernel_is_used,
     check_tainted_kmods,
     ensure_compatibility_of_kmods,
@@ -652,3 +653,11 @@ class TestReadOnlyMountsChecks(unittest.TestCase):
         self.assertTrue(
             "Stopping conversion due to read-only mount to /sys directory" not in checks.logger.critical_msgs[0]
         )
+
+
+def test_check_environment(monkeypatch, caplog):
+    monkeypatch.setenv("CONVERT2RHEL_NOT_SUPPORTED", "1")
+    monkeypatch.setattr(checks, "ask_to_continue", mock.Mock())
+    check_environment()
+    checks.ask_to_continue.assert_called_once()
+    assert "Variable CONVERT2RHEL_UNSUPPORTED has been detected" in caplog.text

--- a/plans/integration/add-possibility-to-skip-functions/main.fmf
+++ b/plans/integration/add-possibility-to-skip-functions/main.fmf
@@ -1,0 +1,9 @@
+discover+:
+    filter:
+        - 'tag: add-possibility-to-skip-functions'
+        - 'tag: centos8'
+
+provision:
+    how: libvirt
+    origin_vm_name: c2r_centos8_template
+    develop: true

--- a/scripts/extract_version_from_rpm_spec.py
+++ b/scripts/extract_version_from_rpm_spec.py
@@ -4,16 +4,13 @@ import click
 
 
 @click.command()
-@click.argument("spec_path")
+@click.argument("spec_path", type=click.Path(exists=True))
 def get_convert2rhel_version(spec_path: str) -> None:
-    """Parse rpm spec file and returns its name-version-release part.
+    """Parse rpm spec file and returns its version-release part.
 
-    Example:
-    ```bash
-    python scripts/extract_version_from_rpm_spec.py packaging/convert2rhel.spec
-    # 0.21-1
-    ```
-
+    Example:\n
+    $ python scripts/extract_version_from_rpm_spec.py packaging/convert2rhel.spec\n
+    $ 0.21-1
     """
     with open(spec_path) as rpm_f:
         try:

--- a/tests/integration/add-possibility-to-skip-functions/main.fmf
+++ b/tests/integration/add-possibility-to-skip-functions/main.fmf
@@ -1,0 +1,6 @@
+summary: add-possibility-to-skip-functions
+tag+:
+  - centos8
+  - add-possibility-to-skip-functions
+test: |
+  pytest -svv

--- a/tests/integration/add-possibility-to-skip-functions/test_add-possibility-to-skip-func.py
+++ b/tests/integration/add-possibility-to-skip-functions/test_add-possibility-to-skip-func.py
@@ -1,0 +1,37 @@
+from envparse import env
+
+
+def test_skipping_functions_messaging(convert2rhel, monkeypatch):
+    """Test just messaging."""
+    monkeypatch.setenv("CONVERT2RHEL_UNSUPPORTED", "1")
+    monkeypatch.setenv("CONVERT2RHEL_DEVEL_SKIP", "tainted_kernel,")
+    with convert2rhel(
+        f"-y "
+        f"--no-rpm-va "
+        f"--serverurl {env.str('RHSM_SERVER_URL')} "
+        f"--username {env.str('RHSM_USERNAME')} "
+        f"--password {env.str('RHSM_PASSWORD')} "
+        f"--pool {env.str('RHSM_POOL')} "
+        f"--debug"
+    ) as c2r:
+        c2r.expect("CONVERT2RHEL_UNSUPPORTED has been detected")
+        c2r.expect("specified to be skipped")
+        c2r.send(chr(3))
+
+
+def test_skipping_functions_works(convert2rhel, insert_custom_kmod, monkeypatch):
+    """Test that conversion passed with custom kmod but skipped kmod check."""
+    monkeypatch.setenv("CONVERT2RHEL_UNSUPPORTED", "1")
+    monkeypatch.setenv("CONVERT2RHEL_DEVEL_SKIP", "kmods_check,")
+    with convert2rhel(
+        f"-y "
+        f"--no-rpm-va "
+        f"--serverurl {env.str('RHSM_SERVER_URL')} "
+        f"--username {env.str('RHSM_USERNAME')} "
+        f"--password {env.str('RHSM_PASSWORD')} "
+        f"--pool {env.str('RHSM_POOL')} "
+        f"--debug"
+    ) as c2r:
+        c2r.expect("CONVERT2RHEL_UNSUPPORTED has been detected")
+        c2r.expect("specified to be skipped")
+    assert c2r.exitstatus == 0

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -97,3 +97,17 @@ def convert2rhel(shell):
             shell("subscription-manager unregister")
 
     return factory
+
+
+@pytest.fixture()
+def insert_custom_kmod(shell):
+    """Insert a custom kernel module.
+
+    Fixture is used for testing scenarious with custom kmods.
+    """
+    origin_kmod_loc = Path("/lib/modules/$(uname -r)/kernel/drivers/net/bonding/bonding.ko.xz")
+    new_kmod_dir = origin_kmod_loc.parent / "custom_module_location"
+
+    shell(f"mkdir {new_kmod_dir.as_posix()}")
+    shell(f"mv {origin_kmod_loc.as_posix()} {new_kmod_dir.as_posix()}")
+    shell(f"insmod {(new_kmod_dir / origin_kmod_loc.name).as_posix()}")

--- a/tests/integration/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
+++ b/tests/integration/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
@@ -19,22 +19,8 @@ def test_good_convertion(convert2rhel):
     assert c2r.exitstatus == 0
 
 
-@pytest.fixture()
-def insert_custom_kmod(shell):
-    def factory():
-        origin_kmod_loc = Path("/lib/modules/$(uname -r)/kernel/drivers/net/bonding/bonding.ko.xz")
-        new_kmod_dir = origin_kmod_loc.parent / "custom_module_location"
-
-        shell(f"mkdir {new_kmod_dir.as_posix()}")
-        shell(f"mv {origin_kmod_loc.as_posix()} {new_kmod_dir.as_posix()}")
-        shell(f"insmod {(new_kmod_dir / origin_kmod_loc.name).as_posix()}")
-
-    return factory
-
-
 @pytest.mark.bad_tests
 def test_bad_convertion(shell, insert_custom_kmod, convert2rhel):
-    insert_custom_kmod()
     with convert2rhel(
         ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
             env.str("RHSM_SERVER_URL"),


### PR DESCRIPTION
closes OAMG-4533, OAMG-4777

Provides the mechanism to skip the execution of any function and replace the returned value of this function with the help of environment variable:
```
CONVERT2RHEL_UNSUPPORTED=1 \
CONVERT2RHEL_DEVEL_SKIP=tainted,kmods_check \
convert2rhel ...
```
will skip the execution of the tainted kernel modules and compatibility of kernel modules checks.

The usage:
```python
@available_for_skipping(aliases=("kmods_check", "supported_kmods"))
def ensure_compatibility_of_kmods():
    ...
```
TODO:
- [ ] integration tests