### PR TITLE
Use YumBase instead of YumBaseCli to get pkg updates

### DIFF
--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -1024,18 +1024,9 @@ def get_total_packages_to_update():
 
 
 def _get_packages_to_update_yum():
-    """Query all the packages with yum that has an update pending on the
-    system."""
-    # Check first if this path is not in the `sys.path`
-    if "/usr/share/yum-cli" not in sys.path:
-        # Yum's installation path for the CLI code
-        # https://github.com/rpm-software-management/yum/blob/4ed25525ee4781907bd204018c27f44948ed83fe/bin/yum#L26
-        sys.path.insert(0, "/usr/share/yum-cli")
-
-    from cli import YumBaseCli  # pylint: disable=E0401
-
-    base = YumBaseCli()
-    packages = base.returnPkgLists(["updates"], None)
+    """Query all the packages with yum that has an update pending on the system."""
+    base = pkgmanager.YumBase()
+    packages = base.doPackageLists(pkgnarrow="updates")
     all_packages = []
     for package in packages.updates:
         all_packages.append(package.name)
@@ -1044,12 +1035,9 @@ def _get_packages_to_update_yum():
 
 
 def _get_packages_to_update_dnf():
-    """Query all the packages with dnf that has an update pending on the
-    system."""
-    from dnf import Base  # pylint: disable=E0401
-
+    """Query all the packages with dnf that has an update pending on the system."""
     packages = []
-    base = Base()
+    base = pkgmanager.Base()
     # Fix the case when we are trying to query packages in Oracle Linux 8
     # when the DNF API gets called, those variables are not populated by default.
     if system_info.id == "oracle":

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -1502,8 +1502,6 @@ def test_get_total_packages_to_update(package_manager_type, packages, monkeypatc
 )
 @pytest.mark.parametrize(("packages"), ((["package-1", "package-2", "package-3"],)))
 def test_get_packages_to_update_yum(packages, monkeypatch):
-    sys.path.insert(0, "/usr/share/yum-cli")
-    from cli import YumBaseCli  # pylint: disable=E0401
 
     PkgName = namedtuple("PkgNames", ["name"])
     PkgUpdates = namedtuple("PkgUpdates", ["updates"])
@@ -1513,11 +1511,8 @@ def test_get_packages_to_update_yum(packages, monkeypatch):
 
     pkg_lists_mock = mock.Mock(return_value=PkgUpdates(transaction_pkgs))
 
-    monkeypatch.setattr(YumBaseCli, "returnPkgLists", value=pkg_lists_mock)
+    monkeypatch.setattr(pkgmanager.YumBase, "doPackageLists", value=pkg_lists_mock)
 
-    # Remvoe the /usr/share/yum-cli from the system path so the code
-    # can load it
-    sys.path.remove("/usr/share/yum-cli")
     assert _get_packages_to_update_yum() == packages
 
 
@@ -1528,17 +1523,15 @@ def test_get_packages_to_update_yum(packages, monkeypatch):
 @pytest.mark.parametrize(("packages"), ((["package-1", "package-2", "package-3"],)))
 @all_systems
 def test_get_packages_to_update_dnf(packages, pretend_os, monkeypatch):
-    from dnf import Base  # pylint: disable=E0401
-
     dummy_mock = mock.Mock()
     PkgName = namedtuple("PkgNames", ["name"])
     transaction_pkgs = [PkgName(package) for package in packages]
 
-    monkeypatch.setattr(Base, "read_all_repos", value=dummy_mock)
-    monkeypatch.setattr(Base, "fill_sack", value=dummy_mock)
-    monkeypatch.setattr(Base, "upgrade_all", value=dummy_mock)
-    monkeypatch.setattr(Base, "resolve", value=dummy_mock)
-    monkeypatch.setattr(Base, "transaction", value=transaction_pkgs)
+    monkeypatch.setattr(pkgmanager.Base, "read_all_repos", value=dummy_mock)
+    monkeypatch.setattr(pkgmanager.Base, "fill_sack", value=dummy_mock)
+    monkeypatch.setattr(pkgmanager.Base, "upgrade_all", value=dummy_mock)
+    monkeypatch.setattr(pkgmanager.Base, "resolve", value=dummy_mock)
+    monkeypatch.setattr(pkgmanager.Base, "transaction", value=transaction_pkgs)
 
     assert _get_packages_to_update_dnf() == packages
 


### PR DESCRIPTION
Using YumBaseCli caused doubling of every log message on the output.

The reason is that instantiating of the YumBaseCli class includes calling logging.basicConfig() which sets up handlers on the root logger.

It is possible to use the YumBase class, which does not affect logging, to get the same data - list of packages having updates available.

The YumBaseCli logging handlers interfered with the convert2rhel logging as we use propage=True to be able to use caplog in our unit tests:
https://github.com/oamg/convert2rhel/pull/179