### PR TITLE
Halt when unable to download backup

### DIFF
--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -207,10 +207,17 @@ class TestUtils(unittest.TestCase):
 
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     @unit_tests.mock(utils, "run_cmd_in_pty", RunSubprocessMocked(ret_code=1))
-    def test_download_pkg_failed_download(self):
+    @unit_tests.mock(os, "environ", {"CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK": "1"})
+    def test_download_pkg_failed_download_overridden(self):
         path = utils.download_pkg("kernel")
 
         self.assertEqual(path, None)
+
+    @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
+    @unit_tests.mock(utils, "run_cmd_in_pty", RunSubprocessMocked(ret_code=1))
+    @unit_tests.mock(os, "environ", {})
+    def test_download_pkg_failed_download_exit(self):
+        self.assertRaises(SystemExit, utils.download_pkg, "kernel")
 
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     @unit_tests.mock(utils, "run_cmd_in_pty", RunSubprocessMocked(ret_code=0))

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -471,10 +471,24 @@ def download_pkg(
 
     output, ret_code = run_cmd_in_pty(cmd, print_output=False)
     if ret_code != 0:
-        loggerinst.warning(
-            "Couldn't download the %s package using yumdownloader.\n"
-            "Output from the yumdownloader call:\n%s" % (pkg, output)
-        )
+        loggerinst.warning("Output from the yumdownloader call:\n%s" % (output))
+
+        if not "CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK" in os.environ:
+            loggerinst.critical(
+                "Couldn't download the %s package. This means we will not be able to do a"
+                " complete rollback and may put the system in a broken state.\n"
+                "Check to make sure that the %s repositories are enabled"
+                " and the package is updated to its latest version.\n"
+                "If you would rather ignore this check set the environment variable"
+                " 'CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK'." % (pkg, system_info.name)
+            )
+        else:
+            loggerinst.warning(
+                "Couldn't download the %s package. This means we will not be able to do a"
+                " complete rollback and may put the system in a broken state.\n"
+                "'CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK' environment variable detected, continuing conversion."
+                % (pkg)
+            )
         return None
 
     path = get_rpm_path_from_yumdownloader_output(cmd, output, dest)


### PR DESCRIPTION
I changed what happens when the conversion can't rollback the rpm files. it now prompts the user after letting them know that the conversion couldn't rollback the packages and shows them the packages that couldn't be rolledback and then prompts the user to see if they want to continue of not.

Fixes OAMG-5463