### PR TITLE
Unregister upon finishing a test

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -94,6 +94,6 @@ def convert2rhel(shell):
             c2r_runtime.expect(pexpect.EOF)
             c2r_runtime.close()
         finally:
-            shell("subscription-manager unsubscribe")
+            shell("subscription-manager unregister")
 
     return factory


### PR DESCRIPTION
We need the system to be unregistered instead of unsubscribed. This way the command fails at the end of a test and the test then fails because of that as well.

Blocks: https://github.com/oamg/convert2rhel/pull/288