### PR TITLE
Add ansible role to set up custom repo for int tests

### DIFF
--- a/plans/integration/check-custom-repo/main.fmf
+++ b/plans/integration/check-custom-repo/main.fmf
@@ -2,6 +2,11 @@ discover+:
     filter:
         - 'tag: check-custom-repo'
 
+prepare+:
+    - name: add custom repos
+      how: ansible
+      playbook: tests/ansible_collections/roles/add-custom-repos/main.yml
+
 provision:
     how: libvirt
     develop: true

--- a/plans/integration/conversion/custom-repos/main.fmf
+++ b/plans/integration/conversion/custom-repos/main.fmf
@@ -3,6 +3,10 @@ discover+:
         - 'tag: custom-repos-conversion'
 
 prepare+:
+    - name: add custom repos
+      how: ansible
+      playbook: tests/ansible_collections/roles/add-custom-repos/main.yml
+      order: 69
     - name: main conversion preparation
       how: shell
       script: pytest -svv tests/integration/conversion/custom-repos/run_conversion.py

--- a/tests/ansible_collections/roles/add-custom-repos/main.yml
+++ b/tests/ansible_collections/roles/add-custom-repos/main.yml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  gather_facts: yes
+  become: false
+- include: rhel7-repos.yml
+  when: ansible_facts['distribution_major_version'] == "7"
+- include: rhel8-repos.yml
+  when: ansible_facts['distribution_major_version'] == "8"

--- a/tests/ansible_collections/roles/add-custom-repos/rhel7-repos.yml
+++ b/tests/ansible_collections/roles/add-custom-repos/rhel7-repos.yml
@@ -1,0 +1,28 @@
+- hosts: all
+  tasks:
+    - name: Add rhel7 server rpms repo
+      yum_repository:
+        name: rhel-7-server-rpms
+        description: RHEL 7.9 for $basearch
+        baseurl: http://rhsm-pulp.corp.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/os/
+        gpgcheck: no
+        enabled: no
+        file: rhel7
+
+    - name: Add rhel7 server optional rpms
+      yum_repository:
+        name: rhel-7-server-optional-rpms
+        description: RHEL 7.9 Optional for $basearch
+        baseurl: http://rhsm-pulp.corp.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/optional/os/
+        gpgcheck: no
+        enabled: no
+        file: rhel7
+
+    - name: Add rhel7 server extras rpms
+      yum_repository:
+        name: rhel-7-server-extras-rpms
+        description: RHEL 7 Extras for $basearch
+        baseurl: http://rhsm-pulp.corp.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/extras/os/
+        gpgcheck: no
+        enabled: no
+        file: rhel7

--- a/tests/ansible_collections/roles/add-custom-repos/rhel8-repos.yml
+++ b/tests/ansible_collections/roles/add-custom-repos/rhel8-repos.yml
@@ -1,0 +1,19 @@
+- hosts: all
+  tasks:
+    - name: Add rhel8 baseos repo
+      yum_repository:
+        name: rhel-8-for-x86_64-baseos-rpms
+        description: RHEL 8 BaseOS for $basearch
+        baseurl: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/$releasever/$basearch/baseos/os/
+        gpgcheck: no
+        enabled: no
+        file: rhel8
+
+    - name: Add rhel8 appstream repo
+      yum_repository:
+        name: rhel-8-for-x86_64-appstream-rpms
+        description: RHEL 8 AppStream for $basearch
+        baseurl: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/$releasever/$basearch/appstream/os/
+        gpgcheck: no
+        enabled: no
+        file: rhel8


### PR DESCRIPTION
We have custom repos on machines provided via libvirt. However in the future we want to run tests on machines provided by Artemis or anything else. Those clean vms do not have custom repos. This PR solve this issue.

Solves [OAMG-5485](https://issues.redhat.com/browse/OAMG-5485).