### PR TITLE
Now the convert2rhel package version is properly recognized

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ lines_after_imports=2
 lines_between_types=1
 known_third_party=[
     "pytest",
+    "click",
 ]
 known_first_party=["convert2rhel"]
 

--- a/requirements/local.centos8.requirements.txt
+++ b/requirements/local.centos8.requirements.txt
@@ -1,5 +1,6 @@
 six==1.15.0
 pexpect==4.3.1
+click==7.1.2
 git+https://github.com/ZhukovGreen/tmt.git@poc/tmt-adoption-for-convert2rhel
 -r centos8.requirements.txt
 -e .

--- a/scripts/extract_version_from_rpm_spec.py
+++ b/scripts/extract_version_from_rpm_spec.py
@@ -1,0 +1,47 @@
+import re
+
+import click
+
+
+@click.command()
+@click.argument("spec_path")
+def get_convert2rhel_version(spec_path: str) -> None:
+    """Parse rpm spec file and returns its name-version-release part.
+
+    Example:
+    ```bash
+    python scripts/extract_version_from_rpm_spec.py packaging/convert2rhel.spec
+    # 0.21-1
+    ```
+
+    """
+    with open(spec_path) as rpm_f:
+        try:
+            click.echo(
+                "-".join(
+                    re.findall(
+                        r"""
+                        # Line which starts with these words
+                        ^(?:Version|Release):
+                        # Spaces afterwards
+                        \s+
+                        # capturing group which we are interested in
+                        (
+                            # Any word could be here
+                            (?:\w+)|
+                            # Or int or float i.e. 21 or 0.21
+                            (?:\d+[.]*\d*)
+                        )
+                        # some special internal rpm spec var (skipping it)
+                        (?:%{.+)*$
+                        """,
+                        rpm_f.read(),
+                        flags=(re.MULTILINE | re.VERBOSE),
+                    )
+                ),
+            )
+        except Exception as e:
+            raise click.ClickException(repr(e)) from e
+
+
+__name__ == "__main__" and get_convert2rhel_version()

--- a/tests/ansible_collections/roles/packaging/tasks/install_rpm_from_local_build.yml
+++ b/tests/ansible_collections/roles/packaging/tasks/install_rpm_from_local_build.yml
@@ -1,7 +1,7 @@
 ---
 - name: Get convert2rhel version
   delegate_to: localhost
-  shell: cat packaging/convert2rhel.spec | awk '/Version.+/ {print $2}'
+  shell: python scripts/extract_version_from_rpm_spec.py packaging/convert2rhel.spec
   args:
     chdir: ../..
   register: pkg_version
@@ -21,7 +21,7 @@
 
 - name: Install el8 convert2rhel package
   yum:
-    name: "{{ repo_root }}/.rpms/convert2rhel-{{ pkg_version.stdout }}-1.el8.noarch.rpm"
+    name: "{{ repo_root }}/.rpms/convert2rhel-{{ pkg_version.stdout }}.el8.noarch.rpm"
     state: present
     disable_gpg_check: true
   when: (ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == "8") or
@@ -29,7 +29,7 @@
 
 - name: Install el7 convert2rhel package
   yum:
-    name: "{{ repo_root }}/.rpms/convert2rhel-{{ pkg_version.stdout }}-1.el7.noarch.rpm"
+    name: "{{ repo_root }}/.rpms/convert2rhel-{{ pkg_version.stdout }}.el7.noarch.rpm"
     state: present
     disable_gpg_check: true
   when: (ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == "7") or


### PR DESCRIPTION
**Warning this MR is needed to be able to test release 0.21-2**

Previous way to recognize the pkg version was:
cat packaging/convert2rhel.spec | awk '/Version.+/ {print $2}'

Release data were ignored in parsing

This MR introduce better parsing mechanism, which is able to identify Version and Release 

 