### PR TITLE
Add checks for handling SIGINT events

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,3 +225,68 @@ For building the copr locally, you will need:
 ```bash
 make copr-build
 ```
+
+### Avoiding calling yum API in some specific cases
+
+We found out a bug that happened during the handling of a SIGINT
+signal (or pressing CTRL + C), the problem was caused when a user pressed those
+combination of keys during any step of the conversion before the point of no
+return, thus, starting the process of rollback and failing in the first call
+`yum` call to check wether or not some packages were installed on the system.
+
+The problem is that when we enter in that state of rollback after a SIGINT,
+`librpm` is handling the signal on their code (without any possibility to
+change this) and when the librpm detects that a SIGINT was raised, it
+understands that the execution of process should stop and a exit code 1 is sent
+to the user. One way to bypass that is not calling `yum` methods that actually
+trigger `librpm` in the process, instead, prefer calling the `yum` binary or
+any other binary that achieve the same output you desire. The reason for this
+change is that `librpm` won't trigger their handling of SIGINT if we call the
+binary directly with `call_yum_cmd` or `run_subporcess` for example, as it
+understands it's a new process and that process wasn't in the middle of the
+SIGINT raising.
+
+For example, checkout the
+[PR#411](https://github.com/oamg/convert2rhel/pull/411/files#diff-51e9ff11d39778d3b26778b293fc350430a82e2feed0dab2938da7c0069ffdc6R84)
+that introduced the change, as well, some exaplantion on why the code was
+changed from calling the yum API to calling the `rpm` command.
+
+Another example is this minimal code reproduction from
+[@abadger](https://github.com/abadger) where you can see the issue.
+
+And lastly, here's a reference ticket that originated this issue
+[OAMG-5756](https://issues.redhat.com/browse/OAMG-5756).
+
+```python
+#!/usr/bin/python2 -tt
+import time
+from yum import YumBase
+from rpmUtils.miscutils import checkSignals
+
+yb = YumBase()
+try:
+    #yb.doConfigSetup(init_plugins=False)
+    yb.runTransaction(False)
+except (BaseException, SystemExit, Exception) as e:
+    print('We were able to catch an exception from runTransaction!')
+    print(type(e))
+    print(e)
+print('Sleeping')
+time.sleep(3)
+# Hit Ctrl-C
+# If KeyboardInterrupt is raised, chances are that this did not cause the
+# problem
+try:
+    checkSignals()
+except (BaseException, SystemExit, Exception) as e:
+    print('We were able to catch an exception from checkSignals!')
+    print(type(e))
+    print(e)
+finally:
+    print('In the finally block')
+# If the previous try: except  exits immediately without message, then the
+# issue occurred.
+# If it raises a KeyboardInterrupt traceback then we're okay.
+# If it prints out anything then we're either okay or encountering a different
+# behaviour.
+```

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -371,7 +371,7 @@ def _get_installed_pkg_objects_dnf(name):
     installed = query.installed()
     if name:
         # name__glob provides "shell-style wildcard match" per
-        #  https://dnf.readthedocs.io/en/latest/api_queries.html#dnf.query.Query.filter
+        # https://dnf.readthedocs.io/en/latest/api_queries.html#dnf.query.Query.filter
         installed = installed.filter(name__glob=name)
     return list(installed)
 

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -82,11 +82,11 @@ def unregister_system():
         return
 
     # We are calling run_subprocess with rpm here because of a bug in
-    # Oracle/CentOS Linux 7 in which the process always exit with 1 in case of a
-    # rollback when KeyboardInterrupt is raised, so, to avoid many changes and
-    # different conditionals, we are doing a simple call for rpm to verify if
+    # Oracle/CentOS Linux 7 in which the process always exits with 1 in case of a
+    # rollback when KeyboardInterrupt is raised.  To avoid many changes and
+    # different conditionals to handle that, we are doing a simple call to rpm to verify if
     # subscription-manager is installed on the system.  This is the current line
-    # on `rpm` that causes the process to exit with any interaction with the yum
+    # in `rpm` that causes the process to exit with any interaction with the yum
     # library
     # https://github.com/rpm-software-management/rpm/blob/rpm-4.11.x/lib/rpmdb.c#L640
     _, ret_code = utils.run_subprocess(["rpm", "--quiet", "-q", "subscription-manager"])

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -28,8 +28,7 @@ from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel import pkghandler, subscription, utils
 from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts
-
-from . import GetLoggerMocked
+from convert2rhel.unit_tests import GetLoggerMocked, run_subprocess_side_effect
 
 
 if sys.version_info[:2] <= (2, 7):
@@ -74,6 +73,14 @@ class TestSubscription(unittest.TestCase):
     class GetRegistrationCmdMocked(unit_tests.MockFunction):
         def __call__(self):
             return "subscription-manager register whatever-options"
+
+    class CallRegistrationCmdMocked(unit_tests.MockFunction):
+        def __init__(self, cmd):
+            self.cmd = cmd
+
+        def __call__(self, cmd):
+            self.cmd = cmd
+            return ("User interrupted process.", 0)
 
     class RunSubprocessMocked(unit_tests.MockFunction):
         def __init__(self, tuples=None):
@@ -241,6 +248,11 @@ class TestSubscription(unittest.TestCase):
         subscription.register_system()
         self.assertEqual(utils.run_subprocess.called, 3)
         self.assertEqual(len(subscription.logging.getLogger.critical_msgs), 0)
+
+    @unit_tests.mock(subscription, "get_registration_cmd", GetRegistrationCmdMocked())
+    @unit_tests.mock(subscription, "call_registration_cmd", CallRegistrationCmdMocked("cmd"))
+    def test_register_system_fail_with_keyboardinterrupt(self):
+        self.assertRaises(KeyboardInterrupt, subscription.register_system)
 
     def test_hiding_password(self):
         test_cmd = "subscription-manager register --force " '--username=jdoe --password="%s" --org=0123'
@@ -488,37 +500,49 @@ def test_download_rhsm_pkgs(version, downloaded_pkgs, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    ("submgr_installed", "unregistration_failure"),
-    (
-        (True, True),
-        (True, False),
-        (False, True),
-        (False, False),
-    ),
+    ("output", "ret_code", "expected"),
+    (("", 0, "System unregistered successfully."), ("Failed to unregister.", 1, "System unregistration failed")),
 )
-def test_unregister_system(submgr_installed, unregistration_failure, monkeypatch, caplog):
-    if unregistration_failure:
-        monkeypatch.setattr(utils, "run_subprocess", mock.Mock(return_value=("output", 1)))
-    else:
-        monkeypatch.setattr(utils, "run_subprocess", mock.Mock(return_value=("output", 0)))
+def test_unregister_system(output, ret_code, expected, monkeypatch, caplog):
+    submgr_command = ("subscription-manager", "unregister")
+    rpm_command = ("rpm", "--quiet", "-q", "subscription-manager")
 
-    if submgr_installed:
-        monkeypatch.setattr(
-            pkghandler, "get_installed_pkg_objects", lambda _: [namedtuple("Pkg", ["name"])("subscription-manager")]
-        )
-    else:
-        monkeypatch.setattr(pkghandler, "get_installed_pkg_objects", lambda _: None)
+    # Mock rpm command
+    run_subprocess_mock = mock.Mock(
+        side_effect=run_subprocess_side_effect(
+            (
+                submgr_command,
+                (
+                    output,
+                    ret_code,
+                ),
+            ),
+            (rpm_command, ("", 0)),
+        ),
+    )
+    monkeypatch.setattr(utils, "run_subprocess", value=run_subprocess_mock)
 
     subscription.unregister_system()
 
-    if submgr_installed:
-        utils.run_subprocess.assert_called_once()
-        if unregistration_failure:
-            assert "System unregistration failed" in caplog.text
-        else:
-            assert "System unregistered successfully." in caplog.text
-    else:
-        assert "The subscription-manager package is not installed." in caplog.text
+    assert expected in caplog.records[-1].message
+
+
+def test_unregister_system_submgr_not_found(monkeypatch, caplog):
+    rpm_command = "rpm --quiet -q subscription-manager"
+    run_subprocess_mock = mock.Mock(
+        side_effect=unit_tests.run_subprocess_side_effect(
+            ((rpm_command,), ("", 1)),
+        )
+    )
+    monkeypatch.setattr(utils, "run_subprocess", value=run_subprocess_mock)
+    subscription.unregister_system()
+    assert "The subscription-manager package is not installed." in caplog.records[-1].message
+
+
+def test_unregister_system_keep_rhsm(monkeypatch, caplog):
+    monkeypatch.setattr(tool_opts, "keep_rhsm", value=True)
+    subscription.unregister_system()
+    assert "Skipping due to the use of --keep-rhsm." in caplog.records[-1].message
 
 
 @mock.patch("convert2rhel.toolopts.tool_opts.keep_rhsm", True)
@@ -559,7 +583,9 @@ def test_verify_rhsm_installed(submgr_installed, keep_rhsm, critical_string, mon
 
     if submgr_installed:
         monkeypatch.setattr(
-            pkghandler, "get_installed_pkg_objects", lambda _: [namedtuple("Pkg", ["name"])("subscription-manager")]
+            pkghandler,
+            "get_installed_pkg_objects",
+            lambda _: [namedtuple("Pkg", ["name"])("subscription-manager")],
         )
 
         subscription.verify_rhsm_installed()


### PR DESCRIPTION
The changes proposed here are intended to solve a problem that involves
the way we deal with SIGINT signals that are captured and processed by
subprocesses or third-party libraries.

This commit solves two problems, the first being regarding the
`subscription-manager` subprocess managing the SIGINT signals and the
second, this time being `librpm` intercepting such signals internally in
its C code.

Jira reference (If any): https://issues.redhat.com/browse/OAMG-5756
Bugzilla reference (If any):

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>