### PR TITLE
Set LANG env var to C the same as LC_ALL

### DIFF
--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -586,11 +586,13 @@ def get_rpm_header(rpm_path, _open=open):
 
 
 def set_locale():
-    """Set the POSIX default locale for the main process as well as the child processes.
+    """Set the C locale, also known as the POSIX locale, for the main process as well as the child processes.
 
     The reason is to get predictable output from the executables we call, not influenced by non-default locale.
+    We need to be setting not only LC_ALL but LANG as well because subscription-manager considers LANG to have priority
+    over LC_ALL even though it goes against POSIX which specifies that LC_ALL overrides LANG.
     """
-    os.environ.update({"LC_ALL": "C"})
+    os.environ.update({"LC_ALL": "C", "LANG": "C"})
 
 
 changed_pkgs_control = ChangedRPMPackagesController()  # pylint: disable=C0103


### PR DESCRIPTION
Not setting the LANG was causing the RHSM registration to fail because subscription-manager considers LANG to have priority over LC_ALL. That goes against [POSIX which specifies that LC_ALL overrides LANG](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html#tag_08_02). So even though we were setting LC_ALL to C which should warrant only ASCII output, the output of subscription-manager contains non-ASCII characters.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2022854