### PR TITLE
Enable `actions` manager for Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "extends": [
     "config:base"
   ],
-  "enabledManagers": ["dockerfile", "pip_requirements"],
+  "enabledManagers": ["dockerfile", "pip_requirements", "actions"],
   "ignorePaths": ["**/centos6*.requirements.txt"],
   "packageRules": [
     {


### PR DESCRIPTION
Let renovate handle the github actions update too.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>