### PR TITLE
✨ Updated Versions of Ansible Preflight Check

### DIFF
--- a/ansible/ansible-convert2rhel.yml
+++ b/ansible/ansible-convert2rhel.yml
@@ -16,11 +16,11 @@
         msg: "Distribution must be CentOS or Oracle Linux"
       when: ansible_distribution != 'CentOS' and ansible_distribution != 'OracleLinux'
 
-    - name: Validate Release Version (6.10, 7.9, 8.4)
+    - name: Validate Release Version (6.10, 7.9, 8.5)
       fail:
-        msg: "Distribution version must be 6.10, 7.9, or 8.4"
+        msg: "Distribution version must be 6.10, 7.9, or 8.5"
       when: (ansible_distribution_version != '6.10' and ansible_distribution_version != '7.9'
-             and ansible_distribution_version != '8.4') or skip_os_version_check|bool
+             and ansible_distribution_version != '8.5') or skip_os_version_check|bool
 
     - name: Download Red Hat GPG key
       get_url:


### PR DESCRIPTION
Updated compability of Ansible Preflight Check to Support CentOS / Oracle Linux 8.5 since CentOS 8.5 was recently released. I tested the playbook and it worked perfectly with 8.5, even fixed some bugs that are currently open as issue, for instance #366.