### PR TITLE
Add EXTRA_ARGS to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ PIP ?= pip3
 VENV ?= .venv3
 PRE_COMMIT ?= pre-commit
 SHOW_CAPTURE ?= no
+PYTEST_ARGS ?=
 
 # Let the user specify DOCKER at the CLI, otherwise try to autodetect a working podman or docker
 ifndef DOCKER
@@ -49,7 +50,7 @@ install: .install .images .env .pre-commit
 	cp .env.example .env
 
 tests-locally: install
-	. $(VENV)/bin/activate; pytest
+	. $(VENV)/bin/activate; pytest $(PYTEST_ARGS)
 
 lint-locally: install
 	. $(VENV)/bin/activate; ./scripts/run_lint.sh
@@ -79,11 +80,11 @@ tests: tests7 tests8
 
 tests7: images
 	@echo 'CentOS Linux 7 tests'
-	@$(DOCKER) run --rm --user=$(id -ur):$(id -gr) -v $(shell pwd):/data:Z $(IMAGE)/centos7 pytest --show-capture=$(SHOW_CAPTURE)
+	@$(DOCKER) run --rm --user=$(id -ur):$(id -gr) -v $(shell pwd):/data:Z $(IMAGE)/centos7 pytest --show-capture=$(SHOW_CAPTURE) $(PYTEST_ARGS)
 
 tests8: images
 	@echo 'CentOS Linux 8 tests'
-	@$(DOCKER) run --rm --user=$(id -ur):$(id -gr) -v $(shell pwd):/data:Z $(IMAGE)/centos8 pytest --show-capture=$(SHOW_CAPTURE)
+	@$(DOCKER) run --rm --user=$(id -ur):$(id -gr) -v $(shell pwd):/data:Z $(IMAGE)/centos8 pytest --show-capture=$(SHOW_CAPTURE) $(PYTEST_ARGS)
 
 rpms: images
 	mkdir -p .rpms

--- a/convert2rhel/unit_tests/README.md
+++ b/convert2rhel/unit_tests/README.md
@@ -117,7 +117,7 @@ make tests7
 make tests8
 ```
 
-If you're willing to pass extra arguments for the pytest execution inside the container
+If you want to pass extra arguments for the pytest execution inside the container
 you can do so by just using the variable `PYTEST_ARGS` after the make command you
 are trying to use, like this:
 

--- a/convert2rhel/unit_tests/README.md
+++ b/convert2rhel/unit_tests/README.md
@@ -117,6 +117,26 @@ make tests7
 make tests8
 ```
 
+If you're willing to pass extra arguments for the pytest execution inside the container
+you can do so by just using the variable `PYTEST_ARGS` after the make command you
+are trying to use, like this:
+
+```bash
+# Run only the test_something test case
+make tests7 PYTEST_ARGS="-k test_something"
+
+# Print pytest version
+make tests7 PYTEST_ARGS="--version"
+```
+
+The same is true when you're trying to execute the tests both with `make tests7` and
+`make tests8`, the `PYTEST_ARGS` will be passed down to both of them
+
+```bash
+# Print pytest version in both containers
+make tests PYTEST_ARGS="--version"
+```
+
 ### Locally
 
 To run the tests locally, you can use an alteady made `make` command we have


### PR DESCRIPTION
This small improvement is to allow us to pass different parameters to the pytest
runner without having to modify anything in the Makefile when necessary.

For example, we can do `make tests EXTRA_ARGS="-k test_efibootinfo"` to test only
this specific test inside the centos7 and 8 containers.

Jira reference (If any): https://issues.redhat.com/browse/OAMG-6434
Bugzilla reference (If any):

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>