### PR TITLE
Improve GPG key import and repository-related messages

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -592,7 +592,9 @@ def check_package_updates():
 
     if len(packages_to_update) > 0:
         repos_message = (
-            "on the enabled system repos" if not reposdir else "on repositories defined in the %s folder" % reposdir
+            "on the enabled system repositories"
+            if not reposdir
+            else "on repositories defined in the %s folder" % reposdir
         )
         logger.warning(
             "The system has %s packages not updated based %s.\n"

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -650,8 +650,8 @@ def install_gpg_keys():
             print_output=False,
         )
         if ret_code != 0:
-            loggerinst.critical("Unable to import GPG key: %s", output)
-        loggerinst.info("GPG keys imported.")
+            loggerinst.critical("Unable to import the GPG key %s:\n %s.", gpg_key, output)
+        loggerinst.info("GPG key %s imported successfuly.", gpg_key)
 
 
 def preserve_only_rhel_kernel():

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -591,7 +591,7 @@ def disable_repos():
     disable_cmd.extend(disable_repos)
     output, ret_code = utils.run_subprocess(disable_cmd, print_output=False)
     if ret_code != 0:
-        loggerinst.critical("Repos were not possible to disable through subscription-manager:\n%s" % output)
+        loggerinst.critical("Repositories were not possible to disable through subscription-manager:\n%s" % output)
     loggerinst.info("Repositories disabled.")
     return
 
@@ -637,7 +637,7 @@ def _submgr_enable_repos(repos_to_enable):
         enable_cmd.append("--enable=%s" % repo)
     output, ret_code = utils.run_subprocess(enable_cmd, print_output=False)
     if ret_code != 0:
-        loggerinst.critical("Repos were not possible to enable through subscription-manager:\n%s" % output)
+        loggerinst.critical("Repositories were not possible to enable through subscription-manager:\n%s" % output)
     loggerinst.info("Repositories enabled through subscription-manager")
 
 

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -266,7 +266,7 @@ class SystemInfo(object):
         rpm_va, _ = utils.run_subprocess(["rpm", "-Va"], print_output=False)
         output_file = os.path.join(logger.LOG_DIR, log_filename)
         utils.store_content_to_file(output_file, rpm_va)
-        self.logger.info("The 'rpm -Va' output has been stored in the %s file" % output_file)
+        self.logger.info("The 'rpm -Va' output has been stored in the %s file." % output_file)
 
     def modified_rpm_files_diff(self):
         """Get a list of modified rpm files after the conversion and compare it to the one from before the conversion."""

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -1082,7 +1082,7 @@ def test_track_installed_submgr_pkgs(installed_pkgs, not_tracked_pkgs, skip_pkg_
             ("repo-1, repo-2", 1),
             True,
             ["repo-1", "repo-2"],
-            "Repos were not possible to enable through subscription-manager:\nrepo-1, repo-2",
+            "Repositories were not possible to enable through subscription-manager:\nrepo-1, repo-2",
         ),
         (
             ["rhel-8-for-x86_64-baseos-eus-rpms", "rhel-8-for-x86_64-appstream-eus-rpms"],
@@ -1132,7 +1132,7 @@ def test_enable_repos_rhel_repoids(
             ("rhel-8-for-x86_64-baseos-eus-rpms, rhel-8-for-x86_64-appstream-eus-rpms", 1),
             ("test-repo-1, test-repo-2", 1),
             True,
-            "Repos were not possible to enable through subscription-manager:\ntest-repo-1, test-repo-2",
+            "Repositories were not possible to enable through subscription-manager:\ntest-repo-1, test-repo-2",
         ),
         (
             ["rhel-8-for-x86_64-baseos-eus-rpms", "rhel-8-for-x86_64-appstream-eus-rpms"],
@@ -1194,7 +1194,7 @@ def test_enable_repos_rhel_repoids_fallback_default_rhsm(
             ("repo-1, repo-2", 1),
             True,
             ["repo-1", "repo-2"],
-            "Repos were not possible to enable through subscription-manager:\nrepo-1, repo-2",
+            "Repositories were not possible to enable through subscription-manager:\nrepo-1, repo-2",
         ),
         (
             ["rhel-8-for-x86_64-baseos-eus-rpms", "rhel-8-for-x86_64-appstream-eus-rpms"],


### PR DESCRIPTION
Repositories should not be abbreviated to "repos" in user facing messages.

The GPG key message was mentioning "keys" being imported while it referred to a single key.