### PR TITLE
fix: check if subscription manager installed before call unregister

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -94,6 +94,7 @@ def convert2rhel(shell):
             c2r_runtime.expect(pexpect.EOF)
             c2r_runtime.close()
         finally:
-            shell("subscription-manager unregister")
+            if shell("rpm -q subscription-manager").returncode == 0:
+                shell("subscription-manager unregister")
 
     return factory


### PR DESCRIPTION
This commit adds a check if subscription manager is installed before call the unregister process