### PR TITLE
Add distro filtering based on tmt context

### DIFF
--- a/tests/integration/check-custom-repo/main.fmf
+++ b/tests/integration/check-custom-repo/main.fmf
@@ -5,6 +5,13 @@ tag+:
   - oracle7
   - oracle8
   - check-custom-repo
+adjust:
+  enabled: false
+  when: >
+    distro!=centos-7 and
+    distro!=centos-8 and
+    distro!=oracle-7 and
+    distro!=oracle-8
 
 /good:
   tag+:

--- a/tests/integration/conversion/basic-conversion/main.fmf
+++ b/tests/integration/conversion/basic-conversion/main.fmf
@@ -5,5 +5,12 @@ tag+:
   - oracle7
   - oracle8
   - basic-conversion
+adjust:
+  enabled: false
+  when: >
+    distro != centos-7 and
+    distro != centos-8 and
+    distro != oracle-7 and
+    distro != oracle-8
 test: |
   pytest -svv

--- a/tests/integration/inhibit-if-kmods-is-not-supported/main.fmf
+++ b/tests/integration/inhibit-if-kmods-is-not-supported/main.fmf
@@ -5,5 +5,12 @@ tag+:
   - oracle7
   - oracle8
   - inhibit-if-kmods-is-not-supported
+adjust:
+  enabled: false
+  when: >
+    distro != centos-7 and
+    distro != centos-8 and
+    distro != oracle-7 and
+    distro != oracle-8
 test: |
   pytest -svv

--- a/tests/integration/inhibit-if-oracle-system-uses-not-standard-kernel/main.fmf
+++ b/tests/integration/inhibit-if-oracle-system-uses-not-standard-kernel/main.fmf
@@ -3,6 +3,11 @@ tag+:
   - oracle7
   - oracle8
   - inhibit-if-oracle-system-uses-not-standard-kernel
+adjust:
+  enabled: false
+  when: >
+    distro != oracle-7 and
+    distro != oracle-8
 
 /good:
   tag+:

--- a/tests/integration/releasever-as-mapping/main.fmf
+++ b/tests/integration/releasever-as-mapping/main.fmf
@@ -5,5 +5,12 @@ tag+:
   - oracle7
   - oracle8
   - releasever-as-mapping
+adjust:
+  enabled: false
+  when: >
+    distro != centos-7 and
+    distro != centos-8 and
+    distro != oracle-7 and
+    distro != oracle-8
 test: |
   pytest -svv

--- a/tests/integration/remove-excluded-pkgs/main.fmf
+++ b/tests/integration/remove-excluded-pkgs/main.fmf
@@ -2,6 +2,10 @@ summary: remove-excluded-pkgs
 tag+:
   - centos8
   - remove-excluded-pkgs
+adjust:
+  enabled: false
+  when: >
+    distro != centos-8
 
 /good:
   test: |

--- a/tests/integration/remove_all_submgr_pkgs/main.fmf
+++ b/tests/integration/remove_all_submgr_pkgs/main.fmf
@@ -5,5 +5,11 @@ tag+:
   - centos7
   - centos8
   - remove_all_submgr_pkgs
-
+adjust:
+  enabled: false
+  when: >
+    distro != centos-7 and
+    distro != centos-8 and
+    distro != oracle-7 and
+    distro != oracle-8
 test: pytest -svv

--- a/tests/integration/resolve-broken-ol8-rollback/main.fmf
+++ b/tests/integration/resolve-broken-ol8-rollback/main.fmf
@@ -5,6 +5,13 @@ tag+:
   - centos7
   - centos8
   - resolve-broken-ol8-rollback
+adjust:
+  enabled: false
+  when: >
+    distro != centos-7 and
+    distro != centos-8 and
+    distro != oracle-7 and
+    distro != oracle-8
 
 /good:
   test: |

--- a/tests/integration/resolve-dependency/main.fmf
+++ b/tests/integration/resolve-dependency/main.fmf
@@ -3,5 +3,10 @@ tag+:
   - centos7
   - oracle7
   - resolve-dependency
+adjust:
+  enabled: false
+  when: >
+    distro != centos-7 and
+    distro != oracle-7
 
 test: pytest -svv


### PR DESCRIPTION
Packit runs all tmt plans for each built rpm.

In order to skip irrelevant plans in this case we need to
additional guard to each test, which makes sure only relevant tests
will be run for a given rpm (distro)

This is solved with the help of https://tmt.readthedocs.io/en/stable/spec/core.html#adjust

ref https://github.com/packit/packit-service/issues/1164#

~~blocked by https://github.com/psss/tmt/issues/839~~

This MR do not affect the current functionality of running the tests and can be merged