### PR TITLE
Remove %s from messages to use the format option

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -111,11 +111,9 @@ def check_tainted_kmods():
         logger.critical(
             "Tainted kernel module(s) detected. "
             "Third-party components are not supported per our "
-            "software support policy\n%s\n\n"
+            "software support policy\n{0}\n\n"
             "Uninstall or disable the following module(s) and run convert2rhel "
-            "again to continue with the conversion:\n  %s",
-            LINK_KMODS_RH_POLICY,
-            module_names,
+            "again to continue with the conversion:\n  {1}".format(LINK_KMODS_RH_POLICY, module_names)
         )
 
 


### PR DESCRIPTION
This fixes the message output when the kernel is in a `tainted` mode, which couldn't display the proper link for Red Hat third-party software policy and the tainted modules that are loaded. 

## Output

```bash
[10/15/2021 14:00:18] DEBUG - Calling command 'grep '(' /proc/modules'
hello 16384 0 - Live 0xffffffffc08fd000 (OE)
CRITICAL - Tainted kernel module(s) detected. Third-party components are not supported per our software support policy
https://access.redhat.com/third-party-software-support

Uninstall or disable the following module(s) and run convert2rhel again to continue with the conversion:
  hello
[10/15/2021 14:00:18] DEBUG - Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/convert2rhel/main.py", line 79, in main
    checks.perform_pre_checks()
  File "/usr/lib/python3.6/site-packages/convert2rhel/checks.py", line 49, in perform_pre_checks
    check_tainted_kmods()
  File "/usr/lib/python3.6/site-packages/convert2rhel/checks.py", line 116, in check_tainted_kmods
    "again to continue with the conversion:\n  {1}".format(LINK_KMODS_RH_POLICY, module_names)
  File "/usr/lib/python3.6/site-packages/convert2rhel/logger.py", line 104, in _critical
    sys.exit(msg)
SystemExit: Tainted kernel module(s) detected. Third-party components are not supported per our software support policy
https://access.redhat.com/third-party-software-support

Uninstall or disable the following module(s) and run convert2rhel again to continue with the conversion:
  hello

No changes were made to the system.
```

Fixes: https://issues.redhat.com/browse/OAMG-5534