### PR TITLE
[RHELC-297] Clean up kmods functionality

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import functools
 import itertools
 import logging
 import os
@@ -55,6 +54,44 @@ COMPATIBLE_KERNELS_VERS = {
     7: "3.10.0",
     8: "4.18.0",
 }
+
+# Python 2.6 compatibility.
+# This code is copied from Pthon-3.10's functools module,
+# licensed under the Python Software Foundation License, version 2
+try:
+    from functools import cmp_to_key
+except ImportError:
+
+    def cmp_to_key(mycmp):
+        """Convert a cmp= function into a key= function"""
+
+        class K(object):
+            __slots__ = ["obj"]
+
+            def __init__(self, obj):
+                self.obj = obj
+
+            def __lt__(self, other):
+                return mycmp(self.obj, other.obj) < 0
+
+            def __gt__(self, other):
+                return mycmp(self.obj, other.obj) > 0
+
+            def __eq__(self, other):
+                return mycmp(self.obj, other.obj) == 0
+
+            def __le__(self, other):
+                return mycmp(self.obj, other.obj) <= 0
+
+            def __ge__(self, other):
+                return mycmp(self.obj, other.obj) >= 0
+
+            __hash__ = None
+
+        return K
+
+
+# End of PSF Licensed code
 
 
 def perform_system_checks():
@@ -438,7 +475,7 @@ def get_most_recent_unique_kernel_pkgs(pkgs):
             list_of_sorted_pkgs.append(
                 max(
                     distinct_kernel_pkgs[1],
-                    key=functools.cmp_to_key(_package_version_cmp),
+                    key=cmp_to_key(_package_version_cmp),
                 )
             )
 

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -338,7 +338,8 @@ def ensure_compatibility_of_kmods():
         )
         logger.critical(
             "The following loaded kernel modules are not available in RHEL:\n{0}\n"
-            "Prevent the modules from loading by following {1}"
+            "First, make sure you have updated the kernel to the latest available version and rebooted the system.\n"
+            "If this message appears again after doing the above, prevent the modules from loading by following {1}"
             " and run convert2rhel again to continue with the conversion.".format(
                 "\n".join(not_supported_kmods), LINK_PREVENT_KMODS_FROM_LOADING
             )

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -97,7 +97,7 @@ def main():
         pkghandler.clean_yum_metadata()
 
         # check the system prior the conversion (possible inhibit)
-        checks.perform_pre_checks()
+        checks.perform_system_checks()
 
         # backup system release file before starting conversion process
         loggerinst.task("Prepare: Backup System")

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -332,12 +332,18 @@ class SystemInfo(object):
         _, return_code = run_subprocess(["rpm", "-q", name], print_cmd=False, print_output=False)
         return return_code == 0
 
-    # TODO write unit tests
     def get_enabled_rhel_repos(self):
-        """Return a tuple of repoids containing RHEL packages.
+        """Get a list of enabled repositories containing RHEL packages.
 
-        These are either the repos enabled through RHSM or the custom
-        repositories passed though CLI.
+        This function can return either the repositories enabled throught the RHSM tool during the conversion or, if
+        the user manually specified the repositories throught the CLI, it will return them based on the
+        `tool_opts.enablerepo` option.
+
+        .. note::
+            The repositories passed through the CLI have more priority than the ones get get from RHSM.
+
+        :return: A list of enabled repos to use during the conversion
+        :rtype: list[str]
         """
         # TODO:
         # if not self.submgr_enabled_repos:

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -157,7 +157,7 @@ def test_perform_pre_checks(monkeypatch):
     monkeypatch.setattr(checks, "is_loaded_kernel_latest", value=is_loaded_kernel_latest_mock)
     monkeypatch.setattr(checks, "check_dbus_is_running", value=check_dbus_is_running_mock)
 
-    checks.perform_pre_checks()
+    checks.perform_system_checks()
 
     check_convert2rhel_latest_mock.assert_called_once()
     check_thirdparty_kmods_mock.assert_called_once()
@@ -169,7 +169,7 @@ def test_perform_pre_checks(monkeypatch):
     check_dbus_is_running_mock.assert_called_once()
 
 
-def test_pre_ponr_checks(monkeypatch):
+def test_perform_pre_ponr_checks(monkeypatch):
     ensure_compatibility_of_kmods_mock = mock.Mock()
     create_transaction_handler_mock = mock.Mock()
     monkeypatch.setattr(

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -315,14 +315,14 @@ def test_c2r_up_to_date(caplog, monkeypatch, convert2rhel_latest_version_test):
         (
             HOST_MODULES_STUB_GOOD,
             None,
-            "Kernel modules are compatible",
+            "loaded kernel modules are available in RHEL",
             None,
         ),
         (
             HOST_MODULES_STUB_BAD,
             SystemExit,
             None,
-            "Kernel modules are compatible",
+            "loaded kernel modules are available in RHEL",
         ),
     ),
 )
@@ -383,13 +383,13 @@ def test_validate_package_manager_transaction(monkeypatch, caplog):
         # ff-memless specified to be ignored in the config, so no exception raised
         (
             "kernel/drivers/input/ff-memless.ko.xz",
-            "Kernel modules are compatible",
-            "The following kernel modules are not supported in RHEL",
+            "loaded kernel modules are available in RHEL",
+            "The following loaded kernel modules are not available in RHEL",
             None,
         ),
         (
             "kernel/drivers/input/other.ko.xz",
-            "The following kernel modules are not supported in RHEL",
+            "The following loaded kernel modules are not available in RHEL",
             None,
             SystemExit,
         ),

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -477,9 +477,18 @@ def test_get_loaded_kmods(monkeypatch):
                     0,
                 ),
             ),
-            (("modinfo", "-F", "filename", "a"), (MODINFO_STUB.split()[0] + "\n", 0)),
-            (("modinfo", "-F", "filename", "b"), (MODINFO_STUB.split()[1] + "\n", 0)),
-            (("modinfo", "-F", "filename", "c"), (MODINFO_STUB.split()[2] + "\n", 0)),
+            (
+                ("modinfo", "-F", "filename", "a"),
+                (MODINFO_STUB.split()[0] + "\n", 0),
+            ),
+            (
+                ("modinfo", "-F", "filename", "b"),
+                (MODINFO_STUB.split()[1] + "\n", 0),
+            ),
+            (
+                ("modinfo", "-F", "filename", "c"),
+                (MODINFO_STUB.split()[2] + "\n", 0),
+            ),
         ),
     )
     monkeypatch.setattr(
@@ -491,10 +500,10 @@ def test_get_loaded_kmods(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    ("repoquery_f_stub", "repoquery_l_stub", "exception"),
+    ("repoquery_f_stub", "repoquery_l_stub"),
     (
-        (REPOQUERY_F_STUB_GOOD, REPOQUERY_L_STUB_GOOD, None),
-        (REPOQUERY_F_STUB_BAD, REPOQUERY_L_STUB_GOOD, SystemExit),
+        (REPOQUERY_F_STUB_GOOD, REPOQUERY_L_STUB_GOOD),
+        (REPOQUERY_F_STUB_BAD, REPOQUERY_L_STUB_GOOD),
     ),
 )
 @centos8
@@ -503,7 +512,6 @@ def test_get_rhel_supported_kmods(
     pretend_os,
     repoquery_f_stub,
     repoquery_l_stub,
-    exception,
 ):
     run_subprocess_mock = mock.Mock(
         side_effect=run_subprocess_side_effect(
@@ -522,24 +530,21 @@ def test_get_rhel_supported_kmods(
         "run_subprocess",
         value=run_subprocess_mock,
     )
-    if exception:
-        with pytest.raises(exception):
-            checks.get_rhel_supported_kmods()
-    else:
-        res = checks.get_rhel_supported_kmods()
-        assert res == set(
-            (
-                "kernel/lib/a.ko",
-                "kernel/lib/a.ko.xz",
-                "kernel/lib/b.ko.xz",
-                "kernel/lib/c.ko.xz",
-                "kernel/lib/c.ko",
-            )
+
+    res = checks.get_rhel_supported_kmods()
+    assert res == set(
+        (
+            "kernel/lib/a.ko",
+            "kernel/lib/a.ko.xz",
+            "kernel/lib/b.ko.xz",
+            "kernel/lib/c.ko.xz",
+            "kernel/lib/c.ko",
         )
+    )
 
 
 @pytest.mark.parametrize(
-    ("pkgs", "exp_res", "exception"),
+    ("pkgs", "exp_res"),
     (
         (
             (
@@ -552,7 +557,6 @@ def test_get_rhel_supported_kmods(
                 "kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",
                 "kernel-debug-core-0:4.18.0-240.15.1.el8_3.x86_64",
             ),
-            None,
         ),
         (
             (
@@ -560,7 +564,6 @@ def test_get_rhel_supported_kmods(
                 "kmod-core-0:4.18.0-240.15.1.el8_3.x86_64",
             ),
             ("kmod-core-0:4.18.0-240.15.1.el8_3.x86_64",),
-            None,
         ),
         (
             (
@@ -568,7 +571,6 @@ def test_get_rhel_supported_kmods(
                 "kmod-core-0:4.18.0-240.15.1.el8_3.x86_64",
             ),
             ("kmod-core-0:4.18.0-240.15.1.el8_3.x86_64",),
-            None,
         ),
         (
             (
@@ -576,7 +578,6 @@ def test_get_rhel_supported_kmods(
                 "kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",
             ),
             ("kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",),
-            None,
         ),
         (
             (
@@ -584,7 +585,6 @@ def test_get_rhel_supported_kmods(
                 "kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",
             ),
             ("kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",),
-            None,
         ),
         (
             (
@@ -592,27 +592,23 @@ def test_get_rhel_supported_kmods(
                 "kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",
             ),
             ("kernel-core-0:4.18.0-240.16.beta5.1.el8_3.x86_64",),
-            None,
         ),
-        (("kernel_bad_package:111111",), (), SystemExit),
+        (("kernel_bad_package:111111",), ("kernel_bad_package:111111",)),
         (
             (
                 "kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",
                 "kernel_bad_package:111111",
                 "kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",
             ),
-            (),
-            SystemExit,
+            (
+                "kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",
+                "kernel_bad_package:111111",
+            ),
         ),
     ),
 )
-def test_get_most_recent_unique_kernel_pkgs(pkgs, exp_res, exception):
-    if not exception:
-        most_recent_pkgs = tuple(checks.get_most_recent_unique_kernel_pkgs(pkgs))
-        assert exp_res == most_recent_pkgs
-    else:
-        with pytest.raises(exception):
-            tuple(checks.get_most_recent_unique_kernel_pkgs(pkgs))
+def test_get_most_recent_unique_kernel_pkgs(pkgs, exp_res):
+    assert tuple(checks.get_most_recent_unique_kernel_pkgs(pkgs)) == exp_res
 
 
 @pytest.mark.parametrize(
@@ -733,7 +729,11 @@ class TestEFIChecks(unittest.TestCase):
     @unit_tests.mock(checks.system_info, "version", _gen_version(7, 9))
     @unit_tests.mock(checks, "logger", GetLoggerMocked())
     @unit_tests.mock(os.path, "exists", lambda x: not x == "/usr/sbin/efibootmgr")
-    @unit_tests.mock(grub, "EFIBootInfo", EFIBootInfoMocked(exception=grub.BootloaderError("errmsg")))
+    @unit_tests.mock(
+        grub,
+        "EFIBootInfo",
+        EFIBootInfoMocked(exception=grub.BootloaderError("errmsg")),
+    )
     def test_check_efi_efi_detected_without_efibootmgr(self):
         self._check_efi_critical("Install efibootmgr to continue converting the UEFI-based system.")
 
@@ -743,7 +743,11 @@ class TestEFIChecks(unittest.TestCase):
     @unit_tests.mock(checks.system_info, "version", _gen_version(7, 9))
     @unit_tests.mock(checks, "logger", GetLoggerMocked())
     @unit_tests.mock(os.path, "exists", lambda x: x == "/usr/sbin/efibootmgr")
-    @unit_tests.mock(grub, "EFIBootInfo", EFIBootInfoMocked(exception=grub.BootloaderError("errmsg")))
+    @unit_tests.mock(
+        grub,
+        "EFIBootInfo",
+        EFIBootInfoMocked(exception=grub.BootloaderError("errmsg")),
+    )
     def test_check_efi_efi_detected_non_intel(self):
         self._check_efi_critical("Only x86_64 systems are supported for UEFI conversions.")
 
@@ -753,7 +757,11 @@ class TestEFIChecks(unittest.TestCase):
     @unit_tests.mock(checks.system_info, "version", _gen_version(7, 9))
     @unit_tests.mock(checks, "logger", GetLoggerMocked())
     @unit_tests.mock(os.path, "exists", lambda x: x == "/usr/sbin/efibootmgr")
-    @unit_tests.mock(grub, "EFIBootInfo", EFIBootInfoMocked(exception=grub.BootloaderError("errmsg")))
+    @unit_tests.mock(
+        grub,
+        "EFIBootInfo",
+        EFIBootInfoMocked(exception=grub.BootloaderError("errmsg")),
+    )
     def test_check_efi_efi_detected_secure_boot(self):
         self._check_efi_critical(
             "The conversion with secure boot is currently not possible.\n"
@@ -767,7 +775,11 @@ class TestEFIChecks(unittest.TestCase):
     @unit_tests.mock(checks.system_info, "version", _gen_version(7, 9))
     @unit_tests.mock(checks, "logger", GetLoggerMocked())
     @unit_tests.mock(os.path, "exists", lambda x: x == "/usr/sbin/efibootmgr")
-    @unit_tests.mock(grub, "EFIBootInfo", EFIBootInfoMocked(exception=grub.BootloaderError("errmsg")))
+    @unit_tests.mock(
+        grub,
+        "EFIBootInfo",
+        EFIBootInfoMocked(exception=grub.BootloaderError("errmsg")),
+    )
     def test_check_efi_efi_detected_bootloader_error(self):
         self._check_efi_critical("errmsg")
 
@@ -986,7 +998,11 @@ class TestReadOnlyMountsChecks(unittest.TestCase):
             return self.return_string, self.return_code
 
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
-    @unit_tests.mock(checks, "call_yum_cmd", CallYumCmdMocked(ret_code=0, ret_string="Abcdef"))
+    @unit_tests.mock(
+        checks,
+        "call_yum_cmd",
+        CallYumCmdMocked(ret_code=0, ret_string="Abcdef"),
+    )
     @unit_tests.mock(checks, "logger", GetLoggerMocked())
     @unit_tests.mock(tool_opts, "no_rhsm", True)
     def test_custom_repos_are_valid(self):
@@ -998,7 +1014,11 @@ class TestReadOnlyMountsChecks(unittest.TestCase):
         )
 
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
-    @unit_tests.mock(checks, "call_yum_cmd", CallYumCmdMocked(ret_code=1, ret_string="Abcdef"))
+    @unit_tests.mock(
+        checks,
+        "call_yum_cmd",
+        CallYumCmdMocked(ret_code=1, ret_string="Abcdef"),
+    )
     @unit_tests.mock(checks, "logger", GetLoggerMocked())
     @unit_tests.mock(tool_opts, "no_rhsm", True)
     def test_custom_repos_are_invalid(self):

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -180,11 +180,9 @@ class TestMain(unittest.TestCase):
     @unit_tests.mock(tool_opts, "no_rhsm", False)
     @unit_tests.mock(cert.SystemCert, "_get_cert", lambda _get_cert: ("anything", "anything"))
     @mock_calls(main.special_cases, "check_and_resolve", CallOrderMocked)
-    @mock_calls(pkghandler, "install_gpg_keys", CallOrderMocked)
     @mock_calls(main.checks, "perform_pre_checks", CallOrderMocked)
-    @mock_calls(main.checks, "perform_pre_ponr_checks", CallOrderMocked)
+    @mock_calls(main.checks, "perform_system_checks", CallOrderMocked)
     @mock_calls(pkghandler, "remove_excluded_pkgs", CallOrderMocked)
-    @mock_calls(subscription, "replace_subscription_manager", CallOrderMocked)
     @mock_calls(subscription, "verify_rhsm_installed", CallOrderMocked)
     @mock_calls(pkghandler, "remove_repofile_pkgs", CallOrderMocked)
     @mock_calls(cert.SystemCert, "install", CallOrderMocked)
@@ -217,7 +215,7 @@ class TestMain(unittest.TestCase):
         intended_call_order["remove_repofile_pkgs"] = 1
         intended_call_order["enable_repos"] = 1
         intended_call_order["perform_pre_ponr_checks"] = 1
-        intended_call_order["perform_pre_checks"] = 1
+        intended_call_order["perform_system_checks"] = 1
 
         # Merge the two together like a zipper, creates a tuple which we can assert with - including method call order!
         zipped_call_order = zip(intended_call_order.items(), self.CallOrderMocked.calls.items())
@@ -231,6 +229,7 @@ class TestMain(unittest.TestCase):
     @mock_calls(main.special_cases, "check_and_resolve", CallOrderMocked)
     @mock_calls(pkghandler, "install_gpg_keys", CallOrderMocked)
     @mock_calls(main.checks, "perform_pre_checks", CallOrderMocked)
+    @mock_calls(main.checks, "perform_system_checks", CallOrderMocked)
     @mock_calls(main.checks, "perform_pre_ponr_checks", CallOrderMocked)
     @mock_calls(pkghandler, "remove_excluded_pkgs", CallOrderMocked)
     @mock_calls(subscription, "replace_subscription_manager", CallOrderMocked)

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -179,9 +179,11 @@ class TestMain(unittest.TestCase):
     @unit_tests.mock(tool_opts, "no_rhsm", False)
     @unit_tests.mock(cert.SystemCert, "_get_cert", lambda _get_cert: ("anything", "anything"))
     @mock_calls(main.special_cases, "check_and_resolve", CallOrderMocked)
-    @mock_calls(main.checks, "perform_pre_checks", CallOrderMocked)
+    @mock_calls(pkghandler, "install_gpg_keys", CallOrderMocked)
     @mock_calls(main.checks, "perform_system_checks", CallOrderMocked)
+    @mock_calls(main.checks, "perform_pre_ponr_checks", CallOrderMocked)
     @mock_calls(pkghandler, "remove_excluded_pkgs", CallOrderMocked)
+    @mock_calls(subscription, "replace_subscription_manager", CallOrderMocked)
     @mock_calls(subscription, "verify_rhsm_installed", CallOrderMocked)
     @mock_calls(pkghandler, "remove_repofile_pkgs", CallOrderMocked)
     @mock_calls(cert.SystemCert, "install", CallOrderMocked)
@@ -227,7 +229,6 @@ class TestMain(unittest.TestCase):
     @unit_tests.mock(cert.SystemCert, "_get_cert", lambda _get_cert: ("anything", "anything"))
     @mock_calls(main.special_cases, "check_and_resolve", CallOrderMocked)
     @mock_calls(pkghandler, "install_gpg_keys", CallOrderMocked)
-    @mock_calls(main.checks, "perform_pre_checks", CallOrderMocked)
     @mock_calls(main.checks, "perform_system_checks", CallOrderMocked)
     @mock_calls(main.checks, "perform_pre_ponr_checks", CallOrderMocked)
     @mock_calls(pkghandler, "remove_excluded_pkgs", CallOrderMocked)
@@ -268,6 +269,59 @@ class TestMain(unittest.TestCase):
         intended_call_order["remove_repofile_pkgs"] = 1
 
         intended_call_order["enable_repos"] = 0
+        intended_call_order["perform_pre_ponr_checks"] = 1
+        intended_call_order["perform_system_checks"] = 1
+
+        # Merge the two together like a zipper, creates a tuple which we can assert with - including method call order!
+        zipped_call_order = zip(intended_call_order.items(), self.CallOrderMocked.calls.items())
+        for expected, actual in zipped_call_order:
+            if expected[1] > 0:
+                self.assertEqual(expected, actual)
+
+    @unit_tests.mock(main.logging, "getLogger", GetLoggerMocked())
+    @unit_tests.mock(tool_opts, "no_rhsm", False)
+    @unit_tests.mock(cert.SystemCert, "_get_cert", lambda _get_cert: ("anything", "anything"))
+    @mock_calls(main.special_cases, "check_and_resolve", CallOrderMocked)
+    @mock_calls(pkghandler, "install_gpg_keys", CallOrderMocked)
+    @mock_calls(main.checks, "perform_pre_ponr_checks", CallOrderMocked)
+    @mock_calls(pkghandler, "remove_excluded_pkgs", CallOrderMocked)
+    @mock_calls(subscription, "replace_subscription_manager", CallOrderMocked)
+    @mock_calls(subscription, "verify_rhsm_installed", CallOrderMocked)
+    @mock_calls(pkghandler, "remove_repofile_pkgs", CallOrderMocked)
+    @mock_calls(cert.SystemCert, "install", CallOrderMocked)
+    @mock_calls(pkghandler, "list_third_party_pkgs", CallOrderMocked)
+    @mock_calls(subscription, "subscribe_system", CallOrderMocked)
+    @mock_calls(repo, "get_rhel_repoids", CallOrderMocked)
+    @mock_calls(subscription, "check_needed_repos_availability", CallOrderMocked)
+    @mock_calls(subscription, "disable_repos", CallOrderMocked)
+    @mock_calls(subscription, "enable_repos", CallOrderMocked)
+    @mock_calls(subscription, "download_rhsm_pkgs", CallOrderMocked)
+    @unit_tests.mock(checks, "check_readonly_mounts", GetFakeFunctionMocked)
+    def test_pre_ponr_conversion_order_without_rhsm(self):
+        self.CallOrderMocked.reset()
+        main.pre_ponr_conversion()
+
+        intended_call_order = OrderedDict()
+
+        intended_call_order["list_third_party_pkgs"] = 1
+        intended_call_order["remove_excluded_pkgs"] = 1
+        intended_call_order["check_and_resolve"] = 1
+        intended_call_order["install_gpg_keys"] = 1
+
+        # Do not expect this one to be called - related to RHSM
+        intended_call_order["download_rhsm_pkgs"] = 0
+        intended_call_order["replace_subscription_manager"] = 0
+        intended_call_order["verify_rhsm_installed"] = 0
+        intended_call_order["install"] = 0
+        intended_call_order["subscribe_system"] = 0
+        intended_call_order["get_rhel_repoids"] = 0
+        intended_call_order["check_needed_repos_availability"] = 0
+        intended_call_order["disable_repos"] = 0
+
+        intended_call_order["remove_repofile_pkgs"] = 1
+
+        intended_call_order["enable_repos"] = 0
+
         intended_call_order["perform_pre_ponr_checks"] = 1
 
         # Merge the two together like a zipper, creates a tuple which we can assert with - including method call order!
@@ -432,7 +486,7 @@ def test_main_rollback_pre_ponr_changes_phase(monkeypatch):
     resolve_system_info_mock = mock.Mock()
     collect_early_data_mock = mock.Mock()
     clean_yum_metadata_mock = mock.Mock()
-    perform_pre_checks_mock = mock.Mock()
+    perform_system_checks_mock = mock.Mock()
     system_release_file_mock = mock.Mock()
     os_release_file_mock = mock.Mock()
     backup_yum_repos_mock = mock.Mock()
@@ -452,7 +506,7 @@ def test_main_rollback_pre_ponr_changes_phase(monkeypatch):
     monkeypatch.setattr(breadcrumbs, "collect_early_data", collect_early_data_mock)
     monkeypatch.setattr(pkghandler, "clear_versionlock", clear_versionlock_mock)
     monkeypatch.setattr(pkghandler, "clean_yum_metadata", clean_yum_metadata_mock)
-    monkeypatch.setattr(checks, "perform_pre_checks", perform_pre_checks_mock)
+    monkeypatch.setattr(checks, "perform_system_checks", perform_system_checks_mock)
     monkeypatch.setattr(system_release_file, "backup", system_release_file_mock)
     monkeypatch.setattr(os_release_file, "backup", os_release_file_mock)
     monkeypatch.setattr(repo, "backup_yum_repos", backup_yum_repos_mock)
@@ -469,7 +523,7 @@ def test_main_rollback_pre_ponr_changes_phase(monkeypatch):
     assert resolve_system_info_mock.call_count == 1
     assert collect_early_data_mock.call_count == 1
     assert clean_yum_metadata_mock.call_count == 1
-    assert perform_pre_checks_mock.call_count == 1
+    assert perform_system_checks_mock.call_count == 1
     assert system_release_file_mock.call_count == 1
     assert os_release_file_mock.call_count == 1
     assert backup_yum_repos_mock.call_count == 1
@@ -488,7 +542,7 @@ def test_main_rollback_post_ponr_changes_phase(monkeypatch, caplog):
     resolve_system_info_mock = mock.Mock()
     collect_early_data_mock = mock.Mock()
     clean_yum_metadata_mock = mock.Mock()
-    perform_pre_checks_mock = mock.Mock()
+    perform_system_checks_mock = mock.Mock()
     system_release_file_mock = mock.Mock()
     os_release_file_mock = mock.Mock()
     backup_yum_repos_mock = mock.Mock()
@@ -510,7 +564,7 @@ def test_main_rollback_post_ponr_changes_phase(monkeypatch, caplog):
     monkeypatch.setattr(breadcrumbs, "collect_early_data", collect_early_data_mock)
     monkeypatch.setattr(pkghandler, "clear_versionlock", clear_versionlock_mock)
     monkeypatch.setattr(pkghandler, "clean_yum_metadata", clean_yum_metadata_mock)
-    monkeypatch.setattr(checks, "perform_pre_checks", perform_pre_checks_mock)
+    monkeypatch.setattr(checks, "perform_system_checks", perform_system_checks_mock)
     monkeypatch.setattr(system_release_file, "backup", system_release_file_mock)
     monkeypatch.setattr(os_release_file, "backup", os_release_file_mock)
     monkeypatch.setattr(repo, "backup_yum_repos", backup_yum_repos_mock)
@@ -529,7 +583,7 @@ def test_main_rollback_post_ponr_changes_phase(monkeypatch, caplog):
     assert resolve_system_info_mock.call_count == 1
     assert collect_early_data_mock.call_count == 1
     assert clean_yum_metadata_mock.call_count == 1
-    assert perform_pre_checks_mock.call_count == 1
+    assert perform_system_checks_mock.call_count == 1
     assert system_release_file_mock.call_count == 1
     assert os_release_file_mock.call_count == 1
     assert backup_yum_repos_mock.call_count == 1

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -17,7 +17,6 @@
 
 
 import os
-import sys
 import unittest
 
 from collections import OrderedDict
@@ -339,12 +338,12 @@ def test_main(monkeypatch):
     resolve_system_info_mock = mock.Mock()
     collect_early_data_mock = mock.Mock()
     clean_yum_metadata_mock = mock.Mock()
-    perform_pre_checks_mock = mock.Mock()
     system_release_file_mock = mock.Mock()
     os_release_file_mock = mock.Mock()
     backup_varsdir_mock = mock.Mock()
     backup_yum_repos_mock = mock.Mock()
     clear_versionlock_mock = mock.Mock()
+    perform_system_checks_mock = mock.Mock()
     pre_ponr_conversion_mock = mock.Mock()
     ask_to_continue_mock = mock.Mock()
     post_ponr_conversion_mock = mock.Mock()
@@ -363,11 +362,11 @@ def test_main(monkeypatch):
     monkeypatch.setattr(breadcrumbs, "collect_early_data", collect_early_data_mock)
     monkeypatch.setattr(pkghandler, "clear_versionlock", clear_versionlock_mock)
     monkeypatch.setattr(pkghandler, "clean_yum_metadata", clean_yum_metadata_mock)
-    monkeypatch.setattr(checks, "perform_pre_checks", perform_pre_checks_mock)
     monkeypatch.setattr(system_release_file, "backup", system_release_file_mock)
     monkeypatch.setattr(os_release_file, "backup", os_release_file_mock)
     monkeypatch.setattr(repo, "backup_yum_repos", backup_yum_repos_mock)
     monkeypatch.setattr(repo, "backup_varsdir", backup_varsdir_mock)
+    monkeypatch.setattr(checks, "perform_system_checks", perform_system_checks_mock)
     monkeypatch.setattr(main, "pre_ponr_conversion", pre_ponr_conversion_mock)
     monkeypatch.setattr(utils, "ask_to_continue", ask_to_continue_mock)
     monkeypatch.setattr(main, "post_ponr_conversion", post_ponr_conversion_mock)
@@ -386,7 +385,6 @@ def test_main(monkeypatch):
     assert resolve_system_info_mock.call_count == 1
     assert collect_early_data_mock.call_count == 1
     assert clean_yum_metadata_mock.call_count == 1
-    assert perform_pre_checks_mock.call_count == 1
     assert system_release_file_mock.call_count == 1
     assert os_release_file_mock.call_count == 1
     assert backup_yum_repos_mock.call_count == 1

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -1926,6 +1926,7 @@ def test_clean_yum_metadata(ret_code, expected, monkeypatch, caplog):
     pkghandler.clean_yum_metadata()
     assert expected in caplog.records[-1].message
 
+
 @all_systems
 def test_get_system_packages_for_replacement(pretend_os, monkeypatch):
     pkgs = ["pkg-1", "pkg-2"]
@@ -1934,6 +1935,7 @@ def test_get_system_packages_for_replacement(pretend_os, monkeypatch):
     result = pkghandler.get_system_packages_for_replacement()
     for pkg in pkgs:
         assert pkg in result
+
 
 @pytest.mark.parametrize(
     ("pkg_1", "pkg_2", "expected"),

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -1315,7 +1315,9 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
     def test_fix_default_kernel_with_no_incorrect_kernel(self):
         pkghandler.fix_default_kernel()
         self.assertTrue(len(pkghandler.logging.getLogger.info_msgs), 2)
-        self.assertTrue(any("Boot kernel validated." in message for message in pkghandler.logging.getLogger.debug_msgs))
+        self.assertTrue(
+            any("Boot kernel validated." in message for message in pkghandler.logging.getLogger.debug_msgs)
+        )
         self.assertTrue(len(pkghandler.logging.getLogger.warning_msgs) == 0)
 
 
@@ -1926,7 +1928,6 @@ def test_clean_yum_metadata(ret_code, expected, monkeypatch, caplog):
     pkghandler.clean_yum_metadata()
     assert expected in caplog.records[-1].message
 
-
 @all_systems
 def test_get_system_packages_for_replacement(pretend_os, monkeypatch):
     pkgs = ["pkg-1", "pkg-2"]
@@ -1935,3 +1936,36 @@ def test_get_system_packages_for_replacement(pretend_os, monkeypatch):
     result = pkghandler.get_system_packages_for_replacement()
     for pkg in pkgs:
         assert pkg in result
+
+@pytest.mark.parametrize(
+    ("pkg_1", "pkg_2", "expected"),
+    (
+        (
+            "kernel-core-0:4.18.0-240.10.1.el8_3.x86_64",
+            "kernel-core-0:4.18.0-240.15.1.el8_3.x86_64",
+            -1,
+        ),
+        (
+            "kmod-core-0:4.18.0-240.15.1.el8_3.x86_64",
+            "kmod-core-0:4.18.0-240.10.1.el8_3.x86_64",
+            1,
+        ),
+        (
+            "kmod-core-0:4.18.0-240.15.1.el8_3.x86_64",
+            "kmod-core-0:4.18.0-240.15.1.el8_3.x86_64",
+            0,
+        ),
+        (
+            "no-arch-0:4.18.0-240.15.1.el8_3",
+            "no-arch-0:4.18.0-240.15.1.el8_3",
+            0,
+        ),
+        (
+            "kmod-core-0.4.18.0-240.15.1.el8_3.x86_64",
+            "kmod-core-0.4.18.0-240.15.1.el8_3.x86_64",
+            0,
+        ),
+    ),
+)
+def test__package_version_cmp(pkg_1, pkg_2, expected):
+    assert pkghandler._package_version_cmp(pkg_1, pkg_2) == expected

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -1315,9 +1315,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
     def test_fix_default_kernel_with_no_incorrect_kernel(self):
         pkghandler.fix_default_kernel()
         self.assertTrue(len(pkghandler.logging.getLogger.info_msgs), 2)
-        self.assertTrue(
-            any("Boot kernel validated." in message for message in pkghandler.logging.getLogger.debug_msgs)
-        )
+        self.assertTrue(any("Boot kernel validated." in message for message in pkghandler.logging.getLogger.debug_msgs))
         self.assertTrue(len(pkghandler.logging.getLogger.warning_msgs) == 0)
 
 

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -402,7 +402,8 @@ def test_get_system_distribution_id(system_release_content, expected):
 def test_get_system_distribution_id_default_system_release_content(pretend_os):
     assert system_info._get_system_distribution_id() == None
 
-@pytest.mark.parametrize( 
+
+@pytest.mark.parametrize(
     (
         "submgr_enabled_repos",
         "tool_opts_no_rhsm",

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-# Required imports:
 import logging
 import os
 import shutil
@@ -247,10 +246,23 @@ def test_get_release_ver_other(
 ):
     monkeypatch.setattr(systeminfo.SystemInfo, "_get_cfg_opt", mock.Mock(return_value=releasever_val))
     monkeypatch.setattr(systeminfo.SystemInfo, "_check_internet_access", mock.Mock(return_value=has_internet))
+    monkeypatch.setattr(
+        systeminfo.SystemInfo,
+        "_get_cfg_opt",
+        mock.Mock(return_value=releasever_val),
+    )
     if self_name:
-        monkeypatch.setattr(systeminfo.SystemInfo, "_get_system_name", mock.Mock(return_value=self_name))
+        monkeypatch.setattr(
+            systeminfo.SystemInfo,
+            "_get_system_name",
+            mock.Mock(return_value=self_name),
+        )
     if self_version:
-        monkeypatch.setattr(systeminfo.SystemInfo, "_get_system_version", mock.Mock(return_value=self_version))
+        monkeypatch.setattr(
+            systeminfo.SystemInfo,
+            "_get_system_version",
+            mock.Mock(return_value=self_version),
+        )
     # calling resolve_system_info one more time to enable our monkeypatches
     if exception:
         with pytest.raises(exception):
@@ -389,3 +401,37 @@ def test_get_system_distribution_id(system_release_content, expected):
 @centos8
 def test_get_system_distribution_id_default_system_release_content(pretend_os):
     assert system_info._get_system_distribution_id() == None
+
+@pytest.mark.parametrize( 
+    (
+        "submgr_enabled_repos",
+        "tool_opts_no_rhsm",
+        "tool_opts_enablerepo",
+        "expected",
+    ),
+    (
+        (
+            ["rhel-repo1.repo", "rhel-repo2.repo"],
+            False,
+            [],
+            ["rhel-repo1.repo", "rhel-repo2.repo"],
+        ),
+        (
+            ["rhel-repo1.repo", "rhel-repo2.repo"],
+            True,
+            ["cli-rhel-repo1.repo", "cli-rhel-repo2.repo"],
+            ["cli-rhel-repo1.repo", "cli-rhel-repo2.repo"],
+        ),
+    ),
+)
+def test_get_enabled_rhel_repos(
+    submgr_enabled_repos,
+    tool_opts_no_rhsm,
+    tool_opts_enablerepo,
+    expected,
+):
+    system_info.submgr_enabled_repos = submgr_enabled_repos
+    tool_opts.enablerepo = tool_opts_enablerepo
+    tool_opts.no_rhsm = tool_opts_no_rhsm
+
+    assert system_info.get_enabled_rhel_repos() == expected

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -430,9 +430,12 @@ def test_get_enabled_rhel_repos(
     tool_opts_no_rhsm,
     tool_opts_enablerepo,
     expected,
+    global_tool_opts,
+    monkeypatch,
 ):
+    monkeypatch.setattr(systeminfo, "tool_opts", global_tool_opts)
     system_info.submgr_enabled_repos = submgr_enabled_repos
-    tool_opts.enablerepo = tool_opts_enablerepo
-    tool_opts.no_rhsm = tool_opts_no_rhsm
+    global_tool_opts.enablerepo = tool_opts_enablerepo
+    global_tool_opts.no_rhsm = tool_opts_no_rhsm
 
     assert system_info.get_enabled_rhel_repos() == expected

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -20,7 +20,6 @@
 
 import os
 import sys
-import unittest
 
 from collections import namedtuple
 
@@ -30,7 +29,6 @@ import six
 import convert2rhel.toolopts
 import convert2rhel.utils
 
-from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel.toolopts import tool_opts
 
 

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -677,23 +677,6 @@ def string_to_version(verstring):
     return (epoch, version, release)
 
 
-def convert_to_int_or_zero(s):
-    """Convert a string to an integer.
-
-    Tries to convert a given string to it's integer counterpart. If it's not possible to convert, then it catches an
-    `ValuerError` excpetion raised by the conversion and return 0 to the caller.
-
-    :param s: The string to be converted
-    :type s: str
-    :return: Returns an int representation of the given string if possible, otherwise, returns 0.
-    :rtype: int
-    """
-    try:
-        return int(s)
-    except ValueError:
-        return 0
-
-
 def remove_orphan_folders():
     """Even after removing redhat-release-* package, some of its folders are
     still present, are empty, and that blocks us from installing centos-release

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -677,6 +677,23 @@ def string_to_version(verstring):
     return (epoch, version, release)
 
 
+def convert_to_int_or_zero(s):
+    """Convert a string to an integer.
+
+    Tries to convert a given string to it's integer counterpart. If it's not possible to convert, then it catches an
+    `ValuerError` excpetion raised by the conversion and return 0 to the caller.
+
+    :param s: The string to be converted
+    :type s: str
+    :return: Returns an int representation of the given string if possible, otherwise, returns 0.
+    :rtype: int
+    """
+    try:
+        return int(s)
+    except ValueError:
+        return 0
+
+
 def remove_orphan_folders():
     """Even after removing redhat-release-* package, some of its folders are
     still present, are empty, and that blocks us from installing centos-release

--- a/tests/integration/tier0/inhibit-if-kmods-is-not-supported/main.fmf
+++ b/tests/integration/tier0/inhibit-if-kmods-is-not-supported/main.fmf
@@ -1,4 +1,4 @@
-summary: kmods tests
+summary: Test for Convert2RHEL being able to handle custom, tainted and force loaded kernel modules.
 
 tier: 0
 

--- a/tests/integration/tier0/inhibit-if-kmods-is-not-supported/main.fmf
+++ b/tests/integration/tier0/inhibit-if-kmods-is-not-supported/main.fmf
@@ -1,6 +1,9 @@
-summary: Test for Convert2RHEL being able to handle custom, tainted and force loaded kernel modules.
+summary: Verify, that Convert2RHEL is able to handle custom, tainted and force loaded kernel modules.
 
 tier: 0
+
+tags+:
+  - kernel
 
 test: |
   pytest -svv

--- a/tests/integration/tier0/inhibit-if-kmods-is-not-supported/main.fmf
+++ b/tests/integration/tier0/inhibit-if-kmods-is-not-supported/main.fmf
@@ -1,8 +1,10 @@
-summary: Verify, that Convert2RHEL is able to handle custom, tainted and force loaded kernel modules.
+summary: Handle custom, tainted and force loaded kernel modules.
+description: |
+    Verify, that Convert2RHEL is able to handle custom, tainted and force loaded kernel modules.
 
 tier: 0
 
-tags+:
+tag+:
   - kernel
 
 test: |

--- a/tests/integration/tier0/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
+++ b/tests/integration/tier0/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
@@ -86,7 +86,7 @@ def test_do_not_inhibit_if_module_is_not_loaded(shell, convert2rhel):
 def test_do_not_inhibit_if_module_is_force_loaded(shell, convert2rhel):
     """
     Test force loads kmod and verifies that Convert2RHEL run is being inhibited.
-    Force loaded kmods are denoted (FE) for F = module was force loaded E = unsigned module was loaded.
+    Force loaded kmods are denoted (FE) where F = module was force loaded E = unsigned module was loaded.
     Convert2RHEL sees force loaded kmod as tainted.
     """
     if "oracle-7" not in system_version and "centos-7" not in system_version:

--- a/tests/integration/tier0/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
+++ b/tests/integration/tier0/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
@@ -1,4 +1,3 @@
-import os
 import platform
 
 from pathlib import Path
@@ -13,6 +12,11 @@ system_version = platform.platform()
 
 @pytest.fixture()
 def insert_custom_kmod(shell):
+    """
+    Move the kernel module to custom location, so it is marked as custom.
+    Then load the kernel module.
+    """
+
     def factory():
         origin_kmod_loc = Path("/lib/modules/$(uname -r)/kernel/drivers/net/bonding/bonding.ko.xz")
         new_kmod_dir = origin_kmod_loc.parent / "custom_module_location"
@@ -32,7 +36,7 @@ def test_inhibit_if_custom_module_loaded(insert_custom_kmod, convert2rhel):
     """
     insert_custom_kmod()
     with convert2rhel(
-        ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
+        "-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug".format(
             env.str("RHSM_SERVER_URL"),
             env.str("RHSM_USERNAME"),
             env.str("RHSM_PASSWORD"),
@@ -59,7 +63,7 @@ def test_do_not_inhibit_if_module_is_not_loaded(shell, convert2rhel):
         prompt_amount = 3
     # If custom module is not loaded the conversion is not inhibited.
     with convert2rhel(
-        ("--no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
+        "--no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug".format(
             env.str("RHSM_SERVER_URL"),
             env.str("RHSM_USERNAME"),
             env.str("RHSM_PASSWORD"),
@@ -71,7 +75,9 @@ def test_do_not_inhibit_if_module_is_not_loaded(shell, convert2rhel):
             c2r.sendline("y")
             prompt_amount -= 1
 
-        assert c2r.expect("Kernel modules are compatible.", timeout=600) == 0
+        # Stop conversion before the point of no return as we do not need to run the full conversion
+        # with the check for kompatible kernel modules being right before the PONR.
+        assert c2r.expect("All loaded kernel modules are available in RHEL.", timeout=600) == 0
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("n")
         assert c2r.exitstatus != 0
@@ -83,15 +89,16 @@ def test_do_not_inhibit_if_module_is_force_loaded(shell, convert2rhel):
     With the check for tainted kernel modules being at the beginning of the script, abort the conversion ASAP
     for the sake of test speed.
     """
+    # Force load the kernel module
     assert shell("modprobe -f -v bonding").returncode == 0
-    # Check for force loaded modules being in /proc/modules
+    # Check for force loaded modules being flagged FE in /proc/modules
     assert "(FE)" in shell("cat /proc/modules").output
 
     with convert2rhel("--no-rpm-va --debug") as c2r:
         assert c2r.expect("Tainted kernel module\(s\) detected") == 0
         assert c2r.exitstatus != 0
 
-    # Clean up
+    # Clean up - unload kmod and check for force loaded modules not being in /proc/modules
     assert shell("modprobe -r -v bonding").returncode == 0
     assert "(FE)" not in shell("cat /proc/modules").output
 
@@ -99,9 +106,12 @@ def test_do_not_inhibit_if_module_is_force_loaded(shell, convert2rhel):
 def test_tainted_kernel_inhibitor(shell, convert2rhel):
     """
     This test marks the kernel as tainted which is not supported by Convert2RHEL.
+    We need to install specific kernel packages to build own custom kernel module.
+    Build own kmod from source file that has been copied to the testing machine during preparation phase.
+    This kmod marks the system with the P, O and E flags.
     """
 
-    # We need to install specific kernel packages to build own custom kernel module.
+    # Install kernel packages
     shell("yum -y install gcc make kernel-headers kernel-devel-$(uname -r) elfutils-libelf-devel")
 
     # Build own kmod form source file that has been copied to the testing machine during preparation phase.
@@ -110,12 +120,12 @@ def test_tainted_kernel_inhibitor(shell, convert2rhel):
     assert shell("insmod /tmp/my-test/my_kmod.ko").returncode == 0
 
     with convert2rhel(
-        ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
+        "-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug".format(
             env.str("RHSM_SERVER_URL"),
             env.str("RHSM_USERNAME"),
             env.str("RHSM_PASSWORD"),
             env.str("RHSM_POOL"),
         )
     ) as c2r:
-        c2r.expect("Tainted kernel module\(s\) detected")
+        c2r.expect("Tainted kernel modules detected")
     assert c2r.exitstatus != 0

--- a/tests/integration/tier0/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
+++ b/tests/integration/tier0/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
@@ -43,7 +43,7 @@ def test_inhibit_if_custom_module_loaded(insert_custom_kmod, convert2rhel):
             env.str("RHSM_POOL"),
         )
     ) as c2r:
-        c2r.expect("The following kernel modules are not supported in RHEL")
+        c2r.expect("The following loaded kernel modules are not available in RHEL")
     assert c2r.exitstatus != 0
 
 


### PR DESCRIPTION
These changes are cleanup of most of the things that were left behind from
PR #193.

Some of the functions were changed to make it easier to read and debug if
necessary, some of them were moved around to the files that made sense to place
they and some of them just needed a docstring to tell what the function was all
about.

This PR it is introduced a unit test for the function `get_enabled_rhel_repos`
since that was introduced in the past and never had a unit test tied to it.

Jira reference (If any): https://issues.redhat.com/browse/OAMG-4668
Bugzilla reference (If any):

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>