### PR TITLE
feat: handle mismatched packages

### DIFF
--- a/plans/integration/resolve-dependency/main.fmf
+++ b/plans/integration/resolve-dependency/main.fmf
@@ -12,6 +12,13 @@ provision:
   provision+:
     origin_vm_name: c2r_centos7_template
 
+/centos8:
+  discover+:
+    filter+:
+      - 'tag: centos8'
+  provision+:
+    origin_vm_name: c2r_centos8_template
+
 /oracle7:
   discover+:
     filter+:

--- a/tests/integration/resolve-dependency/main.fmf
+++ b/tests/integration/resolve-dependency/main.fmf
@@ -1,12 +1,14 @@
 summary: resolve-dependency
 tag+:
-  - centos7
   - oracle7
+  - centos7
+  - centos8
   - resolve-dependency
 adjust:
   enabled: false
   when: >
     distro != centos-7 and
+    distro != centos-8 and
     distro != oracle-7
 
 test: pytest -svv

--- a/tests/integration/resolve-dependency/test_resolve_dependency.py
+++ b/tests/integration/resolve-dependency/test_resolve_dependency.py
@@ -1,3 +1,6 @@
+import re
+
+from collections import namedtuple
 from pathlib import Path
 
 import pytest
@@ -5,18 +8,44 @@ import pytest
 from envparse import env
 
 
+def get_system_version(system_release_content=None):
+    """Return a namedtuple with major and minor elements, both of an int type.
+
+    Examples:
+    Oracle Linux Server release 6.10
+    Oracle Linux Server release 7.8
+    CentOS release 6.10 (Final)
+    CentOS Linux release 7.6.1810 (Core)
+    CentOS Linux release 8.1.1911 (Core)
+    """
+    match = re.search(r".+?(\d+)\.(\d+)\D?", system_release_content)
+    if not match:
+        return "not match"
+    version = namedtuple("Version", ["major", "minor"])(int(match.group(1)), int(match.group(2)))
+
+    return version
+
+
 def test_good_convertion(shell, convert2rhel):
 
-    dependency_pkgs = [
-        "abrt-retrace-client",  # OAMG-4447
-        "libreport-cli",  # OAMG-4447
-        "ghostscript-devel",  # Case 02855547
-        "python2-dnf",  # OAMG-4690
-        "python2-dnf-plugins-core",  # OAMG-4690
-        "redhat-lsb-trialuse",  # OAMG-4942
-        "ldb-tools",  # OAMG-4941
-        "python-requests",  # OAMG-4936
-    ]
+    with open("/etc/system-release", "r") as file:
+        system_release = file.read()
+        system_version = get_system_version(system_release_content=system_release)
+        if system_version.major == 7:
+            dependency_pkgs = [
+                "abrt-retrace-client",  # OAMG-4447
+                "libreport-cli",  # OAMG-4447
+                "ghostscript-devel",  # Case 02855547
+                "python2-dnf",  # OAMG-4690
+                "python2-dnf-plugins-core",  # OAMG-4690
+                "redhat-lsb-trialuse",  # OAMG-4942
+                "ldb-tools",  # OAMG-4941
+                "python-requests",  # OAMG-4936
+            ]
+        elif system_version.major == 8:
+            dependency_pkgs = [
+                "python39-psycopg2-debug",  # OAMG-5239, OAMG-4944 - package not available on Oracle Linux 8
+            ]
 
     # installing dependency packages
     assert shell("yum install -y {}".format(" ".join(dependency_pkgs))).returncode == 0


### PR DESCRIPTION
This adds another set to the problematic dict that shows packages that
cause a mismatch of two packages. This mismatch will happen if a package
depends on something that cannot be installed.

See OAMG-4944

---

Currently just an idea and will need polishing