### PR TITLE
Remove fix-spec-file from packit configuration

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -18,8 +18,6 @@ jobs:
     # do not get the version from a tag (git describe) but from the spec file
     get-current-version:
     - grep -oP '^Version:\s+\K\S+' packaging/convert2rhel.spec
-    # workaround for https://github.com/packit/packit-service/issues/1601
-    fix-spec-file: []
 - job: copr_build
   trigger: commit
   branch: main
@@ -37,8 +35,6 @@ jobs:
     # do not get the version from a tag (git describe) but from the spec file
     get-current-version:
     - grep -oP '^Version:\s+\K\S+' packaging/convert2rhel.spec
-    # workaround for https://github.com/packit/packit-service/issues/1601
-    fix-spec-file: []
 - job: tests
   targets:
     epel-7-x86_64:


### PR DESCRIPTION
We introduced the `fix-spec-file` only as a workaround for https://github.com/packit/packit-service/issues/1601. The issue has been fixed on the packit side so the workaround is no longer needed.

Ccing @TomasTomecek.