### PR TITLE
tests: increase VM timeout from 10 to 15m

### DIFF
--- a/tests/ansible_collections/reboot.yml
+++ b/tests/ansible_collections/reboot.yml
@@ -3,4 +3,4 @@
   tasks:
     - name: Reboot into RHEL
       reboot:
-        reboot_timeout: 600
+        reboot_timeout: 900


### PR DESCRIPTION
The current integration tests for os7 are very flaky and fails most of the time. Increasing it from 10m to 15m should hopefully address most cases for now