### PR TITLE
Disable CentOS 8 integartion tests in upstream CI

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -42,8 +42,9 @@ jobs:
     targets:
       epel-7-x86_64:
         distros: [centos-7]
-      epel-8-x86_64:
-        distros: [centos-8]
+      # Disabled until C8 repos are stable again, see OAMG-6499, OAMG-6535 for more info
+      #epel-8-x86_64:
+      #  distros: [centos-8]
       oraclelinux-7-x86_64:
         distros: [oraclelinux-7]
       oraclelinux-8-x86_64:


### PR DESCRIPTION
Since CentOS 8 reached EOL the repositories were quite unstable. We
decided to disable running tests in upstream CI until this issue gets
resolved. See OAMG6499 and OAMG-6535 for more information.