### PR TITLE
[RHELC-411, RHELC-413] Add the config file option

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ recursive-include convert2rhel/data *
 include man/*
 include LICENSE
 include README.md
+include config/convert2rhel.ini

--- a/config/convert2rhel.ini
+++ b/config/convert2rhel.ini
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# This file should be in mode 0600
+# Example of configuration file convert2rhel.ini for secrets.
+# Possible locations of this file:
+# 1) user specified and passed by -c, --config-file option; highest priority
+# 2) ~/.convert2rhel.ini; lower priority
+# 3) /etc/convert2rhel.ini; the lowest priority
+
+[subscription_manager]
+# password = <insert_password>
+# activation_key = <insert_activation_key>

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -193,7 +193,7 @@ def test_config_file(argv, content, output, message, monkeypatch, tmp_path, capl
     # Re-init needed delete the set data
     convert2rhel.toolopts.tool_opts.__init__()
     path = os.path.join(str(tmp_path), "convert2rhel.ini")
-    with open(path, "w") as file:  # pylint: disable=unspecified-encoding
+    with open(path, "w") as file:
         file.write(content)
     os.chmod(path, 0o600)
 
@@ -228,7 +228,7 @@ def test_multiple_auth_src_combined(argv, content, message, output, caplog, monk
     """Test combination of password file or configuration file and CLI arguments."""
     convert2rhel.toolopts.tool_opts.__init__()
     path = os.path.join(str(tmp_path), "convert2rhel.file")
-    with open(path, "w") as file:  # pylint: disable=unspecified-encoding
+    with open(path, "w") as file:
         file.write(content)
     os.chmod(path, 0o600)
     # The path for file is the last argument
@@ -257,10 +257,10 @@ def test_multiple_auth_src_combined(argv, content, message, output, caplog, monk
 def test_multiple_auth_src_files(argv, content, message, output, caplog, monkeypatch, tmp_path):
     """Test combination of password file, config file and CLI."""
     path0 = os.path.join(str(tmp_path), "convert2rhel.password")
-    with open(path0, "w") as file:  # pylint: disable=unspecified-encoding
+    with open(path0, "w") as file:
         file.write(content[0])
     path1 = os.path.join(str(tmp_path), "convert2rhel.ini")
-    with open(path1, "w") as file:  # pylint: disable=unspecified-encoding
+    with open(path1, "w") as file:
         file.write(content[1])
     # Set the paths
     argv[-3] = path0
@@ -320,7 +320,7 @@ def test_options_from_config_files_default(content, output, monkeypatch, tmp_pat
     """Test config files in default path."""
     path = os.path.join(str(tmp_path), "convert2rhel.ini")
     if content:
-        with open(path, "w") as file:  # pylint: disable=unspecified-encoding
+        with open(path, "w") as file:
             file.write(content)
         os.chmod(path, 0o600)
 
@@ -360,13 +360,13 @@ def test_options_from_config_files_default(content, output, monkeypatch, tmp_pat
 def test_options_from_config_files_specified(content, output, content_lower_priority, monkeypatch, tmp_path, caplog):
     """Test user specified path for config file."""
     path = os.path.join(str(tmp_path), "convert2rhel.ini")
-    with open(path, "w") as file:  # pylint: disable=unspecified-encoding
+    with open(path, "w") as file:
         file.write(content)
     os.chmod(path, 0o600)
 
     path_lower_priority = os.path.join(str(tmp_path), "convert2rhel_lower.ini")
     content_lower_priority = "[subscription_manager]\npassword = low_prior_pass"
-    with open(path_lower_priority, "w") as file:  # pylint: disable=unspecified-encoding
+    with open(path_lower_priority, "w") as file:
         file.write(content_lower_priority)
     os.chmod(path_lower_priority, 0o600)
 

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -18,6 +18,7 @@
 # Required imports:
 
 
+import os
 import sys
 import unittest
 
@@ -144,3 +145,255 @@ def test_both_disable_submgr_and_no_rhsm_options_work(argv, raise_exception, no_
         convert2rhel.toolopts.CLI()
 
     assert convert2rhel.toolopts.tool_opts.no_rhsm == no_rhsm_value
+
+
+@pytest.mark.parametrize(
+    ("argv", "content", "output", "message"),
+    (
+        (
+            mock_cli_arguments([""]),
+            "[subscription_manager]\npassword=conf_pass",
+            {"password": "conf_pass", "activation_key": None},
+            None,
+        ),
+        (
+            mock_cli_arguments(["-p", "password"]),
+            "[subscription_manager]\nactivation_key=conf_key",
+            {"password": "password", "activation_key": None},
+            "Command line authentication method take precedence over method in configuration file.",
+        ),
+        (
+            mock_cli_arguments(["-k", "activation_key"]),
+            "[subscription_manager]\nactivation_key=conf_key",
+            {"password": None, "activation_key": "activation_key"},
+            "Command line authentication method take precedence over method in configuration file.",
+        ),
+        (
+            mock_cli_arguments(["-k", "activation_key"]),
+            "[subscription_manager]\npassword=conf_pass",
+            {"password": "conf_pass", "activation_key": "activation_key"},
+            "Command line authentication method take precedence over method in configuration file.",
+        ),
+        (
+            mock_cli_arguments(["-k", "activation_key", "-p", "password"]),
+            "[subscription_manager]\npassword=conf_pass\nactivation_key=conf_key",
+            {"password": "password", "activation_key": "activation_key"},
+            "Command line authentication method take precedence over method in configuration file.",
+        ),
+        (
+            mock_cli_arguments([""]),
+            "[subscription_manager]\npassword=conf_pass\nactivation_key=conf_key",
+            {"password": "conf_pass", "activation_key": "conf_key"},
+            "Set only one of password or activation key. Activation key take precedence.",
+        ),
+    ),
+)
+def test_config_file(argv, content, output, message, monkeypatch, tmp_path, caplog):
+    # After each test there were left data from previous
+    # Re-init needed delete the set data
+    convert2rhel.toolopts.tool_opts.__init__()
+    path = os.path.join(str(tmp_path), "convert2rhel.ini")
+    with open(path, "w") as file:  # pylint: disable=unspecified-encoding
+        file.write(content)
+    os.chmod(path, 0o600)
+
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setattr(convert2rhel.toolopts, "CONFIG_PATHS", value=[path])
+    convert2rhel.toolopts.CLI()
+
+    assert convert2rhel.toolopts.tool_opts.activation_key == output["activation_key"]
+    assert convert2rhel.toolopts.tool_opts.password == output["password"]
+    if message:
+        assert message in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("argv", "content", "message", "output"),
+    (
+        (
+            mock_cli_arguments(["--password", "pass", "-f"]),
+            "pass_file",
+            "Password file argument take precedence over the password argument.",
+            {"password": "pass_file", "activation_key": None},
+        ),
+        (
+            mock_cli_arguments(["--password", "pass", "--config-file"]),
+            "[subscription_manager]\nactivation_key = key_cnf_file",
+            "Command line authentication method take precedence over method in configuration file.",
+            {"password": "pass", "activation_key": None},
+        ),
+    ),
+)
+def test_multiple_auth_src_combined(argv, content, message, output, caplog, monkeypatch, tmp_path):
+    """Test combination of password file or configuration file and CLI arguments."""
+    convert2rhel.toolopts.tool_opts.__init__()
+    path = os.path.join(str(tmp_path), "convert2rhel.file")
+    with open(path, "w") as file:  # pylint: disable=unspecified-encoding
+        file.write(content)
+    os.chmod(path, 0o600)
+    # The path for file is the last argument
+    argv.append(path)
+
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setattr(convert2rhel.toolopts, "CONFIG_PATHS", value=[""])
+    convert2rhel.toolopts.CLI()
+
+    assert message in caplog.text
+    assert convert2rhel.toolopts.tool_opts.activation_key == output["activation_key"]
+    assert convert2rhel.toolopts.tool_opts.password == output["password"]
+
+
+@pytest.mark.parametrize(
+    ("argv", "content", "message", "output"),
+    (
+        (
+            mock_cli_arguments(["--password", "pass", "-f", "file", "--config-file", "file"]),
+            ("pass_file", "[subscription_manager]\nactivation_key = pass_cnf_file"),
+            "Password file take precedence over the config file.",
+            {"password": "pass_file", "activation_key": None},
+        ),
+    ),
+)
+def test_multiple_auth_src_files(argv, content, message, output, caplog, monkeypatch, tmp_path):
+    """Test combination of password file, config file and CLI."""
+    path0 = os.path.join(str(tmp_path), "convert2rhel.password")
+    with open(path0, "w") as file:  # pylint: disable=unspecified-encoding
+        file.write(content[0])
+    path1 = os.path.join(str(tmp_path), "convert2rhel.ini")
+    with open(path1, "w") as file:  # pylint: disable=unspecified-encoding
+        file.write(content[1])
+    # Set the paths
+    argv[-3] = path0
+    argv[-1] = path1
+    os.chmod(path1, 0o600)
+
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setattr(convert2rhel.toolopts, "CONFIG_PATHS", value=[""])
+    convert2rhel.toolopts.CLI()
+
+    assert message in caplog.text
+    assert convert2rhel.toolopts.tool_opts.activation_key == output["activation_key"]
+    assert convert2rhel.toolopts.tool_opts.password == output["password"]
+
+
+@pytest.mark.parametrize(
+    ("argv", "message", "output"),
+    (
+        (
+            mock_cli_arguments(["--password", "pass", "--activationkey", "key"]),
+            "Set only one of password or activation key.",
+            {"password": "pass", "activation_key": "key"},
+        ),
+    ),
+)
+def test_multiple_auth_src_cli(argv, message, output, caplog, monkeypatch):
+    """Test both auth methods in CLI."""
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setattr(convert2rhel.toolopts, "CONFIG_PATHS", value=[""])
+    convert2rhel.toolopts.CLI()
+
+    assert message in caplog.text
+    assert convert2rhel.toolopts.tool_opts.activation_key == output["activation_key"]
+    assert convert2rhel.toolopts.tool_opts.password == output["password"]
+
+
+@pytest.mark.parametrize(
+    ("content", "output"),
+    (
+        (
+            "[subscription_manager]\npassword = correct_password",
+            {"password": "correct_password", "activation_key": None},
+        ),
+        (
+            "[subscription_manager]\nactivation_key = correct_key\nPassword = correct_password",
+            {"password": "correct_password", "activation_key": "correct_key"},
+        ),
+        (
+            "[subscription_manager]\nincorrect_option = incorrect_content",
+            {"password": None, "activation_key": None},
+        ),
+        ("[INVALID_HEADER]\nactivation_key = correct_key", {"password": None, "activation_key": None}),
+        (None, {"password": None, "activation_key": None}),
+    ),
+)
+def test_options_from_config_files_default(content, output, monkeypatch, tmp_path, caplog):
+    """Test config files in default path."""
+    path = os.path.join(str(tmp_path), "convert2rhel.ini")
+    if content:
+        with open(path, "w") as file:  # pylint: disable=unspecified-encoding
+            file.write(content)
+        os.chmod(path, 0o600)
+
+    paths = ["/nonexisting/path", path]
+    monkeypatch.setattr(convert2rhel.toolopts, "CONFIG_PATHS", value=paths)
+    opts = convert2rhel.toolopts.options_from_config_files()
+
+    assert opts["password"] == output["password"]
+    assert opts["activation_key"] == output["activation_key"]
+    if content:
+        if "INVALID_HEADER" in content:
+            assert "Unsupported header" in caplog.text
+        if "incorrect_option" in content:
+            assert "Unsupported option" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("content", "output", "content_lower_priority"),
+    (
+        (
+            "[subscription_manager]\nactivation_key = correct_key\nPassword = correct_password",
+            {"password": "correct_password", "activation_key": "correct_key"},
+            "[subscription_manager]\npassword = low_prior_pass",
+        ),
+        (
+            "[subscription_manager]\nactivation_key = correct_key\nPassword = correct_password",
+            {"password": "correct_password", "activation_key": "correct_key"},
+            "[INVALID_HEADER]\nincorrect_option = incorrect_option",
+        ),
+        (
+            "[subscription_manager]\nactivation_key = correct_key\nPassword = correct_password",
+            {"password": "correct_password", "activation_key": "correct_key"},
+            "[subscription_manager]\nincorrect_option = incorrect_option",
+        ),
+    ),
+)
+def test_options_from_config_files_specified(content, output, content_lower_priority, monkeypatch, tmp_path, caplog):
+    """Test user specified path for config file."""
+    path = os.path.join(str(tmp_path), "convert2rhel.ini")
+    with open(path, "w") as file:  # pylint: disable=unspecified-encoding
+        file.write(content)
+    os.chmod(path, 0o600)
+
+    path_lower_priority = os.path.join(str(tmp_path), "convert2rhel_lower.ini")
+    content_lower_priority = "[subscription_manager]\npassword = low_prior_pass"
+    with open(path_lower_priority, "w") as file:  # pylint: disable=unspecified-encoding
+        file.write(content_lower_priority)
+    os.chmod(path_lower_priority, 0o600)
+
+    paths = [path_lower_priority]
+    monkeypatch.setattr(convert2rhel.toolopts, "CONFIG_PATHS", value=paths)
+    # user specified path
+    opts = convert2rhel.toolopts.options_from_config_files(path)
+
+    assert opts["password"] == output["password"]
+    assert opts["activation_key"] == output["activation_key"]
+    if "INVALID_HEADER" in content or "INVALID_HEADER" in content_lower_priority:
+        assert "Unsupported header" in caplog.text
+    if "incorrect_option" in content or "incorrect_option" in content_lower_priority:
+        assert "Unsupported option" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "supported_opts",
+    (
+        {"password": "correct_password", "activation_key": "correct_key"},
+        {"password": "correct_password", "activation_key": "correct_key", "invalid_key": "invalid_key"},
+    ),
+)
+def test_set_opts(supported_opts):
+    tool_opts.__init__()
+    convert2rhel.toolopts.ToolOpts.set_opts(tool_opts, supported_opts)
+
+    assert tool_opts.password == supported_opts["password"]
+    assert tool_opts.activation_key == supported_opts["activation_key"]
+    assert not hasattr(tool_opts, "invalid_key")

--- a/packaging/convert2rhel.spec
+++ b/packaging/convert2rhel.spec
@@ -96,6 +96,10 @@ install -d %{buildroot}%{_sharedstatedir}/%{name}/rhsm/
 install -d -m 755 %{buildroot}%{_mandir}/man8
 install -p man/%{name}.8 %{buildroot}%{_mandir}/man8/
 
+# Put the config file into place
+install -d %{buildroot}%{_sysconfdir}/
+install -m 0600 config/convert2rhel.ini %{buildroot}%{_sysconfdir}/convert2rhel.ini
+
 %files
 
 %if 0%{?rhel} && 0%{?rhel} <= 6
@@ -107,6 +111,7 @@ install -p man/%{name}.8 %{buildroot}%{_mandir}/man8/
 %{_datadir}/%{name}/
 %{_sharedstatedir}/%{name}/
 %{python_sitelib}/%{name}*
+%config(noreplace) %attr(0600, root, root) %{_sysconfdir}/convert2rhel.ini
 
 %{!?_licensedir:%global license %%doc}
 %license LICENSE

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -283,3 +283,18 @@ discover+:
   - name: reboot after conversion
     how: ansible
     playbook: tests/ansible_collections/roles/reboot/main.yml
+
+/config_file:
+  adjust:
+      enabled: false
+      when: >
+        distro != centos-8
+  discover+:
+    test: checks-after-conversion
+  prepare+:
+  - name: main conversion preparation
+    how: shell
+    script: pytest -svv tests/integration/tier1/config-file/test_config_file.py
+  - name: reboot after conversion
+    how: ansible
+    playbook: tests/ansible_collections/roles/reboot/main.yml

--- a/tests/integration/tier1/checks-after-conversion/test_release_version.py
+++ b/tests/integration/tier1/checks-after-conversion/test_release_version.py
@@ -12,7 +12,7 @@ def test_correct_distro():
     """
     with open("/etc/migration-results") as json_file:
         json_data = json.load(json_file)
-        source_distro = json_data["activities"][0]["source_os"]
+        source_distro = json_data["activities"][-1]["source_os"]
 
     with open("/etc/system-release", "r") as sys_release:
         destination_distro = sys_release.read()

--- a/tests/integration/tier1/config-file/main.fmf
+++ b/tests/integration/tier1/config-file/main.fmf
@@ -1,0 +1,5 @@
+summary: config file
+
+tier: 0
+
+test: pytest -svv

--- a/tests/integration/tier1/config-file/test_config_file.py
+++ b/tests/integration/tier1/config-file/test_config_file.py
@@ -1,0 +1,125 @@
+import os
+
+from collections import namedtuple
+
+from envparse import env
+
+
+Config = namedtuple("Config", "path content")
+
+
+def create_files(config):
+    for cfg in config:
+        f = open(os.path.expanduser(cfg.path), "w")
+        f.write(cfg.content)
+        f.close()
+        os.chmod(os.path.expanduser(cfg.path), 0o600)
+
+
+def remove_files(config):
+    for cfg in config:
+        os.remove(os.path.expanduser(cfg.path))
+
+
+def test_user_path_custom_filename(convert2rhel):
+    config = [Config("~/.convert2rhel_custom.ini", "[subscription_manager]\nactivation_key = config_activationkey")]
+    create_files(config)
+
+    with convert2rhel('--no-rpm-va --debug -c "~/.convert2rhel_custom.ini"') as c2r:
+        c2r.expect("DEBUG - Found activation_key in /root/.convert2rhel_custom.ini")
+        c2r.sendcontrol("c")
+    assert c2r.exitstatus != 0
+
+    remove_files(config)
+
+
+def test_user_path_std_filename(convert2rhel):
+    config = [Config("~/.convert2rhel.ini", "[subscription_manager]\npassword = config_password")]
+    create_files(config)
+
+    with convert2rhel("--no-rpm-va --debug") as c2r:
+        c2r.expect("DEBUG - Found password in /root/.convert2rhel.ini")
+        c2r.sendcontrol("c")
+    assert c2r.exitstatus != 0
+
+    remove_files(config)
+
+
+def test_user_path_cli_priority(convert2rhel):
+    config = [Config("~/.convert2rhel.ini", "[subscription_manager]\npassword = config_password")]
+    create_files(config)
+
+    with convert2rhel(("--no-rpm-va --password password --debug")) as c2r:
+        c2r.expect("DEBUG - Found password in /root/.convert2rhel.ini")
+        c2r.expect("WARNING - Command line authentication method take precedence over method in configuration file.")
+        c2r.sendcontrol("c")
+    assert c2r.exitstatus != 0
+
+    remove_files(config)
+
+
+def test_user_path_pswd_file_priority(convert2rhel):
+    config = [
+        Config("~/.convert2rhel.ini", "[subscription_manager]\npassword = config_password"),
+        Config("~/password_file", "file_password"),
+    ]
+    create_files(config)
+
+    with convert2rhel(('--no-rpm-va -f "~/password_file" --debug')) as c2r:
+        c2r.expect("DEBUG - Found password in /root/.convert2rhel.ini")
+        c2r.expect("WARNING - Deprecated. Use -c | --config-file instead.")
+        c2r.expect("WARNING - Password file take precedence over the config file.")
+        c2r.sendcontrol("c")
+    assert c2r.exitstatus != 0
+
+    remove_files(config)
+
+
+def test_std_paths_priority_diff_methods(convert2rhel):
+    config = [
+        Config("~/.convert2rhel.ini", "[subscription_manager]\npassword = config_password"),
+        Config("/etc/convert2rhel.ini", "[subscription_manager]\nactivation_key = config2_activationkey"),
+    ]
+    create_files(config)
+
+    with convert2rhel("--no-rpm-va --debug") as c2r:
+        c2r.expect("DEBUG - Found password in /root/.convert2rhel.ini")
+        c2r.expect("DEBUG - Found activation_key in /etc/convert2rhel.ini")
+        c2r.expect("WARNING - Set only one of password or activation key. Activation key take precedence.")
+        c2r.sendcontrol("c")
+    assert c2r.exitstatus != 0
+
+    remove_files(config)
+
+
+def test_std_paths_priority(convert2rhel):
+    config = [
+        Config("~/.convert2rhel.ini", "[subscription_manager]\npassword = config_password"),
+        Config("/etc/convert2rhel.ini", "[subscription_manager]\npassword = config_password"),
+    ]
+    create_files(config)
+
+    with convert2rhel("--no-rpm-va --debug") as c2r:
+        c2r.expect("DEBUG - Found password in /root/.convert2rhel.ini")
+        c2r.sendcontrol("c")
+    assert c2r.exitstatus != 0
+
+    remove_files(config)
+
+
+def test_conversion(convert2rhel):
+    activation_key = ("[subscription_manager]\nactivation_key = {}").format(env.str("RHSM_KEY"))
+    config = [
+        Config("~/.convert2rhel.ini", ("[subscription_manager]\nactivation_key = {}").format(env.str("RHSM_KEY")))
+    ]
+    create_files(config)
+
+    with convert2rhel(
+        ("-y --no-rpm-va --serverurl {} -o {} --debug").format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_ORG"),
+        )
+    ) as c2r:
+        c2r.expect("DEBUG - Found activation_key in /root/.convert2rhel.ini")
+        c2r.expect("Conversion successful!")
+    assert c2r.exitstatus == 0


### PR DESCRIPTION
Add the possibility to give secrets (password or activation key) via configuration file. Configuration file can be 1) user specified and passed via command line or is in 2) ~/convert2rhel.ini, 3) /etc/convert2rhel.ini. The numbers shows priority, 1) is the highest.  The structure of the file is copied to /etc/convert2rhel.ini during installation.

Secrets passed by CLI have precedence and are merged with the secrets in config files. If password is passed via CLI and activation key is in config file, the activation key isn't used. If it would be, during the activation process would be used the activation key and the precedence of secrets from CLI wouldn't be preserved. If there are both, the activation key has priority.

Also contains warnings if user specifies more than one authentication method. And warning if some method has lower priority than others. The priority is: password file > CLI > config file.

[RHELC-411](https://issues.redhat.com/browse/RHELC-411)
[RHELC-413](https://issues.redhat.com/browse/RHELC-413)