### PR TITLE
Fix for unavailable repos on CentOS8

### DIFF
--- a/ansible/setup-convert2rhel.yml
+++ b/ansible/setup-convert2rhel.yml
@@ -31,7 +31,7 @@
         msg: "Distribution version must be 6.10, 7.9, or 8.5"
       when: (ansible_distribution_version != '6.10' and ansible_distribution_version != '7.9'
              and ansible_distribution_version != '8.5') or skip_os_version_check|bool
-             
+
     - name: Patch repositories if dealing with CentOS8.
       block:
       - name: Comment mirrorlist in all repos.
@@ -40,7 +40,7 @@
           regexp: ^mirrorlist
           replace: "#mirrorlist"
         loop: centos8_repos
-          
+
       - name: Switch repo to vault.centos.org.
         replace:
           path: /etc/yum.repos.d/{{ item }}
@@ -48,7 +48,7 @@
           replace: baseurl=https://vault.centos.org
         loop: centos8_repos
       when: ansible_distribution == 'CentOS' and ansible_distribution_major_version | int == 8
-          
+
     - name: Download Red Hat GPG key
       get_url:
         url:  https://www.redhat.com/security/data/fd431d51.txt

--- a/ansible/setup-convert2rhel.yml
+++ b/ansible/setup-convert2rhel.yml
@@ -8,6 +8,16 @@
     skip_os_version_check: false
     # added for RHELDST-7822
     SSLCACERT: "https://ftp.redhat.com/redhat/convert2rhel/redhat-uep.pem"
+    centos8_repos:
+      - CentOS-Linux-AppStream.repo
+      - CentOS-Linux-BaseOS.repo
+      - CentOS-Linux-ContinuousRelease.repo
+      - CentOS-Linux-Devel.repo
+      - CentOS-Linux-Extras.repo
+      - CentOS-Linux-FastTrack.repo
+      - CentOS-Linux-HighAvailability.repo
+      - CentOS-Linux-Plus.repo
+      - CentOS-Linux-PowerTools.repo
 
   tasks:
 
@@ -21,7 +31,24 @@
         msg: "Distribution version must be 6.10, 7.9, or 8.5"
       when: (ansible_distribution_version != '6.10' and ansible_distribution_version != '7.9'
              and ansible_distribution_version != '8.5') or skip_os_version_check|bool
-
+             
+    - name: Patch repositories if dealing with CentOS8.
+      block:
+      - name: Comment mirrorlist in all repos.
+        replace:
+          path: /etc/yum.repos.d/{{ item }}
+          regexp: ^mirrorlist
+          replace: "#mirrorlist"
+        loop: centos8_repos
+          
+      - name: Switch repo to vault.centos.org.
+        replace:
+          path: /etc/yum.repos.d/{{ item }}
+          regexp: "#baseurl=http://mirror.centos.org"
+          replace: baseurl=https://vault.centos.org
+        loop: centos8_repos
+      when: ansible_distribution == 'CentOS' and ansible_distribution_major_version | int == 8
+          
     - name: Download Red Hat GPG key
       get_url:
         url:  https://www.redhat.com/security/data/fd431d51.txt


### PR DESCRIPTION
This fix adds a check if on CentOS8 and performs the needed steps to switch repos to vault.centos.org.