### PR TITLE
[RHELC-673] convert2rhel rpm to require efibootmgr installed

### DIFF
--- a/packaging/convert2rhel.spec
+++ b/packaging/convert2rhel.spec
@@ -31,6 +31,7 @@ BuildRequires:  pexpect
 BuildRequires:  rpm-python
 %endif
 
+Requires:       efibootmgr
 Requires:       rpm
 Requires:       python%{python_pkgversion}
 Requires:       python%{python_pkgversion}-setuptools


### PR DESCRIPTION
In https://github.com/oamg/convert2rhel/pull/223 we introduced support for UEFI-based system conversions. With that we call the efibootmgr utility on a couple of places. Yet, we don't require the utility to be installed and that might lead into unwanted behaviour of convert2rhel.

I've verified that the package is named the same across all major versions of RHEL we allow converting.

Jira: https://issues.redhat.com/browse/RHELC-673