### PR TITLE
Convert STI to TMT: Add test that check variant help message

### DIFF
--- a/plans/integration/check-variant-message/main.fmf
+++ b/plans/integration/check-variant-message/main.fmf
@@ -1,0 +1,20 @@
+discover+:
+    filter:
+        - 'tag: check-variant-message'
+provision:
+    how: libvirt
+    develop: true
+
+/centos7:
+    discover+:
+        filter+:
+            - 'tag: centos7'
+    provision+:
+        origin_vm_name: c2r_centos7_template
+
+/oracle8:
+    discover+:
+        filter+:
+            - 'tag: oracle8'
+    provision+:
+        origin_vm_name: c2r_oracle8_template

--- a/tests/integration/check-variant-message/main.fmf
+++ b/tests/integration/check-variant-message/main.fmf
@@ -1,0 +1,12 @@
+summary: variant help message
+tag+:
+  - centos7
+  - oracle8
+  - check-variant-message
+adjust:
+  enabled: false
+  when: >
+    distro != centos-7 and
+    distro != oracle-8
+test: |
+  pytest -svv

--- a/tests/integration/check-variant-message/test_variant_message.py
+++ b/tests/integration/check-variant-message/test_variant_message.py
@@ -1,0 +1,59 @@
+from envparse import env
+
+
+def test_check_variant_message(convert2rhel):
+    # Run c2r with --variant option
+    with convert2rhel(
+        ("--no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug --variant Server").format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        c2r.expect("WARNING - The -v|--variant option is not supported anymore and has no effect")
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("n")
+    assert c2r.exitstatus != 0
+
+    # Run c2r with --variant option empty
+    with convert2rhel(
+        ("--no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug --variant").format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        c2r.expect("WARNING - The -v|--variant option is not supported anymore and has no effect")
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("n")
+    assert c2r.exitstatus != 0
+
+    # Run c2r with -v option
+    with convert2rhel(
+        ("--no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug -v Client").format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        c2r.expect("WARNING - The -v|--variant option is not supported anymore and has no effect")
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("n")
+    assert c2r.exitstatus != 0
+
+    # Run c2r with -v option empty
+    with convert2rhel(
+        ("--no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug -v").format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        c2r.expect("WARNING - The -v|--variant option is not supported anymore and has no effect")
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("n")
+    assert c2r.exitstatus != 0


### PR DESCRIPTION
This PR converts this STI test (https://gitlab.cee.redhat.com/sturivny/convert_tests/-/blob/master/tests/tests_help_message.yml) to TMT. It checks the variant option help message produced by c2r.