### PR TITLE
Stop if the booted kernel is not owned by any package

### DIFF
--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -705,41 +705,60 @@ def test_bad_kernel_substring(kernel_release, exp_return, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    ("kernel_release", "kernel_pkg", "kernel_pkg_fingerprint", "exp_return"),
+    ("kernel_release", "kernel_pkg", "kernel_pkg_fingerprint", "get_installed_pkg_objects", "exp_return"),
     (
         (
             "4.18.0-240.22.1.el8_3.x86_64",
             "kernel-core",
             "05b555b38483c65d",
+            "yajl.x86_64",
             False,
         ),
         (
             "4.18.0-240.22.1.el8_3.x86_64",
             "kernel-core",
             "somebadsig",
+            "somepkgobj",
             True,
         ),
     ),
 )
 @centos8
-def test_bad_kernel_fingerprint(
+def test_bad_kernel_package_signature(
     kernel_release,
     kernel_pkg,
     kernel_pkg_fingerprint,
+    get_installed_pkg_objects,
     exp_return,
     monkeypatch,
     pretend_os,
 ):
-    run_subprocess_mocked = mock.Mock(spec=run_subprocess, return_value=(kernel_pkg, ""))
+    run_subprocess_mocked = mock.Mock(spec=run_subprocess, return_value=(kernel_pkg, 0))
     get_pkg_fingerprint_mocked = mock.Mock(spec=get_pkg_fingerprint, return_value=kernel_pkg_fingerprint)
+    monkeypatch.setattr(system_info, "name", "CentOS Linux")
     monkeypatch.setattr(checks, "run_subprocess", run_subprocess_mocked)
+    get_installed_pkg_objects_mocked = mock.Mock(spec=get_installed_pkg_objects, return_value=[kernel_pkg])
     monkeypatch.setattr(
         checks,
         "get_installed_pkg_objects",
-        mock.Mock(return_value=[kernel_pkg]),
+        get_installed_pkg_objects_mocked,
     )
     monkeypatch.setattr(checks, "get_pkg_fingerprint", get_pkg_fingerprint_mocked)
     assert _bad_kernel_package_signature(kernel_release) == exp_return
+    run_subprocess_mocked.assert_called_with(
+        ["rpm", "-qf", "--qf", "%{NAME}", "/boot/vmlinuz-%s" % kernel_release], print_output=False
+    )
+
+
+def test_kernel_not_installed(caplog, monkeypatch):
+    run_subprocess_mocked = mock.Mock(spec=run_subprocess, return_value=(" ", 1))
+    monkeypatch.setattr(checks, "run_subprocess", run_subprocess_mocked)
+    assert _bad_kernel_package_signature("4.18.0-240.22.1.el8_3.x86_64")
+    log_message = (
+        "The booted kernel /boot/vmlinuz-4.18.0-240.22.1.el8_3.x86_64 is not owned by any installed package."
+        " It needs to be owned by a package signed by CentOS."
+    )
+    assert log_message in caplog.text
 
 
 class TestReadOnlyMountsChecks(unittest.TestCase):


### PR DESCRIPTION
adds a unit test to catch where the tag "{{NAME}}" has an extra set of curly brace.

This error was fixed in the PR https://github.com/oamg/convert2rhel/pull/389

if you'd like to test this use the commit hash 31a304c63f815efe77fa32170a7f3d253a559310 to use the istant with the error
and use commit hash 9a1c5f50e44d2a098e2458263580d748e7ba6282 for the fix for this error

Jira ticket: [RHELC-126](https://issues.redhat.com/browse/RHELC-126)