### PR TITLE
Improve the non-debug output

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -70,7 +70,6 @@ def main():
         systeminfo.system_info.resolve_system_info()
 
         # check the system prior the conversion (possible inhibit)
-        loggerinst.task("Prepare: Initial system checks before conversion")
         checks.perform_pre_checks()
 
         # backup system release file before starting conversion process

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -571,6 +571,7 @@ def install_gpg_keys():
         )
         if ret_code != 0:
             loggerinst.critical("Unable to import GPG key: %s", output)
+        loggerinst.info("GPG keys imported.")
 
 
 def preserve_only_rhel_kernel():

--- a/convert2rhel/redhatrelease.py
+++ b/convert2rhel/redhatrelease.py
@@ -71,7 +71,7 @@ class YumConf(object):
         """
         self._comment_out_distroverpkg_tag()
         self._write_altered_yum_conf()
-        loggerinst.debug("%s patched." % self._yum_conf_path)
+        loggerinst.info("%s patched." % self._yum_conf_path)
         return
 
     def _comment_out_distroverpkg_tag(self):

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -609,14 +609,14 @@ class TestUEFIChecks(unittest.TestCase):
         self.assertEqual(len(checks.logger.critical_msgs), 1)
         self.assertTrue("Conversion of UEFI systems is currently not supported" in checks.logger.critical_msgs[0])
         if checks.logger.debug_msgs:
-            self.assertFalse("Converting BIOS system" in checks.logger.debug_msgs[0])
+            self.assertFalse("BIOS system detected." in checks.logger.info_msgs[0])
 
     @unit_tests.mock(os.path, "exists", lambda x: not x == "/sys/firmware/efi")
     @unit_tests.mock(checks, "logger", GetLoggerMocked())
     def test_check_uefi_bios_detected(self):
         checks.check_uefi()
         self.assertFalse(checks.logger.critical_msgs)
-        self.assertTrue("Converting BIOS system" in checks.logger.debug_msgs[0])
+        self.assertTrue("BIOS system detected." in checks.logger.info_msgs[0])
 
 
 class TestReadOnlyMountsChecks(unittest.TestCase):
@@ -686,6 +686,7 @@ class TestReadOnlyMountsChecks(unittest.TestCase):
     def test_custom_repos_are_valid(self):
         checks.check_custom_repos_are_valid()
         self.assertEqual(len(checks.logger.info_msgs), 1)
+        self.assertEqual(len(checks.logger.debug_msgs), 1)
         self.assertTrue(
             "The repositories passed through the --enablerepo option are all accessible." in checks.logger.info_msgs
         )


### PR DESCRIPTION
Without using the --debug, the output of the tool was not providing information about whether certain steps succeeded. Or it provided irrelevant information (like the output of `yum clean metadata`).
For example:
```
[06/14/2021 16:59:48] TASK - [Prepare: Initial system checks before conversion] *****************

[06/14/2021 16:59:48] TASK - [Prepare: Checking the firmware interface type] ********************

[06/14/2021 16:59:48] TASK - [Convert: Checking /mnt and /sys are read-write] *******************

[06/14/2021 16:59:48] TASK - [Prepare: Check kernel compatibility with RHEL] ********************

[06/14/2021 16:59:48] TASK - [Prepare: Checking if --enablerepo repositories are accessible] ****
Loaded plugins: fastestmirror
Cleaning repos: rhel-7-server-rpms
4 metadata files removed
3 sqlite files removed
0 metadata files removed
Loading "fastestmirror" plugin
Config time: 0.005
Yum version: 3.4.3
Loading mirror speeds from cached hostfile
Metadata Cache Created
The repositories passed through the --enablerepo option are all accessible.

[06/14/2021 17:11:57] TASK - [Convert: Patch yum configuration file] ****************************

[06/14/2021 17:12:48] TASK - [Convert: Import Red Hat GPG keys] *********************************

```