### PR TITLE
Have the unittest run that makes coverage use the branch point.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -29,10 +30,12 @@ jobs:
           context: .
           file: ./Dockerfiles/centos${{ matrix.centos_ver }}.Dockerfile
           tags: centos${{ matrix.centos_ver }}
+
       - name: Run pytest coverage
         run: |
           docker run --name pytest-container centos${{ matrix.centos_ver }} pytest --cov --cov-report xml --cov-report term
           docker cp pytest-container:/data/coverage.xml .
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
By default, the checkout github workflow will rebase the PR onto the
HEAD of main before running.  This is generally what you want because it
is testing the state your main branch would be in after you merge the
PR.  However, there is a problem with that for codecov.io.  Coverage.io
uses the tree at the branch point to decide what the previous coverage
was and also what the line numbers are.  If we generate the coverage
data using the HEAD of the main branch, then codecov.io will display
the wrong lines as being covered or uncovered.  This will lead it to
think that lines which were previously covered are no longer, which
makes leadds to false positives and makes it hard to tell what has
actually changed.

Changing the checkout action to use the branch point fixes this.

(We also tried to configure codecov.io to use the HEAD of main but were
unsucessful in getting that to work.)