### PR TITLE
[RHELC-635] Call integration tests through GitHub Actions

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,32 @@
+# IMPORTANT NOTE
+# In this workflow there should NOT be checkout action - because of security reasons.
+# More info:
+# https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+
+name: PR welcome message
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  pr_comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## **Thank you for contributing to the Convert2RHEL project!**
+            👋 Hello @${{ github.actor }}, thank you for submitting a PR 🚀!
+            Please note that every PR needs to comply with the [Convert2RHEL Guidelines](https://github.com/oamg/convert2rhel/blob/main/CONTRIBUTING.md) and must pass all tests in order to be mergable.
+            If you want to rebuild a package in copr, you can use following commands as a comment:
+            - **/packit copr-build** to submit a public copr build using packit
+
+            To launch regression testing public members of oamg organization can leave the following comment:
+            - **/rerun** to schedule regression tests using this pr build
+
+            Please [open ticket](https://github.com/oamg/convert2rhel/issues) in case you experience technical problem with the CI.
+
+            **Note:** In case there are problems with tests not being triggered automatically on new PR/commit or pending for a long time, please tag @oamg/convert2rhel-developers in the pr comments.

--- a/.github/workflows/reuse-get-copr-id.yml
+++ b/.github/workflows/reuse-get-copr-id.yml
@@ -1,0 +1,42 @@
+name: reuse-copr-build@TF
+
+on:
+  workflow_call:
+    outputs:
+      artifacts:
+        description: "A string with test artifacts to install in tft test env"
+        value: ${{ jobs.reusable_workflow_copr_build_job.outputs.artifacts }}
+
+jobs:
+  reusable_workflow_copr_build_job:
+    # This job only runs for '/rerun' pull request comments by owner, member, or collaborator of the repo/organization.
+    name: Retrieve Copr build id
+    runs-on: ubuntu-latest
+    outputs:
+      artifacts: ${{ steps.gen_artifacts.outputs.artifacts }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install necessary deps
+        id: deps_install
+        run: sudo apt-get install -y libkrb5-dev
+
+      - name: Get latest convert2rhel PR copr build id
+        id: get_latest_c2r_copr_build_id
+        run: |
+          cat << EOF > copr_fedora.conf
+          [copr-cli]
+          copr_url = https://copr.fedorainfracloud.org
+          EOF
+
+          pip install copr-cli
+          REGEX='convert2rhel.*${{ github.event.number }}*' _COPR_CONFIG=copr_fedora.conf python ${{ github.workspace }}/scripts/get_copr_build_id.py > build_id
+          COPR_ID=$(cat build_id)
+          echo "::set-output name=copr_id::${COPR_ID##*/}"
+
+      - name: Generate artifacts output
+        id: gen_artifacts
+        env:
+          ARTIFACTS: ${{ steps.get_latest_c2r_copr_build_id.outputs.copr_id }}
+        run: |
+          echo "::set-output name=artifacts::${{ env.ARTIFACTS }}"

--- a/.github/workflows/reuse-int-tests.yml
+++ b/.github/workflows/reuse-int-tests.yml
@@ -1,0 +1,134 @@
+name: reuse-tests-tier0@TF
+
+on:
+  workflow_call:
+    secrets:
+      DEBUG:
+        required: true
+      RHSM_KEY:
+        required: true
+      RHSM_ORG:
+        required: true
+      RHSM_PASSWORD:
+        required: true
+      RHSM_POOL:
+        required: true
+      RHSM_SERVER_URL:
+        required: true
+      RHSM_SINGLE_SUB_PASSWORD:
+        required: true
+      RHSM_SINGLE_SUB_POOL:
+        required: true
+      RHSM_SINGLE_SUB_USERNAME:
+        required: true
+      RHSM_USERNAME:
+        required: true
+      SATELLITE_KEY:
+        required: true
+      SATELLITE_KEY_EUS:
+        required: true
+      SATELLITE_ORG:
+        required: true
+      TF_ENDPOINT:
+        required: true
+      TF_API_KEY:
+        required: true
+    inputs:
+      copr_artifacts:
+        required: true
+        type: string
+      tmt_plan_regex:
+        type: string
+        required: false
+        default: "^(?!.*tier0)"
+      environment_settings:
+        type: string
+        required: false
+        default: '{"provisioning": {"post_install_script": "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"}}'
+      arch:
+        type: string
+        required: false
+        default: "x86_64"
+      pull_request_status_name:
+        type: string
+        required: false
+        default: "tier0"
+      copr:
+        type: string
+        required: false
+        default: "epel-8-x86_64"
+      tmt_context:
+        type: string
+        required: false
+        default: "distro=centos-8"
+      distros:
+        type: string
+        required: true
+      variables:
+        type: string
+        required: false
+        default: ""
+      update_pull_request_status:
+        type: string
+        required: false
+        default: "true"
+
+jobs:
+  convert_distro_to_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.convert_to_matrix.outputs.matrix }}
+    steps:
+      - id: convert_to_matrix
+        run: |
+          echo "::set-output name=matrix::$input"
+        env:
+          input: ${{ inputs.distros }}
+
+  reusable_workflow_job:
+    # This job only runs for '/rerun' pull request comments by owner, member, or collaborator of the repo/organization.
+    name: Schedule regression tests on Testing Farm
+    needs: [convert_distro_to_matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: ${{fromJson(needs.convert_distro_to_matrix.outputs.matrix)}}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Schedule regression testing for ${{ inputs.pull_request_status_name }}
+        uses: sclorg/testing-farm-as-github-action@v1.2.11
+        with:
+          # required
+          api_url: ${{ secrets.TF_ENDPOINT }}
+          api_key: ${{ secrets.TF_API_KEY }}
+          git_url: "https://github.com/oamg/convert2rhel"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # optional
+          tf_scope: "private"
+          create_issue_comment: "true"
+          update_pull_request_status: ${{ inputs.update_pull_request_status }}
+          tmt_plan_regex: ${{ inputs.tmt_plan_regex }}
+          compose: ${{ matrix.distro }}
+          arch: ${{ inputs.arch }}
+          copr: ${{ inputs.copr }}
+          copr_artifacts: ${{ inputs.copr_artifacts }}
+          debug: ${{ secrets.DEBUG }}
+          tmt_context: "distro=${{ matrix.distro }}"
+          pull_request_status_name: ${{ inputs.pull_request_status_name }}
+          environment_settings: ${{ inputs.environment_settings }}
+          variables: "DEBUG=${{ secrets.DEBUG }};\
+            RHSM_KEY=${{ secrets.RHSM_KEY }};\
+            RHSM_ORG=${{ secrets.RHSM_ORG }};\
+            RHSM_PASSWORD=${{ secrets.RHSM_PASSWORD }};\
+            RHSM_POOL=${{ secrets.RHSM_POOL }};\
+            RHSM_SERVER_URL=${{ secrets.RHSM_SERVER_URL }};\
+            RHSM_SINGLE_SUB_PASSWORD=${{ secrets.RHSM_SINGLE_SUB_PASSWORD }};\
+            RHSM_SINGLE_SUB_POOL=${{ secrets.RHSM_SINGLE_SUB_PASSWORD }};\
+            RHSM_SINGLE_SUB_USERNAME=${{ secrets.RHSM_SINGLE_SUB_PASSWORD }};\
+            RHSM_USERNAME=${{ secrets.RHSM_USERNAME }};\
+            SATELLITE_KEY=${{ secrets.SATELLITE_KEY }};\
+            SATELLITE_KEY_EUS=${{ secrets.SATELLITE_KEY_EUS }};\
+            SATELLITE_ORG=${{ secrets.SATELLITE_ORG }};\
+            ${{ inputs.variables }}"

--- a/.github/workflows/reuse-int-tests.yml
+++ b/.github/workflows/reuse-int-tests.yml
@@ -57,10 +57,6 @@ on:
         type: string
         required: false
         default: "epel-8-x86_64"
-      tmt_context:
-        type: string
-        required: false
-        default: "distro=centos-8"
       distros:
         type: string
         required: true
@@ -86,7 +82,6 @@ jobs:
           input: ${{ inputs.distros }}
 
   reusable_workflow_job:
-    # This job only runs for '/rerun' pull request comments by owner, member, or collaborator of the repo/organization.
     name: Schedule regression tests on Testing Farm
     needs: [convert_distro_to_matrix]
     strategy:
@@ -95,8 +90,6 @@ jobs:
         distro: ${{fromJson(needs.convert_distro_to_matrix.outputs.matrix)}}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
       - name: Schedule regression testing for ${{ inputs.pull_request_status_name }}
         uses: sclorg/testing-farm-as-github-action@v1.2.11
         with:
@@ -104,6 +97,7 @@ jobs:
           api_url: ${{ secrets.TF_ENDPOINT }}
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: "https://github.com/oamg/convert2rhel"
+          git_ref: "refs/pull/${{ github.event.issue.number }}/head"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # optional
           tf_scope: "private"

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -1,18 +1,20 @@
 name: tmt@TF
 
 on:
-  issue_comment:
-    types:
-      - created
+  pull_request_target:
+    types: [
+      # Default types from `pull_request_target` event
+      opened, synchronize, reopened,
+      # Trigger on labels
+      labeled
+    ]
+    branches: [ main ]
 
 # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
 # This will ensure that only one commit will be running tests at a time on each PR.
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
-
-permissions:
-  checks: read
 
 jobs:
   wait_for_rpm_builds:
@@ -26,18 +28,17 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           checkNames: "rpm-build:epel-7-x86_64;rpm-build:epel-8-x86_64"
     if: |
-      github.event.issue.pull_request
-      && startsWith(github.event.comment.body, '/rerun-all')
-      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      github.event.pull_request
+      && (
+        contains(fromJson('["OWNER", "MEMBER"]'), github.event.pull_request.author_association)
+        || contains(github.event.pull_request.labels.*.name, 'safe-to-test')
+      )
 
   call_workflow_get_copr_id:
     needs: [wait_for_rpm_builds]
     uses: ./.github/workflows/reuse-get-copr-id.yml
-    if: |
-      github.event.issue.pull_request
-      && startsWith(github.event.comment.body, '/rerun-all')
-      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
 
+  # Tier 0 integration tests
   call_workflow_integration_tests_epel_7_tier0:
     needs: [call_workflow_get_copr_id]
     uses: ./.github/workflows/reuse-int-tests.yml
@@ -48,10 +49,6 @@ jobs:
       distros: '["centos-7", "oraclelinux-7"]'
       pull_request_status_name: "epel-7-tier0"
     secrets: inherit
-    if: |
-      github.event.issue.pull_request
-      && startsWith(github.event.comment.body, '/rerun-all')
-      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
 
   call_workflow_integration_tests_epel_8_tier0:
     needs: [call_workflow_get_copr_id]
@@ -62,11 +59,8 @@ jobs:
       distros: '["centos-8.4", "centos-8", "oraclelinux-8.4", "oraclelinux-8.6"]'
       pull_request_status_name: "epel-8-tier0"
     secrets: inherit
-    if: |
-      github.event.issue.pull_request
-      && startsWith(github.event.comment.body, '/rerun-all')
-      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
 
+  # Tier 1 integration tests
   call_workflow_integration_tests_epel_7_tier1:
     needs: [call_workflow_get_copr_id]
     uses: ./.github/workflows/reuse-int-tests.yml
@@ -77,10 +71,6 @@ jobs:
       distros: '["centos-7", "oraclelinux-7"]'
       pull_request_status_name: "epel-7-tier1"
     secrets: inherit
-    if: |
-      github.event.issue.pull_request
-      && startsWith(github.event.comment.body, '/rerun-all')
-      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
 
   call_workflow_integration_tests_epel_8_tier1:
     needs: [call_workflow_get_copr_id]
@@ -91,7 +81,3 @@ jobs:
       distros: '["centos-8.4", "centos-8", "oraclelinux-8.4", "oraclelinux-8.6"]'
       pull_request_status_name: "epel-8-tier1"
     secrets: inherit
-    if: |
-      github.event.issue.pull_request
-      && startsWith(github.event.comment.body, '/rerun-all')
-      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -1,0 +1,97 @@
+name: tmt@TF
+
+on:
+  issue_comment:
+    types:
+      - created
+
+# See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
+# This will ensure that only one commit will be running tests at a time on each PR.
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  checks: read
+
+jobs:
+  wait_for_rpm_builds:
+    name: Wait for CI Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for CI Checks
+        uses: r0x0d/wait-for-ci-checks@main
+        id: status_check
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          checkNames: "rpm-build:epel-7-x86_64;rpm-build:epel-8-x86_64"
+    if: |
+      github.event.issue.pull_request
+      && startsWith(github.event.comment.body, '/rerun-all')
+      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+
+  call_workflow_get_copr_id:
+    needs: [wait_for_rpm_builds]
+    uses: ./.github/workflows/reuse-get-copr-id.yml
+    if: |
+      github.event.issue.pull_request
+      && startsWith(github.event.comment.body, '/rerun-all')
+      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+
+  call_workflow_integration_tests_epel_7_tier0:
+    needs: [call_workflow_get_copr_id]
+    uses: ./.github/workflows/reuse-int-tests.yml
+    with:
+      copr: "epel-7-x86_64"
+      copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
+      tmt_plan_regex: "^(?!.*tier0)"
+      distros: '["centos-7", "oraclelinux-7"]'
+      pull_request_status_name: "epel-7-tier0"
+    secrets: inherit
+    if: |
+      github.event.issue.pull_request
+      && startsWith(github.event.comment.body, '/rerun-all')
+      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+
+  call_workflow_integration_tests_epel_8_tier0:
+    needs: [call_workflow_get_copr_id]
+    uses: ./.github/workflows/reuse-int-tests.yml
+    with:
+      copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
+      tmt_plan_regex: "^(?!.*tier0)"
+      distros: '["centos-8.4", "centos-8", "oraclelinux-8.4", "oraclelinux-8.6"]'
+      pull_request_status_name: "epel-8-tier0"
+    secrets: inherit
+    if: |
+      github.event.issue.pull_request
+      && startsWith(github.event.comment.body, '/rerun-all')
+      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+
+  call_workflow_integration_tests_epel_7_tier1:
+    needs: [call_workflow_get_copr_id]
+    uses: ./.github/workflows/reuse-int-tests.yml
+    with:
+      copr: "epel-7-x86_64"
+      copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
+      tmt_plan_regex: "^(?!.*tier1)"
+      distros: '["centos-7", "oraclelinux-7"]'
+      pull_request_status_name: "epel-7-tier1"
+    secrets: inherit
+    if: |
+      github.event.issue.pull_request
+      && startsWith(github.event.comment.body, '/rerun-all')
+      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+
+  call_workflow_integration_tests_epel_8_tier1:
+    needs: [call_workflow_get_copr_id]
+    uses: ./.github/workflows/reuse-int-tests.yml
+    with:
+      copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
+      tmt_plan_regex: "^(?!.*tier1)"
+      distros: '["centos-8.4", "centos-8", "oraclelinux-8.4", "oraclelinux-8.6"]'
+      pull_request_status_name: "epel-8-tier1"
+    secrets: inherit
+    if: |
+      github.event.issue.pull_request
+      && startsWith(github.event.comment.body, '/rerun-all')
+      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -35,11 +35,14 @@ jobs:
     # do not get the version from a tag (git describe) but from the spec file
     get-current-version:
     - grep -oP '^Version:\s+\K\S+' packaging/convert2rhel.spec
-- job: tests
-  targets:
-    epel-7-x86_64:
-      distros: [centos-7, oraclelinux-7]
-    epel-8-x86_64:
-      distros: [centos-8.4, centos-8, oraclelinux-8.4, oraclelinux-8.6]
-  use_internal_tf: True
-  trigger: pull_request
+
+# Commenting this out for now as we will move the execution of the tests to a GitHub Actions workflow to prevent DDoS
+# in our internal gitlab.
+#- job: tests
+#  targets:
+#    epel-7-x86_64:
+#      distros: [centos-7, oraclelinux-7]
+#    epel-8-x86_64:
+#      distros: [centos-8.4, centos-8, oraclelinux-8.4, oraclelinux-8.6]
+#  use_internal_tf: True
+#  trigger: pull_request

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -35,14 +35,11 @@ jobs:
     # do not get the version from a tag (git describe) but from the spec file
     get-current-version:
     - grep -oP '^Version:\s+\K\S+' packaging/convert2rhel.spec
-
-# Commenting this out for now as we will move the execution of the tests to a GitHub Actions workflow to prevent DDoS
-# in our internal gitlab.
-#- job: tests
-#  targets:
-#    epel-7-x86_64:
-#      distros: [centos-7, oraclelinux-7]
-#    epel-8-x86_64:
-#      distros: [centos-8.4, centos-8, oraclelinux-8.4, oraclelinux-8.6]
-#  use_internal_tf: True
-#  trigger: pull_request
+- job: tests
+  targets:
+    epel-7-x86_64:
+      distros: [centos-7, oraclelinux-7]
+    epel-8-x86_64:
+      distros: [centos-8.4, centos-8, oraclelinux-8.4, oraclelinux-8.6]
+  use_internal_tf: True
+  trigger: pull_request

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -22,6 +22,6 @@ prepare:
   - name: remove all copr repositories
     how: shell
     script: grep -l "copr:copr.fedorainfracloud.org:group_oamg:convert2rhel" /etc/yum.repos.d/* | xargs rm
-# We are commenting this out since we will pass the environment variables through the GitHub Secrets now.
-# environment-file:
-#  - https://gitlab.cee.redhat.com/oamg/convert2rhel/convert2rhel-secrets/-/raw/main/.env
+
+environment-file:
+  - https://gitlab.cee.redhat.com/oamg/convert2rhel/convert2rhel-secrets/-/raw/main/.env

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -22,5 +22,6 @@ prepare:
   - name: remove all copr repositories
     how: shell
     script: grep -l "copr:copr.fedorainfracloud.org:group_oamg:convert2rhel" /etc/yum.repos.d/* | xargs rm
-environment-file:
-  - https://gitlab.cee.redhat.com/oamg/convert2rhel/convert2rhel-secrets/-/raw/main/.env
+# We are commenting this out since we will pass the environment variables through the GitHub Secrets now.
+# environment-file:
+#  - https://gitlab.cee.redhat.com/oamg/convert2rhel/convert2rhel-secrets/-/raw/main/.env

--- a/scripts/get_copr_build_id.py
+++ b/scripts/get_copr_build_id.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import re
+import sys
+
+import copr.v3
+
+
+ENV_VARS = {
+    "_COPR_CONFIG": "~/.config/copr",  # Copr config file. Get it through https://<copr instance>/api/.
+    "COPR_OWNER": "@oamg",  # Owner of the Copr project
+    "COPR_PROJECT": "convert2rhel",  # The Copr project to search
+    "COPR_PACKAGE": "",  # Name of the package to look for. This is optional - if empty, any package in the
+    # project is considered.
+    "REGEX": "",  # A more general way to search for release_id matches via regex. Generalization of PKG_RELEASE
+}
+# override defaults with environment variables
+for env, default in ENV_VARS.items():
+    ENV_VARS[env] = os.getenv(env, default)
+
+
+def get_builds(ownername, projectname, configpath, client=None, debug=False):
+    """ """
+    client = client or copr.v3.Client(copr.v3.config_from_file(path=configpath))
+    builds = client.build_proxy.get_list(
+        status="succeeded",
+        pagination={"order": "id", "order_type": "DESC"},
+        ownername=ownername,
+        projectname=projectname,
+        packagename=ENV_VARS["COPR_PACKAGE"],
+    )
+    if debug:
+        json.dump(builds, sys.stderr, sort_keys=True, indent=2)
+        sys.stderr.write("\n")
+    return builds
+
+
+def get_latest_build(ownername, projectname, configpath, match_criteria, client=None, debug=False):
+    """ """
+    client = client or copr.v3.Client(copr.v3.config_from_file(path=configpath))
+    builds = get_builds(ownername, projectname, configpath, client, debug)
+    for build in builds:
+        # Version in COPR contains VERSION-RELEASE string. We need just the release.
+        full_name = "{}-{}".format(build["source_package"]["name"], build["source_package"]["version"])
+        release = build["source_package"]["version"].split("-")[-1]
+        if re.match(match_criteria, full_name) or release.startswith(match_criteria):
+            return build["id"]
+    return None
+
+
+def _fail(error):
+    """ """
+    if not error.endswith("\n"):
+        error += "\n"
+    sys.stderr.write(error)
+    # dump ENV dictionary
+    sys.stderr.write("Passed (or default) environment variables:\n")
+    for var, value in ENV_VARS.items():
+        sys.stderr.write("  {}: {}\n".format(var, value))
+    sys.exit(1)
+
+
+def main():
+    build_id = get_latest_build(
+        ENV_VARS["COPR_OWNER"],
+        ENV_VARS["COPR_PROJECT"],
+        ENV_VARS["_COPR_CONFIG"],
+        ENV_VARS["REGEX"],
+        debug="--debug" in sys.argv[1:],
+    )
+
+    if not build_id:
+        error_msg = "Error: The build with the required release has not been found: {}".format(ENV_VARS["REGEX"])
+        _fail(error_msg)
+
+    # Output the id of the latest matching build
+    print(build_id)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
We are replacing the integration tests that run with packit to run with
a custom GitHub Actions workflow to prevent DDoS in Red Hat's internal
giltab.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>