### PR TITLE
Explicitly specify distros to test build targets on

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -40,10 +40,12 @@ jobs:
 - job: tests
   metadata:
     targets:
-    - epel-7-x86_64
-    - epel-8-x86_64
-    # TODO enable when OL7/8 images are working in artemis
-    #- oraclelinux-7-x86_64
-    #- oraclelinux-8-x86_64
+      epel-7-x86_64:
+        distros: [centos-7]
+      epel-8-x86_64:
+        distros: [centos-8]
+      # TODO enable when OL7/8 images are working in artemis
+      #oraclelinux-7-x86_64: {}
+      #oraclelinux-8-x86_64: {}
     use_internal_tf: True
   trigger: pull_request


### PR DESCRIPTION
A [convert2rhel specific workaround in packit service](https://github.com/packit/packit-service/pull/1225) has been [reverted](https://github.com/packit/packit-service/pull/1269/commits/3ac2a002308aead558f0c94f88078364f39b78de) because packit service now supports specifying of the [build target to test distros mapping in the config](https://github.com/packit/packit/pull/1407).

Do not merge yet. The change in packit service will be deployed to production next Tuesday, 16th of November, which is the date you should merge this - I'll ping you (if I don't forget ;) )
The [packit.dev docs will be updated](https://github.com/packit/packit.dev/pull/350) once the change is deployed.