### PR TITLE
fix list of recent kernel pkgs was a generator -> tuple

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -260,7 +260,7 @@ def get_most_recent_unique_kernel_pkgs(pkgs):
     """
 
     pkgs_groups = itertools.groupby(sorted(pkgs), lambda pkg_name: pkg_name.split(":")[0])
-    return (
+    return tuple(
         max(distinct_kernel_pkgs[1], key=_repos_version_key)
         for distinct_kernel_pkgs in pkgs_groups
         if distinct_kernel_pkgs[0].startswith(("kernel", "kmod"))


### PR DESCRIPTION
Quick leftover from #285 . I ran tests in a different branch, so they passed but were irrelevant.
After running the tests on #285 I found a bug, which this MR fixes.

Function `get_most_recent_unique_kernel_pkgs` returned a generator, because it was assumed to be used only once. In #285 it was used two times, so second time (when do a repoquery -l it was empty and the conversion inhibited with all kmods are unsupported