### PR TITLE
Fix arguments to run_subprocess to be a list of strings.

### DIFF
--- a/convert2rhel/grub.py
+++ b/convert2rhel/grub.py
@@ -405,7 +405,7 @@ def _add_rhel_boot_entry(efibootinfo_orig):
         "--disk",
         blk_dev,
         "--part",
-        dev_number["minor"],
+        str(dev_number["minor"]),
         "--loader",
         efi_path,
         "--label",


### PR DESCRIPTION
One of the arguments to the command was an int instead of a string.
This didn't cause a problem for run_subprocess() itself but caused
loggerinst.debug() to error when it tried to format the log message
using the argument list.  This change will convert the int to a string
before calling run_subprocess()