### PR TITLE
Update CentOS 8 mirrors in Dockerfile

### DIFF
--- a/Dockerfiles/centos8.Dockerfile
+++ b/Dockerfiles/centos8.Dockerfile
@@ -4,7 +4,7 @@ ENV PYTHON python3
 ENV PIP pip3
 ENV PYTHONDONTWRITEBYTECODE 1
 
-ENV URL_GET_PIP "https://bootstrap.pypa.io/pip/get-pip.py"
+ENV URL_GET_PIP "https://bootstrap.pypa.io/pip/3.6/get-pip.py"
 ENV APP_DEV_DEPS "requirements/centos8.requirements.txt"
 ENV APP_MAIN_DEPS \
     python3 \
@@ -14,6 +14,10 @@ ENV APP_MAIN_DEPS \
 WORKDIR /data
 
 FROM base as install_main_deps
+
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
 RUN dnf update -y && dnf install -y $APP_MAIN_DEPS && dnf clean all
 
 FROM install_main_deps as install_dev_deps

--- a/Dockerfiles/rpmbuild.centos8.Dockerfile
+++ b/Dockerfiles/rpmbuild.centos8.Dockerfile
@@ -1,5 +1,8 @@
 FROM centos:8 as base
 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
 RUN dnf update -y && dnf clean all
 
 ENV APP_MAIN_DEPS \


### PR DESCRIPTION
The CentOS 8 reached EOL in december and archived all their mirorrs from
mirrors.centos.org to vault.centos.org, this broke our CI system and fresh local
development images as well.

Jira reference (If any): https://issues.redhat.com/browse/OAMG-6445
Bugzilla reference (If any):