### PR TITLE
Raise reboot_timeout

### DIFF
--- a/tests/ansible_collections/reboot.yml
+++ b/tests/ansible_collections/reboot.yml
@@ -3,4 +3,4 @@
   tasks:
     - name: Reboot into RHEL
       reboot:
-        reboot_timeout: 60
+        reboot_timeout: 600


### PR DESCRIPTION
60 seconds to wait for the freshly converted cloud vm to be rebooted
and back online is way too optimistic, increasing to 600.