### PR TITLE
Remove unsupported `tier` key from `discover` step

### DIFF
--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -1,6 +1,3 @@
-discover+:
-    tier: 0
-
 /basic_sanity_checks:
   discover+:
     test: basic-sanity-checks

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -1,6 +1,3 @@
-discover+:
-    tier: 1
-
 /activation_key:
   discover+:
     test: checks-after-conversion


### PR DESCRIPTION
The `tier` key is not supported under the `discover` step config
and has no effect there. With the fresh `tmt` it would generate a
bunch of warnings so let's remove it.