### PR TITLE
[RHELC-597] Register with subscription-manager via dbus

### DIFF
--- a/Dockerfiles/centos6.Dockerfile
+++ b/Dockerfiles/centos6.Dockerfile
@@ -11,6 +11,7 @@ ENV PREP_PIP_DEPS "scripts/centos6_pip_prep.sh"
 ENV APP_MAIN_DEPS \
     python-six \
     pexpect \
+    dbus-python \
     gcc \
     python-devel
 

--- a/Dockerfiles/centos7.Dockerfile
+++ b/Dockerfiles/centos7.Dockerfile
@@ -8,6 +8,7 @@ ENV URL_GET_PIP "https://bootstrap.pypa.io/pip/2.7/get-pip.py"
 ENV APP_DEV_DEPS "requirements/centos7.requirements.txt"
 ENV APP_MAIN_DEPS \
     python-six \
+    dbus-python \
     pexpect
 
 WORKDIR /data

--- a/Dockerfiles/centos8.Dockerfile
+++ b/Dockerfiles/centos8.Dockerfile
@@ -9,6 +9,7 @@ ENV APP_DEV_DEPS "requirements/centos8.requirements.txt"
 ENV APP_MAIN_DEPS \
     python3 \
     python3-six \
+    python3-dbus \
     python3-pexpect
 
 WORKDIR /data

--- a/Dockerfiles/rpmbuild.centos7.Dockerfile
+++ b/Dockerfiles/rpmbuild.centos7.Dockerfile
@@ -8,6 +8,7 @@ ENV APP_MAIN_DEPS \
     rpmlint \
     python-devel \
     python-setuptools \
+    dbus-python \
     pexpect \
     python-six
 

--- a/Dockerfiles/rpmbuild.centos8.Dockerfile
+++ b/Dockerfiles/rpmbuild.centos8.Dockerfile
@@ -10,6 +10,7 @@ ENV APP_MAIN_DEPS \
     rpm-build \
     rpmlint \
     python3-devel \
+    python3-dbus \
     python3-pexpect \
     python3-six
 

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -66,6 +66,7 @@ def perform_pre_checks():
     check_rhel_compatible_kernel_is_used()
     check_package_updates()
     is_loaded_kernel_latest()
+    check_dbus_is_running()
 
 
 def perform_pre_ponr_checks():
@@ -698,3 +699,21 @@ def is_loaded_kernel_latest():
                 "If you wish to ignore this message, set the environment variable "
                 "'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK' to 1." % package_to_check
             )
+
+
+def check_dbus_is_running():
+    """Error out if we need to register with rhsm and the dbus daemon is not running."""
+    logger.task("Prepare: Check that DBus Daemon is running")
+
+    if tool_opts.no_rhsm:
+        logger.info("Skipping the check because we have been asked not to subscribe this system to RHSM.")
+        return
+
+    if system_info.dbus_running:
+        logger.info("DBus Daemon is running")
+        return
+
+    logger.critical(
+        "Could not find a running DBus Daemon which is needed to register with subscription manager.\n"
+        "Please start dbus using `systemctl start dbus` or (on CentOS Linux 6), `service messagebus start`"
+    )

--- a/convert2rhel/i18n.py
+++ b/convert2rhel/i18n.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2021 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+One location to keep all locale related information.
+
+convert2rhel is not currently localized but it does interact with other systems which are. this
+module provides a single place to keep that information.  If we decide to localize convert2rhel in
+the future, this file should point us towards all the locations that we may need to change.
+"""
+
+#
+# Display locales
+#
+
+# These locales are about what we want to display to the user. If we decide to localize, these
+# should be updated to retrieve the locale setting (Using the locale module from the python stdlib).
+CONVERT2RHEL_LOCALE = "C"
+# Subscription-manager's DBus API has its own method to set the locale. I'm not sure whether we
+# would want these to obey the Display locale of the programming locale. We're likely to forward
+# the error messages on to the user so display locale feels like the best fit but sometimes error
+# messages are best left un-localized so that they are easier to perform a web-search for.
+# We can make a decision if/when we're ready to localize convert2rhel.
+SUBSCRIPTION_MANAGER_LOCALE = CONVERT2RHEL_LOCALE
+
+#
+# Programming Locale
+#
+
+# This is the locale to use for programs that we run in a subprocess and then have to interpret what
+# they have done by screenscraping their output.
+SCREENSCRAPED_LOCALE = "C"

--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -38,6 +38,45 @@ from convert2rhel.toolopts import tool_opts
 LOG_DIR = "/var/log/convert2rhel"
 
 
+#
+# Pre-dbus import initialization
+#
+
+# We need to initialize the root logger with the NullHandler before dbus is imported.
+# Otherwise, dbus will install Handlers on the root logger which can end up printing
+# our log messages an additional time.  Additionally, bad user data could end up
+# causing the dbus logging to log rhsm passwords and other credentials.
+#
+# Right now we do this here, at the toplevel of logger.py.  In the future we should
+# have a dedicated module for initializing convert2rhel prior to importing other
+# libraries and we can do this step there.
+
+if hasattr(logging, "NullHandler"):
+    NullHandler = logging.NullHandler
+else:
+    # Python 2.6 compatibility.
+    # This code is copied from Pthon-3.10's logging module,
+    # licensed under the Python Software Foundation License, version 2
+    class NullHandler(logging.Handler):
+        def handle(self, record):
+            """Stub."""
+
+        def emit(self, record):
+            """Stub."""
+
+        def createLock(self):
+            self.lock = None
+
+        def _at_fork_reinit(self):
+            pass
+
+    # End of PSF Licensed code
+
+logging.getLogger().addHandler(NullHandler())
+
+# End pre-DBus initialization code
+
+
 class LogLevelTask(object):
     level = 15
     label = "TASK"

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -207,7 +207,9 @@ def _stop_rhsm():
         # there isn't an init script to stop it.  If we find we need to stop it, because we're
         # etting "machine is already registered" errors there, then we'll need to look for
         # rhsm-service in the process list and send it the TERM signal.
-        loggerinst.info("Skipping RHSM service shutdown on {0} {1}.".format(system_info.name, system_info.version.major))
+        loggerinst.info(
+            "Skipping RHSM service shutdown on {0} {1}.".format(system_info.name, system_info.version.major)
+        )
         return
 
     output, ret_code = utils.run_subprocess(cmd, print_output=False)

--- a/convert2rhel/unit_tests/__init__.py
+++ b/convert2rhel/unit_tests/__init__.py
@@ -109,11 +109,17 @@ def safe_repr(obj, short=False):
     return result[:_MAX_LENGTH] + " [truncated]..."
 
 
-def get_pytest_mark(request, mark_name):
+def get_pytest_marker(request, mark_name):
     """
     Get a pytest mark from a request.
+
     The pytest API to retrieve a mark changed between RHEL6 and RHEL7.  This function is
     a compatibility shim to retrieve the value.
+
+    Use this function instead of pytest's `request.node.get_closest_marker(mark_name)` so that it will work on all versions of RHEL that we are targeting.
+    .. seealso::
+        * `pytest's get_closest_marker() function which this function wraps <https://docs.pytest.org/en/stable/reference/reference.html#pytest.nodes.Node.get_closest_marker>`_
+        * `A technique you might use where you would need to use this function to retrieve a mark's value. <https://docs.pytest.org/en/stable/how-to/fixtures.html#using-markers-to-pass-data-to-fixtures>`_
     """
     if pytest.__version__.split(".") <= ["3", "6", "0"]:
         mark = request.node.get_marker(mark_name)

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -116,6 +116,7 @@ def test_perform_pre_checks(monkeypatch):
     check_rhel_compatible_kernel_is_used_mock = mock.Mock()
     check_package_updates_mock = mock.Mock()
     is_loaded_kernel_latest_mock = mock.Mock()
+    check_dbus_is_running_mock = mock.Mock()
 
     monkeypatch.setattr(
         checks,
@@ -154,6 +155,7 @@ def test_perform_pre_checks(monkeypatch):
     )
     monkeypatch.setattr(checks, "check_package_updates", value=check_package_updates_mock)
     monkeypatch.setattr(checks, "is_loaded_kernel_latest", value=is_loaded_kernel_latest_mock)
+    monkeypatch.setattr(checks, "check_dbus_is_running", value=check_dbus_is_running_mock)
 
     checks.perform_pre_checks()
 
@@ -164,6 +166,7 @@ def test_perform_pre_checks(monkeypatch):
     check_rhel_compatible_kernel_is_used_mock.assert_called_once()
     check_package_updates_mock.assert_called_once()
     is_loaded_kernel_latest_mock.assert_called_once()
+    check_dbus_is_running_mock.assert_called_once()
 
 
 def test_pre_ponr_checks(monkeypatch):
@@ -1243,3 +1246,43 @@ def test_is_loaded_kernel_latest_unsupported_skip(
         is_loaded_kernel_latest()
 
     assert expected in caplog.records[-1].message
+
+
+@pytest.mark.parametrize(
+    ("no_rhsm", "dbus_running", "log_msg"),
+    (
+        (True, True, "Skipping the check because we have been asked not to subscribe this system to RHSM."),
+        (True, False, "Skipping the check because we have been asked not to subscribe this system to RHSM."),
+        (False, True, "DBus Daemon is running"),
+    ),
+)
+def test_check_dbus_is_running(
+    caplog, monkeypatch, global_tool_opts, global_system_info, no_rhsm, dbus_running, log_msg
+):
+    monkeypatch.setattr(checks, "tool_opts", global_tool_opts)
+    global_tool_opts.no_rhsm = no_rhsm
+    monkeypatch.setattr(checks, "system_info", global_system_info)
+    global_system_info.dbus_running = dbus_running
+
+    assert checks.check_dbus_is_running() is None
+    assert caplog.records[-1].message == log_msg
+
+    assert log_msg == caplog.records[-1].message
+
+
+def test_check_dbus_is_running_not_running(caplog, monkeypatch, global_tool_opts, global_system_info):
+    monkeypatch.setattr(checks, "tool_opts", global_tool_opts)
+    global_tool_opts.no_rhsm = False
+    monkeypatch.setattr(checks, "system_info", global_system_info)
+    global_system_info.dbus_running = False
+
+    with pytest.raises(SystemExit):
+        checks.check_dbus_is_running()
+
+    log_msg = (
+        "Could not find a running DBus Daemon which is needed to"
+        " register with subscription manager.\nPlease start dbus using `systemctl"
+        " start dbus` or (on CentOS Linux 6), `service messagebus start`"
+    )
+    assert log_msg == caplog.records[-1].message
+    assert caplog.records[-1].levelname == "CRITICAL"

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -31,6 +31,8 @@ import rpm
 
 from six import moves
 
+from convert2rhel import i18n
+
 
 loggerinst = logging.getLogger(__name__)
 
@@ -193,7 +195,11 @@ def run_cmd_in_pty(cmd, expect_script=(), print_cmd=True, print_output=True, col
         loggerinst.debug("Calling command '%s'" % " ".join(cmd))
 
     process = PexpectSpawnWithDimensions(
-        cmd[0], cmd[1:], env={"LC_ALL": "C", "LANG": "C"}, timeout=None, dimensions=(1, columns)
+        cmd[0],
+        cmd[1:],
+        env={"LC_ALL": i18n.SCREENSCRAPED_LOCALE, "LANG": i18n.SCREENSCRAPED_LOCALE},
+        timeout=None,
+        dimensions=(1, columns),
     )
 
     for expect, send in expect_script:
@@ -522,7 +528,7 @@ def set_locale():
     We need to be setting not only LC_ALL but LANG as well because subscription-manager considers LANG to have priority
     over LC_ALL even though it goes against POSIX which specifies that LC_ALL overrides LANG.
     """
-    os.environ.update({"LC_ALL": "C", "LANG": "C"})
+    os.environ.update({"LC_ALL": i18n.SCREENSCRAPED_LOCALE, "LANG": i18n.SCREENSCRAPED_LOCALE})
 
 
 def string_to_version(verstring):

--- a/packaging/convert2rhel.spec
+++ b/packaging/convert2rhel.spec
@@ -31,6 +31,8 @@ BuildRequires:  pexpect
 BuildRequires:  rpm-python
 %endif
 
+# We need to talk to subscription-manager over dbus
+Requires:       dbus
 Requires:       efibootmgr
 Requires:       rpm
 Requires:       python%{python_pkgversion}
@@ -42,12 +44,14 @@ Requires:       dnf
 Requires:       dnf-utils
 Requires:       grubby
 Requires:       python3-pexpect
+Requires:       python3-dbus
 %endif
 %if 0%{?rhel} && 0%{?rhel} <= 7
 Requires:       yum
 # yum-utils includes yumdownloader we use
 Requires:       yum-utils
 Requires:       pexpect
+Requires:       dbus-python
 %endif
 # grub2-tools includes grub2-mkconfig and grub2-install needed by PR#417
 %if 0%{?rhel} && 0%{?rhel} >= 7

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 testpaths = "convert2rhel/unit_tests"
-markers = cert_filename
+markers =
+    cert_filename
+    rhsm_returns

--- a/tests/integration/tier0/check-cve-2022-1662/test_cve_fixes.py
+++ b/tests/integration/tier0/check-cve-2022-1662/test_cve_fixes.py
@@ -27,3 +27,20 @@ def test_passing_password_to_submrg(convert2rhel):
                 # Check for the password not being passed to the subscription-manager
                 print(watcher.get())
                 assert not [cmdline for cmdline in watcher.get() if password in cmdline]
+
+
+def test_passing_activation_key_to_submrg(convert2rhel):
+    organization = "testorg"
+    activation_key = "mfaop90a23f_2%"
+    with convert2rhel(f"-y --no-rpm-va -k {activation_key} -o {organization}") as c2r:
+        # Just to be sure, try to run through all three tries
+        # of the registration process in case the race condition applies
+        for subscription_try in range(2):
+            c2r.expect("Registering the system using subscription-manager ...")
+            # Run watchdog function using multiprocessing pool
+            # as soon as Convert2RHEL tries to call subscription-manager
+            with Pool(processes=1) as pool:
+                watcher = pool.apply_async(watchdog, ())
+                # Check for the password not being passed to the subscription-manager
+                print(watcher.get())
+                assert not [cmdline for cmdline in watcher.get() if activation_key in cmdline]


### PR DESCRIPTION
Part of [RHELC-597](https://issues.redhat.com/browse/RHELC-597)

---

Using the dbus API to register, we're able to stop passing the
activation key over the commandline.

This also lets us avoid pexpect for invoking subscription-manager when
passing the password.

Note that this requires that dbus is installed and running and that the
dbus-python/python-dbus packages are installed.  This package is
available on RHEL6-RHEL9 clones (all that we care about) but is a new
dependency.  The subscription-manager rpm already requires dbus-python so when we install that, we should be installing sbud as well.  RHEL7 and above use systemd which requires that dbus be running.  So RHEL6 is the only place where we might have to install and start up DBus.  Since the supported migration would include upgrading RHEL6 to RHEL7 soon after conversion, we might consider it not worthwhile to stop and remove dbus in this case.  Still have to consider rollback.

This code has been successfully tested on centos8 with activation key.  There are quite a few questions that I'm ready to take some feedback on before going further:

## TODOs

- [ ] DBus Daemon
  - [x] For this release and PR we will 
    - [x] Add an rpm requires for the dbus daemon package
    - [x] Check whether dbus is running:
      - [x] systeminfo.py will record whether dbus is running when convert2rhel starts
      - [x] checks.py will have a new check that fails if the dbus daemon is not running. 
    - [x] If it's not running error and ask the user to start it
  - [ ] I will open a jira ticket to make this behaviour better for the next release:
    - [ ] If the daemon is not running, start it.
    - [ ] During rollback, if the daemon was started by us, stop it.
- [ ] Remove RegistrationCommand.args
  - [x] Leave this in for this release as it isa handy way to log what we are using to talk to subscription-manager 
  - [ ] Will open a jira ticket to remove the function in a later PR.
    - [ ] Will change the logging to enumerate what we call subscription-manager's DBus API with
- [x] Workaround python-dbus broken logging (it initializes the root logger with a Handler that outputs to stderr. This causes our messages to be displayed twice and worse, if the user gives us data which can provoke an error when marshalling data to send to subscription-manager over DBus, then DBus will log the credentials in clear to stderr.)
  - [x] Added a NullHandler to the root logger before importing DBus which should stop DBus from adding the stderr handler.
  - [ ] Will open a jira ticket to move the NullHandler addition to another location next release.  @r0x0d is working on an early-initialization step for the yum merge transaction PR which we can use for this as well.
- [ ] Open jira ticket to determine org even for username + password auth
  - Resulted from speaking with Pino.
  - One customer bz: https://bugzilla.redhat.com/show_bug.cgi?id=1946309
  - Michal said: "We still can't handle this use case. For that reason we state in the product documentation that Satellite users should use the activation key/organization combination."
  - This code should be easy to update to get the organization: https://github.com/oamg/convert2rhel/blob/main/convert2rhel/subscription.py#L208
- [ ] Open a jira ticket to enter rollback if a user hits Ctrl-C during registration.  As coded right now, it will retry three times before entering rollback.
- [ ] Open a jira ticket to look into why using DBus to edit the configuration is not working at the end of `RegistrationCommand.__call__()`.  Looks to be dbus policy-related.
- [ ] Open a jira ticket to figure out:
  - Bug in subscription-manager that prevents force from working when we register when the system is already registered.  WIll this be fixed and can we drop the code that works around it?
  - Why we need to stop the rhsm service. Can we limit the rhsm service stop to only some platforms (RHEL7 and older)? 
  - Could we use reload instead of stop?  Do we need to stop even if unregister succeeds?
  - Some experimentation shows that setting register_opts force: True is having an effect.  Maybe the bug was that we weren't setting the DbusDictionary signature to `sv` and the sub-man server really is doing the right thing?
- [ ] Open a jira ticket to make sub-man config rollback aware. 
- [x] What should the return value of RegistrationCommand be?
  - [x] With Pino and Michal's feedback I lean towards RegistrationCommand returning nothing.
  - [x] On error, raise an exception.
  - [x] Be sure to catch the exception in our registration retry code.
- [x] If we fallback to cli, do we still allow activation_key even though it is insecure?
  - Decided not to fallback to cli since that would mean two code paths to test. 
- [x] Similar questions for python-dbus and dbus-python being installed.
  * The bindings are available on pypi as `dbus-python`.
  - [x] This is now required by the rpm.
- [x] Do we want to use DBUS for registering via passwords or only for activation key?
  - Decided to use DBus for registering via both passwords and activation key.
- [x] In _call_via_dbus(), we need to add more logging.  Call_via_cli lets run_subprocess()/run_in_pty() do most of its logging but we don't have that in _call_via_dbus()
- [x] integration tests to check that activation_key is not visible to the process list (because we're no longer calling subscription-manager with activation_key on the cli.
- [x] A few questions about schema, username, and password for pino.
  - [x] Open a jira ticket to look into what subscription-manager cli does with username:password in the --server-url and change our code to do what it does (our code currently ignores )
  - [x] Pino let us know that any username and password supplied to the subscription-manager cli via --serverurl is ignored.  So we can safely ignore those too.
- [x] unittests
  - [x] Fix current tests that fail after moving to dbus
  - [x] Write new tests to cover new code paths. 
- [x] We're going to keep dbus-python as a Requires in the rpm package so we don't need to conditionalize import
  - [ ]  Do we need dbus-python it in some requirements files?  we don't have pexpect in any requirements.