### PR TITLE
Avoid mutable types as default args.

### DIFF
--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -144,7 +144,7 @@ def call_yum_cmd(
     return stdout, returncode
 
 
-def get_problematic_pkgs(output, excluded_pkgs=set()):
+def get_problematic_pkgs(output, excluded_pkgs=frozenset()):
     """Parse the YUM/DNF output to find what packages are causing a transaction failure."""
     loggerinst.info("Checking for problematic packages")
     problematic_pkgs = {
@@ -201,7 +201,7 @@ def get_pkgs_to_distro_sync(problematic_pkgs):
     )
 
 
-def resolve_dep_errors(output, pkgs=set()):
+def resolve_dep_errors(output, pkgs=frozenset()):
     """Recursive function. If there are dependency errors in the yum output,
     try to resolve them by yum downgrades.
     """


### PR DESCRIPTION
This change removes two places where we use a set as a default value.
Mutable containers should not be used as default arguments as they are
created when the function is defined (basically, the first time the
module is imported) and then that one instance is used anytime the
method is invoked without that argument specified.  This means that
changes to the container will persist to the next time the function is
invoked.

<strike>This change seems to fix a bug we're seeing on oracle7 where we assemble
a list of packages to downgrade that includes gcc & gcc-c++ but then we find
that systemd is a protected package.  At that point, the list of
packages to downgrade seems to revert to just systemd and we build up
the list again.  This time, when we see that gcc is going to be
downgraded but gcc-c++ requires it, we do not decide to downgrade
gcc-c++.  I haven't tracked down precisely why this is but I suspect that
gcc-c++ is getting placed in the default set for the `excluded_pkgs`
argument so that when we iterate over the pakcages the second time we
never re-add gcc-c++ to the list of pakcages to downgrade.</strike>