### PR TITLE
Improve logging of the rhsm registration

### DIFF
--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -114,7 +114,6 @@ def register_system():
     # Loop the registration process until successful registration
     attempt = 0
     while attempt < MAX_NUM_OF_ATTEMPTS_TO_SUBSCRIBE:
-        registration_cmd = RegistrationCommand.from_tool_opts(tool_opts)
         attempt_msg = ""
         if attempt > 0:
             attempt_msg = "Attempt %d of %d: " % (
@@ -126,6 +125,7 @@ def register_system():
             attempt_msg,
         )
 
+        registration_cmd = RegistrationCommand.from_tool_opts(tool_opts)
         output, ret_code = registration_cmd()
         if ret_code == 0:
             # Handling a signal interrupt that was previously handled by
@@ -135,14 +135,6 @@ def register_system():
             return
 
         loggerinst.info("System registration failed with return code = %s" % str(ret_code))
-        if tool_opts.credentials_thru_cli:
-            loggerinst.warning(
-                "Error: Unable to register your system with subscription-manager using the provided credentials."
-            )
-        else:
-            loggerinst.info("Trying again - provide username and password.")
-            tool_opts.username = None
-            tool_opts.password = None
         sleep(REGISTRATION_ATTEMPT_DELAYS[attempt])
         attempt += 1
     loggerinst.critical("Unable to register the system through subscription-manager.")

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -460,7 +460,7 @@ class TestRegisterSystem(object):
         assert caplog.records[-1].levelname == "CRITICAL"
 
     def test_register_system_fail_interactive(self, tool_opts, monkeypatch, caplog):
-        """Check the function tries to register multiple times without critical log."""
+        """Test that the three attempts work: fail to register two times and succeed the third time."""
         tool_opts.credentials_thru_cli = False
         monkeypatch.setattr(subscription, "sleep", mock.Mock())
 


### PR DESCRIPTION
In a case where the system registration using --org and --activationkey failed, the logging message _"Trying again - provide username and password."_ didn't make sense because we're not asking in that case for a username and a password.

Also I moved printing the _"Gathering subscription-manager registration info"_ to be under the "Attempt 2 of 3: Registering" because the info gathering is actually already part of the next attempt.

Original output:
```
[05/18/2022 18:27:13] TASK - [Convert: Subscription Manager - Subscribe system] *****************
Gathering subscription-manager registration info ... 
    ... organization detected
    ... activation key detected
Registering the system using subscription-manager ...
The system has been registered with ID: 8159c801-909d-4b96-9331-3c61e1dc31a5
The registered system name is: c2r-20220518200001
Installed Product Current Status:
Product Name: Red Hat Enterprise Linux for x86_64
Status:       Not Subscribed

Unable to find available subscriptions for all your installed products.
System registration failed with return code = 1
Trying again - provide username and password.
Gathering subscription-manager registration info ... 
    ... organization detected
    ... activation key detected
Attempt 2 of 3: Registering the system using subscription-manager ...
Unregistering from: domain.redhat.com:443/rhsm
The system with UUID 8159c801-909d-4b96-9331-3c61e1dc31a5 has been unregistered
All local data removed
The system has been registered with ID: 20ff0178-5e26-4769-8a10-3c1c1042bd05
```

New output:
```
[05/18/2022 18:27:13] TASK - [Convert: Subscription Manager - Subscribe system] *****************
Registering the system using subscription-manager ...
Gathering subscription-manager registration info ... 
    ... organization detected
    ... activation key detected
The system has been registered with ID: 8159c801-909d-4b96-9331-3c61e1dc31a5
The registered system name is: c2r-20220518200001
Installed Product Current Status:
Product Name: Red Hat Enterprise Linux for x86_64
Status:       Not Subscribed

Unable to find available subscriptions for all your installed products.
System registration failed with return code = 1
Attempt 2 of 3: Registering the system using subscription-manager ...
Gathering subscription-manager registration info ... 
    ... organization detected
    ... activation key detected
Unregistering from: domain.redhat.com:443/rhsm
The system with UUID 8159c801-909d-4b96-9331-3c61e1dc31a5 has been unregistered
All local data removed
The system has been registered with ID: 20ff0178-5e26-4769-8a10-3c1c1042bd05
```