### PR TITLE
Add archive to old log files

### DIFF
--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 
 from convert2rhel import redhatrelease, utils
-from convert2rhel.logger import initialize_logger
+from convert2rhel.logger import setup_logger_handler
 from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts
 
@@ -57,7 +57,7 @@ def pkg_root(is_py2):
 
 @pytest.fixture(autouse=True)
 def setup_logger(tmpdir):
-    initialize_logger(log_name="convert2rhel", log_dir=str(tmpdir))
+    setup_logger_handler(log_name="convert2rhel", log_dir=str(tmpdir))
 
 
 @pytest.fixture()


### PR DESCRIPTION
This PR aims to add the ability to archive old log files before a new run. 

For example: 
* /var/log/convert2rhel/archive/convert2rhel-1635162445070567607.log
* /var/log/convert2rhel/archive/convert2rhel-1635162478219820043.log

The name chosen for the new file is based on the previous log file name (eg; convert2rhel.log), but with an appended timestamp to it. This timestamp is relative to the last modified date (Which means, the last command sent to the log file).

Beware, this PR is also linked to the [sosreport/sos - PR#2734](https://github.com/sosreport/sos/pull/2734) as we have to include the archived logs in the sosreport tool.

Ticket reference: https://issues.redhat.com/browse/OAMG-5458