### PR TITLE
Re-enable tesing on CentOS-8

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -44,9 +44,8 @@ jobs:
     targets:
       epel-7-x86_64:
         distros: [centos-7]
-      # Disabled until C8 repos are stable again, see OAMG-6499, OAMG-6535 for more info
-      #epel-8-x86_64:
-      #  distros: [centos-8]
+      epel-8-x86_64:
+        distros: [centos-8]
       oraclelinux-7-x86_64:
         distros: [oraclelinux-7]
       oraclelinux-8-x86_64:


### PR DESCRIPTION
Try to re-enable testing of centos-8 in upstream CI. Monitor the tests and see if it is having infrastructure errors.