### PR TITLE
[RHELC-280] Add integration test for only installed kernel-core package

### DIFF
--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -307,6 +307,28 @@
           how: ansible
           playbook: tests/ansible_collections/roles/reboot/main.yml
 
+/kernel-core-only:
+    adjust+:
+        - enabled: false
+          when: >
+              distro != centos-8 and
+              distro != oraclelinux-8.
+    discover+:
+        test: checks-after-conversion
+    prepare+:
+        - name: make sure the 'kernel-core' is the only installed kernel package
+          how: shell
+          script: pytest -svv tests/integration/tier1/kernel-core-only/remove_kernel_pkg.py
+        - name: reboot after kernel remove
+          how: ansible
+          playbook: tests/ansible_collections/roles/reboot/main.yml
+        - name: main conversion preparation
+          how: shell
+          script: pytest -svv tests/integration/tier1/method/activation_key.py
+        - name: reboot after conversion
+          how: ansible
+          playbook: tests/ansible_collections/roles/reboot/main.yml
+
 /config_file:
     adjust+:
         - enabled: false

--- a/tests/integration/tier1/kernel-core-only/main.fmf
+++ b/tests/integration/tier1/kernel-core-only/main.fmf
@@ -1,0 +1,10 @@
+summary: kernel-core package is the only kernel package installed
+
+description: |
+  This tests set's up the machine that it contains only `kernel-core` package installed
+  on the system. Test is only viable to run on RHEL-8 like systems.
+
+tier: 1
+
+test: |
+  pytest -svv

--- a/tests/integration/tier1/kernel-core-only/remove_kernel_pkg.py
+++ b/tests/integration/tier1/kernel-core-only/remove_kernel_pkg.py
@@ -1,0 +1,9 @@
+def test_remove_kernel_pkg(shell):
+    """
+    This tests set's up the machine that it contains only kernel-core package on the system.
+    Test is only viable to run on RHEL-8 like systems.
+    """
+
+    assert shell("yum install kernel-core -y").returncode == 0
+
+    assert shell("yum remove kernel -y -x kernel-core").returncode == 0


### PR DESCRIPTION
Test that remove kernel package from the system and leaves only kernel-core package. This is possible only on RHEL-8 systems.

Related ticket: https://issues.redhat.com/browse/RHELC-280