### PR TITLE
Ignore pylint 1.x.x we use for CentOS Linux 6/7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "pylint"
+        # ignore major version 1.x.x we use for CentOS Linux 6 and 7 where version 2.x.x is not available
+        versions: ["1.x.x"]


### PR DESCRIPTION
On these systems pylint 2.x.x is not available.

I'm not sure if Dependabot is going to ignore the 1.x.x version we use. Maybe the ignore clause checks only the version it would update the dependency **to** (not **from**).