### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 minimum_pre_commit_version: "2.9.0"
 repos:
   - repo: "https://github.com/psf/black"
-    rev: "21.10b0"
+    rev: "22.1.0"
     hooks:
       - id: "black"
         name: "Format code (black)"
@@ -15,7 +15,7 @@ repos:
         additional_dependencies: [toml]
 
   - repo: "https://github.com/pre-commit/pre-commit-hooks"
-    rev: "v4.0.1"
+    rev: "v4.1.0"
     hooks:
       - id: "end-of-file-fixer"
       - id: "trailing-whitespace"


### PR DESCRIPTION
Manually updating the pre-commit hooks we use to use the newest version.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>