### PR TITLE
Split ansible playbook into setup and executing stages.

### DIFF
--- a/ansible/run-convert2rhel.yml
+++ b/ansible/run-convert2rhel.yml
@@ -1,0 +1,46 @@
+- name: Run setup tasks
+  import_playbook: setup-convert2rhel.yml
+
+- hosts: all
+  become: yes
+  strategy: free
+
+  # Modify these to be your red hat subscription manager username and password
+  # or override them via ansible-playbook --extra-vars
+  vars:
+    rhsm_username: redhat-user-name
+    rhsm_password: redhat-users-password
+
+  tasks:
+
+    # NOTE 1: use the -y option to answer yes to all yes/no questions the
+    # tool asks carefully and only after you have tested interactively to
+    # ensure that there are not surprises within your environment.  Also
+    # take care to read and follow all prerequisites and backup guidance documented at
+    # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/converting_from_an_rpm-based_linux_distribution_to_rhel/index
+
+    # NOTE 2: the following command may take 20-40 minutes on average to
+    # complete, depending on quantity of packages installed and speed of
+    # network and storage.  This will need to be run in parallel from the
+    # control node or Tower to effectively run against many systems.
+
+    - name: Run Convert2RHEL
+      command: >
+        convert2rhel
+        -u "{{ rhsm_username }}"
+        -p "{{ rhsm_password }}"
+        --auto-attach
+        --debug
+        #        -y
+
+    - name: reboot
+      reboot:
+
+    - name: recollect ansible facts on running distribution on system
+      setup:
+        gather_subset: 'distribution'
+
+    - name: Verify system is converted to Red Hat Enterprise Linux (RHEL)
+      assert:
+        that: ansible_distribution == 'RedHat'
+        msg: "OS conversion failed. OS is NOT Red Hat"

--- a/ansible/setup-convert2rhel.yml
+++ b/ansible/setup-convert2rhel.yml
@@ -2,9 +2,9 @@
   become: yes
   strategy: free
 
+  # You may modify these to fit your environment or use ansible-playbook --extra-vars
+  # to override them if needed.
   vars:
-    rhsm_username: redhat-user-name
-    rhsm_password: redhat-users-password
     skip_os_version_check: false
     # added for RHELDST-7822
     SSLCACERT: "https://ftp.redhat.com/redhat/convert2rhel/redhat-uep.pem"
@@ -56,35 +56,3 @@
     - name: Install Convert2RHEL
       yum:
         name: convert2rhel
-
-    # NOTE 1: use the -y option to answer yes to all yes/no questions the
-    # tool asks carefully and only after you have tested interactively to
-    # ensure that there are not surprises within your environment.  Also
-    # take care to read and follow all prerequisites and backup guidance documented at
-    # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/converting_from_an_rpm-based_linux_distribution_to_rhel/index
-
-    # NOTE 2: the following command may take 20-40 minutes on average to
-    # complete, depending on quantity of packages installed and speed of
-    # network and storage.  This will need to be run in parallel from the
-    # control node or Tower to effectively run against many systems.
-
-    - name: Run Convert2RHEL
-      command: >
-        convert2rhel
-        -u "{{ rhsm_username }}"
-        -p "{{ rhsm_password }}"
-        --auto-attach
-        --debug
-        -y
-
-    - name: reboot
-      reboot:
-
-    - name: recollect ansible facts on running distribution on system
-      setup:
-        gather_subset: 'distribution'
-
-    - name: Verify system is converted to Red Hat Enterprise Linux (RHEL)
-      assert:
-        that: ansible_distribution == 'RedHat'
-        msg: "OS conversion failed. OS is NOT Red Hat"


### PR DESCRIPTION
We may start pointing end users at these playbooks to install and run
convert2rhel.  An end user may want to setup the environment separately
from running convert2rhel so we need to split the two steps into
separate playbooks.

The idea of modifying CentOS 8.5 systems to use vault repositories prior
to running convert2rhel was the prompt for doing this.

Note, @tabowling, this PR is only for the split, not the other things that we talked about doing in the meeting.  IIRC, those were:

* Use activation key instead of rhsm username and password
  * Point users at documentation on setting an activation key
  * Add the ability to give the activation key in a file instead of at the command line.
* If the user is on CentOS 8.5, make sure their repositories are pointed at vault rather than mirrors.centos.org
  * Change their repository files if necessary

/CC @tabowling @bocekm 