### PR TITLE
Feature/better handling of releasever

### DIFF
--- a/convert2rhel/data/6/x86_64/configs/centos-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/centos-6-x86_64.cfg
@@ -25,7 +25,10 @@ repofile_pkgs =
 # Delimited by any whitespace(s).
 default_rhsm_repoids = rhel-6-server-rpms
 
-releasever=6.10
+# If defined, it overrides the default releasever defined by RELEASE_VER_MAPPING.
+# The value is passed to the yum calls through the --releasever option when accessing RHEL repos. Its purpose is to
+# substitute the $releasever variable in a repository baseurl.
+releasever=
 
 # Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
 # that such a module is not available in RHEL and thus is unsupported, we ignore it.

--- a/convert2rhel/data/6/x86_64/configs/oracle-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/oracle-6-x86_64.cfg
@@ -37,7 +37,10 @@ repofile_pkgs =
 # Delimited by any whitespace(s).
 default_rhsm_repoids = rhel-6-server-rpms
 
-releasever=6.10
+# If defined, it overrides the default releasever defined by RELEASE_VER_MAPPING.
+# The value is passed to the yum calls through the --releasever option when accessing RHEL repos. Its purpose is to
+# substitute the $releasever variable in a repository baseurl.
+releasever=
 
 # Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
 # that such a module is not available in RHEL and thus is unsupported, we ignore it.

--- a/convert2rhel/data/6/x86_64/configs/suse_es-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/suse_es-6-x86_64.cfg
@@ -18,7 +18,10 @@ repofile_pkgs =
 # Delimited by any whitespace(s).
 default_rhsm_repoids = rhel-6-server-rpms
 
-releasever=6.10
+# If defined, it overrides the default releasever defined by RELEASE_VER_MAPPING.
+# The value is passed to the yum calls through the --releasever option when accessing RHEL repos. Its purpose is to
+# substitute the $releasever variable in a repository baseurl.
+releasever=
 
 # Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
 # that such a module is not available in RHEL and thus is unsupported, we ignore it.

--- a/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
@@ -31,6 +31,9 @@ repofile_pkgs =
 # Delimited by any whitespace(s).
 default_rhsm_repoids = rhel-7-server-rpms
 
+# If defined, it overrides the default releasever defined by RELEASE_VER_MAPPING.
+# The value is passed to the yum calls through the --releasever option when accessing RHEL repos. Its purpose is to
+# substitute the $releasever variable in a repository baseurl.
 releasever=
 
 # Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message

--- a/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
@@ -31,7 +31,7 @@ repofile_pkgs =
 # Delimited by any whitespace(s).
 default_rhsm_repoids = rhel-7-server-rpms
 
-releasever=7Server
+releasever=
 
 # Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
 # that such a module is not available in RHEL and thus is unsupported, we ignore it.

--- a/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
@@ -37,6 +37,9 @@ repofile_pkgs =
 # Delimited by any whitespace(s).
 default_rhsm_repoids = rhel-7-server-rpms
 
+# If defined, it overrides the default releasever defined by RELEASE_VER_MAPPING.
+# The value is passed to the yum calls through the --releasever option when accessing RHEL repos. Its purpose is to
+# substitute the $releasever variable in a repository baseurl.
 releasever=
 
 # Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message

--- a/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
@@ -37,7 +37,7 @@ repofile_pkgs =
 # Delimited by any whitespace(s).
 default_rhsm_repoids = rhel-7-server-rpms
 
-releasever=7Server
+releasever=
 
 # Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
 # that such a module is not available in RHEL and thus is unsupported, we ignore it.

--- a/convert2rhel/data/7/x86_64/configs/suse_es-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/suse_es-7-x86_64.cfg
@@ -18,7 +18,7 @@ repofile_pkgs =
 # Delimited by any whitespace(s).
 default_rhsm_repoids = rhel-7-server-rpms
 
-releasever=7Server
+releasever=
 
 # Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
 # that such a module is not available in RHEL and thus is unsupported, we ignore it.

--- a/convert2rhel/data/7/x86_64/configs/suse_es-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/suse_es-7-x86_64.cfg
@@ -18,6 +18,9 @@ repofile_pkgs =
 # Delimited by any whitespace(s).
 default_rhsm_repoids = rhel-7-server-rpms
 
+# If defined, it overrides the default releasever defined by RELEASE_VER_MAPPING.
+# The value is passed to the yum calls through the --releasever option when accessing RHEL repos. Its purpose is to
+# substitute the $releasever variable in a repository baseurl.
 releasever=
 
 # Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message

--- a/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
@@ -32,7 +32,7 @@ default_rhsm_repoids =
   rhel-8-for-x86_64-baseos-rpms
   rhel-8-for-x86_64-appstream-rpms
 
-releasever=8.3
+releasever=
 
 # Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
 # that such a module is not available in RHEL and thus is unsupported, we ignore it.

--- a/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/centos-8-x86_64.cfg
@@ -32,6 +32,9 @@ default_rhsm_repoids =
   rhel-8-for-x86_64-baseos-rpms
   rhel-8-for-x86_64-appstream-rpms
 
+# If defined, it overrides the default releasever defined by RELEASE_VER_MAPPING.
+# The value is passed to the yum calls through the --releasever option when accessing RHEL repos. Its purpose is to
+# substitute the $releasever variable in a repository baseurl.
 releasever=
 
 # Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message

--- a/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
@@ -27,7 +27,7 @@ default_rhsm_repoids =
   rhel-8-for-x86_64-baseos-rpms
   rhel-8-for-x86_64-appstream-rpms
 
-releasever=8.3
+releasever=
 
 # Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
 # that such a module is not available in RHEL and thus is unsupported, we ignore it.

--- a/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/oracle-8-x86_64.cfg
@@ -27,6 +27,9 @@ default_rhsm_repoids =
   rhel-8-for-x86_64-baseos-rpms
   rhel-8-for-x86_64-appstream-rpms
 
+# If defined, it overrides the default releasever defined by RELEASE_VER_MAPPING.
+# The value is passed to the yum calls through the --releasever option when accessing RHEL repos. Its purpose is to
+# substitute the $releasever variable in a repository baseurl.
 releasever=
 
 # Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -217,7 +217,7 @@ class SystemInfo(object):
             self.logger.critical(
                 "%s of version %d.%d is not allowed for conversion.\n"
                 "Allowed versions are: %s"
-                % (self.name, self.version.major, self.version.minor, RELEASE_VER_MAPPING.keys())
+                % (self.name, self.version.major, self.version.minor, list(RELEASE_VER_MAPPING.keys()))
             )
 
     def _get_kmods_to_ignore(self):

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -38,21 +38,15 @@ from convert2rhel.toolopts import tool_opts
 # Allowed conversion paths to RHEL. We want to prevent a conversion and minor
 #   version update at the same time.
 RELEASE_VER_MAPPING = {
-    "CentOS Linux": {
-        "8.5": "8.5",
-        "8.4": "8.4",
-        "7.9": "7Server",
-        "6.10": "6Server",
-    },
-    "Oracle Linux Server": {
-        "8.5": "8.5",
-        "8.4": "8.4",
-        "7.9": "7Server",
-        "6.10": "6Server",
-    },
+    "8.5": "8.5",
+    "8.4": "8.4",
+    "7.9": "7Server",
+    "6.10": "6Server",
 }
+
 # For a list of modified rpm files before the conversion starts
 PRE_RPM_VA_LOG_FILENAME = "rpm_va.log"
+
 # For a list of modified rpm files after the conversion finishes for comparison purposes
 POST_RPM_VA_LOG_FILENAME = "rpm_va_after_conversion.log"
 
@@ -218,7 +212,7 @@ class SystemInfo(object):
         releasever_cfg = self._get_cfg_opt("releasever")
         try:
             # return config value or corresponding releasever from the RELEASE_VER_MAPPING
-            return releasever_cfg or RELEASE_VER_MAPPING[self.name][".".join(map(str, self.version))]
+            return releasever_cfg or RELEASE_VER_MAPPING[".".join(map(str, self.version))]
         except KeyError:
             self.logger.critical(
                 "%s of version %d.%d is not allowed for conversion.\n"

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -42,6 +42,7 @@ from convert2rhel.pkghandler import get_pkg_fingerprint
 from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts
 from convert2rhel.unit_tests import GetFileContentMocked, GetLoggerMocked
+from convert2rhel.unit_tests.conftest import centos7, centos8
 from convert2rhel.utils import run_subprocess
 
 
@@ -185,9 +186,10 @@ def test_pre_ponr_checks(monkeypatch):
         ),
     ),
 )
+@centos8
 def test_ensure_compatibility_of_kmods(
     monkeypatch,
-    pretend_centos8,
+    pretend_os,
     caplog,
     host_kmods,
     exception,
@@ -242,9 +244,10 @@ def test_ensure_compatibility_of_kmods(
         ),
     ),
 )
+@centos7
 def test_ensure_compatibility_of_kmods_excluded(
     monkeypatch,
-    pretend_centos7,
+    pretend_os,
     caplog,
     unsupported_pkg,
     msg_in_logs,
@@ -346,9 +349,10 @@ def test_get_installed_kmods(tmpdir, monkeypatch, caplog, run_subprocess_mock, e
         (REPOQUERY_F_STUB_BAD, REPOQUERY_L_STUB_GOOD, SystemExit),
     ),
 )
+@centos8
 def test_get_rhel_supported_kmods(
     monkeypatch,
-    pretend_centos8,
+    pretend_os,
     repoquery_f_stub,
     repoquery_l_stub,
     exception,
@@ -581,13 +585,14 @@ def test_bad_kernel_substring(kernel_release, exp_return, monkeypatch):
         ),
     ),
 )
+@centos8
 def test_bad_kernel_fingerprint(
     kernel_release,
     kernel_pkg,
     kernel_pkg_fingerprint,
     exp_return,
     monkeypatch,
-    pretend_centos8,
+    pretend_os,
 ):
     run_subprocess_mocked = mock.Mock(spec=run_subprocess, return_value=(kernel_pkg, ""))
     get_pkg_fingerprint_mocked = mock.Mock(spec=get_pkg_fingerprint, return_value=kernel_pkg_fingerprint)

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -75,6 +75,61 @@ def setup_logger(tmpdir):
 
 @pytest.fixture()
 def pretend_os(request, pkg_root, monkeypatch):
+    """Parametric fixture to pretend to be one of available OS for convertion.
+
+    See https://docs.pytest.org/en/6.2.x/example/parametrize.html#indirect-parametrization
+    for more information.
+
+    Fixture parameters are:
+        system_version - i.e. "7.9.9"
+        system_name - i.e. "CentOS Linux"
+
+    Examples:
+
+    >>> # low level mode
+    >>> @pytest.mark.parametrize(
+    >>>     "pretend_os",
+    >>>     (
+    >>>         ("7.9.1111", "CentOS Linux"),
+    >>>         ("7.9.1111", "Oracle Linux Server"),
+    >>>         ("8.4.1111", "CentOS Linux"),
+    >>>         ("8.4.1111", "Oracle Linux Server"),
+    >>>     ),
+    >>>     indirect=True,
+    >>> )
+    >>> def example_test(pretend_os):
+    >>>     # Will run 4 tests for each of specified systems.
+    >>>     pass
+
+
+    >>> # using the shortcut
+    >>> @all_systems
+    >>> def example_test(pretend_os):
+    >>>     # Will do the same.
+    >>>     pass
+
+
+    >>> @centos8
+    >>> def example_test(pretend_os):
+    >>>     # Will pretend CentOS 8.
+    >>>     pass
+
+
+    >>> @pytest.mark.parametrize(
+    >>>     "param",
+    >>>     (
+    >>>         ("param_value1",),
+    >>>         ("param_value2",),
+    >>>     ),
+    >>> )
+    >>> @all_systems
+    >>> def example_test(pretend_os):
+    >>>     # Will run 8 tests.
+
+    >>>     # for each of 4 systems it will run the test with each param value.
+    >>>     pass
+
+    """
     system_version, system_name = request.param
     system_version_major, system_version_minor, _ = system_version.split(".")
 

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -73,26 +73,16 @@ def setup_logger(tmpdir):
     initialize_logger(log_name="convert2rhel", log_dir=tmpdir)
 
 
-def _replace_data_dir_base(system_version_num):
-    """Factory function serves as a base to mokeypatch utils.DATA_DIR."""
+@pytest.fixture()
+def pretend_os(request, pkg_root, monkeypatch):
+    system_version, system_name = request.param
+    system_version_major, system_version_minor, _ = system_version.split(".")
 
-    def fixture(monkeypatch, pkg_root):
-        monkeypatch.setattr(
-            utils,
-            "DATA_DIR",
-            value=str(pkg_root / ("convert2rhel/data/%s/x86_64/" % system_version_num)),
-        )
-
-    return fixture
-
-
-_replace_data_dir_for_centos8 = pytest.fixture(_replace_data_dir_base("8"))
-_replace_data_dir_for_centos7 = pytest.fixture(_replace_data_dir_base("7"))
-
-
-def _pretend_fixture_base(monkeypatch, system_release_version):
-    """Apply common logic in pretend_{os_name} fixtures."""
-
+    monkeypatch.setattr(
+        utils,
+        "DATA_DIR",
+        value=str(pkg_root / ("convert2rhel/data/%s/x86_64/" % system_version_major)),
+    )
     monkeypatch.setattr(
         redhatrelease,
         "get_system_release_filepath",
@@ -101,34 +91,39 @@ def _pretend_fixture_base(monkeypatch, system_release_version):
     monkeypatch.setattr(
         utils,
         "get_file_content",
-        value=lambda _: "CentOS Linux release %s" % system_release_version,
+        value=lambda _: "%s release %s" % (system_name, system_version),
     )
     tool_opts.no_rpm_va = True
     system_info.resolve_system_info()
 
 
-def _pretend_centos_base(system_release_version):
-    """Factory function serves as a base to pretend_{os} fixtures."""
-
-    def fixture_centos7(monkeypatch, _replace_data_dir_for_centos7):
-        _pretend_fixture_base(monkeypatch, system_release_version)
-
-    def fixture_centos8(monkeypatch, _replace_data_dir_for_centos8):
-        _pretend_fixture_base(monkeypatch, system_release_version)
-
-    release2data_dir_relations = {
-        "8.3.2011": fixture_centos8,
-        "7.9.2009": fixture_centos7,
-    }
-
-    try:
-        return release2data_dir_relations[system_release_version]
-    except KeyError:
-        raise KeyError(
-            "Unknown system release version %s.\n"
-            "Available are: %s" % (system_release_version, " ".join(release2data_dir_relations)),
-        )
-
-
-pretend_centos8 = pytest.fixture(_pretend_centos_base("8.3.2011"))
-pretend_centos7 = pytest.fixture(_pretend_centos_base("7.9.2009"))
+all_systems = pytest.mark.parametrize(
+    "pretend_os",
+    (
+        ("7.9.1111", "CentOS Linux"),
+        ("7.9.1111", "Oracle Linux Server"),
+        ("8.4.1111", "CentOS Linux"),
+        ("8.4.1111", "Oracle Linux Server"),
+    ),
+    indirect=True,
+)
+centos8 = pytest.mark.parametrize(
+    "pretend_os",
+    (("8.4.1111", "CentOS Linux"),),
+    indirect=True,
+)
+centos7 = pytest.mark.parametrize(
+    "pretend_os",
+    (("7.9.1111", "CentOS Linux"),),
+    indirect=True,
+)
+oracle8 = pytest.mark.parametrize(
+    "pretend_os",
+    (("8.4.1111", "Oracle Linux Server"),),
+    indirect=True,
+)
+oracle7 = pytest.mark.parametrize(
+    "pretend_os",
+    (("7.9.1111", "Oracle Linux Server"),),
+    indirect=True,
+)

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -216,9 +216,7 @@ def test_system_info_has_rpm(pkg_name, present_on_system, expected_return, monke
 @all_systems
 def test_get_release_ver(pretend_os):
     """Test if all pretended OSes presented in theh RELEASE_VER_MAPPING."""
-    assert system_info.releasever in set(
-        itertools.chain(*map(lambda dict_: dict_.values(), RELEASE_VER_MAPPING.values()))
-    )
+    assert system_info.releasever in RELEASE_VER_MAPPING.values()
 
 
 @pytest.mark.parametrize(

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -16,8 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # Required imports:
-
-
+import itertools
 import logging
 import os
 import shutil
@@ -29,9 +28,10 @@ from collections import namedtuple
 import pytest
 
 from convert2rhel import logger, systeminfo, unit_tests, utils  # Imports unit_tests/__init__.py
-from convert2rhel.systeminfo import system_info
+from convert2rhel.systeminfo import RELEASE_VER_MAPPING, system_info
 from convert2rhel.toolopts import tool_opts
 from convert2rhel.unit_tests import is_rpm_based_os
+from convert2rhel.unit_tests.conftest import all_systems, centos8
 
 
 if sys.version_info[:2] <= (2, 7):
@@ -211,3 +211,48 @@ def test_system_info_has_rpm(pkg_name, present_on_system, expected_return, monke
     monkeypatch.setattr(systeminfo, "run_subprocess", value=run_subprocess_mocked)
     assert system_info.is_rpm_installed(pkg_name) == expected_return
     assert run_subprocess_mocked
+
+
+@all_systems
+def test_get_release_ver(pretend_os):
+    """Test if all pretended OSes presented in theh RELEASE_VER_MAPPING."""
+    assert system_info.releasever in set(
+        itertools.chain(*map(lambda dict_: dict_.values(), RELEASE_VER_MAPPING.values()))
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "releasever_val",
+        "self_name",
+        "self_version",
+        "exception",
+    ),
+    (
+        # good cases
+        # if releasever set in config - it takes precedence
+        ("not_existing_release_ver_set_in_config", None, None, None),
+        # Good cases which matches supported pathes
+        ("", "CentOS Linux", systeminfo.Version(8, 4), None),
+        ("", "Oracle Linux Server", systeminfo.Version(8, 4), None),
+        # bad cases
+        ("", "NextCool Linux", systeminfo.Version(8, 4), SystemExit),
+        ("", "CentOS Linux", systeminfo.Version(8, 10000), SystemExit),
+    ),
+)
+# need to pretend centos8 in order to system info were resolved at module init
+@centos8
+def test_get_release_ver_other(pretend_os, monkeypatch, releasever_val, self_name, self_version, exception):
+    monkeypatch.setattr(systeminfo.SystemInfo, "_get_cfg_opt", mock.Mock(return_value=releasever_val))
+    if self_name:
+        monkeypatch.setattr(systeminfo.SystemInfo, "_get_system_name", mock.Mock(return_value=self_name))
+    if self_version:
+        monkeypatch.setattr(systeminfo.SystemInfo, "_get_system_version", mock.Mock(return_value=self_version))
+    # calling resolve_system_info one more time to enable our monkeypatches
+    if exception:
+        with pytest.raises(exception):
+            system_info.resolve_system_info()
+    else:
+        system_info.resolve_system_info()
+    if releasever_val:
+        assert system_info.releasever == releasever_val

--- a/plans/integration/releasever-as-mapping/main.fmf
+++ b/plans/integration/releasever-as-mapping/main.fmf
@@ -1,0 +1,34 @@
+discover+:
+    filter:
+        - 'tag: releasever-as-mapping'
+provision:
+    how: libvirt
+    develop: true
+
+/centos7:
+    discover+:
+        filter+:
+            - 'tag: centos7'
+    provision+:
+        origin_vm_name: c2r_centos7_template
+
+/centos8:
+    discover+:
+        filter+:
+            - 'tag: centos8'
+    provision+:
+        origin_vm_name: c2r_centos8_template
+
+/oracle7:
+    discover+:
+        filter+:
+            - 'tag: oracle7'
+    provision+:
+        origin_vm_name: c2r_oracle7_template
+
+/oracle8:
+    discover+:
+        filter+:
+            - 'tag: oracle8'
+    provision+:
+        origin_vm_name: c2r_oracle8_template

--- a/tests/ansible_collections/roles/install-testing-deps/tasks/main.yml
+++ b/tests/ansible_collections/roles/install-testing-deps/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: Install pytest framework dependencies
   pip:
-    name: ["pytest", "pytest-cov", "envparse", "click", "pexpect"]
+    name: ["pytest", "pytest-cov", "envparse", "click", "pexpect", "pdbpp", "dataclasses"]
     executable: "/usr/local/bin/pip"

--- a/tests/ansible_collections/roles/install-testing-deps/tasks/main.yml
+++ b/tests/ansible_collections/roles/install-testing-deps/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: Install pytest framework dependencies
   pip:
-    name: ["pytest", "pytest-cov", "envparse", "click", "pexpect", "pdbpp", "dataclasses"]
+    name: ["pytest", "pytest-cov", "envparse", "click", "pexpect", "dataclasses"]
     executable: "/usr/local/bin/pip"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -191,8 +191,15 @@ def c2r_config(os_release):
 
 
 @pytest.fixture()
-def config_at_path():
-    """Provide a possibility to"""
+def config_at():
+    """Factory of the Config object.
+
+    Example:
+    >>> with config_at(Path("/etc/system-release")).replace_line(
+    >>>     "release .+",
+    >>>     f"release {os_release.version[0]}.1.1111",
+    >>> ):
+    """
 
     def factory(path: Path) -> Config:
         return Config(path)

--- a/tests/integration/releasever-as-mapping/main.fmf
+++ b/tests/integration/releasever-as-mapping/main.fmf
@@ -1,0 +1,9 @@
+summary: releasever-as-mapping
+tag+:
+  - centos7
+  - centos8
+  - oracle7
+  - oracle8
+  - releasever-as-mapping
+test: |
+  pytest -svv

--- a/tests/integration/releasever-as-mapping/test_releasever_as_mapping.py
+++ b/tests/integration/releasever-as-mapping/test_releasever_as_mapping.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from envparse import env
+
+
+def test_releasever_as_mapping_config_modified(convert2rhel, os_release, c2r_config):
+    """Test if config changes takes precedence."""
+    with c2r_config.replace_line(pattern="releasever=.*", repl=f"releasever=333"):
+        with convert2rhel(
+            ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
+                env.str("RHSM_SERVER_URL"),
+                env.str("RHSM_USERNAME"),
+                env.str("RHSM_PASSWORD"),
+                env.str("RHSM_POOL"),
+            )
+        ) as c2r:
+            c2r.expect("--releasever=333")
+            c2r.send(chr(3))
+    assert c2r.exitstatus == 1
+
+
+def test_releasever_as_mapping_not_existing_release(convert2rhel, config_at_path, os_release):
+    """Test unknown release."""
+    with config_at_path(Path("/etc/system-release")).replace_line(
+        "release .+",
+        f"release {os_release.version[0]}.1.1111",
+    ):
+        with convert2rhel(
+            ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
+                env.str("RHSM_SERVER_URL"),
+                env.str("RHSM_USERNAME"),
+                env.str("RHSM_PASSWORD"),
+                env.str("RHSM_POOL"),
+            )
+        ) as c2r:
+            c2r.expect(
+                f"CRITICAL - {os_release.name} of version {os_release.version[0]}.1 is not allowed for conversion."
+            )
+        assert c2r.exitstatus == 1

--- a/tests/integration/releasever-as-mapping/test_releasever_as_mapping.py
+++ b/tests/integration/releasever-as-mapping/test_releasever_as_mapping.py
@@ -19,9 +19,9 @@ def test_releasever_as_mapping_config_modified(convert2rhel, os_release, c2r_con
     assert c2r.exitstatus == 1
 
 
-def test_releasever_as_mapping_not_existing_release(convert2rhel, config_at_path, os_release):
+def test_releasever_as_mapping_not_existing_release(convert2rhel, config_at, os_release):
     """Test unknown release."""
-    with config_at_path(Path("/etc/system-release")).replace_line(
+    with config_at(Path("/etc/system-release")).replace_line(
         "release .+",
         f"release {os_release.version[0]}.1.1111",
     ):


### PR DESCRIPTION
Use predefined dict for a release version, which  maps CentOS versions to RHEL versions. The config parameter is set to nothing (`releasever=`) by default, however, if set, will take the precedence over the data in predefined dict.

Resolves: https://issues.redhat.com/browse/OAMG-5007
Related: https://bugzilla.redhat.com/show_bug.cgi?id=1962193

TODO:
- [x] integration tests