### PR TITLE
packit: build SRPM in Copr

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,6 +3,8 @@ upstream_package_name: convert2rhel
 downstream_package_name: convert2rhel
 upstream_project_url: https://github.com/oamg/convert2rhel
 
+srpm_build_deps: []
+
 actions:
   # do not get the version from a tag (git describe) but from the spec file
   get-current-version:


### PR DESCRIPTION
and be able to specify the precise list of deps needed to create the
SRPM and since you don't need any extra, we "have to" enforce
this process by defining the `srpm_build_deps` key.