### PR TITLE
Add support for podman to the Makefile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@
 Required dependencies:
 - virtualenv
 - pre-commit
+- podman (or a working docker)
 
 The commands below create a python3 virtual environment with all the necessary dependencies installed,
 build needed images,
@@ -54,7 +55,7 @@ git commit --no-verify
 
 # Building rpms locally
 
-You need podman or docker installed
+You need podman or a working docker installed
 
 ```bash
 make rpms
@@ -63,7 +64,7 @@ make rpms
 # Building copr builds locally
 
 You need:
-- podman or docker installed
+- podman or a working docker installed
 - have an account at https://copr.fedorainfracloud.org/api/, copy copr config
   and paste it to the repo root as .copr.conf
 - request build permissions at https://copr.fedorainfracloud.org/coprs/g/oamg/convert2rhel/permissions/

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ifndef DOCKER
   ifndef DOCKER
     DOCKER := $(shell docker run alpine echo docker 2> /dev/null)
     ifndef DOCKER
-      DUMMY := $(warning Many of the make targets require a working podman or docker.  Please install one of those and check that `poodman run alpine echo hello` or `docker run alpine echo hello` work)
+      DUMMY := $(warning Many of the make targets require a working podman or docker.  Please install one of those and check that `podman run alpine echo hello` or `docker run alpine echo hello` work)
     endif
   endif
 endif


### PR DESCRIPTION
Docker doesn't work everywhere because the version of docker sometimes
needs cgroups v1 but the system is using cgroups v2.  In those places,
podman seems to work fine.

* Give users the ability to specify what docker command to use (ie:
  make install DOCKER=podman)
* Autodetect in the Makefile whether there's a working podman or docker
  if the user did not specify one.  Note that this uses some GNU make
  extensions ($warning).