### PR TITLE
Fix regex in integration test for OL not standard kernel

### DIFF
--- a/tests/ansible_collections/roles/oracle-linux-specific/tasks/boot_standard_kernel.yml
+++ b/tests/ansible_collections/roles/oracle-linux-specific/tasks/boot_standard_kernel.yml
@@ -5,7 +5,7 @@
     state: latest
 
 - name: Get installed kernel version
-  shell: rpm -q --last kernel | head -1 |  gawk 'match($0, /kernel-(.+) \s+.+/, s) {print s[1]}'
+  shell: rpm -q --last kernel | head -1 | cut -d " " -f1 | sed 's/kernel-//'
   register: kernel_ver
 
 - name: Set default kernel to Red Hat compatible kernel

--- a/tests/integration/tier0/inhibit-if-oracle-system-uses-not-standard-kernel/ansible/install_unbreakable_kernel.yml
+++ b/tests/integration/tier0/inhibit-if-oracle-system-uses-not-standard-kernel/ansible/install_unbreakable_kernel.yml
@@ -8,7 +8,7 @@
         state: latest
 
     - name: Get installed kernel version
-      shell: rpm -q --last kernel-uek | head -1 |  gawk 'match($0, /kernel-uek-(.+) \s+.+/, s) {print s[1]}'
+      shell: rpm -q --last kernel-uek | head -1 | cut -d " " -f1 | sed 's/kernel-uek-//'
       register: kernel_ver
 
     - name: Set default kernel to the unbreakable kernel


### PR DESCRIPTION
The regex inside the integration test `inhibit-if-oracle-system-uses-not-standard-kernel` stopped working. We decided to simplify it and also change a similar regex in other place so it has the same approach.
This PR fixes this issue.