### PR TITLE
Prevent RHEL6 unit_tests to output logging text

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,11 @@ tests: tests6 tests7 tests8
 
 tests6: images
 	@echo 'CentOS Linux 6 tests'
-	@$(DOCKER) run --rm --user=$(id -ur):$(id -gr) -v $(shell pwd):/data:Z $(IMAGE)/centos6 pytest --capture=$(SHOW_CAPTURE) $(PYTEST_ARGS)
+ifneq ("$(SHOW_CAPTURE)", "no")
+		$(DOCKER) run --rm --user=$(id -ur):$(id -gr) -v $(shell pwd):/data:Z $(IMAGE)/centos6 pytest --capture=$(SHOW_CAPTURE) $(PYTEST_ARGS)
+else
+		@$(DOCKER) run --rm --user=$(id -ur):$(id -gr) -v $(shell pwd):/data:Z $(IMAGE)/centos6 pytest $(PYTEST_ARGS)
+endif
 
 tests7: images
 	@echo 'CentOS Linux 7 tests'


### PR DESCRIPTION
When executing the RHEL6 unit_tests locally, our container outputs a lot of
logging text that is not necessary.

If the user still wants to print some other text that the tests may output, the
same can be overrided with `SHOW_CAPTURE=[fd|sys]`.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>