### PR TITLE
Update releasever mapping until 8.10

### DIFF
--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -38,6 +38,11 @@ from convert2rhel.toolopts import tool_opts
 # Allowed conversion paths to RHEL. We want to prevent a conversion and minor
 #   version update at the same time.
 RELEASE_VER_MAPPING = {
+    "8.10": "8.10",
+    "8.9": "8.9",
+    "8.8": "8.8",
+    "8.7": "8.7",
+    "8.6": "8.6",
     "8.5": "8.5",
     "8.4": "8.4",
     "7.9": "7Server",


### PR DESCRIPTION
Adding the mappings up the version 8.10 of RHEL releases, which is
publically available here: https://access.redhat.com/support/policy/updates/errata#Maintenance_Support_2_Phase.

Jira reference (If any): https://issues.redhat.com/browse/OAMG-6513
Bugzilla reference (If any):

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>