### PR TITLE
Exclude iwlax2xx-firmware dependency from the conversion in OL8

### DIFF
--- a/convert2rhel/special_cases.py
+++ b/convert2rhel/special_cases.py
@@ -20,7 +20,7 @@ import os
 
 from convert2rhel.grub import is_efi
 from convert2rhel.systeminfo import system_info
-from convert2rhel.utils import RestorableFile, mkdir_p
+from convert2rhel.utils import RestorableFile, mkdir_p, run_subprocess
 
 
 OPENJDK_RPM_STATE_DIR = "/var/lib/rpm-state/"
@@ -33,6 +33,33 @@ shim_x64_pkg_protection_file = RestorableFile(_SHIM_X64_PKG_PROTECTION_FILE_PATH
 def check_and_resolve():
     perform_java_openjdk_workaround()
     unprotect_shim_x64()
+    remove_iwlax2xx_firmware()
+
+
+def remove_iwlax2xx_firmware():
+    """Resolve a yum transaction failure on OL8 related to the iwl7260-firmware and iwlax2xx-firmware.
+
+    This package causes some transaction problems while trying to replace it with it's RHEL counterpart. The reason for
+    this happening is that the iwlax2xx-firmware is an dependency package of iwl7260-firmware in OL8, but in the RHEL
+    repositories, this dependency doesn't exist, all of the files that are available under the iwlax2xx-firmware package
+    in OL8, are in fact, available in the iwl7260-firmware package in RHEL, thus, we are removing this depedency to not
+    cause problems with the conversion anymore.
+
+    Related: https://bugzilla.redhat.com/show_bug.cgi?id=2078916
+    """
+    iwl7260_firmware = system_info.is_rpm_installed(name="iwl7260-firmware")
+    iwlax2xx_firmware = system_info.is_rpm_installed(name="iwlax2xx-firmware")
+
+    logger.info("Removing iwlax2xx-firmware package.")
+    if system_info.id == "oracle" and system_info.version.major == 8:
+        # If we have both of the firmware installed on the system, we need to remove the later one,
+        # iwlax2xx-firmware, since this causes problem in the OL8 conversion in the replace packages step.
+        if iwl7260_firmware and iwlax2xx_firmware:
+            _, exit_code = run_subprocess(("rpm", "-e", "--nodeps", "iwlax2xx-firmware"))
+            if exit_code != 0:
+                logger.error("Unable to remove the package iwlax2xx-firmware.")
+    else:
+        logger.info("Relevant to Oracle Linux 8 only. Skipping.")
 
 
 def perform_java_openjdk_workaround():

--- a/convert2rhel/special_cases.py
+++ b/convert2rhel/special_cases.py
@@ -39,23 +39,23 @@ def check_and_resolve():
 def remove_iwlax2xx_firmware():
     """Resolve a yum transaction failure on OL8 related to the iwl7260-firmware and iwlax2xx-firmware.
 
-    This package causes some transaction problems while trying to replace it with it's RHEL counterpart. The reason for
-    this happening is that the iwlax2xx-firmware is an dependency package of iwl7260-firmware in OL8, but in the RHEL
-    repositories, this dependency doesn't exist, all of the files that are available under the iwlax2xx-firmware package
-    in OL8, are in fact, available in the iwl7260-firmware package in RHEL, thus, we are removing this depedency to not
-    cause problems with the conversion anymore.
+    The iwl7260-firmware package causes a file conflict error while trying to replace it with its RHEL counterpart.
+    The reason for this happening is that the iwlax2xx-firmware is an dependency package of iwl7260-firmware in OL8,
+    but in the RHEL repositories, this dependency doesn't exist, all of the files that are available under the
+    iwlax2xx-firmware package in OL8, are in fact, available in the iwl7260-firmware package in RHEL, thus, we are
+    removing this depedency to not cause problems with the conversion anymore.
 
     Related: https://bugzilla.redhat.com/show_bug.cgi?id=2078916
     """
     iwl7260_firmware = system_info.is_rpm_installed(name="iwl7260-firmware")
     iwlax2xx_firmware = system_info.is_rpm_installed(name="iwlax2xx-firmware")
 
-    logger.info("Removing iwlax2xx-firmware package.")
+    logger.info("Removing the iwlax2xx-firmware package. Its content is provided by the RHEL iwl7260-firmware package.")
     if system_info.id == "oracle" and system_info.version.major == 8:
         # If we have both of the firmware installed on the system, we need to remove the later one,
         # iwlax2xx-firmware, since this causes problem in the OL8 conversion in the replace packages step.
         if iwl7260_firmware and iwlax2xx_firmware:
-            _, exit_code = run_subprocess(("rpm", "-e", "--nodeps", "iwlax2xx-firmware"))
+            _, exit_code = run_subprocess(["rpm", "-e", "--nodeps", "iwlax2xx-firmware"])
             if exit_code != 0:
                 logger.error("Unable to remove the package iwlax2xx-firmware.")
     else:

--- a/convert2rhel/unit_tests/special_cases_test.py
+++ b/convert2rhel/unit_tests/special_cases_test.py
@@ -6,6 +6,8 @@ import pytest
 
 from convert2rhel import special_cases
 from convert2rhel.systeminfo import system_info
+from convert2rhel.unit_tests import run_subprocess_side_effect
+from convert2rhel.unit_tests.conftest import centos8, oracle8
 
 
 if sys.version_info[:2] <= (2, 7):
@@ -113,3 +115,57 @@ def test_unprotect_shim_x64(mock_is_efi, mock_os_remove, sys_id, is_efi, removal
     assert log_msg in caplog.records[-1].message
     if sys_id == "oracle" and is_efi and removal_ok:
         mock_os_remove.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    (
+        "is_iwl7260_installed",
+        "is_iwlax2xx_installed",
+        "subprocess_output",
+        "subprocess_call_count",
+        "expected_message",
+    ),
+    (
+        (True, True, ("output", 0), 1, "Removing iwlax2xx-firmware package."),
+        (True, True, ("output", 1), 1, "Unable to remove the package iwlax2xx-firmware."),
+        (True, False, ("output", 0), 0, "Removing iwlax2xx-firmware package."),
+        (False, True, ("output", 0), 0, "Removing iwlax2xx-firmware package."),
+        (False, False, ("output", 0), 0, "Removing iwlax2xx-firmware package."),
+    ),
+)
+@oracle8
+def test_remove_iwlax2xx_firmware(
+    pretend_os,
+    is_iwl7260_installed,
+    is_iwlax2xx_installed,
+    subprocess_output,
+    subprocess_call_count,
+    expected_message,
+    monkeypatch,
+    caplog,
+):
+    run_subprocess_mock = mock.Mock(
+        side_effect=run_subprocess_side_effect(
+            (("rpm", "-e", "--nodeps", "iwlax2xx-firmware"), subprocess_output),
+        )
+    )
+    is_rpm_installed_mock = mock.Mock(side_effect=[is_iwl7260_installed, is_iwlax2xx_installed])
+    monkeypatch.setattr(
+        special_cases,
+        "run_subprocess",
+        value=run_subprocess_mock,
+    )
+    monkeypatch.setattr(special_cases.system_info, "is_rpm_installed", value=is_rpm_installed_mock)
+
+    special_cases.remove_iwlax2xx_firmware()
+
+    assert run_subprocess_mock.call_count == subprocess_call_count
+    assert is_rpm_installed_mock.call_count == 2
+    assert expected_message in caplog.records[-1].message
+
+
+@centos8
+def test_remove_iwlax2xx_firmware_not_ol8(pretend_os, caplog):
+    special_cases.remove_iwlax2xx_firmware()
+
+    assert "Relevant to Oracle Linux 8 only. Skipping." in caplog.records[-1].message

--- a/convert2rhel/unit_tests/special_cases_test.py
+++ b/convert2rhel/unit_tests/special_cases_test.py
@@ -126,11 +126,35 @@ def test_unprotect_shim_x64(mock_is_efi, mock_os_remove, sys_id, is_efi, removal
         "expected_message",
     ),
     (
-        (True, True, ("output", 0), 1, "Removing iwlax2xx-firmware package."),
+        (
+            True,
+            True,
+            ("output", 0),
+            1,
+            "Removing the iwlax2xx-firmware package. Its content is provided by the RHEL iwl7260-firmware package.",
+        ),
         (True, True, ("output", 1), 1, "Unable to remove the package iwlax2xx-firmware."),
-        (True, False, ("output", 0), 0, "Removing iwlax2xx-firmware package."),
-        (False, True, ("output", 0), 0, "Removing iwlax2xx-firmware package."),
-        (False, False, ("output", 0), 0, "Removing iwlax2xx-firmware package."),
+        (
+            True,
+            False,
+            ("output", 0),
+            0,
+            "Removing the iwlax2xx-firmware package. Its content is provided by the RHEL iwl7260-firmware package.",
+        ),
+        (
+            False,
+            True,
+            ("output", 0),
+            0,
+            "Removing the iwlax2xx-firmware package. Its content is provided by the RHEL iwl7260-firmware package.",
+        ),
+        (
+            False,
+            False,
+            ("output", 0),
+            0,
+            "Removing the iwlax2xx-firmware package. Its content is provided by the RHEL iwl7260-firmware package.",
+        ),
     ),
 )
 @oracle8

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -92,13 +92,6 @@ discover+:
     playbook: tests/ansible_collections/roles/reboot/main.yml
 
 /resolve_dependency:
-  # There is no dependecy package for Oracle Linux 8
-  adjust:
-    enabled: false
-    when: >
-      distro != oraclelinux-7 and
-      distro != centos-7 and
-      distro != centos-8
   discover+:
     test: checks-after-conversion
   prepare+:

--- a/tests/integration/tier1/resolve-dependency/install_dependency_packages.py
+++ b/tests/integration/tier1/resolve-dependency/install_dependency_packages.py
@@ -45,6 +45,8 @@ def test_install_dependency_packages(shell):
         elif system_version.major == 8:
             dependency_pkgs = [
                 "python39-psycopg2-debug",  # OAMG-5239, OAMG-4944 - package not available on Oracle Linux 8
+                "iwl7260-firmware",  # RHELC-567
+                "iwlax2xx-firmware",  # RHELC-567 - causing problems during the conversion on OL8
             ]
 
     # installing dependency packages

--- a/tests/integration/tier1/resolve-dependency/install_dependency_packages.py
+++ b/tests/integration/tier1/resolve-dependency/install_dependency_packages.py
@@ -1,3 +1,4 @@
+import platform
 import re
 
 from collections import namedtuple
@@ -43,11 +44,15 @@ def test_install_dependency_packages(shell):
                 "python-requests",  # OAMG-4936
             ]
         elif system_version.major == 8:
-            dependency_pkgs = [
-                "python39-psycopg2-debug",  # OAMG-5239, OAMG-4944 - package not available on Oracle Linux 8
-                "iwl7260-firmware",  # RHELC-567
-                "iwlax2xx-firmware",  # RHELC-567 - causing problems during the conversion on OL8
-            ]
+            if "oracle-8" in platform.platform():
+                dependency_pkgs = [
+                    "iwl7260-firmware",  # RHELC-567
+                    "iwlax2xx-firmware",  # RHELC-567 - causing problems during the conversion on OL8
+                ]
+            else:
+                dependency_pkgs = [
+                    "python39-psycopg2-debug",  # OAMG-5239, OAMG-4944 - package not available on Oracle Linux 8
+                ]
 
     # installing dependency packages
     assert shell("yum install -y {}".format(" ".join(dependency_pkgs))).returncode == 0


### PR DESCRIPTION
This package is causing problems when replacing the package `iwl7260-firmware`
to it's RHEL counterpart.  The reason for that is in OL8 they splitted the
package `iwl7260-firmware` and the `iwlax2xx-firmware` the later became a
dependency of the former. In RHEL this is not true, there is only the package
`iwl7260-firmware` which contains all the files.

Jira reference (If any): https://issues.redhat.com/browse/RHELC-567
Bugzilla reference (If any):

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>