### PR TITLE
Update the Secure Boot message

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -72,7 +72,10 @@ def check_efi():
         logger.critical("Only x86_64 systems are supported for UEFI conversions.")
     if grub.is_secure_boot():
         logger.info("Secure boot detected.")
-        logger.critical("The conversion with secure boot is currently not possible.")
+        logger.critical(
+            "The conversion with secure boot is currently not possible.\n"
+            "To disable it, follow the instructions available in this article: https://access.redhat.com/solutions/6753681"
+        )
 
     # Get information about the bootloader. Currently the data is not used, but it's
     # good to check that we can obtain all the required data before the PONR. Better to

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -584,7 +584,10 @@ class TestEFIChecks(unittest.TestCase):
     @unit_tests.mock(os.path, "exists", lambda x: x == "/usr/sbin/efibootmgr")
     @unit_tests.mock(grub, "EFIBootInfo", EFIBootInfoMocked(exception=grub.BootloaderError("errmsg")))
     def test_check_efi_efi_detected_secure_boot(self):
-        self._check_efi_critical("The conversion with secure boot is currently not possible.")
+        self._check_efi_critical(
+            "The conversion with secure boot is currently not possible.\n"
+            "To disable it, follow the instructions available in this article: https://access.redhat.com/solutions/6753681"
+        )
         self.assertTrue("Secure boot detected." in checks.logger.info_msgs)
 
     @unit_tests.mock(grub, "is_efi", lambda: True)


### PR DESCRIPTION
Update the secure boot message to point out the user on how to disable secure
boot as it is not currently available in convert2rhel.

Jira reference (If any): https://issues.redhat.com/browse/OAMG-6665
Bugzilla reference (If any):

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>