### PR TITLE
Change http to https for CentOS8 URLs

### DIFF
--- a/Dockerfiles/centos8.Dockerfile
+++ b/Dockerfiles/centos8.Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /data
 FROM base as install_main_deps
 
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \
-    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
 
 RUN dnf update -y && dnf install -y $APP_MAIN_DEPS && dnf clean all
 

--- a/Dockerfiles/rpmbuild.centos8.Dockerfile
+++ b/Dockerfiles/rpmbuild.centos8.Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:8 as base
 
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \
-    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
 
 RUN dnf update -y && dnf clean all
 

--- a/tests/ansible_collections/roles/install-submgr/install_submgr_from_centos_8.yml
+++ b/tests/ansible_collections/roles/install-submgr/install_submgr_from_centos_8.yml
@@ -4,7 +4,7 @@
       yum_repository:
         name: baseos
         description: CentOS Linux 8 BaseOS
-        baseurl: http://vault.centos.org/centos/8/BaseOS/x86_64/os/
+        baseurl: https://vault.centos.org/centos/8/BaseOS/x86_64/os/
         gpgcheck: no
 
     - name: Install subscription-manager from the CentOS Linux 8 BaseOS repo (signed by CentOS)

--- a/tests/integration/tier1/remove-all-submgr-pkgs/ansible/install_submgr_8.yml
+++ b/tests/integration/tier1/remove-all-submgr-pkgs/ansible/install_submgr_8.yml
@@ -4,7 +4,7 @@
       yum_repository:
         name: baseos
         description: CentOS Linux 8 BaseOS
-        baseurl: http://vault.centos.org/centos/8/BaseOS/x86_64/os/
+        baseurl: https://vault.centos.org/centos/8/BaseOS/x86_64/os/
         gpgcheck: no
 
     - name: Install subscription-manager from the CentOS Linux 8 BaseOS repo (signed by CentOS)

--- a/tests/integration/tier1/yum-distro-sync/add-extras-repo/oracle8.yml
+++ b/tests/integration/tier1/yum-distro-sync/add-extras-repo/oracle8.yml
@@ -4,7 +4,7 @@
       yum_repository:
         name: centos8-extras
         description: CentOS extras for $basearch
-        baseurl: http://mirror.centos.org/centos-8/8/extras/$basearch/os/
+        baseurl: https://vault.centos.org/centos/8/extras/$basearch/os/
         gpgcheck: no
         enabled: yes
         file: centos8-extras


### PR DESCRIPTION
It seems that the protocol in C8 URLs changed from `http` to secure `https`. Let's see if this fixes the issues.