### PR TITLE
Do not back up subscription-manager-initial-setup-addon

### DIFF
--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -242,10 +242,8 @@ def remove_original_subscription_manager():
             utils.remove_pkgs([_SUBMGR_PKG_REMOVED_IN_CL_85], backup=False, critical=False)
             submgr_pkg_names.remove(_SUBMGR_PKG_REMOVED_IN_CL_85)
 
-    # Make sure that the list of submgr pkg names is not empty before trying to
-    # remove any other submgr pkg on the system
-    if submgr_pkg_names:
-        utils.remove_pkgs(submgr_pkg_names, critical=False)
+    # Remove any oter subscription-manager packages present on the system
+    utils.remove_pkgs(submgr_pkg_names, critical=False)
 
 
 def install_rhel_subscription_manager():

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -376,6 +376,7 @@ class TestSubscription(unittest.TestCase):
     def test_remove_original_subscription_manager(self):
         subscription.remove_original_subscription_manager()
         self.assertEqual(utils.remove_pkgs.called, 1)
+
     @unit_tests.mock(
         pkghandler,
         "get_installed_pkg_objects",

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -227,3 +227,15 @@ discover+:
   - name: reboot after conversion
     how: ansible
     playbook: tests/ansible_collections/roles/reboot/main.yml
+
+/removed_pkgs_centos_85:
+  adjust:
+    enabled: false
+    when: >
+      distro != centos-8
+  discover+:
+    test: removed-pkgs-centos-85
+  prepare+:
+    - name: install removed pkgs from CentOS 8.5
+      how: ansible
+      playbook: tests/integration/tier1/removed-pkgs-centos-85/ansible/install_removed_pkgs_from_centos_85_repos.yml

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -234,8 +234,14 @@ discover+:
     when: >
       distro != centos-8
   discover+:
-    test: removed-pkgs-centos-85
+    test: checks-after-conversion
   prepare+:
     - name: install removed pkgs from CentOS 8.5
       how: ansible
       playbook: tests/integration/tier1/removed-pkgs-centos-85/ansible/install_removed_pkgs_from_centos_85_repos.yml
+    - name: main conversion preparation
+      how: shell
+      script: pytest -svv tests/integration/tier1/removed-pkgs-centos-85/test_removed_pkgs_centos_85.py
+    - name: reboot after conversion
+      how: ansible
+      playbook: tests/ansible_collections/roles/reboot/main.yml

--- a/tests/integration/tier1/removed-pkgs-centos-85/ansible/install_removed_pkgs_from_centos_85_repos.yml
+++ b/tests/integration/tier1/removed-pkgs-centos-85/ansible/install_removed_pkgs_from_centos_85_repos.yml
@@ -4,14 +4,14 @@
       yum_repository:
         name: baseos-84
         description: CentOS Linux 8.4.2105 - BaseOS
-        baseurl: http://vault.centos.org/$contentdir/8.4.2105/BaseOS/$basearch/os/
+        baseurl: https://vault.centos.org/$contentdir/8.4.2105/BaseOS/$basearch/os/
         enabled: no
         gpgcheck: no
     - name: Add Centos 8.4.2105 AppStream repo
       yum_repository:
         name: appstream-84
         description: CentOS Linux 8.4.2105 - AppStream
-        baseurl: http://vault.centos.org/$contentdir/8.4.2105/AppStream/$basearch/os/
+        baseurl: https://vault.centos.org/$contentdir/8.4.2105/AppStream/$basearch/os/
         enabled: no
         gpgcheck: no
     - name: Install package which isn't in CentOS 8.5 anymore

--- a/tests/integration/tier1/removed-pkgs-centos-85/ansible/install_removed_pkgs_from_centos_85_repos.yml
+++ b/tests/integration/tier1/removed-pkgs-centos-85/ansible/install_removed_pkgs_from_centos_85_repos.yml
@@ -1,0 +1,21 @@
+- hosts: all
+  tasks:
+    - name: Add Centos 8.4.2105 BaseOS repo
+      yum_repository:
+        name: baseos-84
+        description: CentOS Linux 8.4.2105 - BaseOS
+        baseurl: http://vault.centos.org/$contentdir/8.4.2105/BaseOS/$basearch/os/
+        enabled: no
+        gpgcheck: no
+    - name: Add Centos 8.4.2105 AppStream repo
+      yum_repository:
+        name: appstream-84
+        description: CentOS Linux 8.4.2105 - AppStream
+        baseurl: http://vault.centos.org/$contentdir/8.4.2105/AppStream/$basearch/os/
+        enabled: no
+        gpgcheck: no
+    - name: Install package which isn't in CentOS 8.5 anymore
+      yum:
+        name: subscription-manager-initial-setup-addon
+        enablerepo: "appstream-84,baseos-84"
+        state: present

--- a/tests/integration/tier1/removed-pkgs-centos-85/main.fmf
+++ b/tests/integration/tier1/removed-pkgs-centos-85/main.fmf
@@ -1,0 +1,10 @@
+summary: Removed pkgs from CentOS 8.5
+
+tier: 1
+
+adjust:
+  enabled: false
+  when: >
+    distro != centos-8
+
+test: pytest -svv

--- a/tests/integration/tier1/removed-pkgs-centos-85/test_removed_pkgs_centos_85.py
+++ b/tests/integration/tier1/removed-pkgs-centos-85/test_removed_pkgs_centos_85.py
@@ -1,0 +1,16 @@
+from envparse import env
+
+
+def test_removed_pkgs_centos_85(convert2rhel, shell):
+    assert shell("rpm -qi subscription-manager-initial-setup-addon").returncode == 0
+
+    with convert2rhel(
+        ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        c2r.expect("Conversion successful!")
+    assert c2r.exitstatus == 0


### PR DESCRIPTION
Right now the `subscription-manager-initial-setup-addon` package exists in CentOS Linux 8.4, but was removed from CentOS Linux 8.5. That is causing a conversion error when that package is present on a CentOS Linux 8.5 system because convert2rhel is unable to back it up for rollback purposes.

The simplest fix to this is not backing up the package when we remove it as the backup process uses `yumdownloader` and therefore, `yumdownloader` uses any enabled repos that are present on the system.

This primary scenario to cover:
1. I have CentOS Linux 8.4 and I install subscription-manager-initial-setup-addon (it's available in the default repos)
2. I update the system to 8.5 (and I still have the package installed)
3. I run convert2rhel and shouldn't fail on backing up the package as it's N/A in 8.5 repos anymore (it does fail now)

The secondary scenario to cover:
1. I have CentOS Linux 8.4 and I install subscription-manager-initial-setup-addon (it's available in the default repos)
2. I run convert2rhel to convert to RHEL 8.4 EUS and it correctly backs up the package as we hardcode CentOS Linux 8.4 repos in convert2rhel

Jira reference (If any): https://issues.redhat.com/browse/OAMG-6422
Bugzilla reference (If any): https://bugzilla.redhat.com/show_bug.cgi?id=2046292

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>