### PR TITLE
Add test for tainted kernel inhibitor

### DIFF
--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -25,6 +25,11 @@ discover+:
 /inhibit_if_kmods_is_not_supported:
   discover+:
     test: inhibit-if-kmods-is-not-supported
+  prepare+:
+  - name: copy kmod files to the test machine
+    how: ansible
+    playbook: tests/integration/tier0/inhibit-if-kmods-is-not-supported/ansible/main.yml
+
 
 /inhibit_if_oracle_system_uses_not_standard_kernel:
   adjust:

--- a/tests/integration/tier0/backup-release/test_backup_release.py
+++ b/tests/integration/tier0/backup-release/test_backup_release.py
@@ -60,8 +60,8 @@ def test_backup_os_release_with_envar(shell, convert2rhel):
         c2r.sendline("y")
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("y")
-        # On OracleLinux there is one question less than on Centos
-        if platform.platform().find("oracle-8") < 0:
+        # On OracleLinux8 there is one question less than on other distros
+        if "oracle-8" not in platform.platform():
             c2r.expect("Continue with the system conversion?")
             c2r.sendline("y")
         c2r.expect("The tool allows rollback of any action until this point.")

--- a/tests/integration/tier0/inhibit-if-kmods-is-not-supported/ansible/files/Makefile
+++ b/tests/integration/tier0/inhibit-if-kmods-is-not-supported/ansible/files/Makefile
@@ -1,0 +1,4 @@
+obj-m += my_kmod.o
+
+all:
+	make -C /lib/modules/$(shell uname -r)/build M=/tmp/my-test/ modules

--- a/tests/integration/tier0/inhibit-if-kmods-is-not-supported/ansible/files/my_kmod.c
+++ b/tests/integration/tier0/inhibit-if-kmods-is-not-supported/ansible/files/my_kmod.c
@@ -1,0 +1,22 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
+
+MODULE_LICENSE("Proprietary");
+//MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Martin Litwora");
+MODULE_DESCRIPTION("Module for testing purpose, prints 'Hello world!'");
+
+static int __init hello_init(void)
+{
+    printk(KERN_INFO "Hello world!\n");
+    return 0;
+}
+
+static void __exit hello_cleanup(void)
+{
+    printk(KERN_INFO "Cleaning up module.\n");
+}
+
+module_init(hello_init);
+module_exit(hello_cleanup);

--- a/tests/integration/tier0/inhibit-if-kmods-is-not-supported/ansible/main.yml
+++ b/tests/integration/tier0/inhibit-if-kmods-is-not-supported/ansible/main.yml
@@ -1,0 +1,14 @@
+- hosts: all
+  tasks:
+    - name: create directory folder
+      file:
+        path: /tmp/my-test
+        state: directory
+    - name: copy kmod source file
+      copy:
+        src: 'my_kmod.c'
+        dest: /tmp/my-test
+    - name: copy kmod Makefile
+      copy:
+        src: 'Makefile'
+        dest: /tmp/my-test

--- a/tests/integration/tier0/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
+++ b/tests/integration/tier0/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
@@ -1,3 +1,5 @@
+import platform
+
 from pathlib import Path
 
 import pytest
@@ -20,6 +22,8 @@ def insert_custom_kmod(shell):
 
 
 def test_inhibit_if_custom_module_loaded(insert_custom_kmod, convert2rhel):
+    # This test checks that rpmquery works correctly.
+    # If custom module is loaded the conversion has to be inhibited.
     insert_custom_kmod()
     with convert2rhel(
         ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
@@ -35,6 +39,40 @@ def test_inhibit_if_custom_module_loaded(insert_custom_kmod, convert2rhel):
 
 def test_do_not_inhibit_if_module_is_not_loaded(shell, convert2rhel):
     assert shell("modprobe -r -v bonding").returncode == 0
+    # If custom module is not loaded the conversion is not inhibited.
+    with convert2rhel(
+        ("--no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("y")
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("y")
+        # On OracleLinux8 there is one question less than on other distros
+        if "oracle-8" not in platform.platform():
+            c2r.expect("Continue with the system conversion?")
+            c2r.sendline("y")
+        c2r.expect("Kernel modules are compatible.")
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("n")
+    assert c2r.exitstatus != 0
+
+
+def test_tainted_kernel_inhibitor(shell, convert2rhel):
+    # This test marks the kernel as tainted which is not supported by convert2rhel.
+
+    # We need to install specific kernel packages to build own custom kernel module.
+    shell("yum -y install gcc make kernel-headers kernel-devel-$(uname -r) elfutils-libelf-devel")
+
+    # Build own kmod form source file that has been copied to the testing machine during preparation phase.
+    # This kmod marks the system with the P, O and E flags.
+    assert shell("make -C /tmp/my-test/").returncode == 0
+    assert shell("insmod /tmp/my-test/my_kmod.ko").returncode == 0
+
     with convert2rhel(
         ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
             env.str("RHSM_SERVER_URL"),
@@ -43,6 +81,5 @@ def test_do_not_inhibit_if_module_is_not_loaded(shell, convert2rhel):
             env.str("RHSM_POOL"),
         )
     ) as c2r:
-        c2r.expect("Kernel modules are compatible.")
-        c2r.send(chr(3))
+        c2r.expect("Tainted kernel module\(s\) detected")
     assert c2r.exitstatus != 0

--- a/tests/integration/tier0/resolve-broken-ol8-rollback/test_resolve_broken_ol8_rollback.py
+++ b/tests/integration/tier0/resolve-broken-ol8-rollback/test_resolve_broken_ol8_rollback.py
@@ -37,7 +37,7 @@ def test_proper_rhsm_clean_up(shell, convert2rhel):
     # check that packages still are in place
     assert shell("rpm -qi usermode").returncode == 0
     assert shell("rpm -qi rhn-setup").returncode == 0
-    if platform.platform().find("centos-7") != -1:
+    if "centos-7" in platform.platform():
         assert shell("rpm -qi centos-release").returncode == 0
-    elif platform.platform().find("centos-8") != -1:
+    elif "centos-8" in platform.platform():
         assert shell("rpm -qi centos-linux-release").returncode == 0

--- a/tests/integration/tier1/one-kernel-scenario/install_one_kernel.py
+++ b/tests/integration/tier1/one-kernel-scenario/install_one_kernel.py
@@ -7,9 +7,9 @@ def test_install_one_kernel(shell):
     # installing kernel package
     assert shell("yum install kernel-3.10.0-1160.el7.x86_64 -y").returncode == 0
     # set deafault kernel
-    if platform.platform().find("centos-7") != -1:
+    if "centos-7" in platform.platform():
         assert shell("grub2-set-default 'CentOS Linux (3.10.0-1160.el7.x86_64) 7 (Core)'").returncode == 0
-    elif platform.platform().find("oracle-7") != -1:
+    elif "oracle-7" in platform.platform():
         assert shell("grub2-set-default 'Oracle Linux Server 7.9, with Linux 3.10.0-1160.el7.x86_64'").returncode == 0
 
     # replace url in yum.repos.d rhel repo

--- a/tests/integration/tier1/set-locale/use_non_english_language.py
+++ b/tests/integration/tier1/set-locale/use_non_english_language.py
@@ -9,7 +9,7 @@ def test_use_non_english_language(shell):
     """
     # install Chinese language pack for CentOS-8 and Oracle Linux 8
     os = platform.platform()
-    if os.find("centos-8") != -1 or os.find("oracle-8") != -1:
+    if "centos-8" in os or "oracle-8" in os:
         assert shell("dnf install glibc-langpack-zh -y").returncode == 0
 
     # set LANG to Chinese

--- a/tests/integration/tier1/yum-distro-sync/install_problematic_package.py
+++ b/tests/integration/tier1/yum-distro-sync/install_problematic_package.py
@@ -10,7 +10,7 @@ def test_install_problematic_package(shell):
 
     # On artemis images exists packages that needs to be removed so `yum distro-sync` will fail on cpaste.
     # Otherwise it would not fail (yum return 0 when at least one package is ok)
-    if platform.platform().find("centos-8") > 0:
+    if "centos-8" in platform.platform():
         assert (
             shell("yum remove python2-pip python2-pip-wheel python2-setuptools python2-setuptools-wheel -y").returncode
             == 0

--- a/tests/integration/tier1/yum-distro-sync/test_yum_distro_sync.py
+++ b/tests/integration/tier1/yum-distro-sync/test_yum_distro_sync.py
@@ -44,7 +44,7 @@ def test_yum_distro_sync(convert2rhel, shell):
 
 
 def condition_test(output, ret_code):
-    """__ THE SAME__ conditions as in convert2rhel/pkghandler.py are. Just small change -
+    """__THE SAME__ conditions as in convert2rhel/pkghandler.py are. Just small change -
     they returns True or False depending on success or not."""
 
     if ret_code == 0:


### PR DESCRIPTION
This PR adds an integration test verifying that the conversion stops when there's a loaded kernel module marked as tainted. Test builds own kernel module on the testing machine and use it. Kernel is then marked with appropriate flags which makes the kernel 'tainted'. 
This kernel module causes following flags:

- P - proprietary module was loaded
- O - externally-built (“out-of-tree”) module was loaded
- E  - unsigned module was loaded

Conversion of tainted kernel is then inhibited.

Ref. ticket [OAMG-4927](https://issues.redhat.com/browse/OAMG-4927).