### PR TITLE
make tmpdir fixture be LocalPath type for both python3 and 2

### DIFF
--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -19,19 +19,6 @@ def is_py2():
 
 
 @pytest.fixture()
-def tmpdir(tmpdir, is_py2):
-    """Make tmpdir type str for py26.
-
-    Origin LocalPath object is not supported in python26 for os.path.isdir.
-    We're using this method when do a logger setup.
-    """
-    if is_py2:
-        return str(tmpdir)
-    else:
-        return tmpdir
-
-
-@pytest.fixture()
 def read_std(capsys, is_py2):
     """Multipython compatible, modified version of capsys.
 
@@ -70,7 +57,7 @@ def pkg_root(is_py2):
 
 @pytest.fixture(autouse=True)
 def setup_logger(tmpdir):
-    initialize_logger(log_name="convert2rhel", log_dir=tmpdir)
+    initialize_logger(log_name="convert2rhel", log_dir=str(tmpdir))
 
 
 @pytest.fixture()

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -29,7 +29,7 @@ def test_logger_handlers(tmpdir, caplog, read_std, is_py2, capsys):
     # initializing the logger first
     log_fname = "convert2rhel.log"
     tool_opts.debug = True  # debug entries > stdout if True
-    logger_module.initialize_logger(log_name=log_fname, log_dir=tmpdir)
+    logger_module.initialize_logger(log_name=log_fname, log_dir=str(tmpdir))
     logger = logging.getLogger(__name__)
 
     # emitting some log entries
@@ -37,7 +37,7 @@ def test_logger_handlers(tmpdir, caplog, read_std, is_py2, capsys):
     logger.debug("Test debug")
 
     # Test if logs were emmited to the file
-    with open(os.path.join(tmpdir, log_fname)) as log_f:
+    with open(str(tmpdir.join(log_fname))) as log_f:
         assert "Test info" in log_f.readline().rstrip()
         assert "Test debug" in log_f.readline().rstrip()
 
@@ -49,7 +49,7 @@ def test_logger_handlers(tmpdir, caplog, read_std, is_py2, capsys):
 
 def test_tools_opts_debug(tmpdir, read_std, is_py2):
     log_fname = "convert2rhel.log"
-    logger_module.initialize_logger(log_name=log_fname, log_dir=tmpdir)
+    logger_module.initialize_logger(log_name=log_fname, log_dir=str(tmpdir))
     logger = logging.getLogger(__name__)
     tool_opts.debug = True
     logger.debug("debug entry 1")
@@ -73,7 +73,7 @@ def test_tools_opts_debug(tmpdir, read_std, is_py2):
 def test_logger_custom_logger(tmpdir, caplog):
     """Test CustomLogger."""
     log_fname = "convert2rhel.log"
-    logger_module.initialize_logger(log_name=log_fname, log_dir=tmpdir)
+    logger_module.initialize_logger(log_name=log_fname, log_dir=str(tmpdir))
     logger = logging.getLogger(__name__)
     logger.task("Some task")
     logger.file("Some task write to file")


### PR DESCRIPTION
In the previous implementation, the type of the fixture was str in py2. This is fixed now and the type is identical (LocalPath) for both python versions.

ref #262 