### PR TITLE
[RHELC-45] Fix an error logged when removing an RHSM cert

### DIFF
--- a/convert2rhel/cert.py
+++ b/convert2rhel/cert.py
@@ -74,7 +74,7 @@ class SystemCert(object):
             loggerinst.info("Certificate %s removed" % self._target_cert_path)
         except OSError as err:
             if err.errno == 2:
-                """Resolves RHSM error when removing certs, as the system migth not have intalled any certs yet"""
-                loggernist.debug("No RHSM certificates found to be removed")
+                # Resolves RHSM error when removing certs, as the system might not have installed any certs yet
+                loggerinst.debug("No RHSM certificates found to be removed")
             else:
                 loggerinst.error("OSError({0}): {1}".format(err.errno, err.strerror))

--- a/convert2rhel/cert.py
+++ b/convert2rhel/cert.py
@@ -73,4 +73,7 @@ class SystemCert(object):
             os.remove(self._target_cert_path)
             loggerinst.info("Certificate %s removed" % self._target_cert_path)
         except OSError as err:
-            loggerinst.error("OSError({0}): {1}".format(err.errno, err.strerror))
+            if err.errno == 2:
+                pass
+            else:
+                loggerinst.error("OSError({0}): {1}".format(err.errno, err.strerror))

--- a/convert2rhel/cert.py
+++ b/convert2rhel/cert.py
@@ -74,6 +74,7 @@ class SystemCert(object):
             loggerinst.info("Certificate %s removed" % self._target_cert_path)
         except OSError as err:
             if err.errno == 2:
-                pass
+                """Resolves RHSM error when removing certs, as the system migth not have intalled any certs yet"""
+                loggernist.debug("No RHSM certificates found to be removed")
             else:
                 loggerinst.error("OSError({0}): {1}".format(err.errno, err.strerror))

--- a/convert2rhel/cert.py
+++ b/convert2rhel/cert.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import errno
 import logging
 import os
 import shutil
@@ -73,7 +74,7 @@ class SystemCert(object):
             os.remove(self._target_cert_path)
             loggerinst.info("Certificate %s removed" % self._target_cert_path)
         except OSError as err:
-            if err.errno == 2:
+            if err.errno == errno.ENOENT:
                 # Resolves RHSM error when removing certs, as the system might not have installed any certs yet
                 loggerinst.debug("No RHSM certificates found to be removed")
             else:

--- a/convert2rhel/cert.py
+++ b/convert2rhel/cert.py
@@ -76,6 +76,6 @@ class SystemCert(object):
         except OSError as err:
             if err.errno == errno.ENOENT:
                 # Resolves RHSM error when removing certs, as the system might not have installed any certs yet
-                loggerinst.debug("No RHSM certificates found to be removed")
+                loggerinst.info("No RHSM certificates found to be removed.")
             else:
                 loggerinst.error("OSError({0}): {1}".format(err.errno, err.strerror))

--- a/convert2rhel/unit_tests/cert_test.py
+++ b/convert2rhel/unit_tests/cert_test.py
@@ -90,12 +90,12 @@ class TestCert(unittest.TestCase):
         shutil.rmtree(unit_tests.TMP_DIR)
 
 
-def test_remove_cert(caplog, system_cert):
-    cert_filename = system_cert._target_cert_path
+def test_remove_cert(caplog, system_cert_with_target_path):
+    cert_filename = system_cert_with_target_path._target_cert_path
     with open(cert_filename, "wb") as cert_file:
         cert_file.write(b"some content")
 
-    system_cert.remove()
+    system_cert_with_target_path.remove()
 
     assert "/filename removed" in caplog.messages[-1]
 
@@ -113,12 +113,14 @@ def test_remove_cert(caplog, system_cert):
         (OSError(13, "[Errno 13] Permission denied: '/tmpdir/certfile'"), "Permission denied:"),
     ),
 )
-def test_remove_cert_error_conditions(error_condition, expected_text_in_logs, caplog, monkeypatch, system_cert):
+def test_remove_cert_error_conditions(
+    error_condition, expected_text_in_logs, caplog, monkeypatch, system_cert_with_target_path
+):
     def fake_os_remove(path):
         raise error_condition
 
     monkeypatch.setattr(os, "remove", fake_os_remove)
 
-    system_cert.remove()
+    system_cert_with_target_path.remove()
 
     assert expected_text_in_logs != caplog.messages[-1]

--- a/convert2rhel/unit_tests/cert_test.py
+++ b/convert2rhel/unit_tests/cert_test.py
@@ -133,8 +133,6 @@ def test_remove_cert_error_conditions(error_condition, expected_text_in_logs, ca
 
     monkeypatch.setattr(os, "remove", fake_os_remove)
 
-    # Execute the tested code
     remove_cert_setup["sys_cert_instance"].remove()
 
-    # Assert that the test passed
     assert expected_text_in_logs != caplog.messages[-1]

--- a/convert2rhel/unit_tests/cert_test.py
+++ b/convert2rhel/unit_tests/cert_test.py
@@ -98,24 +98,27 @@ def test_remove_cert(caplog, system_cert_with_target_path):
 
     system_cert_with_target_path.remove()
 
-    assert "Certificate /filename removed" in caplog.messages[-1]
+    assert "Certificate %s removed" % cert_file_path in caplog.messages[-1]
 
 
 @pytest.mark.parametrize(
     (
         "error_condition",
-        "expected_text_in_logs",
+        "text_not_expected_in_logs",
     ),
     (
         (
             OSError(2, "No such file or directory"),
             "No such file or directory",
         ),
-        (OSError(13, "[Errno 13] Permission denied: '/tmpdir/certfile'"), "Permission denied:"),
+        (
+            OSError(13, "[Errno 13] Permission denied: '/tmpdir/certfile'"),
+            "OSError(13): Permission denied: '/tmpdir/certfile'",
+        ),
     ),
 )
 def test_remove_cert_error_conditions(
-    error_condition, expected_text_in_logs, caplog, monkeypatch, system_cert_with_target_path
+    error_condition, text_not_expected_in_logs, caplog, monkeypatch, system_cert_with_target_path
 ):
     def fake_os_remove(path):
         raise error_condition
@@ -124,4 +127,5 @@ def test_remove_cert_error_conditions(
 
     system_cert_with_target_path.remove()
 
-    assert expected_text_in_logs != caplog.messages[-1]
+    for message in caplog.messages:
+        assert text_not_expected_in_logs not in message

--- a/convert2rhel/unit_tests/cert_test.py
+++ b/convert2rhel/unit_tests/cert_test.py
@@ -90,26 +90,12 @@ class TestCert(unittest.TestCase):
         shutil.rmtree(unit_tests.TMP_DIR)
 
 
-@pytest.fixture
-def remove_cert_setup(monkeypatch, tmpdir):
-    tmp_file = tmpdir / "filename"
-
-    monkeypatch.setattr(cert.SystemCert, "_get_cert", value=mock.Mock(return_value=("anything", "anything")))
-    monkeypatch.setattr(cert.SystemCert, "_get_target_cert_path", value=mock.Mock(return_value=str(tmp_file)))
-
-    sys_cert = cert.SystemCert()
-
-    return {
-        "cert_path_obj": tmp_file,
-        "sys_cert_instance": sys_cert,
-    }
-
-
 def test_remove_cert(caplog, remove_cert_setup):
-    cert_file = remove_cert_setup["cert_path_obj"]
-    cert_file.write(b"some content")
+    cert_file = system_cert._target_cert_path
+    with open(cert_filename, 'wb') as  cert_file:
+        cert_file.write(b'some content')
 
-    remove_cert_setup["sys_cert_instance"].remove()
+    system_cert[sys_cert].remove()
 
     assert "/filename removed" in caplog.messages[-1]
 

--- a/convert2rhel/unit_tests/cert_test.py
+++ b/convert2rhel/unit_tests/cert_test.py
@@ -98,7 +98,7 @@ def test_remove_cert(caplog, system_cert_with_target_path):
 
     system_cert_with_target_path.remove()
 
-    assert "/filename removed" in caplog.messages[-1]
+    assert "Certificate /filename removed" in caplog.messages[-1]
 
 
 @pytest.mark.parametrize(

--- a/convert2rhel/unit_tests/cert_test.py
+++ b/convert2rhel/unit_tests/cert_test.py
@@ -90,12 +90,12 @@ class TestCert(unittest.TestCase):
         shutil.rmtree(unit_tests.TMP_DIR)
 
 
-def test_remove_cert(caplog, remove_cert_setup):
-    cert_file = system_cert._target_cert_path
-    with open(cert_filename, 'wb') as  cert_file:
-        cert_file.write(b'some content')
+def test_remove_cert(caplog, system_cert):
+    cert_filename = system_cert._target_cert_path
+    with open(cert_filename, "wb") as cert_file:
+        cert_file.write(b"some content")
 
-    system_cert[sys_cert].remove()
+    system_cert.remove()
 
     assert "/filename removed" in caplog.messages[-1]
 
@@ -113,12 +113,12 @@ def test_remove_cert(caplog, remove_cert_setup):
         (OSError(13, "[Errno 13] Permission denied: '/tmpdir/certfile'"), "Permission denied:"),
     ),
 )
-def test_remove_cert_error_conditions(error_condition, expected_text_in_logs, caplog, monkeypatch, remove_cert_setup):
+def test_remove_cert_error_conditions(error_condition, expected_text_in_logs, caplog, monkeypatch, system_cert):
     def fake_os_remove(path):
         raise error_condition
 
     monkeypatch.setattr(os, "remove", fake_os_remove)
 
-    remove_cert_setup["sys_cert_instance"].remove()
+    system_cert.remove()
 
     assert expected_text_in_logs != caplog.messages[-1]

--- a/convert2rhel/unit_tests/cert_test.py
+++ b/convert2rhel/unit_tests/cert_test.py
@@ -90,9 +90,10 @@ class TestCert(unittest.TestCase):
         shutil.rmtree(unit_tests.TMP_DIR)
 
 
+@pytest.mark.cert_filename("filename")
 def test_remove_cert(caplog, system_cert_with_target_path):
-    cert_filename = system_cert_with_target_path._target_cert_path
-    with open(cert_filename, "wb") as cert_file:
+    cert_file_path = system_cert_with_target_path._target_cert_path
+    with open(cert_file_path, "wb") as cert_file:
         cert_file.write(b"some content")
 
     system_cert_with_target_path.remove()

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -68,6 +68,20 @@ def setup_logger(tmpdir):
 
 @pytest.fixture
 def system_cert_with_target_path(monkeypatch, tmpdir, request):
+    """
+    Create a single SystemCert backed by a temp file.
+
+    Use it in unit tests when you need a SystemCert that has a real file backing it.
+
+    You may use a custom pytest.mark named cert_filename to use a specific file name in the temp directory.
+    If you don't the file name will be arbitrary.
+
+    We use this mark instead of using parametrize because parametrize is mainly used to run a test multiple times
+    with diffrent data. For constant data, pytest recommends the use of custom markers.
+
+    .. seealso::
+        https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#using-markers-to-pass-data-to-fixtures
+    """
 
     mark = request.node.get_closest_marker("cert_filename")
     if not mark:

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -67,8 +67,15 @@ def setup_logger(tmpdir):
 
 
 @pytest.fixture
-def system_cert_with_target_path(monkeypatch, tmpdir):
-    tmp_file = tmpdir / "filename"
+def system_cert_with_target_path(monkeypatch, tmpdir, request):
+
+    mark = request.node.get_closest_marker("cert_filename")
+    if not mark:
+        temporary_filename = "filename"
+    else:
+        temporary_filename = mark.args[0]
+
+    tmp_file = tmpdir / temporary_filename
 
     monkeypatch.setattr(cert.SystemCert, "_get_cert", value=mock.Mock(return_value=("anything", "anything")))
     monkeypatch.setattr(cert.SystemCert, "_get_target_cert_path", value=mock.Mock(return_value=str(tmp_file)))

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -57,7 +57,19 @@ def pkg_root():
 
 @pytest.fixture(autouse=True)
 def setup_logger(tmpdir):
-    setup_logger_handler(log_name="convert2rhel", log_dir=str(tmpdir))
+    initialize_logger(log_name="convert2rhel", log_dir=str(tmpdir))
+
+
+@pytest.fixture
+def system_cert(monkeypatch, tmpdir):
+    tmp_file = tmpdir / "filename"
+
+    monkeypatch.setattr(cert.SystemCert, "_get_cert", value=mock.Mock(return_value=("anything", "anything")))
+    monkeypatch.setattr(cert.SystemCert, "_get_target_cert_path", value=mock.Mock(return_value=str(tmp_file)))
+
+    sys_cert = cert.SystemCert()
+
+    return sys_cert
 
 
 @pytest.fixture

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -67,7 +67,7 @@ def setup_logger(tmpdir):
 
 
 @pytest.fixture
-def system_cert(monkeypatch, tmpdir):
+def system_cert_with_target_path(monkeypatch, tmpdir):
     tmp_file = tmpdir / "filename"
 
     monkeypatch.setattr(cert.SystemCert, "_get_cert", value=mock.Mock(return_value=("anything", "anything")))

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 import six
 
-from convert2rhel import redhatrelease, toolopts, utils
+from convert2rhel import cert, redhatrelease, toolopts, utils
 from convert2rhel.logger import setup_logger_handler
 from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -9,6 +9,12 @@ from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts
 
 
+if sys.version_info[:2] <= (2, 7):
+    import mock  # pylint: disable=import-error
+else:
+    from unittest import mock  # pylint: disable=no-name-in-module
+
+
 @pytest.fixture(scope="session")
 def is_py26():
     return sys.version_info[:2] == (2, 6)
@@ -57,7 +63,7 @@ def pkg_root():
 
 @pytest.fixture(autouse=True)
 def setup_logger(tmpdir):
-    initialize_logger(log_name="convert2rhel", log_dir=str(tmpdir))
+    setup_logger_handler(log_name="convert2rhel", log_dir=str(tmpdir))
 
 
 @pytest.fixture

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 testpaths = "convert2rhel/unit_tests"
+markers = cert_filename

--- a/tests/integration/tier0/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/basic-sanity-checks/test_basic_sanity_checks.py
@@ -125,6 +125,7 @@ def test_clean_cache(convert2rhel):
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("n")
 
+
 def test_rhsm_error_logged(convert2rhel):
     """
     Test if the OSError for RHSM certificate being removed

--- a/tests/integration/tier0/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/basic-sanity-checks/test_basic_sanity_checks.py
@@ -134,7 +134,7 @@ def test_rhsm_error_logged(convert2rhel):
     with convert2rhel("--debug --no-rpm-va") as c2r:
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("n")
-        assert c2r.expect("DEBUG - No RHSM certificates found to be removed") == 0
+        assert c2r.expect("No RHSM certificates found to be removed.") == 0
 
     # Check for error not present in log file
     with open("/var/log/convert2rhel/convert2rhel.log", "r") as logfile:


### PR DESCRIPTION
RHSM was throwing an logging error when removing the current certs on the system, this error was not supposed to be displayed at this moment in the conversion because it might've not been installed yet.

If you want to test this fix, you can follow the steps in the Jira ticket and observe that the error message doesn't appear anymore.

Jira: [RHELC-45](https://issues.redhat.com/browse/RHELC-45)