### PR TITLE
Ignore old dockerfiles in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,12 @@
     "config:base"
   ],
   "enabledManagers": ["dockerfile", "pip_requirements", "github-actions"],
-  "ignorePaths": ["**/centos6*.requirements.txt"],
+  "ignorePaths": [
+    "**/centos6.Dockerfile",
+    "**/centos7.Dockerfile",
+    "**/rpmbuild.centos7.Dockerfile",
+    "**/centos6*.requirements.txt"
+  ],
   "packageRules": [
     {
       "matchPackageNames": ["pytest"],


### PR DESCRIPTION
Renovate tries to open pull requests to update old centos dockerfiles to
it's newest version. While this behavior of renovate is the right one,
we don't want them to be updated as we need them to be on a older
version.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>