### PR TITLE
Fix rebooting machines

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -6,6 +6,9 @@ prepare:
   - name: main preparation step
     how: ansible
     playbook: tests/ansible_collections/main.yml
+  - name: reboot system after update
+    how: ansible
+    playbook: tests/ansible_collections/roles/reboot/main.yml
   - name: install latest copr build
     how: install
     copr: '@oamg/convert2rhel'

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -8,9 +8,9 @@ discover+:
   - name: main conversion preparation
     how: shell
     script: pytest -svv tests/integration/tier1/method/activation_key.py
-  - name: reboot machine
+  - name: reboot after conversion
     how: ansible
-    playbook: tests/ansible_collections/reboot.yml
+    playbook: tests/ansible_collections/roles/reboot/main.yml
 
 /rhsm:
   discover+:
@@ -19,9 +19,9 @@ discover+:
   - name: main conversion preparation
     how: shell
     script: pytest -svv tests/integration/tier1/method/rhsm.py
-  - name: reboot machine
+  - name: reboot after conversion
     how: ansible
-    playbook: tests/ansible_collections/reboot.yml
+    playbook: tests/ansible_collections/roles/reboot/main.yml
 
 /satellite:
   discover+:
@@ -30,9 +30,9 @@ discover+:
   - name: main conversion preparation
     how: shell
     script: pytest -svv tests/integration/tier1/method/satellite.py
-  - name: reboot machine
+  - name: reboot after conversion
     how: ansible
-    playbook: tests/ansible_collections/reboot.yml
+    playbook: tests/ansible_collections/roles/reboot/main.yml
 
 /custom_repos:
   discover+:
@@ -44,9 +44,9 @@ discover+:
   - name: main conversion preparation
     how: shell
     script: pytest -svv tests/integration/tier1/method/custom_repos.py
-  - name: reboot machine
+  - name: reboot after conversion
     how: ansible
-    playbook: tests/ansible_collections/reboot.yml
+    playbook: tests/ansible_collections/roles/reboot/main.yml
 
 /changed_yum_conf:
   discover+:
@@ -55,9 +55,9 @@ discover+:
   - name: main conversion preparation
     how: shell
     script: pytest -svv tests/integration/tier1/changed-yum-conf/test_patch_yum_conf.py
-  - name: reboot machine
+  - name: reboot after conversion
     how: ansible
-    playbook: tests/ansible_collections/reboot.yml
+    playbook: tests/ansible_collections/roles/reboot/main.yml
 
 /remove_excluded_pkgs:
   adjust:
@@ -70,9 +70,9 @@ discover+:
   - name: main conversion preparation
     how: shell
     script: pytest -svv tests/integration/tier1/remove-excluded-pkgs/test_remove_excluded_pkgs.py
-  - name: reboot machine
+  - name: reboot after conversion
     how: ansible
-    playbook: tests/ansible_collections/reboot.yml
+    playbook: tests/ansible_collections/roles/reboot/main.yml
 
 /remove_all_submgr_pkgs:
   discover+:
@@ -85,9 +85,9 @@ discover+:
   - name: main conversion preparation
     how: shell
     script: pytest -svv tests/integration/tier1/remove-all-submgr-pkgs/test_remove_all_submgr_pkgs.py
-  - name: reboot machine
+  - name: reboot after conversion
     how: ansible
-    playbook: tests/ansible_collections/reboot.yml
+    playbook: tests/ansible_collections/roles/reboot/main.yml
 
 /resolve_dependency:
   # There is no dependecy package for Oracle Linux 8
@@ -106,9 +106,9 @@ discover+:
   - name: main conversion preparation
     how: shell
     script: pytest -svv tests/integration/tier1/method/rhsm.py
-  - name: reboot machine
+  - name: reboot after conversion
     how: ansible
-    playbook: tests/ansible_collections/reboot.yml
+    playbook: tests/ansible_collections/roles/reboot/main.yml
 
 /one_kernel_scenario:
   adjust:
@@ -127,19 +127,19 @@ discover+:
     script: pytest -svv tests/integration/tier1/one-kernel-scenario/install_one_kernel.py
   - name: reboot machine
     how: ansible
-    playbook: tests/ansible_collections/reboot.yml
+    playbook: tests/ansible_collections/roles/reboot/main.yml
   - name: remove other kernels
     how: shell
     script: pytest -svv tests/integration/tier1/one-kernel-scenario/remove_other_kernels.py
   - name: reboot machine
     how: ansible
-    playbook: tests/ansible_collections/reboot.yml
+    playbook: tests/ansible_collections/roles/reboot/main.yml
   - name: run conversion
     how: shell
     script: pytest -svv tests/integration/tier1/one-kernel-scenario/run_conversion.py
-  - name: reboot machine
+  - name: reboot after conversion
     how: ansible
-    playbook: tests/ansible_collections/reboot.yml
+    playbook: tests/ansible_collections/roles/reboot/main.yml
 
 /language_test:
   discover+:
@@ -151,9 +151,9 @@ discover+:
   - name: main conversion preparation
     how: shell
     script: pytest -svv tests/integration/tier1/method/activation_key.py
-  - name: reboot machine
+  - name: reboot after conversion
     how: ansible
-    playbook: tests/ansible_collections/reboot.yml
+    playbook: tests/ansible_collections/roles/reboot/main.yml
 
 /missing_os_release:
   discover+:
@@ -165,9 +165,9 @@ discover+:
   - name: main conversion preparation
     how: shell
     script: pytest -svv tests/integration/tier1/method/satellite.py
-  - name: reboot machine
+  - name: reboot after conversion
     how: ansible
-    playbook: tests/ansible_collections/reboot.yml
+    playbook: tests/ansible_collections/roles/reboot/main.yml
 
 /yum_distro_sync:
   discover+:
@@ -182,6 +182,6 @@ discover+:
     - name: main conversion preparation
       how: shell
       script: pytest -svv tests/integration/tier1/yum-distro-sync/test_yum_distro_sync.py
-    - name: reboot machine
+    - name: reboot after conversion
       how: ansible
-      playbook: tests/ansible_collections/reboot.yml
+      playbook: tests/ansible_collections/roles/reboot/main.yml

--- a/tests/ansible_collections/reboot.yml
+++ b/tests/ansible_collections/reboot.yml
@@ -1,6 +1,0 @@
----
-- hosts: all
-  tasks:
-    - name: Reboot into RHEL
-      reboot:
-        reboot_timeout: 600

--- a/tests/ansible_collections/roles/oracle-linux-specific/tasks/boot_standard_kernel.yml
+++ b/tests/ansible_collections/roles/oracle-linux-specific/tasks/boot_standard_kernel.yml
@@ -10,7 +10,3 @@
 
 - name: Set default kernel to Red Hat compatible kernel
   shell: "grubby --set-default /boot/vmlinuz-{{ kernel_ver.stdout }}"
-
-- name: Reboot
-  reboot:
-    reboot_timeout: 600

--- a/tests/ansible_collections/roles/reboot/main.yml
+++ b/tests/ansible_collections/roles/reboot/main.yml
@@ -1,0 +1,22 @@
+---
+- hosts: all
+  tasks:
+    - name: Reboot the system
+      reboot:
+        reboot_timeout: 900
+      register: back_again
+      ignore_errors: yes
+
+    - name: Wait additional 10 minutes and try to reconnect (in case of previous task timeout/connection issue)
+      wait_for_connection:
+        timeout: 600
+      # when reboot is successful "changed" is true
+      register: back_again2
+      when: not back_again.changed
+      ignore_errors: yes
+
+    - name: Wait additional 5 minutes as last resort (really slow env)
+      wait_for_connection:
+        timeout: 300
+      when: not back_again2.changed
+      register: back_again3

--- a/tests/ansible_collections/roles/update-system/tasks/update-system.yml
+++ b/tests/ansible_collections/roles/update-system/tasks/update-system.yml
@@ -8,10 +8,3 @@
     # updated at this point. The package version would then differ from the intended one.
     exclude: convert2rhel
   register: update
-
-- name: Reboot
-  reboot:
-  # we need reboot only CentOS, because OL will be
-  #   rebooted in later steps (booting into standard kernel)
-  when: (ansible_facts['distribution'] == "CentOS") and
-        (update.changed)

--- a/tests/ansible_collections/update_templates.yml
+++ b/tests/ansible_collections/update_templates.yml
@@ -1,8 +1,0 @@
----
-- hosts: all
-  tasks:
-
-    - name: Update system
-      yum:
-        name: "*"
-        state: latest


### PR DESCRIPTION
As @mkluson suggested in the https://issues.redhat.com/browse/OAMG-6415 we can try add extra steps for reboot steps. The problem may be that the system reboots correctly, however the ansible play has trouble connecting back to the machine. 

This PR:

- use extra steps to the reboot role so it's able to reconnect to the machine
- there were 3 places where we had a reboot role implemented. Instead use just one role, so it's easier to maintain. This requires updating all test plans that use reboot.
- remove update_templates.yml file as it is not used anymore. We have an update role already.
