### PR TITLE
Remove some unused imports across the codebase

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -22,7 +22,6 @@ import sys
 from convert2rhel import breadcrumbs, cert, checks, grub
 from convert2rhel import logger as logger_module
 from convert2rhel import pkghandler, redhatrelease, repo, special_cases, subscription, systeminfo, toolopts, utils
-from convert2rhel.grub import logger
 
 
 loggerinst = logging.getLogger(__name__)

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -14,7 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import pprint
 
 from collections import namedtuple
 

--- a/convert2rhel/unit_tests/__init__.py
+++ b/convert2rhel/unit_tests/__init__.py
@@ -19,7 +19,6 @@ import os
 import unittest
 
 from functools import wraps
-from warnings import warn
 
 from convert2rhel.utils import run_subprocess
 

--- a/convert2rhel/unit_tests/breadcrumbs_test.py
+++ b/convert2rhel/unit_tests/breadcrumbs_test.py
@@ -15,25 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-
-try:
-    import unittest2 as unittest  # Python 2.6 support
-except ImportError:
-    import unittest
-
 import json
-import os
-import sys
 
 import pytest
 
-
-if sys.version_info[:2] <= (2, 7):
-    import mock  # pylint: disable=import-error
-else:
-    from unittest import mock  # pylint: disable=no-name-in-module
-
-from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel import breadcrumbs
 
 

--- a/convert2rhel/unit_tests/grub_test.py
+++ b/convert2rhel/unit_tests/grub_test.py
@@ -25,12 +25,6 @@ from convert2rhel import grub, utils
 from convert2rhel.unit_tests.checks_test import EFIBootInfoMocked
 
 
-try:
-    import unittest2 as unittest  # Python 2.6 support
-except ImportError:
-    import unittest
-
-
 if sys.version_info[:2] <= (2, 7):
     import mock  # pylint: disable=import-error
 else:

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -41,7 +41,7 @@ from convert2rhel.pkghandler import (
 from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts
 from convert2rhel.unit_tests import GetLoggerMocked, is_rpm_based_os
-from convert2rhel.unit_tests.conftest import all_systems, oracle7
+from convert2rhel.unit_tests.conftest import all_systems
 
 
 if sys.version_info[:2] <= (2, 7):

--- a/convert2rhel/unit_tests/redhatrelease_test.py
+++ b/convert2rhel/unit_tests/redhatrelease_test.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import glob
 import os
 import sys
 import unittest

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # Required imports:
-import itertools
 import logging
 import os
 import shutil

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import getpass
 import os
-import re
 import sys
 import unittest
 

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -21,7 +21,6 @@ import inspect
 import logging
 import os
 import re
-import shlex
 import shutil
 import subprocess
 import sys

--- a/tests/integration/tier0/check-custom-repo/test_custom_repos.py
+++ b/tests/integration/tier0/check-custom-repo/test_custom_repos.py
@@ -5,12 +5,6 @@ from collections import namedtuple
 import pytest
 
 
-try:
-    from pathlib import Path
-except ImportError:
-    from pathlib2 import Path
-
-
 def get_system_version(system_release_content=None):
     """Return a namedtuple with major and minor elements, both of an int type.
 

--- a/tests/integration/tier0/inhibit-if-oracle-system-uses-not-standard-kernel/test_oracle_bad_kernel.py
+++ b/tests/integration/tier0/inhibit-if-oracle-system-uses-not-standard-kernel/test_oracle_bad_kernel.py
@@ -1,11 +1,3 @@
-import pytest
-
-
-try:
-    from pathlib import Path
-except ImportError:
-    from pathlib2 import Path
-
 from envparse import env
 
 

--- a/tests/integration/tier1/changed-yum-conf/test_patch_yum_conf.py
+++ b/tests/integration/tier1/changed-yum-conf/test_patch_yum_conf.py
@@ -1,11 +1,3 @@
-import pytest
-
-
-try:
-    from pathlib import Path
-except ImportError:
-    from pathlib2 import Path
-
 from envparse import env
 
 

--- a/tests/integration/tier1/method/custom_repos.py
+++ b/tests/integration/tier1/method/custom_repos.py
@@ -2,14 +2,6 @@ import re
 
 from collections import namedtuple
 
-import pytest
-
-
-try:
-    from pathlib import Path
-except ImportError:
-    from pathlib2 import Path
-
 
 def get_system_version(system_release_content=None):
     """Return a namedtuple with major and minor elements, both of an int type.

--- a/tests/integration/tier1/method/satellite.py
+++ b/tests/integration/tier1/method/satellite.py
@@ -1,5 +1,3 @@
-import sys
-
 from envparse import env
 
 

--- a/tests/integration/tier1/one-kernel-scenario/remove_other_kernels.py
+++ b/tests/integration/tier1/one-kernel-scenario/remove_other_kernels.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 def test_remove_other_kernels(shell):
     # remove all kernels except the kernel-3.10.0-1160.el7.x86_64
     assert shell("rpm -qa kernel | grep -v 'kernel-3.10.0-1160.el7.x86_64' | xargs yum -y remove")

--- a/tests/integration/tier1/remove-excluded-pkgs/test_remove_excluded_pkgs.py
+++ b/tests/integration/tier1/remove-excluded-pkgs/test_remove_excluded_pkgs.py
@@ -1,7 +1,3 @@
-import sys
-
-import pexpect
-
 from envparse import env
 
 

--- a/tests/integration/tier1/resolve-dependency/install_dependency_packages.py
+++ b/tests/integration/tier1/resolve-dependency/install_dependency_packages.py
@@ -1,11 +1,6 @@
 import re
 
 from collections import namedtuple
-from pathlib import Path
-
-import pytest
-
-from envparse import env
 
 
 def get_system_version(system_release_content=None):


### PR DESCRIPTION
There was some unused imports left in a few files across the database.

I got a list of the files with the unused imports by running flake8 against the
`main` branch.

```bash
flake 8 convert2rhel/ > result.txt
cat result.txt | grep F401
```

For the integration tests: 

```bash
flake 8 tests/ > result.txt
cat result.txt | grep F401
```

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>