### PR TITLE
Fix lazy evaluation of string logs for loglevel.FILE

### DIFF
--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -33,7 +33,6 @@ import sys
 from time import gmtime, strftime
 
 from convert2rhel.toolopts import tool_opts
-from convert2rhel.utils import format_msg_with_datetime
 
 
 LOG_DIR = "/var/log/convert2rhel"
@@ -153,7 +152,7 @@ def _debug(self, msg, *args, **kwargs):
         if tool_opts.debug:
             self._log(logging.DEBUG, msg, args, **kwargs)
         else:
-            self._log(LogLevelFile.level, format_msg_with_datetime(msg, "debug"), args, **kwargs)
+            self._log(LogLevelFile.level, msg, args, **kwargs)
 
 
 class bcolors:
@@ -183,7 +182,7 @@ class CustomFormatter(logging.Formatter, object):
             new_fmt = fmt_orig if self.color_disabled else bcolors.OKGREEN + fmt_orig + bcolors.ENDC
             self._fmt = new_fmt
             self.datefmt = "%m/%d/%Y %H:%M:%S"
-        elif record.levelno in [logging.INFO, LogLevelFile.level]:
+        elif record.levelno in [logging.INFO]:
             self._fmt = "%(message)s"
             self.datefmt = ""
         elif record.levelno in [logging.WARNING]:

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import datetime
 import errno
 import getpass
 import inspect
@@ -55,12 +54,6 @@ DATA_DIR = "/usr/share/convert2rhel/"
 # Directory for temporary data to be stored during runtime
 TMP_DIR = "/var/lib/convert2rhel/"
 BACKUP_DIR = os.path.join(TMP_DIR, "backup")
-
-
-def format_msg_with_datetime(msg, level):
-    """Return a string with msg formatted according to the level"""
-    temp_date = datetime.datetime.now().strftime("%m/%d/%Y %H:%M:%S")
-    return "[%s] %s - %s", temp_date, level.upper(), msg
 
 
 def get_executable_name():


### PR DESCRIPTION
For log messages, you can do lazy evaluation of the format string to
occassionally boost performance when a log message is not used.  For
instance:

``` python
  class Hypothetical(object):
      def __str__(self):
          return self.calculate_fibonacci_10000()
  log.debug("10,000th fibonacci number is: %s", Hypothetical())
```
The format string will not be interpolated (and thus the 10,000th
fibonacci number will not be calculated) unless we are actually going to
log the debug() output.

The code in commit b870460 broke that because it calculated its own
format string and args for the message, interfering with whatever was
passed in via function parameter.  This change fixes that by moving the
formatting pieces of b870460 into the CustomFormatter class.  By that
time, the message string has already been interpolated so any changes to
the message string will not interfere.  Additionally, in the formatter
class, those pieces can be performed by standard logging.Formatter
features so we don't need the custom code to do that anymore.

OAMG-6571 #in-progress