### PR TITLE
WIP: Enable integration testing for RHEL 6 conversions 

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -40,9 +40,11 @@ jobs:
 - job: tests
   metadata:
     targets:
-      epel-7-x86_64:
-        distros: [centos-7, oraclelinux-7]
-      epel-8-x86_64:
-        distros: [centos-8.4, centos-8, oraclelinux-8.4, oraclelinux-8.6]
+      epel-6-x86_64:
+        distros: [centos-6]
+#      epel-7-x86_64:
+#        distros: [centos-7, oraclelinux-7]
+#      epel-8-x86_64:
+#        distros: [centos-8.4, centos-8, oraclelinux-8.4, oraclelinux-8.6]
     use_internal_tf: True
   trigger: pull_request


### PR DESCRIPTION
Enable conversion to RHEL-6.

Current stauts:
Image in TF is not working. We need to upload/update working image with Centos6. One option can be to use from 1minutetip