### PR TITLE
Hardcode RHEL 8.3 as a target

### DIFF
--- a/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
@@ -32,7 +32,7 @@ default_rhsm_repoids =
   rhel-8-for-x86_64-baseos-rpms
   rhel-8-for-x86_64-appstream-rpms
 
-releasever=8
+releasever=8.3
 
 # Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
 # that such a module is not available in RHEL and thus is unsupported, we ignore it.

--- a/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
@@ -27,7 +27,7 @@ default_rhsm_repoids =
   rhel-8-for-x86_64-baseos-rpms
   rhel-8-for-x86_64-appstream-rpms
 
-releasever=8
+releasever=8.3
 
 # Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
 # that such a module is not available in RHEL and thus is unsupported, we ignore it.


### PR DESCRIPTION
With RHEL 8.4 out and CentOS/Oracle Linux still 8.3, the conversion is stopped on kernel differences. Before we introduce a proper solution, this change is letting the systems convert to RHEL 8.3 instead of 8.4.