### PR TITLE
Fix yum distro-sync problem

### DIFF
--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -87,9 +87,9 @@ def call_yum_cmd_w_downgrades(cmd, pkgs, retries=MAX_YUM_CMD_CALLS):
         return
 
     # handle success condition #3
-    # false positive: yum distro-sync returns non-zero code when got package, which isn't in rhel repos
-    # on older (original yum) returns 0, but on newer dnf 1
-    # just in case if all packages given aren't in rhel repos. If one of them is, ret code is 0 and finishes successfully
+    # false positive: yum distro-sync returns 1 and an error message on RHEL 8+ based systems when none of the passed
+    # packages is available in RHEL repositories. If at least one of them is available, yum returns 0. On RHEL 7- yum
+    # returns 0 in both cases.
     no_packages_marked_error_exists = output.endswith("Error: No packages marked for distribution synchronization.\n")
     if ret_code == 1 and no_packages_marked_error_exists:
         return

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -86,6 +86,14 @@ def call_yum_cmd_w_downgrades(cmd, pkgs, retries=MAX_YUM_CMD_CALLS):
     if ret_code == 1 and nothing_to_do_error_exists:
         return
 
+    # handle success condition #3
+    # false positive: yum distro-sync returns non-zero code when got package, which isn't in rhel repos
+    # on older (original yum) returns 0, but on newer dnf 1
+    # just in case if all packages given aren't in rhel repos. If one of them is, ret code is 0 and finishes successfully
+    no_packages_marked_error_exists = output.endswith("Error: No packages marked for distribution synchronization.\n")
+    if ret_code == 1 and no_packages_marked_error_exists:
+        return
+
     # handle error condition
     loggerinst.info("Resolving dependency errors ... ")
     output = resolve_dep_errors(output)

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -161,3 +161,14 @@ discover+:
   - name: reboot machine
     how: ansible
     playbook: tests/ansible_collections/reboot.yml
+
+/yum_distro_sync:
+  discover+:
+    test: yum-distro-sync
+  prepare+:
+    - name: install problematic package
+      how: shell
+      script: pytest -svv tests/integration/tier1/yum-distro-sync/install_problematic_package.py
+    - name: reboot machine
+      how: ansible
+      playbook: tests/ansible_collections/reboot.yml

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -166,6 +166,9 @@ discover+:
   discover+:
     test: checks-after-conversion
   prepare+:
+    - name: enable extras repo for Oracle Linux
+      how: ansible
+      playbook: tests/integration/tier1/yum-distro-sync/add-extras-repo/main.yml
     - name: install problematic package
       how: shell
       script: pytest -svv tests/integration/tier1/yum-distro-sync/install_problematic_package.py

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -164,11 +164,14 @@ discover+:
 
 /yum_distro_sync:
   discover+:
-    test: yum-distro-sync
+    test: checks-after-conversion
   prepare+:
     - name: install problematic package
       how: shell
       script: pytest -svv tests/integration/tier1/yum-distro-sync/install_problematic_package.py
+    - name: main conversion preparation
+      how: shell
+      script: pytest -svv tests/integration/tier1/yum-distro-sync/test_yum_distro_sync.py
     - name: reboot machine
       how: ansible
       playbook: tests/ansible_collections/reboot.yml

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -79,12 +79,15 @@ def convert2rhel(shell):
     >>>     c2r.expect("Kernel is compatible with RHEL")
     >>> assert c2r.exitstatus == 0
 
+    Unregister means that system wouldn't be unregistered
+    from subscription-manager after conversion.
     """
 
     @contextmanager
     def factory(
         options: str,
         timeout: int = 60 * 60,
+        unregister: bool = True,
     ) -> ContextManager[pexpect.spawn]:
         c2r_runtime = pexpect.spawn(
             f"convert2rhel {options}",
@@ -101,7 +104,8 @@ def convert2rhel(shell):
             c2r_runtime.expect(pexpect.EOF)
             c2r_runtime.close()
         finally:
-            shell("subscription-manager unregister")
+            if unregister:
+                shell("subscription-manager unregister")
 
     return factory
 

--- a/tests/integration/tier1/yum-distro-sync/add-extras-repo/main.yml
+++ b/tests/integration/tier1/yum-distro-sync/add-extras-repo/main.yml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  gather_facts: yes
+  become: false
+- include: oracle7.yml
+  when: ansible_facts['distribution'] == "OracleLinux" and ansible_facts['distribution_major_version'] == "7"
+- include: oracle8.yml
+  when: ansible_facts['distribution'] == "OracleLinux" and ansible_facts['distribution_major_version'] == "8"

--- a/tests/integration/tier1/yum-distro-sync/add-extras-repo/oracle7.yml
+++ b/tests/integration/tier1/yum-distro-sync/add-extras-repo/oracle7.yml
@@ -1,0 +1,10 @@
+- hosts: all
+  tasks:
+    - name: Add CentOS extras repo to OL7
+      yum_repository:
+        name: centos7-extras
+        description: CentOS extras for $basearch
+        baseurl: http://mirror.centos.org/centos-7/7/extras/$basearch/
+        gpgcheck: no
+        enabled: yes
+        file: centos7-extras

--- a/tests/integration/tier1/yum-distro-sync/add-extras-repo/oracle8.yml
+++ b/tests/integration/tier1/yum-distro-sync/add-extras-repo/oracle8.yml
@@ -1,0 +1,10 @@
+- hosts: all
+  tasks:
+    - name: Add CentOS extras repo to OL8
+      yum_repository:
+        name: centos8-extras
+        description: CentOS extras for $basearch
+        baseurl: http://mirror.centos.org/centos-8/8/extras/$basearch/os/
+        gpgcheck: no
+        enabled: yes
+        file: centos8-extras

--- a/tests/integration/tier1/yum-distro-sync/install_problematic_package.py
+++ b/tests/integration/tier1/yum-distro-sync/install_problematic_package.py
@@ -1,3 +1,6 @@
+import platform
+
+
 def test_install_problematic_package(shell):
     """Need to install a package, which is in CentOS repos (which we are converting) and is not present in RHEL
     repositories. The package in question (cpaste) is from the CentOS Extras repo which is enabled by default on
@@ -5,4 +8,11 @@ def test_install_problematic_package(shell):
 
     When the test starts failing we will need to change the selected package."""
 
+    # On artemis images exists packages that needs to be removed so `yum distro-sync` will fail on cpaste.
+    # Otherwise it would not fail (yum return 0 when at least one package is ok)
+    if platform.platform().find("centos-8") > 0:
+        assert (
+            shell("yum remove python2-pip python2-pip-wheel python2-setuptools python2-setuptools-wheel -y").returncode
+            == 0
+        )
     assert shell("yum install -y cpaste").returncode == 0

--- a/tests/integration/tier1/yum-distro-sync/install_problematic_package.py
+++ b/tests/integration/tier1/yum-distro-sync/install_problematic_package.py
@@ -1,0 +1,8 @@
+def test_install_problematic_package(shell):
+    """Need to install a package, which is in CentOS repos (which we are converting) and is not present in RHEL
+    repositories. The package in question (cpaste) is from the CentOS Extras repo which is enabled by default on
+    CentOS systems.
+
+    When the test starts failing we will need to change the selected package."""
+
+    assert shell("yum install -y cpaste").returncode == 0

--- a/tests/integration/tier1/yum-distro-sync/main.fmf
+++ b/tests/integration/tier1/yum-distro-sync/main.fmf
@@ -1,0 +1,3 @@
+summary: yum-distro-sync
+
+test: pytest -svv

--- a/tests/integration/tier1/yum-distro-sync/main.fmf
+++ b/tests/integration/tier1/yum-distro-sync/main.fmf
@@ -1,3 +1,5 @@
 summary: yum-distro-sync
 
+tier: 1
+
 test: pytest -svv

--- a/tests/integration/tier1/yum-distro-sync/test_yum_distro_sync.py
+++ b/tests/integration/tier1/yum-distro-sync/test_yum_distro_sync.py
@@ -1,0 +1,66 @@
+from envparse import env
+
+
+def test_yum_distro_sync(convert2rhel, shell):
+    """Test yum distro-sync command edge-cases when given packages aren't in enabled repositories.
+
+    Following is done:
+        1) Install a problematic package (cpaste) - done in preparation step
+        2) Run the conversion
+        3) Run the distro-sync in two variants
+            - just with the problematic package
+            - with some another package, which is in RHEL repositories
+        4) Do the same checks and conditions as is in convert2rhel/pkghandler.py in call_yum_cmd_w_downgrades.
+
+    Another problem is, that yum behaves differently on Centos 7 and Centos 8
+        - on Centos 7 gives 0 and any error in both cases
+        - on Centos 8  gives 0 and any error if in list of packages for distro-sync is at least
+          one, which can be successfully distro synced. If all of the given cannot be synced, there
+          is an error, which caused problems: https://issues.redhat.com/browse/OAMG-4600. But
+          the error isn't in fact error, the package stays there
+          and just isn't supported by Red Hat.
+    """
+
+    with convert2rhel(
+        ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        ),
+        unregister=False,
+    ) as c2r:
+        c2r.expect("Conversion successful!")
+    assert c2r.exitstatus == 0
+
+    out = shell("yum distro-sync cpaste zip")  # any error on Centos 7 and Centos 8
+    assert condition_test(out.output, out.returncode)
+
+    out = shell("yum distro-sync cpaste")  # an error on Centos 8, which should be skipped
+    assert condition_test(out.output, out.returncode)
+
+    shell("subscription-manager unregister")
+
+
+def condition_test(output, ret_code):
+    """__ THE SAME__ conditions as in convert2rhel/pkghandler.py are. Just small change -
+    they returns True or False depending on success or not."""
+
+    if ret_code == 0:
+        return True
+
+    # handle success condition #2
+    # false positive: yum returns non-zero code when there is nothing to do
+    nothing_to_do_error_exists = output.endswith("Error: Nothing to do\n")
+    if ret_code == 1 and nothing_to_do_error_exists:
+        return True
+
+    # handle success condition #3
+    # false positive: yum distro-sync returns non-zero code when got package, which isn't in rhel repos
+    # on older (original yum) returns 0, but on newer dnf 1
+    # just in case if all packages given aren't in rhel repos. If one of them is, ret code is 0 and finishes successfully
+    no_packages_marked_error_exists = output.endswith("Error: No packages marked for distribution synchronization.\n")
+    if ret_code == 1 and no_packages_marked_error_exists:
+        return True
+
+    return False

--- a/tests/integration/tier1/yum-distro-sync/test_yum_distro_sync.py
+++ b/tests/integration/tier1/yum-distro-sync/test_yum_distro_sync.py
@@ -13,8 +13,8 @@ def test_yum_distro_sync(convert2rhel, shell):
         4) Do the same checks and conditions as is in convert2rhel/pkghandler.py in call_yum_cmd_w_downgrades.
 
     Another problem is, that yum behaves differently on Centos 7 and Centos 8
-        - on Centos 7 gives 0 and any error in both cases
-        - on Centos 8  gives 0 and any error if in list of packages for distro-sync is at least
+        - on Centos 7 returns 0 and any error in both cases
+        - on Centos 8  returns 0 and any error if in list of packages for distro-sync is at least
           one, which can be successfully distro synced. If all of the given cannot be synced, there
           is an error, which caused problems: https://issues.redhat.com/browse/OAMG-4600. But
           the error isn't in fact error, the package stays there
@@ -33,10 +33,11 @@ def test_yum_distro_sync(convert2rhel, shell):
         c2r.expect("Conversion successful!")
     assert c2r.exitstatus == 0
 
-    out = shell("yum distro-sync cpaste zip")  # any error on Centos 7 and Centos 8
+    # any error on Centos 7 and Centos 8
+    out = shell("yum distro-sync cpaste zip")
     assert condition_test(out.output, out.returncode)
-
-    out = shell("yum distro-sync cpaste")  # an error on Centos 8, which should be skipped
+    # an error on Centos 8, which should be skipped
+    out = shell("yum distro-sync cpaste")
     assert condition_test(out.output, out.returncode)
 
     shell("subscription-manager unregister")


### PR DESCRIPTION
On RHEL 8 based systems the `yum distro-sync` command returns 1 when no package passed to it is available in the enabled RHEL repositories. Convert2RHEL did not account for this situation because there's essentially "nothing to do" so it expected return code 0 (the same as when for example trying to update a package).

We have these 2 case when running distro-sync on RHEL 8 based systems:
- If all of the packages passed to distro-sync are unavailable in the enabled repos, yum returns 1 with a message `Error: No packages marked for distribution synchronization.`
- If at least one package from those passed to distro-sync is available in the enabled repos, yum returns 0. No problem occurs in this case.

On top of that, yum distro-sync behaves differently on RHEL 7 and 8. On RHEL 7 yum returns 0 and no error in both above cases (just `No packages marked for distribution synchronization`).

Related: https://issues.redhat.com/browse/OAMG-4600