### PR TITLE
Add CentOS 7 to coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ jobs:
     name: coverage-centos${{ matrix.centos_ver }}
     strategy:
       matrix:
-        centos_ver: [8]
+        centos_ver: [7, 8]
 
     runs-on: ubuntu-20.04
     steps:

--- a/requirements/centos7.requirements.txt
+++ b/requirements/centos7.requirements.txt
@@ -3,3 +3,4 @@ astroid==1.6.6
 pytest==4.6.11
 pathlib2==2.3.7.post1
 mock==3.0.5
+pytest-cov==2.12.1


### PR DESCRIPTION
Enabling the CentOS 7 docker build to run and send coverage do codecov.io

Jira reference (If any): https://issues.redhat.com/browse/OAMG-6611
Bugzilla reference (If any): 

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>