### PR TITLE
Change running user to `root` when running tests on container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,20 +69,21 @@ images: .images
 	@$(DOCKER) build -f Dockerfiles/rpmbuild.centos7.Dockerfile -t $(IMAGE)/centos7rpmbuild .
 	touch $@
 
-tests: images
-	@echo 'CentOS Linux 7 tests'
-	@$(DOCKER) run --user=$(id -ur):$(id -gr) --rm -v $(shell pwd):/data:Z $(IMAGE)/centos7 pytest --show-capture=$(SHOW_CAPTURE)
-	@echo 'CentOS Linux 8 tests'
-	@$(DOCKER) run --user=$(id -ur):$(id -gr) --rm -v $(shell pwd):/data:Z $(IMAGE)/centos8 pytest --show-capture=$(SHOW_CAPTURE)
-
 lint: images
 	@$(DOCKER) run --rm -v $(shell pwd):/data:Z $(IMAGE)/centos8 bash -c "scripts/run_lint.sh"
 
 lint-errors: images
 	@$(DOCKER) run --rm -v $(shell pwd):/data:Z $(IMAGE)/centos8 bash -c "scripts/run_lint.sh --errors-only"
 
+tests: tests7 tests8
+
+tests7: images
+	@echo 'CentOS Linux 7 tests'
+	@$(DOCKER) run --rm --user=$(id -ur):$(id -gr) -v $(shell pwd):/data:Z $(IMAGE)/centos7 pytest --show-capture=$(SHOW_CAPTURE)
+
 tests8: images
-	@$(DOCKER) run --rm -v $(shell pwd):/data:Z $(IMAGE)/centos8 pytest --show-capture=$(SHOW_CAPTURE)
+	@echo 'CentOS Linux 8 tests'
+	@$(DOCKER) run --rm --user=$(id -ur):$(id -gr) -v $(shell pwd):/data:Z $(IMAGE)/centos8 pytest --show-capture=$(SHOW_CAPTURE)
 
 rpms: images
 	mkdir -p .rpms


### PR DESCRIPTION
When I run the tests in containers on my machine, I get a permission error for some tests (cert_test.py) because they perform a validation of the test certificates are read/write, and as we are setting up our current project directory in the container , the same goes there as `root:root`.

This fix is intended to run the tests as the root user inside the container, as this is a simple change and as this command is only run locally, I believe it should solve the problem.

I also added another command to run the tests in the CentOS7 container.

Here's the output before the fix: 

<details>
  <summary>Click to expand.</summary>

  ```bash
  (.venv3) [r0x0d@fedora convert2rhel]$ make tests8
  ============================= test session starts ==============================
  platform linux -- Python 3.6.8, pytest-6.2.1, py-1.11.0, pluggy-0.13.1
  rootdir: /data, configfile: pytest.ini, testpaths: convert2rhel/unit_tests
  plugins: cov-2.11.0
  collected 301 items
  
  convert2rhel/unit_tests/breadcrumbs_test.py ......                       [  1%]
  convert2rhel/unit_tests/cert_test.py F..F..                              [  3%]
  convert2rhel/unit_tests/checks_test.py ................................. [ 14%]
  ..........                                                               [ 18%]
  convert2rhel/unit_tests/example_test.py .                                [ 18%]
  convert2rhel/unit_tests/grub_test.py ................................... [ 30%]
  ...............................                                          [ 40%]
  convert2rhel/unit_tests/logger_test.py ...                               [ 41%]
  convert2rhel/unit_tests/main_test.py .....                               [ 43%]
  convert2rhel/unit_tests/other_test.py ..                                 [ 43%]
  convert2rhel/unit_tests/pkghandler_test.py ............................. [ 53%]
  .................................                                        [ 64%]
  convert2rhel/unit_tests/redhatrelease_test.py ............               [ 68%]
  convert2rhel/unit_tests/repo_test.py .                                   [ 68%]
  convert2rhel/unit_tests/special_cases_test.py ........                   [ 71%]
  convert2rhel/unit_tests/subscription_test.py ........................... [ 80%]
  ..                                                                       [ 81%]
  convert2rhel/unit_tests/systeminfo_test.py ..................            [ 87%]
  convert2rhel/unit_tests/toolopts_test.py .................               [ 92%]
  convert2rhel/unit_tests/utils_test.py ......................             [100%]
  
  =================================== FAILURES ===================================
  _________________________ TestCert.test_get_cert_path __________________________
  
  self = <convert2rhel.unit_tests.cert_test.TestCert testMethod=test_get_cert_path>
  
      @unit_tests.mock(utils, "DATA_DIR", unit_tests.TMP_DIR)
      def test_get_cert_path(self):
          # Check there are certificates for all the supported RHEL variants
          for arch, rhel_versions in self.certs.items():
              for rhel_version, pem in rhel_versions.items():
                  utils.DATA_DIR = os.path.join(self.base_data_dir, rhel_version, arch)
  >               system_cert = cert.SystemCert()
  
  convert2rhel/unit_tests/cert_test.py:62:
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  convert2rhel/cert.py:31: in __init__
      self._cert_filename, self._source_cert_dir = self._get_cert()
  convert2rhel/cert.py:40: in _get_cert
      loggerinst.critical("Error: Could not access %s." % cert_dir)
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  
  self = <Logger convert2rhel.cert (FILE)>
  msg = 'Error: Could not access /data/convert2rhel/data/6/x86_64/rhel-certs.'
  args = (), kwargs = {}
  
      def _critical(self, msg, *args, **kwargs):
          if self.isEnabledFor(logging.CRITICAL):
              self._log(logging.CRITICAL, msg, args, **kwargs)
  >           sys.exit(msg)
  E           SystemExit: Error: Could not access /data/convert2rhel/data/6/x86_64/rhel-certs.
  
  convert2rhel/logger.py:104: SystemExit
  __________________________ TestCert.test_install_cert __________________________
  
  self = <convert2rhel.unit_tests.cert_test.TestCert testMethod=test_install_cert>
  
      @unit_tests.mock(tool_opts, "arch", "x86_64")
      @unit_tests.mock(utils, "DATA_DIR", os.path.join(base_data_dir, "6", "x86_64"))
      def test_install_cert(self):
          # By initializing the cert object we get a path to an existing
          # certificate based on the mocked parameters above
  >       system_cert = cert.SystemCert()
  
  convert2rhel/unit_tests/cert_test.py:91:
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  convert2rhel/cert.py:31: in __init__
      self._cert_filename, self._source_cert_dir = self._get_cert()
  convert2rhel/cert.py:40: in _get_cert
      loggerinst.critical("Error: Could not access %s." % cert_dir)
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  
  self = <Logger convert2rhel.cert (FILE)>
  msg = 'Error: Could not access /data/convert2rhel/data/6/x86_64/rhel-certs.'
  args = (), kwargs = {}
  
      def _critical(self, msg, *args, **kwargs):
          if self.isEnabledFor(logging.CRITICAL):
              self._log(logging.CRITICAL, msg, args, **kwargs)
  >           sys.exit(msg)
  E           SystemExit: Error: Could not access /data/convert2rhel/data/6/x86_64/rhel-certs.
  
  convert2rhel/logger.py:104: SystemExit
  =============================== warnings summary ===============================
  convert2rhel/unit_tests/utils_test.py::test_remove_tmp_dir[/nonexisting]
    /data/convert2rhel/utils.py:283: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
      loggerinst.warn("Failed removing temporary folder %s\nError (%s): %s" % (TMP_DIR, err.errno, err.strerror))
  
  convert2rhel/unit_tests/utils_test.py::test_remove_tmp_dir[None]
    /data/convert2rhel/utils.py:285: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
      loggerinst.warn("TypeError error while removing temporary folder %s" % TMP_DIR)
  
  ../usr/local/lib/python3.6/site-packages/_pytest/cacheprovider.py:428
    /usr/local/lib/python3.6/site-packages/_pytest/cacheprovider.py:428: PytestCacheWarning: cache could not write path /data/.pytest_cache/v/cache/nodeids
      config.cache.set("cache/nodeids", sorted(self.cached_nodeids))
  
  ../usr/local/lib/python3.6/site-packages/_pytest/cacheprovider.py:382
    /usr/local/lib/python3.6/site-packages/_pytest/cacheprovider.py:382: PytestCacheWarning: cache could not write path /data/.pytest_cache/v/cache/lastfailed
      config.cache.set("cache/lastfailed", self.lastfailed)
  
  ../usr/local/lib/python3.6/site-packages/_pytest/stepwise.py:49
    /usr/local/lib/python3.6/site-packages/_pytest/stepwise.py:49: PytestCacheWarning: cache could not write path /data/.pytest_cache/v/cache/stepwise
      session.config.cache.set(STEPWISE_CACHE_DIR, [])
  
  -- Docs: https://docs.pytest.org/en/stable/warnings.html
  =========================== short test summary info ============================
  FAILED convert2rhel/unit_tests/cert_test.py::TestCert::test_get_cert_path - S...
  FAILED convert2rhel/unit_tests/cert_test.py::TestCert::test_install_cert - Sy...
  ================== 2 failed, 299 passed, 5 warnings in 6.01s ===================
  make: *** [Makefile:88: tests8] Error 1
  ```
</details>

And this is the output of an ls inside the container in the mounted volume

<details>
  <summary>Click to expand.</summary>
  
```bash
bash-4.4$ ls -lash
  total 148K
     0 drwxrwxr-x. 1 root root  670 Nov 16 17:45 .
     0 dr-xr-xr-x. 1 root root    0 Nov 16 17:45 ..
   52K -rw-r--r--. 1 root root  52K Nov 16 13:56 .coverage
  4.0K -rw-rw-r--. 1 root root  773 Nov  4 19:12 .env
  4.0K -rw-rw-r--. 1 root root  773 Nov  4 18:57 .env.example
     0 drwxrwxr-x. 1 root root   14 Nov  4 18:57 .fmf
     0 drwxrwxr-x. 1 root root  204 Nov 16 17:38 .git
     0 drwxrwxr-x. 1 root root   18 Nov  4 18:57 .github
  4.0K -rw-rw-r--. 1 root root  192 Nov  4 18:57 .gitignore
     0 drwxrwxr-x. 1 root root  166 Nov 16 17:40 .idea
     0 -rw-rw-r--. 1 root root    0 Nov 16 17:32 .images
     0 -rw-rw-r--. 1 root root    0 Nov  4 19:09 .install
  4.0K -rw-rw-r--. 1 root root 1.3K Nov 10 15:54 .packit.yaml
     0 -rw-rw-r--. 1 root root    0 Nov  4 19:12 .pre-commit
  4.0K -rw-rw-r--. 1 root root  643 Nov 16 17:36 .pre-commit-config.yaml
  4.0K -rw-rw-r--. 1 root root 1.5K Nov  4 18:57 .pylintrc
     0 drwxrwxr-x. 1 root root   64 Nov  8 19:30 .pytest_cache
     0 drwxrwxr-x. 1 root root   72 Nov  5 13:48 .venv3
     0 drwxr-xr-x. 1 root root   26 Nov  5 12:23 .vscode
  4.0K -rw-rw-r--. 1 root root 1.6K Nov 11 14:31 CONTRIBUTING.md
     0 drwxrwxr-x. 1 root root  180 Nov 16 17:36 Dockerfiles
   36K -rw-rw-r--. 1 root root  35K Nov  4 18:57 LICENSE
  4.0K -rw-rw-r--. 1 root root   86 Nov  4 18:57 MANIFEST.in
  4.0K -rw-rw-r--. 1 root root 3.8K Nov 16 17:45 Makefile
  4.0K -rw-rw-r--. 1 root root  788 Nov  4 18:57 README.md
     0 drwxrwxr-x. 1 root root   48 Nov 10 15:54 ansible
     0 drwxrwxr-x. 1 root root  402 Nov 16 17:36 convert2rhel
     0 drwxrwxr-x. 1 root root 1.1K Nov 16 13:56 htmlcov
     0 drwxrwxr-x. 1 root root   54 Nov 16 13:18 man
     0 drwxrwxr-x. 1 root root   34 Nov 10 15:54 packaging
     0 drwxrwxr-x. 1 root root   70 Nov 10 15:54 plans
  4.0K -rw-rw-r--. 1 root root  473 Nov  4 18:57 pyproject.toml
  4.0K -rw-rw-r--. 1 root root   47 Nov  4 18:57 pytest.ini
     0 drwxrwxr-x. 1 root root  204 Nov 10 15:54 requirements
     0 drwxrwxr-x. 1 root root  118 Nov 16 13:18 scripts
  4.0K -rw-rw-r--. 1 root root   64 Nov  4 18:57 setup.cfg
  4.0K -rwxrwxr-x. 1 root root 2.2K Nov  4 18:57 setup.py
     0 drwxrwxr-x. 1 root root   60 Nov  4 18:57 tests
  4.0K -rw-rw-r--. 1 root root    9 Nov 10 15:54 workaround.yaml

bash-4.4$ id
  uid=1000(app) gid=1000(app) groups=1000(app)
  ```
  </details>