### PR TITLE
Add basic conversion test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
+# General
+    # set integration tests logger level to DEBUG if True
+    # otherwise INFO
+DEBUG=True
+
 # RHSM (Red Hat Subscription Manager related secrets)
 RHSM_POOL=
 RHSM_PASSWORD=

--- a/plans/integration/conversion/basic-conversion/main.fmf
+++ b/plans/integration/conversion/basic-conversion/main.fmf
@@ -1,0 +1,34 @@
+discover+:
+    filter+:
+        - 'tag: basic-conversion'
+provision:
+    how: libvirt
+    develop: true
+
+/centos7:
+    discover+:
+        filter+:
+            - 'tag: centos7'
+    provision+:
+        origin_vm_name: c2r_centos7_template
+
+/centos8:
+    discover+:
+        filter+:
+            - 'tag: centos8'
+    provision+:
+        origin_vm_name: c2r_centos8_template
+
+/oracle7:
+    discover+:
+        filter+:
+            - 'tag: oracle7'
+    provision+:
+        origin_vm_name: c2r_oracle7_template
+
+/oracle8:
+    discover+:
+        filter+:
+            - 'tag: oracle8'
+    provision+:
+        origin_vm_name: c2r_oracle8_template

--- a/plans/integration/conversion/main.fmf
+++ b/plans/integration/conversion/main.fmf
@@ -1,0 +1,11 @@
+discover+:
+    filter:
+        - 'tag: conversion'
+
+prepare+:
+    - name: main conversion preparation
+      how: shell
+      script: pytest -svv tests/integration/conversion/run_conversion.py
+    - name: reboot machine
+      how: ansible
+      playbook: tests/ansible_collections/reboot.yml

--- a/tests/ansible_collections/reboot.yml
+++ b/tests/ansible_collections/reboot.yml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  tasks:
+    - name: Reboot into RHEL
+      reboot:

--- a/tests/ansible_collections/reboot.yml
+++ b/tests/ansible_collections/reboot.yml
@@ -3,3 +3,4 @@
   tasks:
     - name: Reboot into RHEL
       reboot:
+        reboot_timeout: 60

--- a/tests/ansible_collections/roles/oracle-linux-specific/tasks/boot_standard_kernel.yml
+++ b/tests/ansible_collections/roles/oracle-linux-specific/tasks/boot_standard_kernel.yml
@@ -13,3 +13,4 @@
 
 - name: Reboot
   reboot:
+    reboot_timeout: 60

--- a/tests/integration/conversion/basic-conversion/main.fmf
+++ b/tests/integration/conversion/basic-conversion/main.fmf
@@ -1,0 +1,9 @@
+summary: basic-conversion
+tag+:
+  - centos7
+  - centos8
+  - oracle7
+  - oracle8
+  - basic-conversion
+test: |
+  pytest -svv

--- a/tests/integration/conversion/basic-conversion/test_basic_conversion.py
+++ b/tests/integration/conversion/basic-conversion/test_basic_conversion.py
@@ -1,0 +1,3 @@
+def test_basic_conversion(shell):
+    os_release = shell("cat /etc/os-release").output
+    assert "Red Hat Enterprise Linux" in os_release

--- a/tests/integration/conversion/main.fmf
+++ b/tests/integration/conversion/main.fmf
@@ -1,0 +1,2 @@
+tag+:
+  - conversion

--- a/tests/integration/conversion/run_conversion.py
+++ b/tests/integration/conversion/run_conversion.py
@@ -1,0 +1,14 @@
+from envparse import env
+
+
+def test_run_convertion(convert2rhel):
+    with convert2rhel(
+        ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        c2r.expect("Conversion successful!")
+    assert c2r.exitstatus == 0


### PR DESCRIPTION
Add a placeholder for writing conversion tests (tests after successful conversion) and add a basic conversion test.


Replaces #216

~~**Blocked by failing centos8 conversion now #277**~~
~~**Blocked with #304**~~

Testing this MR might be possible after updating tmt:
```pip install git+https://github.com/ZhukovGreen/tmt.git@poc/tmt-adoption-for-convert2rhel --no-cache-dir```

and

prepend your .env with `DEBUG=True` 