### PR TITLE
Remove unused CentOS Linux 6 pip deps file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,22 +12,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "pylint"
-        # ignore major version 1.x.x we use for CentOS Linux 6 and 7 where
-        # version 2.x.x is not available
-        versions: ["1.x.x"]
-
-      - dependency-name: "pytest"
-        # ignore major version 3.x.x and 4.x.x since we use it for CentOS 6/7
-        # and newer versions are not available for these systems
-        versions: ["3.x.x", "4.x.x"]
-
-      - dependency-name: "astroid"
-        # ignore major version 1.x.x we use for CentOS Linux 6 and 7 where
-        # version 2.x.x is not available
-        versions: ["1.x.x"]
-
-      - dependency-name: "mock"
-        # ignore version 3.0.5 we use for CentOS Linux 6 and 7 on which version 4.x.x is not available
-        versions: ["3.0.5"]

--- a/requirements/centos6.requirements.txt
+++ b/requirements/centos6.requirements.txt
@@ -1,7 +1,0 @@
-pylint==1.1.0
-astroid==1.6.6
-unittest2==0.5.1
-pytest==3.2.5
-mock==3.0.5
-pytest-catchlog==1.2.2
-pathlib2==2.3.7.post1


### PR DESCRIPTION
We currently don't run anything (tests/analysis) on CentOS Linux 6.

Also, the dependabot ignore clauses do not work as we expected - it ignores just the versions to be updated to, not those to be updated from.