### PR TITLE
Fix detection of gcc-c++ and other package names.

### DIFF
--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -41,11 +41,9 @@ versionlock_file = utils.RestorableFile(_VERSIONLOCK_FILE_PATH)  # pylint: disab
 #
 
 # This regex finds package NEVRs + arch (name epoch version release and
-# architechture) in a string.  It separates the epoch from the rest of the
-# NEVR, leaving us to parse the name from the remaining NVR.
-# Note that the regex requires at least two dashes but the NVR can contain
-# more than that.  For instance: gcc-c++-4.8.5-44.0.3.el7.x86_64
-PKG_NEVR = r"\b([0-9]+:)?(\S+-\S+-\S+)\b"
+# architechture) in a string.  Note that the regex requires at least two dashes but the
+# NEVR can contain more than that.  For instance: gcc-c++-4.8.5-44.0.3.el7.x86_64
+PKG_NEVR = r"\b(?:([0-9]+):)?(\S+)-(\S+)-(\S+)\b"
 
 # It would be better to construct this dynamically but we don't have lru_cache
 # in Python-2.6 and modifying a global after your program initializes isn't a
@@ -235,8 +233,7 @@ def find_pkg_names(output, message_key="%s"):
 
     names = set()
     nvrs = regular_expression.findall(output)
-    for nvr in (entry[1] for entry in nvrs if entry[1]):
-        name, _version, _release = nvr.rsplit("-", 2)
+    for _epoch, name, _version, _release in nvrs:
         names.add(name)
 
     return names

--- a/convert2rhel/unit_tests/data/pkghandler_yum_distro_sync_output_expect_deps_for_3_pkgs_found.txt
+++ b/convert2rhel/unit_tests/data/pkghandler_yum_distro_sync_output_expect_deps_for_3_pkgs_found.txt
@@ -1,0 +1,294 @@
+Loaded plugins: product-id, search-disabled-repos, subscription-manager
+Repository rhel-7-server-rpms is listed more than once in the configuration
+Repository rhel-7-server-optional-rpms is listed more than once in the configuration
+Repository rhel-7-server-extras-rpms is listed more than once in the configuration
+Resolving Dependencies
+--> Running transaction check
+---> Package glibc.x86_64 0:2.17-325.el7_9 will be a downgrade
+---> Package glibc.x86_64 0:2.17-325.0.1.el7_9 will be erased
+---> Package glibc-common.x86_64 0:2.17-325.el7_9 will be a downgrade
+---> Package glibc-common.x86_64 0:2.17-325.0.1.el7_9 will be erased
+---> Package glibc-devel.x86_64 0:2.17-325.el7_9 will be a downgrade
+---> Package glibc-devel.x86_64 0:2.17-325.0.1.el7_9 will be erased
+---> Package glibc-headers.x86_64 0:2.17-325.el7_9 will be a downgrade
+---> Package glibc-headers.x86_64 0:2.17-325.0.1.el7_9 will be erased
+---> Package libgcc.x86_64 0:4.8.5-44.el7 will be a downgrade
+---> Package libgcc.x86_64 0:4.8.5-44.0.3.el7 will be erased
+---> Package libstdc++.x86_64 0:4.8.5-44.el7 will be a downgrade
+---> Package libstdc++.x86_64 0:4.8.5-44.0.3.el7 will be erased
+---> Package systemd.x86_64 0:219-78.el7_9.3 will be a downgrade
+---> Package systemd.x86_64 0:219-78.0.5.el7_9.3 will be erased
+---> Package systemd-libs.x86_64 0:219-78.el7_9.3 will be a downgrade
+---> Package systemd-libs.x86_64 0:219-78.0.5.el7_9.3 will be erased
+---> Package systemd-sysv.x86_64 0:219-78.el7_9.3 will be a downgrade
+---> Package systemd-sysv.x86_64 0:219-78.0.5.el7_9.3 will be erased
+--> Finished Dependency Resolution
+Error: Package: gcc-c++-4.8.5-44.0.3.el7.x86_64 (@ol7_latest)
+           Requires: libstdc++ = 4.8.5-44.0.3.el7
+           Removing: libstdc++-4.8.5-44.0.3.el7.x86_64 (installed)
+               libstdc++ = 4.8.2-16.el7
+               libstdc++ = 4.8.5-44.0.3.el7
+           Downgraded By: libstdc++-4.8.5-44.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7
+               libstdc++ = 4.8.5-44.el7
+           Available: libstdc++-4.8.2-16.el7.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7
+           Available: libstdc++-4.8.2-16.2.el7_0.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.2.el7_0
+           Available: libstdc++-4.8.3-9.el7.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7
+               libstdc++ = 4.8.3-9.el7
+           Available: libstdc++-4.8.5-4.el7.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7
+               libstdc++ = 4.8.5-4.el7
+           Available: libstdc++-4.8.5-11.el7.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7
+               libstdc++ = 4.8.5-11.el7
+           Available: libstdc++-4.8.5-16.el7.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7
+               libstdc++ = 4.8.5-16.el7
+           Available: libstdc++-4.8.5-16.el7_4.1.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7_4
+               libstdc++ = 4.8.5-16.el7_4.1
+           Available: libstdc++-4.8.5-16.el7_4.2.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7_4
+               libstdc++ = 4.8.5-16.el7_4.2
+           Available: libstdc++-4.8.5-28.el7.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7
+               libstdc++ = 4.8.5-28.el7
+           Available: libstdc++-4.8.5-28.el7_5.1.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7_5
+               libstdc++ = 4.8.5-28.el7_5.1
+           Available: libstdc++-4.8.5-36.el7.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7
+               libstdc++ = 4.8.5-36.el7
+           Available: libstdc++-4.8.5-36.el7_6.1.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7_6
+               libstdc++ = 4.8.5-36.el7_6.1
+           Available: libstdc++-4.8.5-36.el7_6.2.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7_6
+               libstdc++ = 4.8.5-36.el7_6.2
+           Available: libstdc++-4.8.5-39.el7.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7
+               libstdc++ = 4.8.5-39.el7
+Error: Package: libstdc++-devel-4.8.5-44.0.3.el7.x86_64 (@ol7_latest)
+           Requires: libstdc++(x86-64) = 4.8.5-44.0.3.el7
+           Removing: libstdc++-4.8.5-44.0.3.el7.x86_64 (installed)
+               libstdc++(x86-64) = 4.8.5-44.0.3.el7
+           Downgraded By: libstdc++-4.8.5-44.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-44.el7
+           Available: libstdc++-4.8.2-16.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.2-16.el7
+           Available: libstdc++-4.8.2-16.2.el7_0.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.2-16.2.el7_0
+           Available: libstdc++-4.8.3-9.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.3-9.el7
+           Available: libstdc++-4.8.5-4.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-4.el7
+           Available: libstdc++-4.8.5-11.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-11.el7
+           Available: libstdc++-4.8.5-16.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-16.el7
+           Available: libstdc++-4.8.5-16.el7_4.1.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-16.el7_4.1
+           Available: libstdc++-4.8.5-16.el7_4.2.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-16.el7_4.2
+           Available: libstdc++-4.8.5-28.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-28.el7
+           Available: libstdc++-4.8.5-28.el7_5.1.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-28.el7_5.1
+           Available: libstdc++-4.8.5-36.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-36.el7
+           Available: libstdc++-4.8.5-36.el7_6.1.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-36.el7_6.1
+           Available: libstdc++-4.8.5-36.el7_6.2.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-36.el7_6.2
+           Available: libstdc++-4.8.5-39.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-39.el7
+Error: Package: gcc-4.8.5-44.0.3.el7.x86_64 (@ol7_latest)
+           Requires: libgcc >= 4.8.5-44.0.3.el7
+           Removing: libgcc-4.8.5-44.0.3.el7.x86_64 (installed)
+               libgcc = 4.8.2-16.el7
+               libgcc = 4.8.5-44.0.3.el7
+           Downgraded By: libgcc-4.8.5-44.el7.x86_64 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7
+               libgcc = 4.8.5-44.el7
+           Available: libgcc-4.8.2-16.el7.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7
+           Available: libgcc-4.8.2-16.2.el7_0.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.2.el7_0
+           Available: libgcc-4.8.3-9.el7.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7
+               libgcc = 4.8.3-9.el7
+           Available: libgcc-4.8.5-4.el7.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7
+               libgcc = 4.8.5-4.el7
+           Available: libgcc-4.8.5-11.el7.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7
+               libgcc = 4.8.5-11.el7
+           Available: libgcc-4.8.5-16.el7.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7
+               libgcc = 4.8.5-16.el7
+           Available: libgcc-4.8.5-16.el7_4.1.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7_4
+               libgcc = 4.8.5-16.el7_4.1
+           Available: libgcc-4.8.5-16.el7_4.2.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7_4
+               libgcc = 4.8.5-16.el7_4.2
+           Available: libgcc-4.8.5-28.el7.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7
+               libgcc = 4.8.5-28.el7
+           Available: libgcc-4.8.5-28.el7_5.1.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7_5
+               libgcc = 4.8.5-28.el7_5.1
+           Available: libgcc-4.8.5-36.el7.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7
+               libgcc = 4.8.5-36.el7
+           Available: libgcc-4.8.5-36.el7_6.1.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7_6
+               libgcc = 4.8.5-36.el7_6.1
+           Available: libgcc-4.8.5-36.el7_6.2.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7_6
+               libgcc = 4.8.5-36.el7_6.2
+           Available: libgcc-4.8.5-39.el7.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7
+               libgcc = 4.8.5-39.el7
+**********************************************************************
+yum can be configured to try to resolve such errors by temporarily enabling
+disabled repos and searching for missing dependencies.
+To enable this functionality please set 'notify_only=0' in /etc/yum/pluginconf.d/search-disabled-repos.conf
+**********************************************************************
+
+Error: Package: gcc-c++-4.8.5-44.0.3.el7.x86_64 (@ol7_latest)
+           Requires: libstdc++ = 4.8.5-44.0.3.el7
+           Removing: libstdc++-4.8.5-44.0.3.el7.x86_64 (installed)
+               libstdc++ = 4.8.2-16.el7
+               libstdc++ = 4.8.5-44.0.3.el7
+           Downgraded By: libstdc++-4.8.5-44.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7
+               libstdc++ = 4.8.5-44.el7
+           Available: libstdc++-4.8.2-16.el7.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7
+           Available: libstdc++-4.8.2-16.2.el7_0.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.2.el7_0
+           Available: libstdc++-4.8.3-9.el7.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7
+               libstdc++ = 4.8.3-9.el7
+           Available: libstdc++-4.8.5-4.el7.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7
+               libstdc++ = 4.8.5-4.el7
+           Available: libstdc++-4.8.5-11.el7.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7
+               libstdc++ = 4.8.5-11.el7
+           Available: libstdc++-4.8.5-16.el7.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7
+               libstdc++ = 4.8.5-16.el7
+           Available: libstdc++-4.8.5-16.el7_4.1.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7_4
+               libstdc++ = 4.8.5-16.el7_4.1
+           Available: libstdc++-4.8.5-16.el7_4.2.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7_4
+               libstdc++ = 4.8.5-16.el7_4.2
+           Available: libstdc++-4.8.5-28.el7.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7
+               libstdc++ = 4.8.5-28.el7
+           Available: libstdc++-4.8.5-28.el7_5.1.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7_5
+               libstdc++ = 4.8.5-28.el7_5.1
+           Available: libstdc++-4.8.5-36.el7.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7
+               libstdc++ = 4.8.5-36.el7
+           Available: libstdc++-4.8.5-36.el7_6.1.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7_6
+               libstdc++ = 4.8.5-36.el7_6.1
+           Available: libstdc++-4.8.5-36.el7_6.2.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7_6
+               libstdc++ = 4.8.5-36.el7_6.2
+           Available: libstdc++-4.8.5-39.el7.i686 (rhel-7-server-rpms)
+               libstdc++ = 4.8.2-16.el7
+               libstdc++ = 4.8.5-39.el7
+Error: Package: libstdc++-devel-4.8.5-44.0.3.el7.x86_64 (@ol7_latest)
+           Requires: libstdc++(x86-64) = 4.8.5-44.0.3.el7
+           Removing: libstdc++-4.8.5-44.0.3.el7.x86_64 (installed)
+               libstdc++(x86-64) = 4.8.5-44.0.3.el7
+           Downgraded By: libstdc++-4.8.5-44.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-44.el7
+           Available: libstdc++-4.8.2-16.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.2-16.el7
+           Available: libstdc++-4.8.2-16.2.el7_0.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.2-16.2.el7_0
+           Available: libstdc++-4.8.3-9.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.3-9.el7
+           Available: libstdc++-4.8.5-4.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-4.el7
+           Available: libstdc++-4.8.5-11.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-11.el7
+           Available: libstdc++-4.8.5-16.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-16.el7
+           Available: libstdc++-4.8.5-16.el7_4.1.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-16.el7_4.1
+           Available: libstdc++-4.8.5-16.el7_4.2.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-16.el7_4.2
+           Available: libstdc++-4.8.5-28.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-28.el7
+           Available: libstdc++-4.8.5-28.el7_5.1.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-28.el7_5.1
+           Available: libstdc++-4.8.5-36.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-36.el7
+           Available: libstdc++-4.8.5-36.el7_6.1.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-36.el7_6.1
+           Available: libstdc++-4.8.5-36.el7_6.2.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-36.el7_6.2
+           Available: libstdc++-4.8.5-39.el7.x86_64 (rhel-7-server-rpms)
+               libstdc++(x86-64) = 4.8.5-39.el7
+Error: Package: gcc-4.8.5-44.0.3.el7.x86_64 (@ol7_latest)
+           Requires: libgcc >= 4.8.5-44.0.3.el7
+           Removing: libgcc-4.8.5-44.0.3.el7.x86_64 (installed)
+               libgcc = 4.8.2-16.el7
+               libgcc = 4.8.5-44.0.3.el7
+           Downgraded By: libgcc-4.8.5-44.el7.x86_64 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7
+               libgcc = 4.8.5-44.el7
+           Available: libgcc-4.8.2-16.el7.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7
+           Available: libgcc-4.8.2-16.2.el7_0.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.2.el7_0
+           Available: libgcc-4.8.3-9.el7.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7
+               libgcc = 4.8.3-9.el7
+           Available: libgcc-4.8.5-4.el7.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7
+               libgcc = 4.8.5-4.el7
+           Available: libgcc-4.8.5-11.el7.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7
+               libgcc = 4.8.5-11.el7
+           Available: libgcc-4.8.5-16.el7.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7
+               libgcc = 4.8.5-16.el7
+           Available: libgcc-4.8.5-16.el7_4.1.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7_4
+               libgcc = 4.8.5-16.el7_4.1
+           Available: libgcc-4.8.5-16.el7_4.2.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7_4
+               libgcc = 4.8.5-16.el7_4.2
+           Available: libgcc-4.8.5-28.el7.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7
+               libgcc = 4.8.5-28.el7
+           Available: libgcc-4.8.5-28.el7_5.1.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7_5
+               libgcc = 4.8.5-28.el7_5.1
+           Available: libgcc-4.8.5-36.el7.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7
+               libgcc = 4.8.5-36.el7
+           Available: libgcc-4.8.5-36.el7_6.1.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7_6
+               libgcc = 4.8.5-36.el7_6.1
+           Available: libgcc-4.8.5-36.el7_6.2.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7_6
+               libgcc = 4.8.5-36.el7_6.2
+           Available: libgcc-4.8.5-39.el7.i686 (rhel-7-server-rpms)
+               libgcc = 4.8.2-16.el7
+               libgcc = 4.8.5-39.el7
+ You could try using --skip-broken to work around the problem
+** Found 1 pre-existing rpmdb problem(s), 'yum check' output follows:
+initscripts-9.49.53-1.0.1.el7_9.1.x86_64 has missing requires of oraclelinux-release

--- a/tests/integration/tier1/resolve-dependency/install_dependency_packages.py
+++ b/tests/integration/tier1/resolve-dependency/install_dependency_packages.py
@@ -27,6 +27,10 @@ def get_system_version(system_release_content=None):
 
 
 def test_install_dependency_packages(shell):
+    """Having certain packages installed used to cause conversion failures - namely yum dependency resolution errors.
+
+    This test verifies that having these packages pre-installed does not cause a failure anymore
+    """
 
     with open("/etc/system-release", "r") as file:
         system_release = file.read()
@@ -40,6 +44,7 @@ def test_install_dependency_packages(shell):
                 "python2-dnf-plugins-core",  # OAMG-4690
                 "redhat-lsb-trialuse",  # OAMG-4942
                 "ldb-tools",  # OAMG-4941
+                "gcc-c++",  # OAMG-6136
                 "python-requests",  # OAMG-4936
             ]
         elif system_version.major == 8:


### PR DESCRIPTION
The regular expression that was being used to parse package names out of
yum output was missing gcc-c++, NetworkManager, and other package names.
Using a simpler regex and a function that parses the package names from
the rest of the NVR should fix that.

This fixes a user visible problem where packages like gcc-c++ can cause
convert2rhel to fail to downgrade packages.  This is because gcc-c++
would be missed by the regex and thus we'd be unable to figure out that
we need to downgrade gcc-c++ when at the same time as we downgrade gcc.

Resolves [OAMG-6136](https://issues.redhat.com/browse/OAMG-6136).