### PR TITLE
Change timestamp format for breadcrumbs

### DIFF
--- a/convert2rhel/breadcrumbs.py
+++ b/convert2rhel/breadcrumbs.py
@@ -21,7 +21,7 @@ import os
 import re
 import sys
 
-from time import gmtime, strftime
+from datetime import datetime
 
 from convert2rhel import pkghandler, systeminfo
 
@@ -113,7 +113,7 @@ class Breadcrumbs(object):
 
     def _get_formated_time(self):
         """Set timestamp in format YYYYMMDDHHMMZ"""
-        return strftime("%Y%m%dT%H%M%Z", gmtime())
+        return datetime.utcnow().isoformat() + "Z"
 
     def _set_env(self):
         """Catch and set CONVERT2RHEL_ environment variables"""


### PR DESCRIPTION
This PR changes how the timestamp output is presented in the
/etc/migrations-results is presented on the file.

Before, it used `gmlocal()` which outputs the current time in GMT, now, this
file will have `utcnow()` timestamp output to be more equal on how leapp do
their breadcrumbs.

with gmlocal():
            "activity_started": "20211201T1810GMT",
            "activity_ended": "20211201T1811GMT",

with utcnow():
            "activity_started": "2021-12-02T11:56:07.425477Z",
            "activity_ended": "2021-12-02T11:56:59.478299Z",


Reference ticket: https://issues.redhat.com/browse/OAMG-6139