### PR TITLE
Add live kernel version checks and package status

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -380,10 +380,8 @@ def get_unsupported_kmods(host_kmods, rhel_supported_kmods):
 def check_rhel_compatible_kernel_is_used():
     """Ensure the booted kernel is signed, is standard (not UEK, realtime, ...), and has the same version as in RHEL.
 
-        By requesting that, we can be confiden    base.conf.substitutions["ocidomain"] = "oracle.com"
-        base.conf.substitutions["ociregion"] = ""
-    t that the RHEL kernel will provide the same capabilities as on the
-        original system.
+    By requesting that, we can be confident that the RHEL kernel will provide the same capabilities as on the
+    original system.
     """
     logger.task("Prepare: Check kernel compatibility with RHEL")
     if any(
@@ -510,12 +508,13 @@ def is_loaded_kernel_latest():
         # Sort out for the most recent kernel with reverse order
         # In case `repoquery` returns more than one kernel in the output
         # We display the latest one to the user.
-        _, most_recent_kernel = sorted(packages, reverse=True)[0]
+        _, latest_kernel = sorted(packages, reverse=True)[0]
+        latest_kernel = latest_kernel.replace('"', "")
 
         # The loaded kernel version
         uname_output, _ = run_subprocess(["uname", "-r"], print_output=False)
         loaded_kernel = uname_output.rsplit(".", 1)[0]
-        match = compare_package_versions(most_recent_kernel, str(loaded_kernel))
+        match = compare_package_versions(latest_kernel, str(loaded_kernel))
 
         if match == 0:
             logger.info("Kernel currently loaded is at the latest version.")
@@ -526,7 +525,7 @@ def is_loaded_kernel_latest():
                 " Current loaded kernel: %s\n\n"
                 "To proceed with the conversion, update the kernel version by executing the following step:\n\n"
                 "1. yum install %s-%s -y\n"
-                "2. reboot" % (most_recent_kernel, loaded_kernel, package_to_check, most_recent_kernel)
+                "2. reboot" % (latest_kernel, loaded_kernel, package_to_check, latest_kernel)
             )
     else:
         # Repoquery failed to detected any kernel or kernel-core packages in it's repositories

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -85,6 +85,9 @@ def main():
         systeminfo.system_info.resolve_system_info()
         breadcrumbs.breadcrumbs.collect_early_data()
 
+        loggerinst.task("Prepare: Clear YUM/DNF version locks")
+        pkghandler.clear_versionlock()
+
         # check the system prior the conversion (possible inhibit)
         checks.perform_pre_checks()
 
@@ -93,9 +96,6 @@ def main():
         redhatrelease.system_release_file.backup()
         redhatrelease.os_release_file.backup()
         repo.backup_yum_repos()
-
-        loggerinst.task("Prepare: Clear YUM/DNF version locks")
-        pkghandler.clear_versionlock()
 
         # begin conversion process
         process_phase = ConversionPhase.PRE_PONR_CHANGES

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -1059,7 +1059,7 @@ def _get_packages_to_update_dnf():
     # Same thing for CentOS, but this time, the URL for the vault has changed
     # and instead of just ussing $releasever (8.5, 8.4...), we need either
     # using the correct $releasever (8.5.2111) or setting up the $contentdir
-    if system_info.id == "centos":
+    elif system_info.id == "centos":
         base.conf.substitutions["contentdir"] = system_info.id
 
     base.read_all_repos()

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -1055,6 +1055,13 @@ def _get_packages_to_update_dnf():
     if system_info.id == "oracle":
         base.conf.substitutions["ocidomain"] = "oracle.com"
         base.conf.substitutions["ociregion"] = ""
+
+    # Same thing for CentOS, but this time, the URL for the vault has changed
+    # and instead of just ussing $releasever (8.5, 8.4...), we need either
+    # using the correct $releasever (8.5.2111) or setting up the $contentdir
+    if system_info.id == "centos":
+        base.conf.substitutions["contentdir"] = system_info.id
+
     base.read_all_repos()
     base.fill_sack()
 

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -41,6 +41,7 @@ from convert2rhel.pkghandler import (
 from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts
 from convert2rhel.unit_tests import GetLoggerMocked, is_rpm_based_os
+from convert2rhel.unit_tests.conftest import all_systems, oracle7
 
 
 if sys.version_info[:2] <= (2, 7):
@@ -193,7 +194,13 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
 
         self.assertEqual(
             utils.run_subprocess.cmd,
-            ["yum", "install", "-y", "--releasever=8", "--setopt=module_platform_id=platform:el8"],
+            [
+                "yum",
+                "install",
+                "-y",
+                "--releasever=8",
+                "--setopt=module_platform_id=platform:el8",
+            ],
         )
 
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
@@ -230,7 +237,14 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         pkghandler.call_yum_cmd("install")
 
         self.assertEqual(
-            utils.run_subprocess.cmd, ["yum", "install", "-y", "--disablerepo=*", "--enablerepo=rhel-7-extras-rpm"]
+            utils.run_subprocess.cmd,
+            [
+                "yum",
+                "install",
+                "-y",
+                "--disablerepo=*",
+                "--enablerepo=rhel-7-extras-rpm",
+            ],
         )
 
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
@@ -241,7 +255,10 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
     def test_call_yum_cmd_with_submgr_enabled_repos(self):
         pkghandler.call_yum_cmd("install")
 
-        self.assertEqual(utils.run_subprocess.cmd, ["yum", "install", "-y", "--enablerepo=rhel-7-extras-rpm"])
+        self.assertEqual(
+            utils.run_subprocess.cmd,
+            ["yum", "install", "-y", "--enablerepo=rhel-7-extras-rpm"],
+        )
 
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     @unit_tests.mock(system_info, "releasever", None)
@@ -262,7 +279,14 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
 
         self.assertEqual(
             utils.run_subprocess.cmd,
-            ["yum", "install", "-y", "--disablerepo=disable-repo", "--enablerepo=enable-repo", "pkg"],
+            [
+                "yum",
+                "install",
+                "-y",
+                "--disablerepo=disable-repo",
+                "--enablerepo=enable-repo",
+                "pkg",
+            ],
         )
 
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
@@ -284,7 +308,11 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
     @unit_tests.mock(pkghandler, "call_yum_cmd", CallYumCmdMocked())
     @unit_tests.mock(pkghandler, "get_installed_pkgs_by_fingerprint", lambda _: ["pkg"])
     @unit_tests.mock(pkghandler, "resolve_dep_errors", lambda output: output)
-    @unit_tests.mock(pkghandler, "get_problematic_pkgs", lambda pkg: {"errors": set([pkg]), "mismatches": set()})
+    @unit_tests.mock(
+        pkghandler,
+        "get_problematic_pkgs",
+        lambda pkg: {"errors": set([pkg]), "mismatches": set()},
+    )
     @unit_tests.mock(utils, "remove_pkgs", RemovePkgsMocked())
     def test_call_yum_cmd_w_downgrades_remove_problematic_pkgs(self):
         pkghandler.call_yum_cmd.return_code = 1
@@ -1057,7 +1085,10 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
 
         pkghandler.handle_no_newer_rhel_kernel_available()
 
-        self.assertEqual(utils.run_subprocess.cmd, ["yum", "install", "-y", "kernel-4.7.2-201.fc24"])
+        self.assertEqual(
+            utils.run_subprocess.cmd,
+            ["yum", "install", "-y", "kernel-4.7.2-201.fc24"],
+        )
 
     class ReplaceNonRhelInstalledKernelMocked(unit_tests.MockFunction):
         def __init__(self):
@@ -1093,7 +1124,10 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
 
         self.assertEqual(len(utils.remove_pkgs.pkgs), 1)
         self.assertEqual(utils.remove_pkgs.pkgs[0], "kernel-4.7.4-200.fc24")
-        self.assertEqual(utils.run_subprocess.cmd, ["yum", "install", "-y", "kernel-4.7.4-200.fc24"])
+        self.assertEqual(
+            utils.run_subprocess.cmd,
+            ["yum", "install", "-y", "kernel-4.7.4-200.fc24"],
+        )
 
     class DownloadPkgMocked(unit_tests.MockFunction):
         def __init__(self):
@@ -1127,7 +1161,14 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertEqual(utils.download_pkg.enable_repos, ["enabled_rhsm_repo"])
         self.assertEqual(
             utils.run_subprocess.cmd,
-            ["rpm", "-i", "--force", "--nodeps", "--replacepkgs", "%skernel-4.7.4-200.fc24*" % utils.TMP_DIR],
+            [
+                "rpm",
+                "-i",
+                "--force",
+                "--nodeps",
+                "--replacepkgs",
+                "%skernel-4.7.4-200.fc24*" % utils.TMP_DIR,
+            ],
         )
 
         # test the use case where custom repos are used for the conversion
@@ -1392,7 +1433,11 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
     ),
 )
 def test_call_yum_cmd_w_downgrades(monkeypatch, retcode, output):
-    monkeypatch.setattr(pkghandler, "call_yum_cmd", value=mock.Mock(return_value=(output, retcode)))
+    monkeypatch.setattr(
+        pkghandler,
+        "call_yum_cmd",
+        value=mock.Mock(return_value=(output, retcode)),
+    )
     resolve_dep_errors = mock.Mock()
     monkeypatch.setattr(pkghandler, "resolve_dep_errors", value=resolve_dep_errors)
     monkeypatch.setattr(pkghandler, "get_problematic_pkgs", value=mock.Mock())
@@ -1408,7 +1453,11 @@ def test_call_yum_cmd_w_downgrades(monkeypatch, retcode, output):
         ("123-4.fc35", "123-4.fc35", 0),
         ("123-5.fc35", "123-4.fc35", 1),
         ("123-3.fc35", "123-4.fc35", -1),
-        ("4.6~pre16262021g84ef6bd9-3.fc35", "4.6~pre16262021g84ef6bd9-3.fc35", 0),
+        (
+            "4.6~pre16262021g84ef6bd9-3.fc35",
+            "4.6~pre16262021g84ef6bd9-3.fc35",
+            0,
+        ),
         ("2:8.2.3568-1.fc35", "2:8.2.3568-1.fc35", 0),
     ),
 )
@@ -1438,12 +1487,19 @@ def test_compare_package_versions(version1, version2, expected):
 )
 def test_get_total_packages_to_update(package_manager_type, packages, monkeypatch):
     monkeypatch.setattr(pkgmanager, "TYPE", package_manager_type)
-    monkeypatch.setattr(pkghandler, "_get_packages_to_update_%s" % package_manager_type, value=lambda: packages)
+    monkeypatch.setattr(
+        pkghandler,
+        "_get_packages_to_update_%s" % package_manager_type,
+        value=lambda: packages,
+    )
 
     assert get_total_packages_to_update() == packages
 
 
-@pytest.mark.skipif(pkgmanager.TYPE != "yum", reason="No yum module detected on the system, skipping it.")
+@pytest.mark.skipif(
+    pkgmanager.TYPE != "yum",
+    reason="No yum module detected on the system, skipping it.",
+)
 @pytest.mark.parametrize(("packages"), ((["package-1", "package-2", "package-3"],)))
 def test_get_packages_to_update_yum(packages, monkeypatch):
     sys.path.insert(0, "/usr/share/yum-cli")
@@ -1459,12 +1515,19 @@ def test_get_packages_to_update_yum(packages, monkeypatch):
 
     monkeypatch.setattr(YumBaseCli, "returnPkgLists", value=pkg_lists_mock)
 
+    # Remvoe the /usr/share/yum-cli from the system path so the code
+    # can load it
+    sys.path.remove("/usr/share/yum-cli")
     assert _get_packages_to_update_yum() == packages
 
 
-@pytest.mark.skipif(pkgmanager.TYPE != "dnf", reason="No dnf module detected on the system, skipping it.")
+@pytest.mark.skipif(
+    pkgmanager.TYPE != "dnf",
+    reason="No dnf module detected on the system, skipping it.",
+)
 @pytest.mark.parametrize(("packages"), ((["package-1", "package-2", "package-3"],)))
-def test_get_packages_to_update_dnf(packages, monkeypatch):
+@all_systems
+def test_get_packages_to_update_dnf(packages, pretend_os, monkeypatch):
     from dnf import Base  # pylint: disable=E0401
 
     dummy_mock = mock.Mock()
@@ -1577,7 +1640,10 @@ Available Packages
 kernel.x86_64    4.7.4-200.fc24   @updates"""
 
 with open(
-    os.path.join(os.path.dirname(__file__), "data/pkghandler_yum_distro_sync_output_expect_deps_for_3_pkgs_found.txt")
+    os.path.join(
+        os.path.dirname(__file__),
+        "data/pkghandler_yum_distro_sync_output_expect_deps_for_3_pkgs_found.txt",
+    )
 ) as f:
     YUM_DISTRO_SYNC_OUTPUT = f.read()
 
@@ -1698,17 +1764,49 @@ def test_get_problematic_pkgs_requires_unusual_names():
         ("Error: Package: not_a_package_name", "%s", set()),
         ("gcc-10.3.1-1.el8.x86_64", "%s", set(["gcc"])),
         ("gcc-c++-10.3.1-1.el8.x86_64", "%s", set(["gcc-c++"])),
-        ("ImageMagick-c++-6.9.10.68-6.el7_9.i686", "%s", set(["ImageMagick-c++"])),
+        (
+            "ImageMagick-c++-6.9.10.68-6.el7_9.i686",
+            "%s",
+            set(["ImageMagick-c++"]),
+        ),
         ("389-ds-base-1.3.10.2-14.el7_9.x86_64", "%s", set(["389-ds-base"])),
-        ("devtoolset-11-libstdc++-devel-11.2.1-1.2.el7.x86_64", "%s", set(["devtoolset-11-libstdc++-devel"])),
-        ("devtoolset-1.1-libstdc++-devel-11.2.1-1.2.el7.x86_64", "%s", set(["devtoolset-1.1-libstdc++-devel"])),
-        ("java-1.8.0-openjdk-1.8.0.312.b07-2.fc33.x86_64", "%s", set(["java-1.8.0-openjdk"])),
+        (
+            "devtoolset-11-libstdc++-devel-11.2.1-1.2.el7.x86_64",
+            "%s",
+            set(["devtoolset-11-libstdc++-devel"]),
+        ),
+        (
+            "devtoolset-1.1-libstdc++-devel-11.2.1-1.2.el7.x86_64",
+            "%s",
+            set(["devtoolset-1.1-libstdc++-devel"]),
+        ),
+        (
+            "java-1.8.0-openjdk-1.8.0.312.b07-2.fc33.x86_64",
+            "%s",
+            set(["java-1.8.0-openjdk"]),
+        ),
         # Test NEVR with an epoch
-        ("NetworkManager-1:1.18.8-2.0.1.el7_9.x86_64", "%s", set(["NetworkManager"])),
+        (
+            "NetworkManager-1:1.18.8-2.0.1.el7_9.x86_64",
+            "%s",
+            set(["NetworkManager"]),
+        ),
         # Test with simple error messages that we've pre-compiled the regex for
-        ("Error: Package: gcc-10.3.1-1.el8.x86_64", "Error: Package: %s", set(["gcc"])),
-        ("multilib versions: gcc-10.3.1-1.el8.i686", "multilib versions: %s", set(["gcc"])),
-        ("problem with installed package: gcc-10.3.1-1.el8.x86_64", "problem with installed package: %s", set(["gcc"])),
+        (
+            "Error: Package: gcc-10.3.1-1.el8.x86_64",
+            "Error: Package: %s",
+            set(["gcc"]),
+        ),
+        (
+            "multilib versions: gcc-10.3.1-1.el8.i686",
+            "multilib versions: %s",
+            set(["gcc"]),
+        ),
+        (
+            "problem with installed package: gcc-10.3.1-1.el8.x86_64",
+            "problem with installed package: %s",
+            set(["gcc"]),
+        ),
         # Test that a template that was not pre-compiled works
         (
             """Some Test Junk
@@ -1727,7 +1825,11 @@ def test_get_problematic_pkgs_requires_unusual_names():
             set(["gcc", "gcc-c++", "bash"]),
         ),
         # Test with actual yum output
-        (YUM_DISTRO_SYNC_OUTPUT, "Error: Package: %s", set(["gcc", "gcc-c++", "libstdc++-devel"])),
+        (
+            YUM_DISTRO_SYNC_OUTPUT,
+            "Error: Package: %s",
+            set(["gcc", "gcc-c++", "libstdc++-devel"]),
+        ),
     ),
 )
 def test_find_pkg_names(output, message, expected_names):
@@ -1762,7 +1864,11 @@ def test_find_pkg_names_no_names(output, message):
     ),
 )
 def test_filter_installed_pkgs(packages, expected, is_rpm_installed, monkeypatch):
-    monkeypatch.setattr(system_info, "is_rpm_installed", mock.Mock(return_value=is_rpm_installed))
+    monkeypatch.setattr(
+        system_info,
+        "is_rpm_installed",
+        mock.Mock(return_value=is_rpm_installed),
+    )
     assert pkghandler.filter_installed_pkgs(packages) == expected
 
 

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -347,3 +347,19 @@ def test_prompt_user(question, is_password, response, monkeypatch):
         monkeypatch.setattr(moves, "input", lambda _: response)
 
     assert prompt_user(question, is_password) == response
+
+
+@pytest.mark.parametrize(
+    ("string_version", "nevra"),
+    (
+        ("5.14.15-300.fc35", ("0", "5.14.15", "300.fc35")),
+        ("0.17-9.fc35", ("0", "0.17", "9.fc35")),
+        ("2.34.1-2.fc35", ("0", "2.34.1", "2.fc35")),
+        ("0.9.1-2.20210420git36391559.fc35", ("0", "0.9.1", "2.20210420git36391559.fc35")),
+        ("2:8.2.3568-1.fc35", ("2", "8.2.3568", "1.fc35")),
+        ("4.6~pre16262021g84ef6bd9-3.fc35", ("0", "4.6~pre16262021g84ef6bd9", "3.fc35")),
+    ),
+)
+def test_string_to_version(string_version, nevra):
+    nevra_version = utils.string_to_version(string_version)
+    assert nevra_version == nevra

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -620,4 +620,25 @@ def set_locale():
     os.environ.update({"LC_ALL": "C", "LANG": "C"})
 
 
+def string_to_version(verstring):
+    """Return a tuple of (epoch, version, release) from a version string
+    This function was taken from softwarefactory-project/rdopkg
+    (https://github.com/softwarefactory-project/rdopkg/blob/1.4.0/rdopkg/utils/specfile.py)
+    """
+
+    # is there an epoch?
+    components = verstring.split(":")
+    if len(components) > 1:
+        epoch = components[0]
+        components.pop(0)
+    else:
+        epoch = "0"
+
+    remaining = components[:2][0].split("-")
+    version = remaining[0]
+    release = remaining[1]
+
+    return (epoch, version, release)
+
+
 changed_pkgs_control = ChangedRPMPackagesController()  # pylint: disable=C0103

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -204,3 +204,26 @@ discover+:
   - name: reboot after conversion
     how: ansible
     playbook: tests/ansible_collections/roles/reboot/main.yml
+
+/system_up_to_date:
+  discover+:
+    test: checks-after-conversion
+  prepare+:
+  - name: preapre non latest kernel
+    how: shell
+    script: pytest -svv tests/integration/tier1/system-up-to-date/install_non_latest_kernel.py
+  - name: reboot machine
+    how: ansible
+    playbook: tests/ansible_collections/roles/reboot/main.yml
+  - name: test inhibitor on non latest kernels
+    how: shell
+    script: pytest -svv tests/integration/tier1/system-up-to-date/test_non_latest_kernel_inhibitor.py
+  - name: reboot machine
+    how: ansible
+    playbook: tests/ansible_collections/roles/reboot/main.yml
+  - name: test conversion non updated package
+    how: shell
+    script: pytest -svv tests/integration/tier1/system-up-to-date/test_system_up_to_date.py
+  - name: reboot after conversion
+    how: ansible
+    playbook: tests/ansible_collections/roles/reboot/main.yml

--- a/tests/integration/main.fmf
+++ b/tests/integration/main.fmf
@@ -1,2 +1,2 @@
 summary: Integration tests
-duration: 60m
+duration: 90m

--- a/tests/integration/tier0/backup-release/test_backup_release.py
+++ b/tests/integration/tier0/backup-release/test_backup_release.py
@@ -21,8 +21,11 @@ def test_backup_os_release_no_envar(shell, convert2rhel):
     assert shell("wget --no-check-certificate --output-document {} {}".format(pkg_dst, pkg_url)).returncode == 0
     assert shell("rpm -i {}".format(pkg_dst)).returncode == 0
 
-    # Move all repos to other location so it is not used
+    # Move all repos to other location, so it is not being used
     assert shell("mkdir /tmp/s_backup && mv /etc/yum.repos.d/* /tmp/s_backup/").returncode == 0
+
+    # Since we are moving all repos away, we need to bypass kernel check
+    os.environ["CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK"] = "1"
 
     assert shell("find /etc/os-release").returncode == 0
     with convert2rhel(
@@ -71,6 +74,10 @@ def test_backup_os_release_with_envar(shell, convert2rhel):
 
     # Restore repos
     assert shell("mv /tmp/s_backup/* /etc/yum.repos.d/").returncode == 0
+
+    # Clean up
+    del os.environ["CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK"]
+    del os.environ["CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK"]
 
 
 def test_missing_system_release(shell, convert2rhel):

--- a/tests/integration/tier1/convert-offline-systems/run_conversion.py
+++ b/tests/integration/tier1/convert-offline-systems/run_conversion.py
@@ -1,10 +1,16 @@
 import os
+import platform
 
 from envparse import env
 
 
-def test_convert_offline_systems(convert2rhel):
+def test_convert_offline_systems(shell, convert2rhel):
     """Test converting systems not connected to the Internet but requiring sub-mgr (e.g. managed by Satellite)."""
+
+    # The CentOS8 Extras repo url is unreachable due to offline system setup.
+    # The repoquery returns an error, thus we need to disable this repository.
+    if "centos-8" in platform.platform():
+        shell("yum-config-manager --disable extras --disable epel-modular")
 
     os.environ["CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK"] = "1"
     with convert2rhel(

--- a/tests/integration/tier1/method/activation_key.py
+++ b/tests/integration/tier1/method/activation_key.py
@@ -9,5 +9,5 @@ def test_activation_key_conversion(convert2rhel):
             env.str("RHSM_ORG"),
         )
     ) as c2r:
-        pass
+        c2r.expect("Conversion successful!")
     assert c2r.exitstatus == 0

--- a/tests/integration/tier1/one-kernel-scenario/install_one_kernel.py
+++ b/tests/integration/tier1/one-kernel-scenario/install_one_kernel.py
@@ -1,7 +1,5 @@
 import platform
 
-import pytest
-
 
 def test_install_one_kernel(shell):
     # installing kernel package

--- a/tests/integration/tier1/one-kernel-scenario/run_conversion.py
+++ b/tests/integration/tier1/one-kernel-scenario/run_conversion.py
@@ -1,20 +1,39 @@
-from collections import namedtuple
-
-import pytest
+import os
+import platform
 
 
 def test_run_conversion_using_custom_repos(shell, convert2rhel):
+    "TODO better description and function name"
 
-    # with open("/etc/system-release", "r") as file:
-    #    system_release = file.read()
-    #    if "Oracle Linux Server release 7.9" in system_release:
+    system_distro = platform.platform()
+
+    enable_repo_opt = """
+        --enablerepo rhel-7-server-rpms
+        --enablerepo rhel-7-server-optional-rpms
+        --enablerepo rhel-7-server-extras-rpms
+        """
+
+    # python3 causes issues
     assert shell("yum remove -y python3").returncode == 0
 
-    enable_repo_opt = "--enablerepo rhel-7-server-rpms --enablerepo rhel-7-server-optional-rpms --enablerepo rhel-7-server-extras-rpms"
+    # The 'updates' and 'ol7_latest' repository on 'CentOS7' and 'Oracle7' respectively
+    # contains higher version of kernel, so the update would get inhibited due to
+    # the kernel not being at the latest version installed on the system.
+    # We also need to enable env variable to allow unsupported rollback.
+    if "centos" in system_distro:
+        assert shell("yum-config-manager --disable updates").returncode == 0
+    elif "oracle" in system_distro:
+        assert shell("yum-config-manager --disable ol7_latest").returncode == 0
+        # This internal repo breaks the conversion on the instances we are getting
+        # from Testing Farm
+        shell("rm /etc/yum.repos.d/copr_build-convert2rhel-1.repo")
+
+    os.environ["CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK"] = "1"
+    os.environ["CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK"] = "1"
 
     with convert2rhel("-y --no-rpm-va --disable-submgr {} --debug".format(enable_repo_opt)) as c2r:
         c2r.expect("Conversion successful!")
 
     assert c2r.exitstatus == 0
-    # if "Oracle Linux Server release 7.9" in system_release:
+
     assert shell("yum install -y python3 --enablerepo=*").returncode == 0

--- a/tests/integration/tier1/set-locale/use_non_english_language.py
+++ b/tests/integration/tier1/set-locale/use_non_english_language.py
@@ -15,3 +15,9 @@ def test_use_non_english_language(shell):
     # set LANG to Chinese
     assert shell("localectl list-locales | grep zh_CN.utf8").returncode == 0
     assert shell("localectl set-locale LANG=zh_CN.utf8").returncode == 0
+
+    # Testing farm is returning an error on CentOS7 mentioning
+    # setting incompatible LC_CTYPE C.UTF-8.
+    # However the C.UTF-8 was added on RHEL-8 like distros.
+    if "centos-7" in os:
+        assert shell("localectl set-locale LC_CTYPE=zh_CN.utf8").returncode == 0

--- a/tests/integration/tier1/system-up-to-date/install_non_latest_kernel.py
+++ b/tests/integration/tier1/system-up-to-date/install_non_latest_kernel.py
@@ -1,0 +1,24 @@
+import platform
+
+
+def test_install_one_kernel(shell):
+    """
+    Install specific kernel version and configure
+    the system to boot to it. The kernel version is not the
+    latest one available in repositories.
+    """
+    system_version = platform.platform()
+
+    # Set default kernel
+    if "centos-7" in system_version:
+        assert shell("yum install kernel-3.10.0-1160.el7.x86_64 -y").returncode == 0
+        shell("grub2-set-default 'CentOS Linux (3.10.0-1160.el7.x86_64) 7 (Core)'")
+    elif "oracle-7" in system_version:
+        assert shell("yum install kernel-3.10.0-1160.el7.x86_64 -y").returncode == 0
+        shell("grub2-set-default 'Oracle Linux Server 7.9, with Linux 3.10.0-1160.el7.x86_64'")
+    elif "centos-8" in system_version:
+        assert shell("yum install kernel-4.18.0-240.22.1.el8_3 -y").returncode == 0
+        shell("grub2-set-default 'CentOS Linux (4.18.0-240.22.1.el8_3.x86_64) 8'")
+    elif "oracle-8" in system_version:
+        assert shell("yum install kernel-4.18.0-240.22.1.el8_3 -y").returncode == 0
+        shell("grub2-set-default 'Oracle Linux Server (4.18.0-240.22.1.el8_3.x86_64) 8.3'")

--- a/tests/integration/tier1/system-up-to-date/main.fmf
+++ b/tests/integration/tier1/system-up-to-date/main.fmf
@@ -1,0 +1,5 @@
+summary: system-up-to-date
+
+tier: 1
+
+test: pytest -svv

--- a/tests/integration/tier1/system-up-to-date/test_non_latest_kernel_inhibitor.py
+++ b/tests/integration/tier1/system-up-to-date/test_non_latest_kernel_inhibitor.py
@@ -1,0 +1,46 @@
+import platform
+
+from envparse import env
+
+
+def set_latest_kernel(shell):
+    # We need to get the name of the latest kernel
+    # present in the repositories
+
+    # Install 'yum-utils' required by the repoquery command
+    shell("yum install yum-utils -y")
+
+    # Get the name of the latest kernel
+    latest_kernel = shell(
+        "repoquery --quiet --qf '%{BUILDTIME}\t%{VERSION}-%{RELEASE}' kernel 2>/dev/null | tail -n 1 | awk '{printf $NF}'"
+    ).output
+
+    # Get the full name of the kerenl
+    full_name = shell(
+        "grubby --info ALL | grep \"title=.*{}\" | tr -d '\"' | sed 's/title=//'".format(latest_kernel)
+    ).output
+
+    # Set the latest kernel as the one we want to reboot to
+    shell("grub2-set-default '{}'".format(full_name.strip()))
+
+
+def test_non_latest_kernel(shell, convert2rhel):
+    """
+    System has non latest kernel installed, thus the conversion
+    has to be inhibited.
+    """
+    system_version = platform.platform()
+
+    with convert2rhel(
+        ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        c2r.expect("The current kernel version loaded is different from the latest version in your repos.")
+    assert c2r.exitstatus != 0
+
+    # Clean up, reboot is required after this
+    set_latest_kernel(shell)

--- a/tests/integration/tier1/system-up-to-date/test_system_up_to_date.py
+++ b/tests/integration/tier1/system-up-to-date/test_system_up_to_date.py
@@ -1,0 +1,82 @@
+import os
+import platform
+
+from envparse import env
+
+
+system_version = platform.platform()
+
+
+def test_skip_kernel_check(shell, convert2rhel):
+    """
+    Test that it is possible to use env variable in some case to override
+    the kernel check inhibitor. One of the way to allow this is to not have
+    any kernel packages present in repos.
+    """
+    shell("mkdir /tmp/my_tmp; mv /etc/yum.repos.d/* /tmp/my_tmp")
+
+    with convert2rhel(
+        ("--no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        if "centos-7" in system_version or "oracle-7" in system_version:
+            c2r.expect("Could not find any kernel from repositories to compare against the loaded kernel.")
+        elif "centos-8" in system_version or "oracle-8" in system_version:
+            c2r.expect("Could not find any kernel-core from repositories to compare against the loaded kernel.")
+    assert c2r.exitstatus != 0
+
+    os.environ["CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK"] = "1"
+
+    with convert2rhel(
+        ("--no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        c2r.expect("Detected 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK' environment variable")
+        c2r.sendcontrol("c")
+    assert c2r.exitstatus != 0
+
+    # Clean up
+    shell("mv /tmp/my_tmp/* /etc/yum.repos.d/")
+
+
+def test_system_not_updated(shell, convert2rhel):
+    """
+    System contains at least one package that is not updated to
+    the latest version. The c2r has to display a warning message
+    about that. Also not updated package it's version
+    is locked. Display a warning about used version lock.
+    """
+    centos_8_pkg_url = "https://vault.centos.org/8.1.1911/BaseOS/x86_64/os/Packages/wpa_supplicant-2.7-1.el8.x86_64.rpm"
+
+    # Try to downgrade two packages.
+    # On CentOS-8 we cannot do the downgrade as the repos contain only the latest package version.
+    # We need to install package from older repository as a workaround.
+    if "centos-8" in system_version:
+        assert shell("yum install -y {}".format(centos_8_pkg_url)).returncode == 0
+    else:
+        assert shell("yum install openldap wpa_supplicant -y").returncode == 0
+        assert shell("yum downgrade openldap wpa_supplicant -y").returncode == 0
+
+    assert shell("yum install -y yum-plugin-versionlock").returncode == 0
+    assert shell("yum versionlock wpa_supplicant").returncode == 0
+
+    # Run utility until the reboot
+    with convert2rhel(
+        ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        c2r.expect("WARNING - YUM/DNF versionlock plugin is in use. It may cause the conversion to fail.")
+        c2r.expect(r"WARNING - The system has \d+ packages not updated.")
+    assert c2r.exitstatus == 0


### PR DESCRIPTION
This PR aims to add a couple of checks before the conversion runs. The checks will prevent the conversion from falling before the process is finished. 

The checks are the following: 

* Check if all the system packages are updated (Through yum/dnf API calls) in enabled repos
* Check if the booted kernel is at the latest version (Through a comparison between `rpm` and `uname`)

If both of the conditions are met, then the conversion will proceed normally in the workflow.

Ticket reference: https://issues.redhat.com/browse/OAMG-4659
Linked ticket: https://issues.redhat.com/browse/OAMG-4709