### PR TITLE
Fix lazy-object-proxy version in requirements for centos7

### DIFF
--- a/requirements/centos7.requirements.txt
+++ b/requirements/centos7.requirements.txt
@@ -4,3 +4,4 @@ pytest==4.6.11
 pytest-cov==2.11.0
 mock==2.0.0
 pathlib2==2.3.5
+lazy-object-proxy==1.6.0


### PR DESCRIPTION
When running the lint or tests in the CI, the image fails to build because of
the dependency version for `lazy-object-proxy` being v1.7.0, this PR intends
to fix the version to v.1.6.0 as it's the working version.

Output of CI failing because of the dep version:
* https://github.com/oamg/convert2rhel/runs/4534232358?check_suite_focus=true#step:4:686

Output of `pipdeptree`:
```bash
[root@c3e8cf79269c /]# pipdeptree
pylint==1.9.5
  - astroid [required: >=1.6,<2.0, installed: 1.6.6]
    - backports.functools-lru-cache [required: Any, installed: 1.6.4]
    - enum34 [required: >=1.1.3, installed: 1.1.10]
    - lazy-object-proxy [required: Any, installed: 1.6.0]
    - singledispatch [required: Any, installed: 3.7.0]
      - six [required: Any, installed: 1.16.0]
    - six [required: Any, installed: 1.16.0]
    - wrapt [required: Any, installed: 1.13.3]
  - backports.functools-lru-cache [required: Any, installed: 1.6.4]
  - configparser [required: Any, installed: 4.0.2]
  - isort [required: >=4.2.5, installed: 4.3.21]
    - backports.functools-lru-cache [required: Any, installed: 1.6.4]
    - futures [required: Any, installed: 3.3.0]
  - mccabe [required: Any, installed: 0.6.1]
  - singledispatch [required: Any, installed: 3.7.0]
    - six [required: Any, installed: 1.16.0]
  - six [required: Any, installed: 1.16.0]
```

Output of `pip show lazy-object-proxy`:
```bash
[root@c3e8cf79269c /]# pip show lazy-object-proxy
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support pip 21.0 will remove support for this functionality.
Name: lazy-object-proxy
Version: 1.6.0
Summary: A fast and thorough lazy object proxy.
Home-page: https://github.com/ionelmc/python-lazy-object-proxy
Author: Ionel Cristian Mărieș
Author-email: contact@ionelmc.ro
License: BSD-2-Clause
Location: /usr/lib64/python2.7/site-packages
Requires:
Required-by: astroid
```

Jira reference (If any):
Bugzilla reference (If any):