### PR TITLE
Fix old logs archival

### DIFF
--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -126,7 +126,7 @@ def archive_old_logger_files(log_name, log_dir):
 
     file_name, suffix = tuple(log_name.rsplit(".", 1))
     archive_log_file = "%s/%s-%s.%s" % (archive_log_dir, file_name, formatted_time, suffix)
-    shutil.copyfile(current_log_file, archive_log_file)
+    shutil.move(current_log_file, archive_log_file)
 
 
 def _task(self, msg, *args, **kwargs):

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -110,3 +110,5 @@ def test_archive_old_logger_files(log_name, path_exists, tmpdir, caplog):
         assert len(archive_files) == 1
         with open(os.path.join(archive_dir, archive_files[0])) as archive_f:
             assert archive_f.read() == test_data
+
+    assert not os.path.exists(log_file)


### PR DESCRIPTION
This PR introduces a fix for the log archival introduced in the
[PR#359](https://github.com/oamg/convert2rhel/pull/359).

The feature introduced there did a `copyfile` instead of a `move` to the
`archive` directory, wich was not the expected way of archiving a log.

Using a `copyfile` instead of a `move` causes the log file to be copied to the
`archive` directory as expected, but we still keep appending the log to the
`convert2rhel.log` file.

Jira reference (If any): https://issues.redhat.com/browse/RHELC-566
Bugzilla reference (If any):

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>