### PR TITLE
[RHELC-67] Add gnome-documents-libs to excluded packages

### DIFF
--- a/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
@@ -21,6 +21,7 @@ excluded_pkgs =
   mod_proxy_html
   rhn*
   yum-rhn-plugin
+  gnome-documents-libs
 
 # List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
 # Delimited by any whitespace(s).

--- a/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/oracle-7-x86_64.cfg
@@ -23,6 +23,7 @@ excluded_pkgs =
   yum-plugin-ulninfo
   yum-rhn-plugin
   python-requests
+  gnome-documents-libs
 
 # List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
 # The rhn-client-tools package contains repofiles on OL 7.6 and older, but when it's installed it's not possible to

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -59,11 +59,29 @@ discover+:
     how: ansible
     playbook: tests/ansible_collections/roles/reboot/main.yml
 
-/remove_excluded_pkgs:
+/remove_excluded_pkgs_epel8:
   adjust:
     enabled: false
     when: >
       distro != centos-8
+  environment+:
+    PACKAGES: centos-backgrounds centos-gpg-keys
+  discover+:
+    test: checks-after-conversion
+  prepare+:
+  - name: main conversion preparation
+    how: shell
+    script: pytest -svv tests/integration/tier1/remove-excluded-pkgs/test_remove_excluded_pkgs.py
+  - name: reboot after conversion
+    how: ansible
+    playbook: tests/ansible_collections/roles/reboot/main.yml
+
+/remove_excluded_pkgs_epel7:
+  adjust:
+    enabled: false
+    when: distro != oraclelinux-7 and distro != centos-7
+  environment+:
+        PACKAGES: gnome-documents-libs
   discover+:
     test: checks-after-conversion
   prepare+:

--- a/tests/integration/tier1/remove-excluded-pkgs/main.fmf
+++ b/tests/integration/tier1/remove-excluded-pkgs/main.fmf
@@ -1,4 +1,4 @@
-summary: remove-excluded-pkgs
+summary: Check removal of excluded packages
 
 tier: 1
 

--- a/tests/integration/tier1/remove-excluded-pkgs/test_remove_excluded_pkgs.py
+++ b/tests/integration/tier1/remove-excluded-pkgs/test_remove_excluded_pkgs.py
@@ -31,4 +31,4 @@ def test_remove_excluded_pkgs(shell, convert2rhel):
     assert c2r.exitstatus == 0
 
     # check excluded packages were really removed
-    assert shell(f"rpm -qi {packages}").returncode == 1
+    assert shell(f"rpm -qi {packages}").returncode != 0

--- a/tests/integration/tier1/remove-excluded-pkgs/test_remove_excluded_pkgs.py
+++ b/tests/integration/tier1/remove-excluded-pkgs/test_remove_excluded_pkgs.py
@@ -1,16 +1,19 @@
+import os
+
 from envparse import env
 
 
 def test_remove_excluded_pkgs(shell, convert2rhel):
-    """Ensure c2r removes pkgs, which specified as excluded_pkgs in config."""
-
-    excluded_pkg_1 = "centos-gpg-keys"
-    excluded_pkg_2 = "centos-backgrounds"
-
-    # install some of excluded packages
+    """
+    Ensure Convert2RHEL removes packages, which are specified as excluded_pkgs in config.
+    Verification scenarios cover just some packages causing major issues.
+    Those are specified in their respective test plan (remove_excluded_pkgs_epel7 and remove_excluded_pkgs_epel8).
+    Packages are set as an environment variable.
+    """
+    packages = os.environ["PACKAGES"]
     assert (
         shell(
-            f"yum install -y {excluded_pkg_1} {excluded_pkg_2}",
+            f"yum install -y {packages}",
         ).returncode
         == 0
     )
@@ -28,5 +31,4 @@ def test_remove_excluded_pkgs(shell, convert2rhel):
     assert c2r.exitstatus == 0
 
     # check excluded packages were really removed
-    assert shell(f"rpm -qi {excluded_pkg_1}").returncode == 1
-    assert shell(f"rpm -qi {excluded_pkg_2}").returncode == 1
+    assert shell(f"rpm -qi {packages}").returncode == 1


### PR DESCRIPTION
The gnome-documents-libs package is causing file conflicts with gnome-documents
during the package transaction as they both share similar files.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2043724

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>