### PR TITLE
chore: change `actions` to `github-actions`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "extends": [
     "config:base"
   ],
-  "enabledManagers": ["dockerfile", "pip_requirements", "actions"],
+  "enabledManagers": ["dockerfile", "pip_requirements", "github-actions"],
   "ignorePaths": ["**/centos6*.requirements.txt"],
   "packageRules": [
     {


### PR DESCRIPTION
The manager for updating GitHub actions was supposed to be `github-actions`. Due to word-wrapping on the docs we thought it was just `actions`

https://docs.renovatebot.com/modules/manager/#supported-managers

![image](https://user-images.githubusercontent.com/6598829/186147382-b02c60c5-37a7-4442-aee6-9ca24a3e3b8d.png)
