### PR TITLE
Resolve >120 chars line pre-commit failure

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -228,7 +228,7 @@ def is_help_msg_exit(process_phase, err):
 def rollback_changes():
     """Perform a rollback of changes made during conversion."""
 
-    loggerinst.warn("Abnormal exit! Performing rollback ...")
+    loggerinst.warning("Abnormal exit! Performing rollback ...")
     subscription.rollback()
     utils.changed_pkgs_control.restore_pkgs()
     repo.restore_yum_repos()

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -832,7 +832,7 @@ def clear_versionlock():
     """
 
     if os.path.isfile(_VERSIONLOCK_FILE_PATH) and os.path.getsize(_VERSIONLOCK_FILE_PATH) > 0:
-        loggerinst.warn("YUM/DNF versionlock plugin is in use. It may cause the conversion to fail.")
+        loggerinst.warning("YUM/DNF versionlock plugin is in use. It may cause the conversion to fail.")
         loggerinst.info("Upon continuing, we will clear all package version locks.")
         utils.ask_to_continue()
 

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -205,7 +205,9 @@ def remove_original_subscription_manager():
     if not submgr_pkgs:
         loggerinst.info("No packages related to subscription-manager installed.")
         return
-    loggerinst.info("Upon continuing, we will uninstall the following subscription-manager/katello-ca-consumer packages:\n")
+    loggerinst.info(
+        "Upon continuing, we will uninstall the following subscription-manager/katello-ca-consumer packages:\n"
+    )
     pkghandler.print_pkg_info(submgr_pkgs)
     utils.ask_to_continue()
     submgr_pkg_names = [pkg.name for pkg in submgr_pkgs]


### PR DESCRIPTION
And pytest deprecation warnings about using logger.warn() instead of logger.warning().