### PR TITLE
fix: wrong order of the commands in make rpms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,3 +82,4 @@ rpms: images
 	docker build -f Dockerfiles/rpmbuild.centos7.Dockerfile -t $(IMAGE)/centos7rpmbuild .
 	docker cp $$(docker create $(IMAGE)/centos8rpmbuild):/data/.rpms .
 	docker cp $$(docker create $(IMAGE)/centos7rpmbuild):/data/.rpms .
+	docker rm $$(docker ps -aq) -f

--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,5 @@ rpms: images
 	rm -frv .rpms/*
 	docker build -f Dockerfiles/rpmbuild.centos8.Dockerfile -t $(IMAGE)/centos8rpmbuild .
 	docker build -f Dockerfiles/rpmbuild.centos7.Dockerfile -t $(IMAGE)/centos7rpmbuild .
-	$(eval centos8_id := $(shell docker create $(IMAGE)/centos8rpmbuild))
-	docker cp $(centos8_id):/data/.rpms .
-	docker rm $(centos8_id)
-	$(eval centos7_id := $(shell docker create $(IMAGE)/centos7rpmbuild))
-	docker cp $(centos7_id):/data/.rpms .
-	docker rm $(centos7_id)
+	docker cp $$(docker create $(IMAGE)/centos8rpmbuild):/data/.rpms .
+	docker cp $$(docker create $(IMAGE)/centos7rpmbuild):/data/.rpms .


### PR DESCRIPTION
Closes OAMG-5037

Makefile eval, inside a target, executed before any other command.
In our case, this was resulted in getting the image id before building it, so rpms were outdated at 1 build.

This MR fixes this issue