### PR TITLE
Rename --disable-submgr option to --no-rhsm

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -133,7 +133,7 @@ def check_custom_repos_are_valid():
     """
     logger.task("Prepare: Checking if --enablerepo repositories are accessible")
 
-    if not tool_opts.disable_submgr:
+    if not tool_opts.no_rhsm:
         logger.info("Skipping the check of repositories due to the use of RHSM for the conversion.")
         return
 

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -165,7 +165,7 @@ def pre_ponr_conversion():
     special_cases.check_and_resolve()
 
     rhel_repoids = []
-    if not toolopts.tool_opts.disable_submgr:
+    if not toolopts.tool_opts.no_rhsm:
         loggerinst.task("Convert: Subscription Manager - Download packages")
         subscription.download_rhsm_pkgs()
         loggerinst.task("Convert: Subscription Manager - Replace")
@@ -188,7 +188,7 @@ def pre_ponr_conversion():
 
     # we need to enable repos after removing repofile pkgs, otherwise we don't get backups
     # to restore from on a rollback
-    if not toolopts.tool_opts.disable_submgr:
+    if not toolopts.tool_opts.no_rhsm:
         loggerinst.task("Convert: Subscription Manager - Enable RHEL repositories")
         subscription.enable_repos(rhel_repoids)
 

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -455,5 +455,5 @@ def exit_on_failed_download(paths):
         loggerinst.critical(
             "Unable to download the subscription-manager package or its dependencies. See details of"
             " the failed yumdownloader call above. These packages are necessary for the conversion"
-            " unless you use the --disable-submgr option."
+            " unless you use the --no-rhsm option."
         )

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -293,7 +293,7 @@ class SystemInfo(object):
         #         "system_info.get_enabled_rhel_repos is not "
         #          "to be consumed before registering the system with RHSM."
         #     )
-        return self.submgr_enabled_repos if not tool_opts.disable_submgr else tool_opts.enablerepo
+        return self.submgr_enabled_repos if not tool_opts.no_rhsm else tool_opts.enablerepo
 
 
 # Code to be executed upon module import

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -687,7 +687,7 @@ class TestReadOnlyMountsChecks(unittest.TestCase):
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     @unit_tests.mock(checks, "call_yum_cmd", CallYumCmdMocked(ret_code=0, ret_string="Abcdef"))
     @unit_tests.mock(checks, "logger", GetLoggerMocked())
-    @unit_tests.mock(tool_opts, "disable_submgr", True)
+    @unit_tests.mock(tool_opts, "no_rhsm", True)
     def test_custom_repos_are_valid(self):
         checks.check_custom_repos_are_valid()
         self.assertEqual(len(checks.logger.info_msgs), 1)
@@ -699,7 +699,7 @@ class TestReadOnlyMountsChecks(unittest.TestCase):
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     @unit_tests.mock(checks, "call_yum_cmd", CallYumCmdMocked(ret_code=1, ret_string="Abcdef"))
     @unit_tests.mock(checks, "logger", GetLoggerMocked())
-    @unit_tests.mock(tool_opts, "disable_submgr", True)
+    @unit_tests.mock(tool_opts, "no_rhsm", True)
     def test_custom_repos_are_invalid(self):
         self.assertRaises(SystemExit, checks.check_custom_repos_are_valid)
         self.assertEqual(len(checks.logger.critical_msgs), 1)

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -147,7 +147,7 @@ class TestMain(unittest.TestCase):
         self.assertEqual(pkghandler.versionlock_file.restore.called, 1)
 
     @unit_tests.mock(main.logging, "getLogger", GetLoggerMocked())
-    @unit_tests.mock(tool_opts, "disable_submgr", False)
+    @unit_tests.mock(tool_opts, "no_rhsm", False)
     @unit_tests.mock(cert.SystemCert, "_get_cert_path", unit_tests.MockFunction)
     @mock_calls(main.special_cases, "check_and_resolve", CallOrderMocked)
     @mock_calls(main.checks, "perform_pre_checks", CallOrderMocked)
@@ -193,7 +193,7 @@ class TestMain(unittest.TestCase):
                 self.assertEqual(expected, actual)
 
     @unit_tests.mock(main.logging, "getLogger", GetLoggerMocked())
-    @unit_tests.mock(tool_opts, "disable_submgr", False)
+    @unit_tests.mock(tool_opts, "no_rhsm", False)
     @unit_tests.mock(cert.SystemCert, "_get_cert_path", unit_tests.MockFunction)
     @mock_calls(main.special_cases, "check_and_resolve", CallOrderMocked)
     @mock_calls(main.checks, "perform_pre_checks", CallOrderMocked)

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -203,7 +203,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     @unit_tests.mock(system_info, "releasever", None)
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
-    @unit_tests.mock(tool_opts, "disable_submgr", True)
+    @unit_tests.mock(tool_opts, "no_rhsm", True)
     @unit_tests.mock(tool_opts, "disablerepo", ["*"])
     @unit_tests.mock(tool_opts, "enablerepo", ["rhel-7-extras-rpm"])
     def test_call_yum_cmd_with_disablerepo_and_enablerepo(self):
@@ -1120,7 +1120,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
 
     @unit_tests.mock(system_info, "submgr_enabled_repos", ["enabled_rhsm_repo"])
     @unit_tests.mock(tool_opts, "enablerepo", [])  # to be changed later in the test
-    @unit_tests.mock(tool_opts, "disable_submgr", False)  # to be changed later in the test
+    @unit_tests.mock(tool_opts, "no_rhsm", False)  # to be changed later in the test
     @unit_tests.mock(utils, "ask_to_continue", DumbCallableObject())
     @unit_tests.mock(utils, "download_pkg", DownloadPkgMocked())
     @unit_tests.mock(utils, "run_subprocess", RunSubprocessMocked())
@@ -1138,7 +1138,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
 
         # test the use case where custom repos are used for the conversion
         system_info.submgr_enabled_repos = []
-        tool_opts.disable_submgr = True
+        tool_opts.no_rhsm = True
         tool_opts.enablerepo = ["custom_repo"]
         pkghandler.replace_non_rhel_installed_kernel(version)
         self.assertEqual(utils.download_pkg.enable_repos, ["custom_repo"])


### PR DESCRIPTION
Both are still possible to use and both have the same effect.

The reason is that:
1. we are not disabling the subscription-manager (bad choice of wording) and
2. the same option is used in LEAPP for RHEL system upgrades.