### PR TITLE
Update 6.x config files to have the eus_rhsm_repoids entry.

### DIFF
--- a/convert2rhel/data/6/x86_64/configs/centos-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/centos-6-x86_64.cfg
@@ -25,6 +25,10 @@ repofile_pkgs =
 # Delimited by any whitespace(s).
 default_rhsm_repoids = rhel-6-server-rpms
 
+# List of Extended Update Support (EUS) repoids to enable through subscription-manager when the --enablerepo option is
+# not used. Delimited by any whitespace(s).
+eus_rhsm_repoids =
+
 # If defined, it overrides the default releasever defined by RELEASE_VER_MAPPING.
 # The value is passed to the yum calls through the --releasever option when accessing RHEL repos. Its purpose is to
 # substitute the $releasever variable in a repository baseurl.

--- a/convert2rhel/data/6/x86_64/configs/oracle-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/oracle-6-x86_64.cfg
@@ -37,6 +37,10 @@ repofile_pkgs =
 # Delimited by any whitespace(s).
 default_rhsm_repoids = rhel-6-server-rpms
 
+# List of Extended Update Support (EUS) repoids to enable through subscription-manager when the --enablerepo option is
+# not used. Delimited by any whitespace(s).
+eus_rhsm_repoids =
+
 # If defined, it overrides the default releasever defined by RELEASE_VER_MAPPING.
 # The value is passed to the yum calls through the --releasever option when accessing RHEL repos. Its purpose is to
 # substitute the $releasever variable in a repository baseurl.

--- a/convert2rhel/data/6/x86_64/configs/suse_es-6-x86_64.cfg
+++ b/convert2rhel/data/6/x86_64/configs/suse_es-6-x86_64.cfg
@@ -18,6 +18,10 @@ repofile_pkgs =
 # Delimited by any whitespace(s).
 default_rhsm_repoids = rhel-6-server-rpms
 
+# List of Extended Update Support (EUS) repoids to enable through subscription-manager when the --enablerepo option is
+# not used. Delimited by any whitespace(s).
+eus_rhsm_repoids =
+
 # If defined, it overrides the default releasever defined by RELEASE_VER_MAPPING.
 # The value is passed to the yum calls through the --releasever option when accessing RHEL repos. Its purpose is to
 # substitute the $releasever variable in a repository baseurl.


### PR DESCRIPTION
Like RHEL 7 clones, we need an empty entry for this since there are no
eus repos but the code looks for it.