### PR TITLE
Add integration tests for user response during registration

### DIFF
--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -1,6 +1,10 @@
 discover+:
     tier: 0
 
+/check_user_response:
+  discover+:
+    test: check-user-response
+
 /check_custom_repo:
   discover+:
     test: check-custom-repo

--- a/tests/integration/tier0/check-user-response/main.fmf
+++ b/tests/integration/tier0/check-user-response/main.fmf
@@ -1,0 +1,6 @@
+summary: check user response during registration
+
+tier: 0
+
+test: |
+  pytest -svv

--- a/tests/integration/tier0/check-user-response/test_user_response.py
+++ b/tests/integration/tier0/check-user-response/test_user_response.py
@@ -1,0 +1,21 @@
+def test_check_user_response(convert2rhel):
+
+    # Run c2r registration with no username
+    with convert2rhel("-y " "--no-rpm-va") as c2r:
+        c2r.expect(" ... activation key not found, username and password required")
+        c2r.expect("Username: ")
+        c2r.sendline()
+        if c2r.expect("Username: ") == 0:
+            c2r.sendcontrol("d")
+    assert c2r.exitstatus != 0
+
+    # Run c2r registration with username but no password
+    with convert2rhel("-y " "--no-rpm-va") as c2r:
+        c2r.expect(" ... activation key not found, username and password required")
+        c2r.expect("Username: ")
+        c2r.sendline("foo")
+        c2r.expect("Password: ")
+        c2r.sendline()
+        if c2r.expect("Password: ") == 0:
+            c2r.sendcontrol("d")
+    assert c2r.exitstatus != 0

--- a/tests/integration/tier0/check-user-response/test_user_response.py
+++ b/tests/integration/tier0/check-user-response/test_user_response.py
@@ -5,8 +5,8 @@ def test_check_user_response(convert2rhel):
         c2r.expect(" ... activation key not found, username and password required")
         c2r.expect("Username: ")
         c2r.sendline()
-        if c2r.expect("Username: ") == 0:
-            c2r.sendcontrol("d")
+        assert c2r.expect("Username: ") == 0
+        c2r.sendcontrol("d")
     assert c2r.exitstatus != 0
 
     # Run c2r registration with username but no password
@@ -16,6 +16,6 @@ def test_check_user_response(convert2rhel):
         c2r.sendline("foo")
         c2r.expect("Password: ")
         c2r.sendline()
-        if c2r.expect("Password: ") == 0:
-            c2r.sendcontrol("d")
+        assert c2r.expect("Password: ") == 0
+        c2r.sendcontrol("d")
     assert c2r.exitstatus != 0

--- a/tests/integration/tier0/check-user-response/test_user_response.py
+++ b/tests/integration/tier0/check-user-response/test_user_response.py
@@ -1,21 +1,27 @@
+from envparse import env
+
+
 def test_check_user_response(convert2rhel):
 
-    # Run c2r registration with no username
-    with convert2rhel("-y " "--no-rpm-va") as c2r:
+    # Run c2r registration with no username and password provided
+    # check for user prompt enforcing input, then continue with registration
+    with convert2rhel(
+        "-y --no-rpm-va --serverurl {}".format(
+            env.str("RHSM_SERVER_URL"),
+        )
+    ) as c2r:
         c2r.expect(" ... activation key not found, username and password required")
         c2r.expect("Username: ")
         c2r.sendline()
         assert c2r.expect("Username: ") == 0
-        c2r.sendcontrol("d")
-    assert c2r.exitstatus != 0
-
-    # Run c2r registration with username but no password
-    with convert2rhel("-y " "--no-rpm-va") as c2r:
-        c2r.expect(" ... activation key not found, username and password required")
-        c2r.expect("Username: ")
-        c2r.sendline("foo")
+        # Provide username, expect password prompt
+        c2r.sendline(env.str("RHSM_USERNAME"))
         c2r.expect("Password: ")
         c2r.sendline()
         assert c2r.expect("Password: ") == 0
+        # Provide password, expect registration
+        c2r.sendline(env.str("RHSM_PASSWORD"))
+        assert c2r.expect("Registering the system using subscription-manager ...") == 0
+        assert c2r.expect("Enter number of the chosen subscription: ") == 0
         c2r.sendcontrol("d")
     assert c2r.exitstatus != 0


### PR DESCRIPTION
Integration test for #390.

During registration, while no username nor password was provided check if user prompt requests input for said data.
Then continue with the registration properly.