### PR TITLE
Playbook fixes

### DIFF
--- a/ansible/setup-convert2rhel.yml
+++ b/ansible/setup-convert2rhel.yml
@@ -30,7 +30,7 @@
       fail:
         msg: "Distribution version must be 6.10, 7.9, or 8.5"
       when: (ansible_distribution_version != '6.10' and ansible_distribution_version != '7.9'
-             and ansible_distribution_version != '8.5') or skip_os_version_check|bool
+             and ansible_distribution_version != '8.5') and skip_os_version_check|bool
 
     - name: Patch repositories if dealing with CentOS8.
       block:

--- a/ansible/setup-convert2rhel.yml
+++ b/ansible/setup-convert2rhel.yml
@@ -39,14 +39,14 @@
           path: /etc/yum.repos.d/{{ item }}
           regexp: ^mirrorlist
           replace: "#mirrorlist"
-        loop: centos8_repos
+        loop: "{{ centos8_repos }}"
 
       - name: Switch repo to vault.centos.org.
         replace:
           path: /etc/yum.repos.d/{{ item }}
           regexp: "#baseurl=http://mirror.centos.org"
           replace: baseurl=https://vault.centos.org
-        loop: centos8_repos
+        loop: "{{ centos8_repos }}"
       when: ansible_distribution == 'CentOS' and ansible_distribution_major_version | int == 8
 
     - name: Download Red Hat GPG key


### PR DESCRIPTION
Fixes two playbook issues.  These issues prevented the ansible playbook from converting centos machines.  People could still run convert2rhel from the command line.

*   Fix syntax of looping over centos8_repos. As reported in #533, the loop syntax we have in the ansible playbook is
    not quite right.  Instead of simply writing the variable name as we have it now, we are responsible for asking for it to be expanded in the loop construct (using "{{ }}").

    Fixes #533

*  Fix setup playbook feature allowing user to skip os version check. As reported in #532, the logic in the ansible playbook was to fail when either the version check showed an unhandled version OR the skip_os_version_check was set to true. This meant that the toggle would either check the version or the playbook will fail.

    By using AND in that logic, we get the behaviour we want.  Either the toggle will check the version or the playbook's check will succeed

    It is confusing because it is a `fail:` task.  So a true value in the  conditional WILL fail the playbook while a false value in the     conditional means that the playbook WILL NOT fail here.

    Fixes #532

https://issues.redhat.com/browse/RHELC-650
