### PR TITLE
Improve rpm query to sort out the latest kernel version

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -386,7 +386,7 @@ def check_rhel_compatible_kernel_is_used():
             "1. Ensure that the {0} {1} base repository is enabled\n"
             "2. Run: yum install kernel\n"
             "3. (optional) Run: grubby --set-default "
-            '/boot/vmlinuz-`rpm -q --qf="%{{buildtime}}\\t%{{EVR}}.%{{ARCH}}\\n" kernel | sort -nr | head -1 | cut -f2`\n'
+            '/boot/vmlinuz-`rpm -q --qf="%{{BUILDTIME}}\\t%{{EVR}}.%{{ARCH}}\\n" kernel | sort -nr | head -1 | cut -f2`\n'
             "4. Reboot the machine and if step 3 was not applied choose the kernel"
             " installed in step 2 manually".format(system_info.name, system_info.version.major)
         )


### PR DESCRIPTION
This change improves the command used to set a default non-uek kernel on the Oracle Linux systems.

## OL 6 Outputs

```bash 
[root@c2r-20211014113529 ~]# rpm -qa kernel
kernel-2.6.32-696.el6.x86_64
kernel-2.6.32-754.22.1.el6.x86_64
kernel-2.6.32-754.35.1.el6.x86_64
```

Sorted kernel versions by the latest build

```bash
[root@c2r-20211014113529 ~]# rpm -q --qf="%{BUILDTIME}\t%{EVR}.%{ARCH}\n" kernel | sort -nr | head -1 | cut -f2
2.6.32-754.35.1.el6.x86_64
```

Detailed output with the `BUILDTIME` query format parameter 

```bash
[root@c2r-20211014113529 ~]# rpm -q --qf="%{BUILDTIME}\t%{EVR}.%{ARCH}\n" kernel | sort -nr 
1602098698	2.6.32-754.35.1.el6.x86_64
1568226128	2.6.32-754.22.1.el6.x86_64
1490222097	2.6.32-696.el6.x86_64
```

## OL 7 Outputs

Installed kernel versions
```bash
[root@c2r-20211014110341 ~]# rpm -qa kernel
kernel-3.10.0-1127.el7.x86_64
kernel-3.10.0-1160.36.2.el7.x86_64
kernel-3.10.0-1160.45.1.el7.x86_64
```

Sorted kernel versions by the latest build

```bash
[root@c2r-20211014105117 ~]# rpm -q --qf="%{BUILDTIME}\t%{EVR}.%{ARCH}\n" kernel | sort -nr | head -1 | cut -f2
4.18.0-305.19.1.el8_4.x86_64
```

Detailed output with the `BUILDTIME` query format parameter 

```bash
[root@c2r-20211014105117 ~]# rpm -q --qf="%{BUILDTIME}\t%{EVR}.%{ARCH}\n" kernel | sort -nr 
1631739354	4.18.0-305.19.1.el8_4.x86_64
1626833593	4.18.0-305.10.2.el8_4.x86_64
```

## OL 8 Outputs

Installed kernel versions 

```bash
[root@c2r-20211014105117 ~]# rpm -qa kernel
kernel-4.18.0-305.19.1.el8_4.x86_64
kernel-4.18.0-305.10.2.el8_4.x86_64
```

Sorted kernel versions by the latest build

```bash
[root@c2r-20211014105117 ~]# rpm -q --qf="%{BUILDTIME}\t%{EVR}.%{ARCH}\n" kernel | sort -nr | head -1 | cut -f2
4.18.0-305.19.1.el8_4.x86_64
```

Detailed output with the `BUILDTIME` query format parameter 

```bash
[root@c2r-20211014105117 ~]# rpm -q --qf="%{BUILDTIME}\t%{EVR}.%{ARCH}\n" kernel | sort -nr 
1631739354	4.18.0-305.19.1.el8_4.x86_64
1626833593	4.18.0-305.10.2.el8_4.x86_64
```