### PR TITLE
Add integration test to verify requiring root

### DIFF
--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -1,6 +1,10 @@
 discover+:
     tier: 0
 
+/check_user_privileges:
+  discover+:
+    test: check-privileges
+
 /check_custom_repo:
   discover+:
     test: check-custom-repo

--- a/tests/integration/tier0/check-privileges/main.fmf
+++ b/tests/integration/tier0/check-privileges/main.fmf
@@ -1,0 +1,6 @@
+summary: check user privileges
+
+tier: 0
+
+test: |
+  pytest -svv

--- a/tests/integration/tier0/check-privileges/test_user_privileges.py
+++ b/tests/integration/tier0/check-privileges/test_user_privileges.py
@@ -1,0 +1,17 @@
+import os
+
+
+def test_check_user_privileges(shell):
+    user = "testuser"
+    # Create non-root user if not created already
+    os.system(f"useradd '{user}'")
+    # Set user to non-root entity 'testuser' and run c2r
+    result = shell("runuser -l testuser -c 'convert2rhel'")
+    # Check the program exits as it is required to be run by root
+    assert result.returncode != 0
+    # Check the program exits for the correct reason
+    assert (
+        result.output == "The tool needs to be run under the root user.\n" "\n" "No changes were made to the system.\n"
+    )
+    # Delete testuser (if present)
+    os.system(f"userdel -r '{user}'")


### PR DESCRIPTION
Run as a basic user and check for the program to exit as it is required to run as root.

Relates to https://github.com/oamg/convert2rhel/pull/81.