### PR TITLE
Add quotes around the activation key

### DIFF
--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -128,7 +128,7 @@ def get_registration_cmd():
         # -> username/password not required
         # -> organization required
         loggerinst.info("    ... activation key detected: %s" % tool_opts.activation_key)
-        registration_cmd += " --activationkey=%s" % tool_opts.activation_key
+        registration_cmd += ' --activationkey="%s"' % tool_opts.activation_key
     else:
         # No activation key -> username/password required
         if tool_opts.username and tool_opts.password:


### PR DESCRIPTION
When registering the system through subscription-manager, the key can contain a space character.

Related: https://access.redhat.com/discussions/5676681#comment-2117741