### PR TITLE
fix: python 2 FileExistsError

### DIFF
--- a/convert2rhel/unit_tests/cert_test.py
+++ b/convert2rhel/unit_tests/cert_test.py
@@ -108,7 +108,7 @@ def test_remove_cert(monkeypatch, filename, caplog):
         path = os.path.join(unit_tests.TMP_DIR, filename)
         if filename == "existing.file":
             os.mknod(path)
-    except FileExistsError:
+    except OSError:
         pass
 
     monkeypatch.setattr(cert.SystemCert, "_get_cert", value=mock.Mock(return_value=("anything", "anything")))


### PR DESCRIPTION
FileExistsError does not exist in python 2. Missed in review of #203

OSError can be used instead