### PR TITLE
Use proper comparison of the env var

### DIFF
--- a/tests/ansible_collections/roles/packaging/tasks/main.yml
+++ b/tests/ansible_collections/roles/packaging/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - include: build_rpm.yml
-  when: build_rpm
+  when: build_rpm == true
 - include: install_rpm_from_local_build.yml
   when: (rpm_provider == "local") and
         (build_rpm == true)


### PR DESCRIPTION
Little improvement of the env vars check in ansible-playbook.

the previous solution is deprecated
