### PR TITLE
[RHELC-635] Follow-up tft integration as github actions

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -24,8 +24,9 @@ jobs:
             If you want to rebuild a package in copr, you can use following commands as a comment:
             - **/packit copr-build** to submit a public copr build using packit
 
-            To launch regression testing public members of oamg organization can leave the following comment:
-            - **/rerun** to schedule regression tests using this pr build
+            To launch regression testing public members of oamg organization don't need any extra step. The automation kicks that off for you!
+
+            If you're an external collaborator (Meaning that you're not part of oamg), ping the `@oamg/convert2rhel-developers` group to assign the testing label to your pr.
 
             Please [open ticket](https://github.com/oamg/convert2rhel/issues) in case you experience technical problem with the CI.
 

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -29,4 +29,4 @@ jobs:
 
             Please [open ticket](https://github.com/oamg/convert2rhel/issues) in case you experience technical problem with the CI.
 
-            **Note:** In case there are problems with tests not being triggered automatically on new PR/commit or pending for a long time, please tag @oamg/convert2rhel-developers in the pr comments.
+            **Note:** In case there are problems with tests not being triggered automatically on new PR/commit or pending for a long time, please tag `@oamg/convert2rhel-developers` in the pr comments.

--- a/.github/workflows/reuse-int-tests.yml
+++ b/.github/workflows/reuse-int-tests.yml
@@ -67,14 +67,14 @@ on:
 
 jobs:
   reusable_workflow_job:
-    name: Schedule regression tests on Testing Farm
+    name: Schedule integration tests on Testing Farm
     strategy:
       fail-fast: false
       matrix:
         distro: ${{ inputs.distros }}
     runs-on: ubuntu-latest
     steps:
-      - name: Schedule regression testing for ${{ inputs.pull_request_status_name }}
+      - name: Schedule integration testing for ${{ inputs.pull_request_status_name }}
         uses: sclorg/testing-farm-as-github-action@v1.2.11
         with:
           # required
@@ -94,6 +94,6 @@ jobs:
           copr_artifacts: ${{ inputs.copr_artifacts }}
           debug: ${{ secrets.DEBUG }}
           tmt_context: "distro=${{ matrix.distro }}"
-          pull_request_status_name: ${{ inputs.pull_request_status_name }}
+          pull_request_status_name: ${{ inputs.pull_request_status_name }}/${{ matrix.distro }}
           environment_settings: ${{ inputs.environment_settings }}
           secrets: "DEBUG=${{ secrets.DEBUG }};RHSM_KEY=${{ secrets.RHSM_KEY }};RHSM_ORG=${{ secrets.RHSM_ORG }};RHSM_PASSWORD=${{ secrets.RHSM_PASSWORD }};RHSM_POOL=${{ secrets.RHSM_POOL }};RHSM_SERVER_URL=${{ secrets.RHSM_SERVER_URL }};RHSM_SINGLE_SUB_PASSWORD=${{ secrets.RHSM_SINGLE_SUB_PASSWORD }};RHSM_SINGLE_SUB_POOL=${{ secrets.RHSM_SINGLE_SUB_PASSWORD }};RHSM_SINGLE_SUB_USERNAME=${{ secrets.RHSM_SINGLE_SUB_PASSWORD }};RHSM_USERNAME=${{ secrets.RHSM_USERNAME }};SATELLITE_KEY=${{ secrets.SATELLITE_KEY }};SATELLITE_KEY_EUS=${{ secrets.SATELLITE_KEY_EUS }};SATELLITE_ORG=${{ secrets.SATELLITE_ORG }}"

--- a/.github/workflows/reuse-int-tests.yml
+++ b/.github/workflows/reuse-int-tests.yml
@@ -60,34 +60,18 @@ on:
       distros:
         type: string
         required: true
-      variables:
-        type: string
-        required: false
-        default: ""
       update_pull_request_status:
         type: string
         required: false
         default: "true"
 
 jobs:
-  convert_distro_to_matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.convert_to_matrix.outputs.matrix }}
-    steps:
-      - id: convert_to_matrix
-        run: |
-          echo "::set-output name=matrix::$input"
-        env:
-          input: ${{ inputs.distros }}
-
   reusable_workflow_job:
     name: Schedule regression tests on Testing Farm
-    needs: [convert_distro_to_matrix]
     strategy:
       fail-fast: false
       matrix:
-        distro: ${{fromJson(needs.convert_distro_to_matrix.outputs.matrix)}}
+        distro: ${{ inputs.distros }}
     runs-on: ubuntu-latest
     steps:
       - name: Schedule regression testing for ${{ inputs.pull_request_status_name }}
@@ -112,17 +96,4 @@ jobs:
           tmt_context: "distro=${{ matrix.distro }}"
           pull_request_status_name: ${{ inputs.pull_request_status_name }}
           environment_settings: ${{ inputs.environment_settings }}
-          variables: "DEBUG=${{ secrets.DEBUG }};\
-            RHSM_KEY=${{ secrets.RHSM_KEY }};\
-            RHSM_ORG=${{ secrets.RHSM_ORG }};\
-            RHSM_PASSWORD=${{ secrets.RHSM_PASSWORD }};\
-            RHSM_POOL=${{ secrets.RHSM_POOL }};\
-            RHSM_SERVER_URL=${{ secrets.RHSM_SERVER_URL }};\
-            RHSM_SINGLE_SUB_PASSWORD=${{ secrets.RHSM_SINGLE_SUB_PASSWORD }};\
-            RHSM_SINGLE_SUB_POOL=${{ secrets.RHSM_SINGLE_SUB_PASSWORD }};\
-            RHSM_SINGLE_SUB_USERNAME=${{ secrets.RHSM_SINGLE_SUB_PASSWORD }};\
-            RHSM_USERNAME=${{ secrets.RHSM_USERNAME }};\
-            SATELLITE_KEY=${{ secrets.SATELLITE_KEY }};\
-            SATELLITE_KEY_EUS=${{ secrets.SATELLITE_KEY_EUS }};\
-            SATELLITE_ORG=${{ secrets.SATELLITE_ORG }};\
-            ${{ inputs.variables }}"
+          secrets: "DEBUG=${{ secrets.DEBUG }};RHSM_KEY=${{ secrets.RHSM_KEY }};RHSM_ORG=${{ secrets.RHSM_ORG }};RHSM_PASSWORD=${{ secrets.RHSM_PASSWORD }};RHSM_POOL=${{ secrets.RHSM_POOL }};RHSM_SERVER_URL=${{ secrets.RHSM_SERVER_URL }};RHSM_SINGLE_SUB_PASSWORD=${{ secrets.RHSM_SINGLE_SUB_PASSWORD }};RHSM_SINGLE_SUB_POOL=${{ secrets.RHSM_SINGLE_SUB_PASSWORD }};RHSM_SINGLE_SUB_USERNAME=${{ secrets.RHSM_SINGLE_SUB_PASSWORD }};RHSM_USERNAME=${{ secrets.RHSM_USERNAME }};SATELLITE_KEY=${{ secrets.SATELLITE_KEY }};SATELLITE_KEY_EUS=${{ secrets.SATELLITE_KEY_EUS }};SATELLITE_ORG=${{ secrets.SATELLITE_ORG }}"

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -61,34 +61,34 @@ jobs:
       pull_request_status_name: "epel-7-tier0"
     secrets: inherit
 
-  # call_workflow_integration_tests_epel_8_tier0:
-  #   needs: [call_workflow_get_copr_id, convert_distros_to_matrix]
-  #   uses: ./.github/workflows/reuse-int-tests.yml
-  #   with:
-  #     copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
-  #     tmt_plan_regex: "^(?!.*tier0)"
-  #     distros: ${{fromJson(needs.convert_distros_to_matrix.outputs.matrix_epel8)}}
-  #     pull_request_status_name: "epel-8-tier0"
-  #   secrets: inherit
+  call_workflow_integration_tests_epel_8_tier0:
+    needs: [call_workflow_get_copr_id, convert_distros_to_matrix]
+    uses: ./.github/workflows/reuse-int-tests.yml
+    with:
+      copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
+      tmt_plan_regex: "^(?!.*tier0)"
+      distros: ${{fromJson(needs.convert_distros_to_matrix.outputs.matrix_epel8)}}
+      pull_request_status_name: "epel-8-tier0"
+    secrets: inherit
 
-  # # Tier 1 integration tests
-  # call_workflow_integration_tests_epel_7_tier1:
-  #   needs: [call_workflow_get_copr_id, convert_distros_to_matrix]
-  #   uses: ./.github/workflows/reuse-int-tests.yml
-  #   with:
-  #     copr: "epel-7-x86_64"
-  #     copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
-  #     tmt_plan_regex: "^(?!.*tier1)"
-  #     distros: ${{fromJson(needs.convert_distros_to_matrix.outputs.matrix_epel7)}}
-  #     pull_request_status_name: "epel-7-tier1"
-  #   secrets: inherit
+  # Tier 1 integration tests
+  call_workflow_integration_tests_epel_7_tier1:
+    needs: [call_workflow_get_copr_id, convert_distros_to_matrix]
+    uses: ./.github/workflows/reuse-int-tests.yml
+    with:
+      copr: "epel-7-x86_64"
+      copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
+      tmt_plan_regex: "^(?!.*tier1)"
+      distros: ${{fromJson(needs.convert_distros_to_matrix.outputs.matrix_epel7)}}
+      pull_request_status_name: "epel-7-tier1"
+    secrets: inherit
 
-  # call_workflow_integration_tests_epel_8_tier1:
-  #   needs: [call_workflow_get_copr_id, convert_distros_to_matrix]
-  #   uses: ./.github/workflows/reuse-int-tests.yml
-  #   with:
-  #     copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
-  #     tmt_plan_regex: "^(?!.*tier1)"
-  #     distros: ${{fromJson(needs.convert_distros_to_matrix.outputs.matrix_epel8)}}
-  #     pull_request_status_name: "epel-8-tier1"
-  # secrets: inherit
+  call_workflow_integration_tests_epel_8_tier1:
+    needs: [call_workflow_get_copr_id, convert_distros_to_matrix]
+    uses: ./.github/workflows/reuse-int-tests.yml
+    with:
+      copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
+      tmt_plan_regex: "^(?!.*tier1)"
+      distros: ${{fromJson(needs.convert_distros_to_matrix.outputs.matrix_epel8)}}
+      pull_request_status_name: "epel-8-tier1"
+    secrets: inherit

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -21,6 +21,9 @@ jobs:
     name: Wait for CI Checks
     runs-on: ubuntu-latest
     steps:
+      - name: DEBUG ONLY
+        run: |
+          echo ${{ github.event.pull_request.author_association }}
       - name: Wait for CI Checks
         uses: r0x0d/wait-for-ci-checks@main
         id: status_check

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -38,46 +38,57 @@ jobs:
     needs: [wait_for_rpm_builds]
     uses: ./.github/workflows/reuse-get-copr-id.yml
 
+  convert_distros_to_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix_epel7: ${{ steps.convert_distros_to_matrix.outputs.matrix_epel7 }}
+      matrix_epel8: ${{ steps.convert_distros_to_matrix.outputs.matrix_epel8 }}
+    steps:
+      - id: convert_distros_to_matrix
+        run: |
+          echo "::set-output name=matrix_epel7::'["centos-7", "oraclelinux-7"]'"
+          echo "::set-output name=matrix_epel8::'["centos-8.4", "centos-8", "oraclelinux-8.4", "oraclelinux-8.6"]'"
+
   # Tier 0 integration tests
   call_workflow_integration_tests_epel_7_tier0:
-    needs: [call_workflow_get_copr_id]
+    needs: [call_workflow_get_copr_id, convert_distros_to_matrix]
     uses: ./.github/workflows/reuse-int-tests.yml
     with:
       copr: "epel-7-x86_64"
       copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
       tmt_plan_regex: "^(?!.*tier0)"
-      distros: '["centos-7", "oraclelinux-7"]'
+      distros: ${{fromJson(needs.convert_distros_to_matrix.outputs.matrix_epel7)}}
       pull_request_status_name: "epel-7-tier0"
     secrets: inherit
 
-  call_workflow_integration_tests_epel_8_tier0:
-    needs: [call_workflow_get_copr_id]
-    uses: ./.github/workflows/reuse-int-tests.yml
-    with:
-      copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*tier0)"
-      distros: '["centos-8.4", "centos-8", "oraclelinux-8.4", "oraclelinux-8.6"]'
-      pull_request_status_name: "epel-8-tier0"
-    secrets: inherit
+  # call_workflow_integration_tests_epel_8_tier0:
+  #   needs: [call_workflow_get_copr_id, convert_distros_to_matrix]
+  #   uses: ./.github/workflows/reuse-int-tests.yml
+  #   with:
+  #     copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
+  #     tmt_plan_regex: "^(?!.*tier0)"
+  #     distros: ${{fromJson(needs.convert_distros_to_matrix.outputs.matrix_epel8)}}
+  #     pull_request_status_name: "epel-8-tier0"
+  #   secrets: inherit
 
-  # Tier 1 integration tests
-  call_workflow_integration_tests_epel_7_tier1:
-    needs: [call_workflow_get_copr_id]
-    uses: ./.github/workflows/reuse-int-tests.yml
-    with:
-      copr: "epel-7-x86_64"
-      copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*tier1)"
-      distros: '["centos-7", "oraclelinux-7"]'
-      pull_request_status_name: "epel-7-tier1"
-    secrets: inherit
+  # # Tier 1 integration tests
+  # call_workflow_integration_tests_epel_7_tier1:
+  #   needs: [call_workflow_get_copr_id, convert_distros_to_matrix]
+  #   uses: ./.github/workflows/reuse-int-tests.yml
+  #   with:
+  #     copr: "epel-7-x86_64"
+  #     copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
+  #     tmt_plan_regex: "^(?!.*tier1)"
+  #     distros: ${{fromJson(needs.convert_distros_to_matrix.outputs.matrix_epel7)}}
+  #     pull_request_status_name: "epel-7-tier1"
+  #   secrets: inherit
 
-  call_workflow_integration_tests_epel_8_tier1:
-    needs: [call_workflow_get_copr_id]
-    uses: ./.github/workflows/reuse-int-tests.yml
-    with:
-      copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*tier1)"
-      distros: '["centos-8.4", "centos-8", "oraclelinux-8.4", "oraclelinux-8.6"]'
-      pull_request_status_name: "epel-8-tier1"
-    secrets: inherit
+  # call_workflow_integration_tests_epel_8_tier1:
+  #   needs: [call_workflow_get_copr_id, convert_distros_to_matrix]
+  #   uses: ./.github/workflows/reuse-int-tests.yml
+  #   with:
+  #     copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
+  #     tmt_plan_regex: "^(?!.*tier1)"
+  #     distros: ${{fromJson(needs.convert_distros_to_matrix.outputs.matrix_epel8)}}
+  #     pull_request_status_name: "epel-8-tier1"
+  # secrets: inherit

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -35,11 +35,11 @@ jobs:
     # do not get the version from a tag (git describe) but from the spec file
     get-current-version:
     - grep -oP '^Version:\s+\K\S+' packaging/convert2rhel.spec
-- job: tests
-  targets:
-    epel-7-x86_64:
-      distros: [centos-7, oraclelinux-7]
-    epel-8-x86_64:
-      distros: [centos-8.4, centos-8, oraclelinux-8.4, oraclelinux-8.6]
-  use_internal_tf: True
-  trigger: pull_request
+# - job: tests
+#   targets:
+#     epel-7-x86_64:
+#       distros: [centos-7, oraclelinux-7]
+#     epel-8-x86_64:
+#       distros: [centos-8.4, centos-8, oraclelinux-8.4, oraclelinux-8.6]
+#   use_internal_tf: True
+#   trigger: pull_request

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -35,11 +35,11 @@ jobs:
     # do not get the version from a tag (git describe) but from the spec file
     get-current-version:
     - grep -oP '^Version:\s+\K\S+' packaging/convert2rhel.spec
-# - job: tests
-#   targets:
-#     epel-7-x86_64:
-#       distros: [centos-7, oraclelinux-7]
-#     epel-8-x86_64:
-#       distros: [centos-8.4, centos-8, oraclelinux-8.4, oraclelinux-8.6]
-#   use_internal_tf: True
-#   trigger: pull_request
+- job: tests
+  targets:
+    epel-7-x86_64:
+      distros: [centos-7, oraclelinux-7]
+    epel-8-x86_64:
+      distros: [centos-8.4, centos-8, oraclelinux-8.4, oraclelinux-8.6]
+  use_internal_tf: True
+  trigger: pull_request

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -24,5 +24,5 @@ prepare:
     script: grep -l "copr:copr.fedorainfracloud.org:group_oamg:convert2rhel" /etc/yum.repos.d/* | xargs rm
 
 # Commenting this out in favour of using a github actions with tft
-# environment-file:
-#  - https://gitlab.cee.redhat.com/oamg/convert2rhel/convert2rhel-secrets/-/raw/main/.env
+environment-file:
+  - https://gitlab.cee.redhat.com/oamg/convert2rhel/convert2rhel-secrets/-/raw/main/.env

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -23,5 +23,6 @@ prepare:
     how: shell
     script: grep -l "copr:copr.fedorainfracloud.org:group_oamg:convert2rhel" /etc/yum.repos.d/* | xargs rm
 
-environment-file:
-  - https://gitlab.cee.redhat.com/oamg/convert2rhel/convert2rhel-secrets/-/raw/main/.env
+# Commenting this out in favour of using a github actions with tft
+# environment-file:
+#  - https://gitlab.cee.redhat.com/oamg/convert2rhel/convert2rhel-secrets/-/raw/main/.env


### PR DESCRIPTION
Follow-up work for the tft integration as a github actions instead of
packit integration.

The last PR #574 introduced the workflow and the reusable workflow files
that will permit us to continue the testing and validate that everything
works as expected as a github action.

## TODO

- [x] Do not run workflows for external collaborators
  - Proof: https://github.com/oamg/convert2rhel/pull/578 
- [x] Run workflows only if the user is from `oamg` organization
- [x] Parse the matrix distros output only once and send to the reusable workflows
- [ ] Check with QE if it's okay for them the way I'm setting up the tests
- [x] Use backticks for the welcome pr message
- [ ] Check if the link is correct for opening issues about our CI (Maybe use jira for that instead of github issues?)

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>