### PR TITLE
Add dataclasses backport package dependency to oracle-system-not-stan…

### DIFF
--- a/tests/integration/inhibit-if-oracle-system-uses-not-standard-kernel/ansible/basic_setup.yml
+++ b/tests/integration/inhibit-if-oracle-system-uses-not-standard-kernel/ansible/basic_setup.yml
@@ -38,5 +38,5 @@
 
     - name: Install pytest framework dependencies
       pip:
-        name: ["pytest", "pytest-cov", "envparse", "click", "pexpect"]
+        name: ["pytest", "pytest-cov", "envparse", "click", "pexpect", "dataclasses"]
         executable: "/usr/local/bin/pip"


### PR DESCRIPTION
This plan inhibit-if-oracle-system-uses-not-standard-kernel do not run the main ansible roles, so it started failing when we updated the dependencies. This MR fixes the issue

I was thinking to implement it as the env var which will contain the names of the roles to skip, however the implementation as a result became too complex, without the evidence that actually we need this functionality, so I fallback to this naive solution