### PR TITLE
Set max duration for test

### DIFF
--- a/tests/integration/main.fmf
+++ b/tests/integration/main.fmf
@@ -1,1 +1,2 @@
 summary: Integration tests
+duration: 30m


### PR DESCRIPTION
Setting maximal duration for all tests to 30 minutes. Without this the default value is 5 minutes. In 5 minutes any test cannot be successfully finished.
[Documentation](https://tmt.readthedocs.io/en/stable/spec/tests.html#duration)