### PR TITLE
Add dependabot.yml for keeping track of deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Maintain dependencies for pip
+  - package-ecosystem: "pip"
+    directory: "requirements/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Add a really simple configuration for dependabot, it tracks down the
`actions` and `pip` dependencies to keep them up-to-date.

Jira reference: https://issues.redhat.com/browse/OAMG-6328
Bugzilla reference (If any):