### PR TITLE
Port run_subprocess to take the command as a list instead of a string.

### DIFF
--- a/convert2rhel/redhatrelease.py
+++ b/convert2rhel/redhatrelease.py
@@ -100,7 +100,7 @@ class YumConf(object):
         """Return true if the YUM/DNF configuration file has been modified by the user."""
         conf = "/etc/yum.conf" if pkgmanager.TYPE == "yum" else "/etc/dnf/dnf.conf"
 
-        output, _ = utils.run_subprocess("rpm -Vf %s" % conf, print_output=False)
+        output, _ = utils.run_subprocess(["rpm", "-Vf", conf], print_output=False)
         # rpm -Vf does not return information about the queried file but about all files owned by the rpm
         # that owns the queried file. Character '5' on position 3 means that the file was modified.
         return True if re.search(r"^.{2}5.*? %s$" % conf, output, re.MULTILINE) else False

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -145,7 +145,7 @@ class SystemInfo(object):
         return version
 
     def _get_architecture(self):
-        arch, _ = utils.run_subprocess("uname -i", print_output=False)
+        arch, _ = utils.run_subprocess(["uname", "-i"], print_output=False)
         arch = arch.strip()  # Remove newline
         self.logger.info("%-20s %s" % ("Architecture:", arch))
         return arch
@@ -230,7 +230,7 @@ class SystemInfo(object):
         return self._get_cfg_opt("kmods_to_ignore").split()
 
     def _get_booted_kernel(self):
-        kernel_vra = run_subprocess("uname -r", print_output=False)[0].rstrip()
+        kernel_vra = run_subprocess(["uname", "-r"], print_output=False)[0].rstrip()
         self.logger.debug("Booted kernel VRA (version, release, architecture): {0}".format(kernel_vra))
         return kernel_vra
 
@@ -249,7 +249,7 @@ class SystemInfo(object):
             " minutes. It can be disabled by using the"
             " --no-rpm-va option."
         )
-        rpm_va, _ = utils.run_subprocess("rpm -Va", print_output=False)
+        rpm_va, _ = utils.run_subprocess(["rpm", "-Va"], print_output=False)
         output_file = os.path.join(logger.LOG_DIR, log_filename)
         utils.store_content_to_file(output_file, rpm_va)
         self.logger.info("The 'rpm -Va' output has been stored in the %s file" % output_file)
@@ -283,7 +283,7 @@ class SystemInfo(object):
 
     @staticmethod
     def is_rpm_installed(name):
-        _, return_code = run_subprocess("rpm -q '%s'" % name, print_cmd=False, print_output=False)
+        _, return_code = run_subprocess(["rpm", "-q", name], print_cmd=False, print_output=False)
         return return_code == 0
 
     # TODO write unit tests

--- a/convert2rhel/unit_tests/__init__.py
+++ b/convert2rhel/unit_tests/__init__.py
@@ -181,7 +181,7 @@ class CountableMockObject(MockFunction):
 def is_rpm_based_os():
     """Check if the OS is rpm based."""
     try:
-        run_subprocess("rpm")
+        run_subprocess(["rpm"])
     except EnvironmentError:
         return False
     else:
@@ -257,7 +257,7 @@ def run_subprocess_side_effect(*stubs):
 
     def factory(*args, **kwargs):
         for kws, result in stubs:
-            if all(kw in args[0].split() for kw in kws):
+            if all(kw in args[0] for kw in kws):
                 return result
         else:
             return run_subprocess(*args, **kwargs)

--- a/convert2rhel/unit_tests/grub_test.py
+++ b/convert2rhel/unit_tests/grub_test.py
@@ -109,7 +109,7 @@ def test__get_partition(monkeypatch, caplog, expected_res, directory, exception,
         assert grub._get_partition(directory) == expected_res
         assert len(caplog.records) == 0
     utils.run_subprocess.assert_called_once_with(
-        "/usr/sbin/grub2-probe --target=device %s" % directory, print_output=False
+        ["/usr/sbin/grub2-probe", "--target=device", directory], print_output=False
     )
 
 
@@ -132,7 +132,7 @@ def test__get_blk_device(monkeypatch, caplog, expected_res, device, exception, s
         assert grub._get_blk_device(device) == expected_res
 
     if subproc_called:
-        utils.run_subprocess.assert_called_once_with("lsblk -spnlo name %s" % device, print_output=False)
+        utils.run_subprocess.assert_called_once_with(["lsblk", "-spnlo", "name", device], print_output=False)
 
     else:
         utils.run_subprocess.assert_not_called()
@@ -157,7 +157,7 @@ def test__get_device_number(monkeypatch, caplog, expected_res, device, exc, subp
         assert grub._get_device_number(device) == expected_res
 
     if subproc_called:
-        utils.run_subprocess.assert_called_once_with("lsblk -spnlo MAJ:MIN %s" % device, print_output=False)
+        utils.run_subprocess.assert_called_once_with(["lsblk", "-spnlo", "MAJ:MIN", device], print_output=False)
     else:
         utils.run_subprocess.assert_not_called()
         assert len(caplog.records) == 0
@@ -453,7 +453,7 @@ def test_efibootinfo(
         assert current_bootnum in efibootinfo_obj.entries
 
     if subproc_called:
-        utils.run_subprocess.assert_called_once_with("/usr/sbin/efibootmgr -v", print_output=False)
+        utils.run_subprocess.assert_called_once_with(["/usr/sbin/efibootmgr", "-v"], print_output=False)
     else:
         utils.run_subprocess.assert_not_called()
 

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -84,7 +84,7 @@ class TestSubscription(unittest.TestCase):
             self.tuples = tuples
             self.default_tuple = ("output", 0)
             self.called = 0
-            self.cmd = ""
+            self.cmd = []
 
         def __call__(self, cmd, *args, **kwargs):
             self.cmd = cmd
@@ -139,7 +139,7 @@ class TestSubscription(unittest.TestCase):
     def test_get_registration_cmd(self):
         tool_opts.username = "user"
         tool_opts.password = "pass with space"
-        expected = 'subscription-manager register --force --username=user --password="pass with space"'
+        expected = ["subscription-manager", "register", "--force", "--username=user", "--password=pass with space"]
         self.assertEqual(subscription.get_registration_cmd(), expected)
 
     @unit_tests.mock(subscription, "get_avail_subs", GetAvailSubsMocked())
@@ -219,7 +219,14 @@ class TestSubscription(unittest.TestCase):
         tool_opts.username = "user"
         tool_opts.password = "pass"
         tool_opts.serverurl = "url"
-        expected = 'subscription-manager register --force --username=user --password="pass" --serverurl="url"'
+        expected = [
+            "subscription-manager",
+            "register",
+            "--force",
+            "--username=user",
+            "--password=pass",
+            "--serverurl=url",
+        ]
         self.assertEqual(subscription.get_registration_cmd(), expected)
 
     @unit_tests.mock(subscription.logging, "getLogger", GetLoggerMocked())
@@ -295,7 +302,7 @@ class TestSubscription(unittest.TestCase):
 
     @unit_tests.mock(os.path, "isdir", lambda x: True)
     @unit_tests.mock(os, "listdir", lambda x: ["filename"])
-    @unit_tests.mock(pkghandler, "call_yum_cmd", lambda a, b, enable_repos, disable_repos, set_releasever: (None, 1))
+    @unit_tests.mock(pkghandler, "call_yum_cmd", lambda a, args, enable_repos, disable_repos, set_releasever: (None, 1))
     def test_install_rhel_subscription_manager_unable_to_install(self):
         self.assertRaises(SystemExit, subscription.install_rhel_subscription_manager)
 

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -166,7 +166,7 @@ class TestSysteminfo(unittest.TestCase):
         system_info.generate_rpm_va()
 
         self.assertTrue(utils.run_subprocess.called > 0)
-        self.assertEqual(utils.run_subprocess.used_args[0][0], "rpm -Va")
+        self.assertEqual(utils.run_subprocess.used_args[0][0], ["rpm", "-Va"])
         self.assertTrue(os.path.isfile(self.rpmva_output_file))
         self.assertEqual(utils.get_file_content(self.rpmva_output_file), "rpmva\n")
 


### PR DESCRIPTION
Security hardening: change the run_subprocess() function to take the command as a list instead of a string.

This is complete and ready for review. @Andrew-ang9 and I have been working on this together.

Implements: https://issues.redhat.com/browse/OAMG-6183