### PR TITLE
Fix cli option sanitization for py2.6

### DIFF
--- a/convert2rhel/breadcrumbs.py
+++ b/convert2rhel/breadcrumbs.py
@@ -89,7 +89,7 @@ class Breadcrumbs(object):
 
     def _set_executed(self):
         """Set how was Convert2RHEL executed"""
-        cli_options_to_sanitize = {"--password", "-p", "--activationkey", "-k"}
+        cli_options_to_sanitize = frozenset(("--password", "-p", "--activationkey", "-k"))
         self.executed = sanitize_cli_options(sys.argv, cli_options_to_sanitize)
 
     def _set_nevra(self):


### PR DESCRIPTION
This piece of code was not Python 2.6-compatible so it was failing on CentOS/Oracle Linux 6 .