### PR TITLE
Improve of Python 2 & 3 compatibility

### DIFF
--- a/Dockerfiles/centos6.Dockerfile
+++ b/Dockerfiles/centos6.Dockerfile
@@ -28,6 +28,9 @@ COPY $PREP_PIP_DEPS $PREP_PIP_DEPS
 COPY $APP_DEV_DEPS $APP_DEV_DEPS
 COPY $APP_PRE_DEV_DEPS $APP_PRE_DEV_DEPS
 RUN chmod +x $PREP_PIP_DEPS
+# The SSL implementation that python-2.6 uses is insecure and pip refuses to install
+# packages using it. This script will use curl to download the packages securely and
+# then pip can be asked to install from the local files
 RUN $PREP_PIP_DEPS
 RUN $PIP install --no-index --find-links /data -r $APP_PRE_DEV_DEPS
 RUN $PIP install --no-index --find-links /data -r $APP_DEV_DEPS

--- a/Dockerfiles/centos6.Dockerfile
+++ b/Dockerfiles/centos6.Dockerfile
@@ -1,0 +1,40 @@
+FROM centos:6 as base
+
+ENV PYTHON python2
+ENV PIP pip2
+ENV PYTHONDONTWRITEBYTECODE 1
+
+ENV URL_GET_PIP "https://fedora-archive.ip-connect.vn.ua/epel/6/x86_64/Packages/p/python-pip-7.1.0-2.el6.noarch.rpm"
+ENV APP_DEV_DEPS "requirements/centos6.requirements.txt"
+ENV APP_PRE_DEV_DEPS "requirements/centos6_pre.requirements.txt"
+ENV PREP_PIP_DEPS "scripts/centos6_pip_prep.sh"
+ENV APP_MAIN_DEPS \
+    python-six \
+    pexpect \
+    gcc \
+    python-devel
+
+WORKDIR /data
+
+FROM base as install_main_deps
+RUN sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Base.repo &&\
+    sed -i 's/^#baseurl.*$/baseurl=https:\/\/vault.centos.org\/6.10\/os\/x86_64/g' \
+    /etc/yum.repos.d/CentOS-Base.repo
+RUN yum update -y && yum install -y $APP_MAIN_DEPS && yum clean all
+
+FROM install_main_deps as install_dev_deps
+RUN yum install -y $URL_GET_PIP
+COPY $PREP_PIP_DEPS $PREP_PIP_DEPS
+COPY $APP_DEV_DEPS $APP_DEV_DEPS
+COPY $APP_PRE_DEV_DEPS $APP_PRE_DEV_DEPS
+RUN chmod +x $PREP_PIP_DEPS
+RUN $PREP_PIP_DEPS
+RUN $PIP install --no-index --find-links /data -r $APP_PRE_DEV_DEPS
+RUN $PIP install --no-index --find-links /data -r $APP_DEV_DEPS
+
+FROM install_dev_deps as install_application
+RUN groupadd --gid=1000 -r app && \
+    useradd -r --uid=1000 --gid=1000 app
+RUN chown -R app:app .
+COPY --chown=app:app . .
+USER app:app

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,10 @@ lint-errors: images
 
 tests: tests7 tests8
 
+tests6: images
+	@echo 'CentOS Linux 6 tests'
+	@$(DOCKER) run --rm --user=$(id -ur):$(id -gr) -v $(shell pwd):/data:Z $(IMAGE)/centos6 pytest --show-capture=$(SHOW_CAPTURE) $(PYTEST_ARGS)
+
 tests7: images
 	@echo 'CentOS Linux 7 tests'
 	@$(DOCKER) run --rm --user=$(id -ur):$(id -gr) -v $(shell pwd):/data:Z $(IMAGE)/centos7 pytest --show-capture=$(SHOW_CAPTURE) $(PYTEST_ARGS)
@@ -86,10 +90,6 @@ tests7: images
 tests8: images
 	@echo 'CentOS Linux 8 tests'
 	@$(DOCKER) run --rm --user=$(id -ur):$(id -gr) -v $(shell pwd):/data:Z $(IMAGE)/centos8 pytest --show-capture=$(SHOW_CAPTURE) $(PYTEST_ARGS)
-
-tests6: images
-	@echo 'CentOS Linux 6 tests'
-	@$(DOCKER) run --user=$(id -ur):$(id -gr) --rm -v $(shell pwd):/data:Z $(IMAGE)/centos6 pytest
 
 rpms: images
 	mkdir -p .rpms

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ clean:
 images: .images
 
 .images:
+	@$(DOCKER) build -f Dockerfiles/centos6.Dockerfile -t $(IMAGE)/centos6 .
 	@$(DOCKER) build -f Dockerfiles/centos7.Dockerfile -t $(IMAGE)/centos7 .
 	@$(DOCKER) build -f Dockerfiles/centos8.Dockerfile -t $(IMAGE)/centos8 .
 	@$(DOCKER) build -f Dockerfiles/rpmbuild.centos8.Dockerfile -t $(IMAGE)/centos8rpmbuild .
@@ -85,6 +86,10 @@ tests7: images
 tests8: images
 	@echo 'CentOS Linux 8 tests'
 	@$(DOCKER) run --rm --user=$(id -ur):$(id -gr) -v $(shell pwd):/data:Z $(IMAGE)/centos8 pytest --show-capture=$(SHOW_CAPTURE) $(PYTEST_ARGS)
+
+tests6: images
+	@echo 'CentOS Linux 6 tests'
+	@$(DOCKER) run --user=$(id -ur):$(id -gr) --rm -v $(shell pwd):/data:Z $(IMAGE)/centos6 pytest
 
 rpms: images
 	mkdir -p .rpms

--- a/convert2rhel/breadcrumbs.py
+++ b/convert2rhel/breadcrumbs.py
@@ -15,13 +15,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import itertools
 import json
 import os
 import re
 import sys
 
 from datetime import datetime
+
+from six.moves import zip_longest
 
 from convert2rhel import pkghandler, systeminfo
 
@@ -161,11 +162,7 @@ def sanitize_cli_options(all_cli_options, options_to_sanitize):
     """
 
     def sanitized_iterator():
-        """In older version of python is zip_longest called izip_longest"""
-        if sys.version_info[:2] <= (2, 7):
-            elems = itertools.izip_longest(all_cli_options, all_cli_options[1:], fillvalue=None)
-        else:
-            elems = itertools.zip_longest(all_cli_options, all_cli_options[1:], fillvalue=None)
+        elems = zip_longest(all_cli_options, all_cli_options[1:], fillvalue=None)
 
         for (c, n) in elems:
             # we need to handle 2 possible cases how arguments are specified

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -14,12 +14,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import socket
-
 import difflib
 import logging
 import os
 import re
+import socket
 
 from collections import namedtuple
 

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -16,23 +16,18 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import socket
 
-from collections import namedtuple
-
-from convert2rhel.utils import run_subprocess
-
-
-try:
-    import ConfigParser as configparser
-except ImportError:
-    import configparser  # pylint: disable=import-error
-
 import difflib
 import logging
 import os
 import re
 
+from collections import namedtuple
+
+from six.moves import configparser
+
 from convert2rhel import logger, utils
 from convert2rhel.toolopts import tool_opts
+from convert2rhel.utils import run_subprocess
 
 
 # Allowed conversion paths to RHEL. We want to prevent a conversion and minor

--- a/convert2rhel/unit_tests/backup_test.py
+++ b/convert2rhel/unit_tests/backup_test.py
@@ -3,15 +3,14 @@ import sys
 import unittest
 
 import pytest
+import six
 
 from convert2rhel import backup, repo, unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel.unit_tests.conftest import all_systems, centos8
 
 
-if sys.version_info[:2] <= (2, 7):
-    import mock  # pylint: disable=import-error
-else:
-    from unittest import mock  # pylint: disable=no-name-in-module
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
 
 
 class TestBackup(unittest.TestCase):

--- a/convert2rhel/unit_tests/cert_test.py
+++ b/convert2rhel/unit_tests/cert_test.py
@@ -14,26 +14,18 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import os
+import shutil
+import unittest
+
+import pytest
+import six
 
 from convert2rhel import unit_tests
 
 
-try:
-    import unittest2 as unittest  # Python 2.6 support
-except ImportError:
-    import unittest
-
-import os
-import shutil
-import sys
-
-import pytest
-
-
-if sys.version_info[:2] <= (2, 7):
-    import mock  # pylint: disable=import-error
-else:
-    from unittest import mock  # pylint: disable=no-name-in-module
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
 
 from convert2rhel import cert, utils
 from convert2rhel.systeminfo import system_info

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -16,11 +16,12 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
-import sys
+import unittest
 
 from collections import namedtuple
 
 import pytest
+import six
 
 from convert2rhel import checks, grub, pkgmanager, systeminfo, unit_tests
 from convert2rhel.checks import (
@@ -40,15 +41,9 @@ from convert2rhel.unit_tests.conftest import centos7, centos8, oracle8
 from convert2rhel.utils import run_subprocess
 
 
-try:
-    import unittest2 as unittest  # Python 2.6 support
-except ImportError:
-    import unittest
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
 
-if sys.version_info[:2] <= (2, 7):
-    import mock  # pylint: disable=import-error
-else:
-    from unittest import mock  # pylint: disable=no-name-in-module
 
 MODINFO_STUB = (
     "/lib/modules/5.8.0-7642-generic/kernel/lib/a.ko.xz\n"

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+import six
 
 from convert2rhel import redhatrelease, toolopts, utils
 from convert2rhel.logger import setup_logger_handler
@@ -46,12 +47,11 @@ def read_std(capsys, is_py2):
 
 
 @pytest.fixture()
-def pkg_root(is_py2):
+def pkg_root():
     """Return the pathlib.Path of the convert2rhel package root."""
-    if is_py2:
-        import pathlib2 as pathlib  # pylint: disable=import-error
-    else:
-        import pathlib  # pylint: disable=import-error
+    six.add_move(six.MovedModule("pathlib", "pathlib2", "pathlib"))
+    from six.moves import pathlib
+
     return pathlib.Path(__file__).parents[2]
 
 

--- a/convert2rhel/unit_tests/grub_test.py
+++ b/convert2rhel/unit_tests/grub_test.py
@@ -17,18 +17,16 @@
 
 import copy
 import os
-import sys
 
 import pytest
+import six
 
 from convert2rhel import grub, utils
 from convert2rhel.unit_tests.checks_test import EFIBootInfoMocked
 
 
-if sys.version_info[:2] <= (2, 7):
-    import mock  # pylint: disable=import-error
-else:
-    from unittest import mock  # pylint: disable=no-name-in-module
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
 
 
 # TODO(pstodulk): put here a real examples of an output..

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -29,6 +29,7 @@ from convert2rhel import backup, grub
 from convert2rhel import logger as logger_module
 from convert2rhel.breadcrumbs import breadcrumbs
 
+
 six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
 from six.moves import mock
 

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -20,36 +20,21 @@ import os
 import sys
 import unittest
 
-
-if sys.version_info[:2] <= (2, 7):
-    import mock  # pylint: disable=import-error
-else:
-    from unittest import mock  # pylint: disable=no-name-in-module
+from collections import OrderedDict
 
 import pytest
+import six
 
 from convert2rhel import backup, grub
 from convert2rhel import logger as logger_module
 from convert2rhel.breadcrumbs import breadcrumbs
 
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
-
-from convert2rhel import (
-    cert,
-    checks,
-    main,
-    pkghandler,
-    redhatrelease,
-    repo,
-    special_cases,
-    subscription,
-    unit_tests,
-    utils,
-)
+from convert2rhel import cert, checks
+from convert2rhel import logger as logger_module
+from convert2rhel import main, pkghandler, redhatrelease, repo, special_cases, subscription, unit_tests, utils
 from convert2rhel.toolopts import tool_opts
 
 

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -24,12 +24,11 @@ from collections import namedtuple
 
 import pytest
 import rpm
+import six
 
 
-if sys.version_info[:2] <= (2, 7):
-    import mock  # pylint: disable=import-error
-else:
-    from unittest import mock  # pylint: disable=no-name-in-module
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
 
 from convert2rhel import backup, pkghandler, pkgmanager, unit_tests, utils  # Imports unit_tests/__init__.py
 from convert2rhel.pkghandler import (
@@ -41,12 +40,6 @@ from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts
 from convert2rhel.unit_tests import GetLoggerMocked, is_rpm_based_os
 from convert2rhel.unit_tests.conftest import all_systems, centos8
-
-
-if sys.version_info[:2] <= (2, 7):
-    import mock  # pylint: disable=import-error
-else:
-    from unittest import mock  # pylint: disable=no-name-in-module
 
 
 class TestPkgHandler(unit_tests.ExtendedTestCase):

--- a/convert2rhel/unit_tests/redhatrelease_test.py
+++ b/convert2rhel/unit_tests/redhatrelease_test.py
@@ -16,18 +16,16 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
-import sys
 import unittest
 
 import pytest
+import six
 
 
-if sys.version_info[:2] <= (2, 7):
-    import mock  # pylint: disable=import-error
-else:
-    from unittest import mock  # pylint: disable=no-name-in-module
-
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
 from collections import namedtuple
+
+from six.moves import mock
 
 from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel import pkgmanager, redhatrelease, utils

--- a/convert2rhel/unit_tests/special_cases_test.py
+++ b/convert2rhel/unit_tests/special_cases_test.py
@@ -1,8 +1,7 @@
-import sys
-
 from collections import namedtuple
 
 import pytest
+import six
 
 from convert2rhel import special_cases
 from convert2rhel.systeminfo import system_info
@@ -10,10 +9,8 @@ from convert2rhel.unit_tests import run_subprocess_side_effect
 from convert2rhel.unit_tests.conftest import centos8, oracle8
 
 
-if sys.version_info[:2] <= (2, 7):
-    import mock  # pylint: disable=import-error
-else:
-    from unittest import mock  # pylint: disable=no-name-in-module
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
 
 
 @mock.patch("convert2rhel.special_cases.perform_java_openjdk_workaround")

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -17,13 +17,13 @@
 
 import logging
 import os
-import sys
 import unittest
 
 from collections import namedtuple
 
 import pexpect
 import pytest
+import six
 
 from convert2rhel import backup, pkghandler, subscription, toolopts, unit_tests, utils
 from convert2rhel.systeminfo import system_info
@@ -31,10 +31,8 @@ from convert2rhel.unit_tests import GetLoggerMocked, run_subprocess_side_effect
 from convert2rhel.unit_tests.conftest import centos7, centos8
 
 
-if sys.version_info[:2] <= (2, 7):
-    import mock  # pylint: disable=import-error
-else:
-    from unittest import mock  # pylint: disable=no-name-in-module
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
 
 
 class DumbCallable(unit_tests.MockFunction):

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -26,6 +26,7 @@ import unittest
 from collections import namedtuple
 
 import pytest
+import six
 
 from convert2rhel import logger, systeminfo, unit_tests, utils  # Imports unit_tests/__init__.py
 from convert2rhel.systeminfo import RELEASE_VER_MAPPING, system_info
@@ -34,10 +35,8 @@ from convert2rhel.unit_tests import is_rpm_based_os
 from convert2rhel.unit_tests.conftest import all_systems, centos8
 
 
-if sys.version_info[:2] <= (2, 7):
-    import mock  # pylint: disable=import-error
-else:
-    from unittest import mock  # pylint: disable=no-name-in-module
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
 
 
 class TestSysteminfo(unittest.TestCase):

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -22,6 +22,7 @@ import sys
 import unittest
 
 import pytest
+import six
 
 import convert2rhel.toolopts
 import convert2rhel.utils
@@ -30,10 +31,8 @@ from convert2rhel import unit_tests  # Imports unit_tests/__init__.py
 from convert2rhel.toolopts import tool_opts
 
 
-if sys.version_info[:2] <= (2, 7):
-    import mock  # pylint: disable=import-error
-else:
-    from unittest import mock  # pylint: disable=no-name-in-module
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
 
 
 def mock_cli_arguments(args):

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -21,28 +21,19 @@ import sys
 import unittest
 
 import pytest
-
-from six import moves
+import six
 
 from convert2rhel.utils import prompt_user
 
 
-if sys.version_info[:2] <= (2, 7):
-    import mock  # pylint: disable=import-error
-else:
-    from unittest import mock  # pylint: disable=no-name-in-module
-
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
 from collections import namedtuple
+
+from six.moves import mock
 
 from convert2rhel import unit_tests, utils  # Imports unit_tests/__init__.py
 from convert2rhel.systeminfo import system_info
 from convert2rhel.unit_tests import is_rpm_based_os
-
-
-if sys.version_info[:2] <= (2, 7):
-    import mock  # pylint: disable=import-error
-else:
-    from unittest import mock  # pylint: disable=no-name-in-module
 
 
 class TestUtils(unittest.TestCase):
@@ -345,7 +336,7 @@ def test_prompt_user(question, is_password, response, monkeypatch):
     if is_password:
         monkeypatch.setattr(getpass, "getpass", lambda _: response)
     else:
-        monkeypatch.setattr(moves, "input", lambda _: response)
+        monkeypatch.setattr(six.moves, "input", lambda _: response)
 
     assert prompt_user(question, is_password) == response
 

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -330,9 +330,9 @@ def remove_tmp_dir():
         shutil.rmtree(TMP_DIR)
         loggerinst.info("Temporary folder %s removed" % TMP_DIR)
     except OSError as err:
-        loggerinst.warn("Failed removing temporary folder %s\nError (%s): %s" % (TMP_DIR, err.errno, err.strerror))
+        loggerinst.warning("Failed removing temporary folder %s\nError (%s): %s" % (TMP_DIR, err.errno, err.strerror))
     except TypeError:
-        loggerinst.warn("TypeError error while removing temporary folder %s" % TMP_DIR)
+        loggerinst.warning("TypeError error while removing temporary folder %s" % TMP_DIR)
 
 
 class DictWListValues(dict):

--- a/requirements/centos6.requirements.txt
+++ b/requirements/centos6.requirements.txt
@@ -1,0 +1,8 @@
+pylint==1.1.0
+astroid==1.2
+unittest2==0.5.1
+pytest==3.2.5
+pytest-cov==2.5.1
+mock==2.0.0
+pytest-catchlog==1.2.2
+pathlib2==2.3.5

--- a/requirements/centos6_pre.requirements.txt
+++ b/requirements/centos6_pre.requirements.txt
@@ -1,0 +1,8 @@
+setuptools-scm==1.5.2
+pbr==1.3
+logilab-common==0.53.0
+py==1.4.33
+argparse==1.4.0
+coverage==3.7.1
+funcsigs==1.0.2
+scandir==0.4

--- a/scripts/centos6_pip_prep.sh
+++ b/scripts/centos6_pip_prep.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# The SSL implementation that python-2.6 uses is insecure and pip refuses to install
+# packages using it. This script will use curl to download the packages securely and
+# then pip can be asked to install from the local files
+
 links=(
     "https://files.pythonhosted.org/packages/3a/05/f4936fde0aa8ce3b646b6014c59417c8cc7c1958df41e05bc77fcb098743/scandir-0.4.zip"
     "https://files.pythonhosted.org/packages/94/4a/db842e7a0545de1cdb0439bb80e6e42dfe82aaeaadd4072f2263a4fbed23/funcsigs-1.0.2.tar.gz"

--- a/scripts/centos6_pip_prep.sh
+++ b/scripts/centos6_pip_prep.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+links=(
+    "https://files.pythonhosted.org/packages/3a/05/f4936fde0aa8ce3b646b6014c59417c8cc7c1958df41e05bc77fcb098743/scandir-0.4.zip"
+    "https://files.pythonhosted.org/packages/94/4a/db842e7a0545de1cdb0439bb80e6e42dfe82aaeaadd4072f2263a4fbed23/funcsigs-1.0.2.tar.gz"
+    "https://files.pythonhosted.org/packages/09/4f/89b06c7fdc09687bca507dc411c342556ef9c5a3b26756137a4878ff19bf/coverage-3.7.1.tar.gz"
+    "https://files.pythonhosted.org/packages/18/dd/e617cfc3f6210ae183374cd9f6a26b20514bbb5a792af97949c5aacddf0f/argparse-1.4.0.tar.gz"
+    "https://files.pythonhosted.org/packages/2a/a5/139ca93a9ffffd9fc1d3f14be375af3085f53cc490c508cf1c988b886baa/py-1.4.33.tar.gz"
+    "https://files.pythonhosted.org/packages/e0/e5/36c349db721aac9a76ec1b40dd6aa48855aa600f11f7fab11655b7463dd2/logilab-common-0.53.0.tar.gz"
+    "https://files.pythonhosted.org/packages/b8/2d/b8a38176b243617b1e36144a905c1892325b0b0079f142e3ae3f0b14cfe4/pbr-1.3.0.tar.gz"
+    "https://files.pythonhosted.org/packages/d6/1b/1850d5174bf770cfcb3fda651e68b43e0b610d43e13a0d95a250457b9bf9/setuptools_scm-1.5.2.tar.gz"
+    "https://files.pythonhosted.org/packages/09/69/cf252f211dbbf58bbbe01a3931092d8a8df8d55f5fe23ac5cef145aa6468/pylint-1.1.0.tar.gz"
+    "https://files.pythonhosted.org/packages/b0/ac/dbbfed5f086b61ace9e70d821b524c888cebf5512b147985876ef1b09cd1/astroid-1.2.0.tar.gz"
+    "https://files.pythonhosted.org/packages/69/4e/ba9d0ccf3d4132abefdaac222c396f9c6f00537218fd15611e675f7a1e6d/unittest2-0.5.1.zip"
+    "https://files.pythonhosted.org/packages/1f/f8/8cd74c16952163ce0db0bd95fdd8810cbf093c08be00e6e665ebf0dc3138/pytest-3.2.5.tar.gz"
+    "https://files.pythonhosted.org/packages/24/b4/7290d65b2f3633db51393bdf8ae66309b37620bc3ec116c5e357e3e37238/pytest-cov-2.5.1.tar.gz"
+    "https://files.pythonhosted.org/packages/0c/53/014354fc93c591ccc4abff12c473ad565a2eb24dcd82490fae33dbf2539f/mock-2.0.0.tar.gz"
+    "https://files.pythonhosted.org/packages/f2/2b/2faccdb1a978fab9dd0bf31cca9f6847fbe9184a0bdcc3011ac41dd44191/pytest-catchlog-1.2.2.zip"
+    "https://files.pythonhosted.org/packages/94/d8/65c86584e7e97ef824a1845c72bbe95d79f5b306364fa778a3c3e401b309/pathlib2-2.3.5.tar.gz"
+    )
+
+for link in ${links[@]}; do
+    curl $link -o ${link##*\/}
+done


### PR DESCRIPTION
Mainly in unit test there was used a condition for importing the corresponding variant of module for python 2 or 3, if they have different names. The better way is to use the `six` library.

Changed the conditions to imports through `six`, removed partial compatibility with Python 2.6 (just in some of unit test, not in all of them - module `unittest2`), removed unused imports in tests and small improvement of `utils.py`: changed deprecated `warn` to `warning` which caused deprecated error in unit tests.

RHELC-588