### PR TITLE
[RHELC-640] chore(renovate): Ignore CentOS 6 deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,13 @@
   "extends": [
     "config:base"
   ],
-  "enabledManagers": ["docker", "python"]
+  "enabledManagers": ["docker", "python"],
+  "ignorePaths": ["**/centos6*.requirements.txt"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["pytest"],
+      "matchFiles": ["requirements/centos8.requirements.txt"],
+      "allowedVersions": "<=7.0"
+    }
+  ]
 }


### PR DESCRIPTION
Ignoring CentOS Linux 6 dependencies in requirements file as we don't want to update them.

This also only allows 7.0.x updates for pytest with centos8 requirements file