### PR TITLE
The new version of ansible-core has removed support for toplevel include

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-        ref: ${{ github.event.pull_request.head.sha }}
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/tests/ansible_collections/roles/add-custom-repos/main.yml
+++ b/tests/ansible_collections/roles/add-custom-repos/main.yml
@@ -2,11 +2,11 @@
 - hosts: all
   gather_facts: yes
   become: false
-- include: rhel7-repos.yml
+- import_playbook: rhel7-repos.yml
   when: ansible_facts['distribution_major_version'] == "7"
   # When Oracle Linux 8.7 is released, the "8.6" needs to change to "8.7" and the
   # "8.6" is to be moved to the condition below related to enabling RHEL 8 EUS repos
-- include: rhel8-repos.yml
+- import_playbook: rhel8-repos.yml
   when: ansible_facts['distribution_version'] == "8.5" or ansible_facts['distribution_version'] == "8.6"
-- include: rhel8-eus-repos.yml
+- import_playbook: rhel8-eus-repos.yml
   when: ansible_facts['distribution_version'] == "8.4"

--- a/tests/ansible_collections/roles/install-submgr/main.yml
+++ b/tests/ansible_collections/roles/install-submgr/main.yml
@@ -4,9 +4,9 @@
   become: false
   # On Oracle Linux 7 a "rhn-client-tols" package may be present on
   # the system which prevents "subscription-manager" to be installed
-- include: remove_rhn_client_tools.yml
+- import_playbook: remove_rhn_client_tools.yml
   when: ansible_facts['distribution_major_version'] == "7" and ansible_facts['distribution'] == "OracleLinux"
-- include: install_submgr_from_ubi_7.yml
+- import_playbook: install_submgr_from_ubi_7.yml
   when: ansible_facts['distribution_major_version'] == "7"
-- include: install_submgr_from_centos_8.yml
+- import_playbook: install_submgr_from_centos_8.yml
   when: ansible_facts['distribution_major_version'] == "8"

--- a/tests/integration/tier1/yum-distro-sync/add-extras-repo/main.yml
+++ b/tests/integration/tier1/yum-distro-sync/add-extras-repo/main.yml
@@ -2,7 +2,7 @@
 - hosts: all
   gather_facts: yes
   become: false
-- include: oracle7.yml
+- import_playbook: oracle7.yml
   when: ansible_facts['distribution'] == "OracleLinux" and ansible_facts['distribution_major_version'] == "7"
-- include: oracle8.yml
+- import_playbook: oracle8.yml
   when: ansible_facts['distribution'] == "OracleLinux" and ansible_facts['distribution_major_version'] == "8"


### PR DESCRIPTION
import_playook is almost the same thing.  Replace usage of toplevel
include with import_playbook.