### PR TITLE
[RHELC-693] Check if org and key passed

### DIFF
--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -420,6 +420,11 @@ class CLI(object):
                 " We're going to use the password file."
             )
 
+        if (tool_opts.org and not tool_opts.activation_key) or (not tool_opts.org and tool_opts.activation_key):
+            loggerinst.critical(
+                "Either the --organization or the --activationkey option is missing. You can't use one without the other."
+            )
+
         if tool_opts.username and tool_opts.password:
             tool_opts.credentials_thru_cli = True
 


### PR DESCRIPTION
The check making sure the organization is specified by the user is currently skipped when you don't specify the organization on the command line AND you pass the activation key through either the CLI OR the config file.

[RHELC-693](https://issues.redhat.com/browse/RHELC-693)