### PR TITLE
Turn on collection of branch coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ known_third_party=[
 known_first_party=["convert2rhel"]
 
 [tool.coverage.run]
-branch = false
+branch = true
 source = ["convert2rhel"]
 omit = ["convert2rhel/unit_tests/*",]
 


### PR DESCRIPTION
Branch coverage tests that the tests cover when a condition is true and
when it is false, even if both branches do not have statements.  This is
useful, for instance, when one branch doesn't set all the variables that
another branch does.  For instance:

def function(allow):
   if allow:
       variable = True
   return variable

def test_function():
    assert function(True) is True

With just statement coverge, the function would read as 100% covered.
Turning branch coverage on will show that the allow=False case is
untested.  Writing a test for that will reveal the bug where variable is
not set when it is returned: https://coverage.readthedocs.io/en/6.3.2/branch.html