### PR TITLE
[RHELC-642] Add integration test that install custom kernel

### DIFF
--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -67,3 +67,17 @@ discover+:
   - name: install subscription manager
     how: ansible
     playbook: tests/ansible_collections/roles/install-submgr/main.yml
+
+/custom_kernel:
+  adjust:
+    enabled: false
+    when: >
+      distro != oraclelinux-7 and
+      distro != centos-7 and
+      distro != centos-8.4
+  discover+:
+    test: custom-kernel
+  prepare+:
+  - name: install custom kernel
+    how: ansible
+    playbook: tests/integration/tier0/custom-kernel/install_custom_kernel.py

--- a/tests/integration/tier0/custom-kernel/install_custom_kernel.py
+++ b/tests/integration/tier0/custom-kernel/install_custom_kernel.py
@@ -1,0 +1,41 @@
+import platform
+
+from envparse import env
+
+
+def test_install_custom_kernel(shell):
+    # We install CentOS kernel on Oracle Linux and vice versa to mimic the custom kernel
+    # that is not signed by the running OS official vendor
+    system_version = platform.platform()
+
+    if "centos-7" in system_version:
+        # Install dependency for kernel-uek
+        assert (
+            shell(
+                "yum install https://yum.oracle.com/repo/OracleLinux/OL7/latest/x86_64/getPackage/linux-firmware-20200124-999.4.git1eb2408c.el7.noarch.rpm -y"
+            ).returncode
+            == 0
+        )
+        assert (
+            shell(
+                "yum install https://yum.oracle.com/repo/OracleLinux/OL7/UEKR6/x86_64/getPackage/kernel-uek-5.4.17-2011.0.7.el7uek.x86_64.rpm -y"
+            ).returncode
+            == 0
+        )
+        shell("grub2-set-default 'CentOS Linux (5.4.17-2011.0.7.el7uek.x86_64) 7 (Core)'")
+    elif "oracle-7" in system_version:
+        assert (
+            shell(
+                "yum install http://mirror.centos.org/centos/7/os/x86_64/Packages/kernel-3.10.0-1160.el7.x86_64.rpm -y"
+            ).returncode
+            == 0
+        )
+        shell("grub2-set-default 'Oracle Linux Server 7.9, with Linux 3.10.0-1160.el7.x86_64'")
+    elif "centos-8.4" in system_version:
+        assert (
+            shell(
+                "yum install https://yum.oracle.com/repo/OracleLinux/OL8/4/baseos/base/x86_64/getPackage/kernel-core-4.18.0-305.el8.x86_64.rpm -y"
+            ).returncode
+            == 0
+        )
+        shell("grub2-set-default 'Oracle Linux Server (4.18.0-305.el8.x86_64) 8.4'")

--- a/tests/integration/tier0/custom-kernel/main.fmf
+++ b/tests/integration/tier0/custom-kernel/main.fmf
@@ -1,0 +1,6 @@
+summary: custom kernel inhibitor
+
+tier: 0
+
+test: |
+  pytest -svv

--- a/tests/integration/tier0/custom-kernel/test_cutsom_kernel.py
+++ b/tests/integration/tier0/custom-kernel/test_cutsom_kernel.py
@@ -1,0 +1,18 @@
+import platform
+
+from envparse import env
+
+
+def test_custom_kernel(convert2rhel):
+    # Run c2r with --variant option
+    system_version = platform.platform()
+
+    if "centos-7" in system_version:
+        string = "CentOS"
+    elif "oracle-7" in system_version:
+        string = "Oracle"
+
+    with convert2rhel(("--no-rpm-va --debug")) as c2r:
+        c2r.expect("WARNING - Custom kernel detected. The booted kernel needs to be signed by")
+        c2r.expect("CRITICAL - The booted kernel version is incompatible with the standard RHEL kernel.")
+    assert c2r.exitstatus != 0


### PR DESCRIPTION
Install custom kernel on the system that is not signed by the running OS and verify that the system inhibits/reports warning.

Tickets that are little bit related to this: https://github.com/oamg/convert2rhel/pull/389, https://github.com/oamg/convert2rhel/pull/424

Bug found: https://issues.redhat.com/browse/RHELC-642
