### PR TITLE
[RHELC-570] Cleanup pexpect terminal size

### DIFF
--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 
 import pytest
@@ -23,6 +24,39 @@ def is_py26():
 @pytest.fixture(scope="session")
 def is_py2():
     return sys.version_info[:2] <= (2, 7)
+
+
+@pytest.fixture
+def clear_loggers():
+    """
+    Remove handlers from the loggers.
+
+    If logger handlers are created while we are using capsys or capfd, then
+    the logger handlers get created with pytest's capture.  If pytest's
+    capture feature is disabled later, the logger handlers will get errors
+    trying to write to a closed file.  This is this issue:
+
+        https://github.com/pytest-dev/pytest/issues/5502
+
+    In our unittests, there are some tests that use pexpect that have to
+    disable pytest's capture otherwise pexpect-2.3 will malfunction.  The
+    combination of these two things causes logging calls during the utils
+    tests to complain that they are trying to log to a closed file handle.
+
+    Adding this fixture to any unit test which both uses capsys/capfd and
+    creates the logger handlers (by calling
+    `convert2rhel.logger.setup_logger_handler()`) fixes the issue.  The
+    fixture works by removing the handlers that `setup_logger_handler()`
+    (actually, all of the handlers) created when the test completes.
+    """
+    # Nothing to do in setup
+    yield
+    # In teardown, we clear all the logger handlers.
+    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
+    for logger in loggers:
+        handlers = getattr(logger, "handlers", [])
+        for handler in handlers:
+            logger.removeHandler(handler)
 
 
 @pytest.fixture()

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -52,10 +52,11 @@ def clear_loggers():
     # Nothing to do in setup
     yield
     # In teardown, we clear all the logger handlers.
-    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
+    loggers = logging.Logger.manager.loggerDict.values()
     for logger in loggers:
-        handlers = getattr(logger, "handlers", [])
-        for handler in handlers:
+        if not hasattr(logger, "handlers"):
+            continue
+        for handler in logger.handlers[:]:
             logger.removeHandler(handler)
 
 

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -21,14 +21,15 @@ import os
 import pytest
 
 from convert2rhel import logger as logger_module
-from convert2rhel.toolopts import tool_opts
 
 
-def test_logger_handlers(tmpdir, caplog, read_std, is_py2, capsys):
+def test_logger_handlers(monkeypatch, tmpdir, caplog, read_std, is_py2, global_tool_opts, clear_loggers):
     """Test if the logger handlers emmits the events to the file and stdout."""
+    monkeypatch.setattr(logger_module, "tool_opts", global_tool_opts)
+
     # initializing the logger first
     log_fname = "convert2rhel.log"
-    tool_opts.debug = True  # debug entries > stdout if True
+    global_tool_opts.debug = True  # debug entries > stdout if True
     logger_module.setup_logger_handler(log_name=log_fname, log_dir=str(tmpdir))
     logger = logging.getLogger(__name__)
 
@@ -45,13 +46,19 @@ def test_logger_handlers(tmpdir, caplog, read_std, is_py2, capsys):
     stdouterr_out, stdouterr_err = read_std()
     assert "Test info: data" in stdouterr_out
     assert "Test debug: other data" in stdouterr_out
+    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
+    for logger in loggers:
+        handlers = getattr(logger, "handlers", [])
+        for handler in handlers:
+            logger.removeHandler(handler)
 
 
-def test_tools_opts_debug(tmpdir, read_std, is_py2):
+def test_tools_opts_debug(monkeypatch, tmpdir, read_std, is_py2, global_tool_opts, clear_loggers):
+    monkeypatch.setattr(logger_module, "tool_opts", global_tool_opts)
     log_fname = "convert2rhel.log"
     logger_module.setup_logger_handler(log_name=log_fname, log_dir=str(tmpdir))
     logger = logging.getLogger(__name__)
-    tool_opts.debug = True
+    global_tool_opts.debug = True
     logger.debug("debug entry 1: %s", "data")
     stdouterr_out, stdouterr_err = read_std()
     # TODO should be in stdout, but this only works when running this test
@@ -64,10 +71,16 @@ def test_tools_opts_debug(tmpdir, read_std, is_py2):
         else:
             # this workaround is not working for py2 - passing
             pass
-    tool_opts.debug = False
+
+    global_tool_opts.debug = False
     logger.debug("debug entry 2: %s", "data")
     stdouterr_out, stdouterr_err = read_std()
     assert "debug entry 2: data" not in stdouterr_out
+    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
+    for logger in loggers:
+        handlers = getattr(logger, "handlers", [])
+        for handler in handlers:
+            logger.removeHandler(handler)
 
 
 def test_logger_custom_logger(tmpdir, caplog):

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -46,11 +46,6 @@ def test_logger_handlers(monkeypatch, tmpdir, caplog, read_std, is_py2, global_t
     stdouterr_out, stdouterr_err = read_std()
     assert "Test info: data" in stdouterr_out
     assert "Test debug: other data" in stdouterr_out
-    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
-    for logger in loggers:
-        handlers = getattr(logger, "handlers", [])
-        for handler in handlers:
-            logger.removeHandler(handler)
 
 
 def test_tools_opts_debug(monkeypatch, tmpdir, read_std, is_py2, global_tool_opts, clear_loggers):
@@ -76,14 +71,9 @@ def test_tools_opts_debug(monkeypatch, tmpdir, read_std, is_py2, global_tool_opt
     logger.debug("debug entry 2: %s", "data")
     stdouterr_out, stdouterr_err = read_std()
     assert "debug entry 2: data" not in stdouterr_out
-    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
-    for logger in loggers:
-        handlers = getattr(logger, "handlers", [])
-        for handler in handlers:
-            logger.removeHandler(handler)
 
 
-def test_logger_custom_logger(tmpdir, caplog):
+def test_logger_custom_logger(tmpdir, caplog, clear_loggers):
     """Test CustomLogger."""
     log_fname = "convert2rhel.log"
     logger_module.setup_logger_handler(log_name=log_fname, log_dir=str(tmpdir))

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -446,7 +446,7 @@ class TestRegisterSystem(object):
         fake_spawn = mock.Mock()
         fake_spawn.before.decode = mock.Mock(return_value="nope")
         fake_spawn.exitstatus = 1
-        monkeypatch.setattr(utils, "PexpectSizedWindowSpawn", fake_spawn)
+        monkeypatch.setattr(utils, "PexpectSpawnWithDimensions", fake_spawn)
 
         tool_opts.username = "user"
         tool_opts.password = "pass"
@@ -486,7 +486,7 @@ class TestRegisterSystem(object):
         fake_process = FakeProcess()
         fake_process.before.decode = mock.Mock(side_effect=("nope", "nope", "Success"))
         fake_spawn = mock.Mock(return_value=fake_process)
-        monkeypatch.setattr(utils, "PexpectSizedWindowSpawn", fake_spawn)
+        monkeypatch.setattr(utils, "PexpectSpawnWithDimensions", fake_spawn)
 
         subscription.register_system()
 

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -275,12 +275,21 @@ print(terminal_size()[0])
     ),
 )
 def test_run_cmd_in_pty_size_set_on_startup(columns, tmpdir):
+    """Test whether run_cmd_in_pty sets the terminal window size on startup."""
     with open(str(tmpdir / "terminal-test.py"), "w") as f:
         f.write(TERMINAL_SIZE_SCRIPT)
 
     output, return_code = utils.run_cmd_in_pty([sys.executable, str(tmpdir / "terminal-test.py")], columns=columns)
 
     assert int(output.strip()) == columns
+
+
+def test_run_cmd_in_pty_size_set_on_startup_unknown_typeerror():
+    """Test whether we re-raise TypeError when we don't know how to handle it."""
+    # Our compat class handles TypeError caused by passing dimensions.  Check
+    # that TypeError caused by something else re-raises the TypeError.
+    with pytest.raises(TypeError, match=".*got an unexpected keyword argument 'unknown'"):
+        _dummy = utils.PexpectSpawnWithDimensions("/bin/true", [], unknown=False)
 
 
 def test_get_package_name_from_rpm(monkeypatch):

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -240,7 +240,7 @@ def test_run_cmd_in_pty_quiet_options(print_cmd, print_output, global_tool_opts,
     with capfd.disabled():
         output, code = utils.run_cmd_in_pty(["echo", "foo bar"], print_cmd=print_cmd, print_output=print_output)
 
-    expected_count = 1  # There will always be one debug log stating the pty columns
+    expected_count = 0
     if print_cmd:
         assert caplog.records[0].levelname == "DEBUG"
         assert caplog.records[0].message.strip() == "Calling command 'echo foo bar'"

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -195,9 +195,6 @@ def run_cmd_in_pty(cmd, expect_script=(), print_cmd=True, print_output=True, col
     process = PexpectSpawnWithDimensions(
         cmd[0], cmd[1:], env={"LC_ALL": "C", "LANG": "C"}, timeout=None, dimensions=(1, columns)
     )
-    # The setting of window size is super unreliable
-    process.setwinsize(1, columns)
-    loggerinst.debug("Pseudo-PTY created with columns set to: %s" % (process.getwinsize(),))
 
     for expect, send in expect_script:
         process.expect(expect)

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -245,12 +245,16 @@ class PexpectSpawnWithDimensions(pexpect.spawn):
             # With pexpect-2.4+, dimensions is a valid keyword arg
             super(PexpectSpawnWithDimensions, self).__init__(*args, **kwargs)
         except TypeError:
+            #
             # This is a kludge to give us a dimensions kwarg on pexpect 2.3 or less.
+            #
             if "dimensions" not in kwargs:
+                # We can only handle the case where the exception is because dimensions was passed
+                # to pexpect.spawn.  If that's not what's happening here, re-raise the exception.
                 raise
 
-            real_setwinsize = self.setwinsize
             dimensions = kwargs.pop("dimensions")
+            real_setwinsize = self.setwinsize
 
             # pexpect.spawn.__init__() calls setwinsize to set the rows and columns to a default
             # value.  Temporarily override setwinsize with a version that hardcodes the rows
@@ -268,7 +272,7 @@ class PexpectSpawnWithDimensions(pexpect.spawn):
             self.setwinsize = real_setwinsize
 
             # I don't have a good explanation but this call, after the process has been started
-            # by pexpect.spawn.__init__() is also needed on at least RHEL7.
+            # by pexpect.spawn.__init__(), is also needed on at least RHEL7.
             self.setwinsize(dimensions[0], dimensions[1])
 
 

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -188,10 +188,10 @@ def run_cmd_in_pty(cmd, expect_script=(), print_cmd=True, print_output=True, col
     if print_cmd:
         loggerinst.debug("Calling command '%s'" % " ".join(cmd))
 
-    process = PexpectSizedWindowSpawn(cmd[0], cmd[1:], env={"LC_ALL": "C", "LANG": "C"}, timeout=None)
-    # Needed on RHEL-8+ (see comments near PexpectSizedWindowSpawn definition)
-    process.setwinsize(1, columns)
-    loggerinst.debug("Pseudo-PTY columns set to: %s" % (process.getwinsize(),))
+    process = PexpectSpawnWithDimensions(
+        cmd[0], cmd[1:], env={"LC_ALL": "C", "LANG": "C"}, timeout=None, dimensions=(1, columns)
+    )
+    loggerinst.debug("Pseudo-PTY created with columns set to: %s" % (process.getwinsize(),))
 
     for expect, send in expect_script:
         process.expect(expect)
@@ -217,28 +217,59 @@ def run_cmd_in_pty(cmd, expect_script=(), print_cmd=True, print_output=True, col
     return output, return_code
 
 
-# For pexpect released prior to 2015 (RHEL7's pexpect-2.3),
-# spawn.__init__() hardcodes a call to setwinsize(24, 80) to set the
-# initial terminal size. There is no official way to set the terminal size
-# to a custom value before the process starts. This can cause an issue with
-# truncated lines for processes which read the terminal size when they
-# start and never refresh that value (like yumdownloader)
-#
-# overriding setwinsize to set the columns to the size we want in this
-# subclass is a kludge for the issue. On pexpect-2.3, it fixes the issue
-# because of the setwinsize call in __init__() at the cost of never being
-# able to change the column size later.  On later pexpect (RHEL-8 has
-# pexpect-4.3), this doesn't fix the issue of the terminal size being small
-# when the subprocess starts but dnf download checks the terminal's size
-# just before it prints the statusline we care about. So setting the
-# terminal size via setwinsize() after the process is created works (note:
-# there is a race condition there but it's unlikely to ever trigger as it
-# would require downloading a package to happen quicker than the time
-# between calling spawn.__init__() and spawn.setwinsize())
-class PexpectSizedWindowSpawn(pexpect.spawn):
-    # https://github.com/pexpect/pexpect/issues/134
-    def setwinsize(self, rows, cols):
-        super(PexpectSizedWindowSpawn, self).setwinsize(rows, 120)
+class PexpectSpawnWithDimensions(pexpect.spawn):
+    """
+    Pexpect.spawn class that can set terminal size before starting process.
+
+    This class is a workaround to the fact that pexpect-2.3 cannot officially set the terminal size
+    until after the process is started.  On RHEL7, we use pexpect 2.3 along with yumdownloader.
+    yundownloader checks the terminal size when it starts and then uses that terminal size for
+    printing out its progress lines even if the size changes later.  This causes output to be
+    truncated (losing information about the downloaded packages) because the line would be longer
+    than the 80 columns which pexpect.spawn hardcodes as the startup value.
+
+    Modern versions of pexpect (from 2015) fix this by giving spawn a dimensions() argument to set
+    the startup terminal size.  We can emulate this by overriding the setwindowsize() function in
+    a subclass through the use of a big kludge:
+
+    pexpect-2.3's __init__() calls setwindowsize() to set the initial terminal size. If we
+    override setwindowsize() to hardcode the dimensions that we pass in to the subclass's
+    constructor prior to calling the base class's __init__(), pexpect will end up calling our
+    overridden setwindowsize(), making the terminal the size that we want. If we then revert
+    setwindowsize() back to the real function prior to returning from the subclass's __init__(),
+    user's of the returned spawn object won't know that we temporarily overrode that method.
+    """
+
+    def __init__(self, *args, **kwargs):
+        try:
+            # With pexpect-2.4+, dimensions is a valid keyword arg
+            super(PexpectSpawnWithDimensions, self).__init__(*args, **kwargs)
+        except TypeError:
+            # This is a kludge to give us a dimensions kwarg on pexpect 2.3 or less.
+            if "dimensions" not in kwargs:
+                raise
+
+            real_setwinsize = self.setwinsize
+            dimensions = kwargs.pop("dimensions")
+
+            # pexpect.spawn.__init__() calls setwinsize to set the rows and columns to a default
+            # value.  Temporarily override setwinsize with a version that hardcodes the rows
+            # and columns to set rows and columns before the process is spawned.
+            # https://github.com/pexpect/pexpect/issues/134
+            def _setwinsize(self, rows, cols):
+                # This is a closure.  It takes dimensions from the function's defining scope.
+                super(PexpectSpawnWithDimensions, self).setwinsize(dimensions[0], dimensions[1])
+
+            self.setwinsize = _setwinsize
+
+            super(PexpectSpawnWithDimensions, self).__init__(*args, **kwargs)
+
+            # Restore the real setwinsize
+            self.setwinsize = real_setwinsize
+
+            # I don't have a good explanation but this call, after the process has been started
+            # by pexpect.spawn.__init__() is also needed on at least RHEL7.
+            self.setwinsize(dimensions[0], dimensions[1])
 
 
 def let_user_choose_item(num_of_options, item_to_choose):


### PR DESCRIPTION
For some of the programs we run, we have to set the terminal size before the process starts.  In the past we've done this by subclassing pexpect.spawn on all platforms.  Newer pexpect gives us the dimensions parameter to spawn() to do this in a better way.  This change will use dimensions.spawn() when available and our hack when it is not.

Fixes [RHELC-570](https://issues.redhat.com/browse/RHELC-570)