### PR TITLE
Add basic sanity checks

### DIFF
--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -1,6 +1,10 @@
 discover+:
     tier: 0
 
+/basic_sanity_checks:
+  discover+:
+    test: basic-sanity-checks
+
 /check_user_response:
   discover+:
     test: check-user-response

--- a/tests/integration/tier0/basic-sanity-checks/main.fmf
+++ b/tests/integration/tier0/basic-sanity-checks/main.fmf
@@ -1,0 +1,6 @@
+summary: user privileges, manpage exists, basic smoke
+
+tier: 0
+
+test: |
+  pytest -svv

--- a/tests/integration/tier0/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/basic-sanity-checks/test_basic_sanity_checks.py
@@ -14,4 +14,14 @@ def test_check_user_privileges(shell):
         result.output == "The tool needs to be run under the root user.\n" "\n" "No changes were made to the system.\n"
     )
     # Delete testuser (if present)
-    os.system(f"userdel -r '{user}'")
+    assert os.system(f"userdel -r '{user}'") == 0
+
+
+def test_manpage_exists(shell):
+    assert shell("man -w convert2rhel").returncode == 0
+
+
+def test_smoke_basic(shell):
+    assert shell("convert2rhel --help").returncode == 0
+    assert shell("convert2rhel -h").returncode == 0
+    assert shell("convert2rhel <<< n").returncode != 0

--- a/tests/integration/tier0/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/basic-sanity-checks/test_basic_sanity_checks.py
@@ -1,10 +1,7 @@
-import os
-
-
 def test_check_user_privileges(shell):
     user = "testuser"
     # Create non-root user if not created already
-    os.system(f"useradd '{user}'")
+    assert shell(f"useradd '{user}'").returncode == 0
     # Set user to non-root entity 'testuser' and run c2r
     result = shell("runuser -l testuser -c 'convert2rhel'")
     # Check the program exits as it is required to be run by root
@@ -14,7 +11,7 @@ def test_check_user_privileges(shell):
         result.output == "The tool needs to be run under the root user.\n" "\n" "No changes were made to the system.\n"
     )
     # Delete testuser (if present)
-    assert os.system(f"userdel -r '{user}'") == 0
+    assert shell(f"userdel -r '{user}'").returncode == 0
 
 
 def test_manpage_exists(shell):

--- a/tests/integration/tier0/check-privileges/main.fmf
+++ b/tests/integration/tier0/check-privileges/main.fmf
@@ -1,6 +1,0 @@
-summary: check user privileges
-
-tier: 0
-
-test: |
-  pytest -svv


### PR DESCRIPTION
As a part of morf tool decommission add some basic sanity checks to the
integration tests using tmt.
- check for manpage
- basic smoke test

Rename the test scenario previously named as check-privileges and add
mentioned above.

