### PR TITLE
Install json-c from UBI 8

### DIFF
--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -509,6 +509,7 @@ def download_rhsm_pkgs():
             "dnf-plugin-subscription-manager",
             "python3-syspurpose",
             "python3-cloud-what",
+            "json-c.x86_64",  # there's also an i686 version which we don't need
         ]
         _download_rhsm_pkgs(pkgs_to_download, _UBI_8_REPO_PATH, _UBI_8_REPO_CONTENT)
 

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -480,7 +480,7 @@ Version = namedtuple("Version", ["major", "minor"])
 @pytest.mark.parametrize(
     (
         "version",
-        "downloaded_pkgs",
+        "pkgs_to_download",
     ),
     (
         (
@@ -514,19 +514,20 @@ Version = namedtuple("Version", ["major", "minor"])
                     "dnf-plugin-subscription-manager",
                     "python3-syspurpose",
                     "python3-cloud-what",
+                    "json-c.x86_64",
                 )
             ),
         ),
     ),
 )
-def test_download_rhsm_pkgs(version, downloaded_pkgs, monkeypatch):
+def test_download_rhsm_pkgs(version, pkgs_to_download, monkeypatch):
     monkeypatch.setattr(system_info, "version", Version(*version))
     monkeypatch.setattr(subscription, "_download_rhsm_pkgs", DownloadRHSMPkgsMocked())
     monkeypatch.setattr(utils, "mkdir_p", DumbCallable())
     subscription.download_rhsm_pkgs()
 
     assert subscription._download_rhsm_pkgs.called == 1
-    assert frozenset(subscription._download_rhsm_pkgs.pkgs_to_download) == downloaded_pkgs
+    assert frozenset(subscription._download_rhsm_pkgs.pkgs_to_download) == pkgs_to_download
 
 
 class TestUnregisteringSystem:


### PR DESCRIPTION
To be able to install the subscription-manager packages, we download
them from the Universal Base Image (UBI) 8 BaseOS publicly available
repository. This repository has been recently updated with packages
corresponding to RHEL 8.6 packages.

When trying to install these downloaded RHEL 8.6 subscription-manager
packages on CentOS/Oracle Linux 8.5 and older, the installation fails
because dnf-plugin-subscription-manager depends on
libjson-c.so.4(JSONC_0.14)(64bit). This symbol is newly available in
RHEL 8.6 json-c package and is not available in the json-c package
distributed with CentOS Linux/Oracle Linux/RHEL 8.5 and older.

For this reason we need to download and install the newer json-c package
version from the UBI 8 repository.