### PR TITLE
fix: allow underscore in package nevr regex

### DIFF
--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -159,7 +159,7 @@ def get_problematic_pkgs(output, excluded_pkgs=set()):
         loggerinst.info("Found protected packages: %s" % set(protected))
         problematic_pkgs["protected"] = set(protected) - excluded_pkgs
 
-    package_nevr_re = r"[0-9]*:?([a-z][a-z0-9-]*?)-[0-9]"
+    package_nevr_re = r"[0-9]*:?([a-z][a-z0-9-_]*?)-[0-9]"
     deps = re.findall("Error: Package: %s" % package_nevr_re, output, re.MULTILINE)
     if deps:
         loggerinst.info("Found packages causing dependency errors: %s" % set(deps))

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -312,6 +312,8 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertIn("libreport-plugin-rhtsupport", error_pkgs["required"])
         self.assertIn("python2-hawkey", error_pkgs["all"])
         self.assertIn("python2-hawkey", error_pkgs["required"])
+        self.assertIn("mod_ldap", error_pkgs["all"])
+        self.assertIn("mod_ldap", error_pkgs["errors"])
         self.assertIn("redhat-lsb-trialuse", error_pkgs["all"])
         self.assertIn("redhat-lsb-trialuse", error_pkgs["errors"])
         self.assertIn("redhat-lsb-core", error_pkgs["all"])
@@ -1398,7 +1400,13 @@ Error: Package: redhat-lsb-trialuse-4.1-27.el7.centos.1.x86_64 (@base/7)
            Downgraded By: redhat-lsb-core-4.1-27.el7.x86_64 (rhel-7-server-rpms)
                redhat-lsb-core(x86-64) = 4.1-27.el7
            Available: redhat-lsb-core-4.1-24.el7.x86_64 (rhel-7-server-rpms)
-               redhat-lsb-core(x86-64) = 4.1-24.el7"""
+               redhat-lsb-core(x86-64) = 4.1-24.el7
+Error: Package: mod_ldap-2.1.11-34.el7.x86_64 (rhel-7-server-rpms)
+           Requires: python2_hawkey >= 0.7.0
+           Removing: python2_hawkey-0.22.5-2.el7_9.x86_64 (@extras/7)
+               python2_hawkey = 0.22.5-2.el7_9
+           Downgraded By: python2_hawkey-0.6.3-4.el7.x86_64 (rhel-7-server-rpms)
+               python2_hawkey = 0.6.3-4.el7"""
 
 YUM_MULTILIB_ERROR = """
 Error: Protected multilib versions: 2:p11-kit-0.18.7-1.fc19.i686 != p11-kit-0.18.3-1.fc19.x86_64


### PR DESCRIPTION
The regex used to get problematic packages did not catch all package
name variants. Packages like `mod_ldap` has an underscore in it instead of
a dash. This fix makes it possible to fetch packages like it.