### PR TITLE
Add type stubs for six library

### DIFF
--- a/requirements/centos7.requirements.txt
+++ b/requirements/centos7.requirements.txt
@@ -4,3 +4,4 @@ pytest==4.6.11
 pathlib2==2.3.7.post1
 mock==3.0.5
 pytest-cov==2.12.1
+types-six==1.16.18

--- a/requirements/centos8.requirements.txt
+++ b/requirements/centos8.requirements.txt
@@ -3,3 +3,4 @@ astroid==2.11.7
 pytest==7.0.1
 pytest-cov==3.0.0
 coverage[toml]
+types-six==1.16.18


### PR DESCRIPTION
Add the type stubs for the six library so we can have better insights when
using static analysis tools, like pyright.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>