### PR TITLE
Fix tests after RHEL8.5 release

### DIFF
--- a/tests/integration/tier0/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
+++ b/tests/integration/tier0/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
@@ -34,7 +34,7 @@ def test_inhibit_if_custom_module_loaded(insert_custom_kmod, convert2rhel):
 
 
 def test_do_not_inhibit_if_module_is_not_loaded(shell, convert2rhel):
-    assert shell("modprobe -r -v bonding").output == "rmmod bonding\n"
+    assert shell("modprobe -r -v bonding").returncode == 0
     with convert2rhel(
         ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
             env.str("RHSM_SERVER_URL"),


### PR DESCRIPTION
Inside the kmod integration test we call `modprobe -r` command which can sometimes remove unused dependency modules. This can result in multi-line output string thus the assert in the test can fail. This PR replaces the output for return-code assert.  