### PR TITLE
Convert STI to TMT: Move dependency check test to conversion directory

### DIFF
--- a/plans/integration/conversion/rhsm/main.fmf
+++ b/plans/integration/conversion/rhsm/main.fmf
@@ -6,6 +6,8 @@ prepare+:
     - name: main conversion preparation
       how: shell
       script: pytest -svv tests/integration/conversion/rhsm/run_conversion.py
+      order: 70
     - name: reboot machine
       how: ansible
       playbook: tests/ansible_collections/reboot.yml
+      order: 80

--- a/plans/integration/conversion/rhsm/resolve-dependency/main.fmf
+++ b/plans/integration/conversion/rhsm/resolve-dependency/main.fmf
@@ -1,9 +1,16 @@
 discover+:
   filter:
     - 'tag: resolve-dependency'
+
 provision:
   how: libvirt
   develop: true
+
+prepare+:
+    - name: install dependency packages
+      how: shell
+      script: pytest -svv tests/integration/conversion/rhsm/resolve-dependency/install_dependency_packages.py
+      order: 60
 
 /centos7:
   discover+:

--- a/tests/integration/conversion/rhsm/resolve-dependency/install_dependency_packages.py
+++ b/tests/integration/conversion/rhsm/resolve-dependency/install_dependency_packages.py
@@ -26,7 +26,7 @@ def get_system_version(system_release_content=None):
     return version
 
 
-def test_good_convertion(shell, convert2rhel):
+def test_install_dependency_packages(shell):
 
     with open("/etc/system-release", "r") as file:
         system_release = file.read()
@@ -49,15 +49,3 @@ def test_good_convertion(shell, convert2rhel):
 
     # installing dependency packages
     assert shell("yum install -y {}".format(" ".join(dependency_pkgs))).returncode == 0
-
-    with convert2rhel(
-        "-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
-        )
-    ) as c2r:
-        c2r.expect("Conversion successful!")
-
-    assert c2r.exitstatus == 0

--- a/tests/integration/conversion/rhsm/resolve-dependency/main.fmf
+++ b/tests/integration/conversion/rhsm/resolve-dependency/main.fmf
@@ -10,5 +10,5 @@ adjust:
     distro != centos-7 and
     distro != centos-8 and
     distro != oracle-7
-
-test: pytest -svv
+test: |
+  pytest -svv

--- a/tests/integration/conversion/rhsm/resolve-dependency/test_resolve_dependency.py
+++ b/tests/integration/conversion/rhsm/resolve-dependency/test_resolve_dependency.py
@@ -1,0 +1,3 @@
+def test_dependency_packages(shell):
+    os_release = shell("cat /etc/os-release").output
+    assert "Red Hat Enterprise Linux" in os_release


### PR DESCRIPTION
The equivalent of the dependency-check test (https://gitlab.cee.redhat.com/sturivny/convert_tests/-/blob/master/tests/tests_resolve_dep.yml) already exists in tmt. I moved this test to the `conversion` directory for better structure. 

This PR follows up the PR323 (https://github.com/oamg/convert2rhel/pull/323)