### PR TITLE
[RHELC-678] Remove UEFI condition from shim-x64 workaround

### DIFF
--- a/convert2rhel/special_cases.py
+++ b/convert2rhel/special_cases.py
@@ -19,7 +19,6 @@ import logging
 import os
 
 from convert2rhel.backup import RestorableFile
-from convert2rhel.grub import is_efi
 from convert2rhel.systeminfo import system_info
 from convert2rhel.utils import mkdir_p, run_subprocess
 

--- a/convert2rhel/special_cases.py
+++ b/convert2rhel/special_cases.py
@@ -112,9 +112,6 @@ def unprotect_shim_x64():
     """
     logger.info("Removing shim-x64 package yum protection.")
     if system_info.id == "oracle" and system_info.version.major == 7:
-        if not is_efi():
-            logger.info("Relevant to UEFI firmware only. Skipping.")
-            return
         shim_x64_pkg_protection_file.backup()
         try:
             os.remove(shim_x64_pkg_protection_file.filepath)

--- a/convert2rhel/unit_tests/special_cases_test.py
+++ b/convert2rhel/unit_tests/special_cases_test.py
@@ -92,7 +92,6 @@ def test_perform_java_openjdk_workaround(
 @pytest.mark.parametrize(
     ("sys_id", "is_efi", "removal_ok", "log_msg"),
     (
-        ("oracle", False, True, "Relevant to UEFI firmware only"),
         ("oracle", True, True, "removed in accordance with"),
         ("oracle", True, False, "Unable to remove"),
         ("centos", True, True, "Relevant to Oracle Linux 7 only"),

--- a/convert2rhel/unit_tests/special_cases_test.py
+++ b/convert2rhel/unit_tests/special_cases_test.py
@@ -90,18 +90,16 @@ def test_perform_java_openjdk_workaround(
 
 
 @pytest.mark.parametrize(
-    ("sys_id", "is_efi", "removal_ok", "log_msg"),
+    ("sys_id", "removal_ok", "log_msg"),
     (
-        ("oracle", True, True, "removed in accordance with"),
-        ("oracle", True, False, "Unable to remove"),
-        ("centos", True, True, "Relevant to Oracle Linux 7 only"),
+        ("oracle", True, "removed in accordance with"),
+        ("oracle", False, "Unable to remove"),
+        ("centos", True, "Relevant to Oracle Linux 7 only"),
     ),
 )
 @mock.patch("os.remove")
-@mock.patch("convert2rhel.special_cases.is_efi")
-def test_unprotect_shim_x64(mock_is_efi, mock_os_remove, sys_id, is_efi, removal_ok, log_msg, monkeypatch, caplog):
+def test_unprotect_shim_x64(mock_os_remove, sys_id, removal_ok, log_msg, monkeypatch, caplog):
     monkeypatch.setattr(system_info, "id", sys_id)
-    mock_is_efi.return_value = is_efi
     monkeypatch.setattr(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
     if not removal_ok:
         mock_os_remove.side_effect = OSError()
@@ -109,7 +107,7 @@ def test_unprotect_shim_x64(mock_is_efi, mock_os_remove, sys_id, is_efi, removal
     special_cases.unprotect_shim_x64()
 
     assert log_msg in caplog.records[-1].message
-    if sys_id == "oracle" and is_efi and removal_ok:
+    if sys_id == "oracle" and removal_ok:
         mock_os_remove.assert_called_once()
 
 

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -74,6 +74,21 @@ discover+:
     how: ansible
     playbook: tests/ansible_collections/roles/reboot/main.yml
 
+/handle_special_pkgs_case:
+  adjust:
+    enabled: false
+    when: >
+      distro != oraclelinux-7
+  discover+:
+    test: checks-after-conversion
+  prepare+:
+  - name: main conversion preparation
+    how: shell
+    script: pytest -svv tests/integration/tier1/handle-special-pkgs-case/test_handle_shim_x64_pkg.py
+  - name: reboot after conversion
+    how: ansible
+    playbook: tests/ansible_collections/roles/reboot/main.yml
+
 /remove_all_submgr_pkgs:
   discover+:
     test: checks-after-conversion

--- a/tests/integration/tier1/handle-special-pkgs-case/main.fmf
+++ b/tests/integration/tier1/handle-special-pkgs-case/main.fmf
@@ -1,0 +1,5 @@
+summary: handle-special-pkgs-case
+
+tier: 1
+
+test: pytest -svv

--- a/tests/integration/tier1/handle-special-pkgs-case/test_handle_shim_x64_pkg.py
+++ b/tests/integration/tier1/handle-special-pkgs-case/test_handle_shim_x64_pkg.py
@@ -26,7 +26,7 @@ def test_handle_shim_x64_pkg(shell, convert2rhel):
             env.str("RHSM_POOL"),
         )
     ) as c2r:
-        c2r.expect_exact("Removing shim-x64 package yum protection.") == 0
+       assert c2r.expect_exact("Removing shim-x64 package yum protection.") == 0
         c2r.expect("removed in accordance with")
     assert c2r.exitstatus == 0
 

--- a/tests/integration/tier1/handle-special-pkgs-case/test_handle_shim_x64_pkg.py
+++ b/tests/integration/tier1/handle-special-pkgs-case/test_handle_shim_x64_pkg.py
@@ -26,7 +26,7 @@ def test_handle_shim_x64_pkg(shell, convert2rhel):
             env.str("RHSM_POOL"),
         )
     ) as c2r:
-       assert c2r.expect_exact("Removing shim-x64 package yum protection.") == 0
+        assert c2r.expect_exact("Removing shim-x64 package yum protection.") == 0
         c2r.expect("removed in accordance with")
     assert c2r.exitstatus == 0
 

--- a/tests/integration/tier1/handle-special-pkgs-case/test_handle_shim_x64_pkg.py
+++ b/tests/integration/tier1/handle-special-pkgs-case/test_handle_shim_x64_pkg.py
@@ -1,0 +1,36 @@
+from envparse import env
+
+
+def test_handle_shim_x64_pkg(shell, convert2rhel):
+    """Ensure c2r handle the shim-x64 package.
+
+    This test needs to pass on both BIOS and UEFI systems as this packages needs
+    to have it's protection config removed during the conversion.
+    """
+
+    shim_x64_pkg = "shim-x64"
+    # Install the shim-x64 package
+    assert (
+        shell(
+            f"yum install -y {shim_x64_pkg}",
+        ).returncode
+        == 0
+    )
+
+    # run utility until the reboot
+    with convert2rhel(
+        ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        c2r.expect_exact("Removing shim-x64 package yum protection.") == 0
+        c2r.expect("removed in accordance with")
+    assert c2r.exitstatus == 0
+
+    # Check that the package is still present on the system
+    assert shell(f"rpm -qi {shim_x64_pkg}").returncode == 0
+    # Check that the package is converted
+    assert "Red Hat" in shell(f"rpm -qi {shim_x64_pkg} | grep 'Vendor'").output


### PR DESCRIPTION
shim-x64 packages can be installed on systems that are running BIOS too,
so our previous workaround included only UEFI systems.

This commit removes that condition by backing up and removing the
shim-x64 package protection on both UEFI and BIOS now.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>