### PR TITLE
Do not update convert2rhel package during test preparation step

### DIFF
--- a/tests/ansible_collections/roles/update-system/tasks/update-system.yml
+++ b/tests/ansible_collections/roles/update-system/tasks/update-system.yml
@@ -3,6 +3,10 @@
   yum:
     name: "*"
     state: latest
+    # In case the package is already installed on the system (by user or CI system)
+    # and the version of the package is not the latest in copr repo it would be
+    # updated at this point. The package version would then differ from the intended one.
+    exclude: convert2rhel
   register: update
 
 - name: Reboot


### PR DESCRIPTION
Scenario:
We make a request to a testing farm and tell it to install artifact (convert2rhel package). TF then install this package in artifact installation phase. This happens before the the preparation phase in our playbook (`plans/main.fmf`). If the installed package is not the latest version inside the copr repo it then will be updated during our playbook installation. This would break the test case where we want to test specific version of the package (eg. some older PR build).