### PR TITLE
[RHELC-635] Fix errors from tmt pipeline

### DIFF
--- a/.github/workflows/reuse-int-tests.yml
+++ b/.github/workflows/reuse-int-tests.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: ${{ inputs.distros }}
+        distro: ${{ fromJson(inputs.distros) }}
     runs-on: ubuntu-latest
     steps:
       - name: Schedule integration testing for ${{ inputs.pull_request_status_name }}

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -21,9 +21,6 @@ jobs:
     name: Wait for CI Checks
     runs-on: ubuntu-latest
     steps:
-      - name: DEBUG ONLY
-        run: |
-          echo ${{ github.event.pull_request.author_association }}
       - name: Wait for CI Checks
         uses: r0x0d/wait-for-ci-checks@main
         id: status_check
@@ -33,7 +30,7 @@ jobs:
     if: |
       github.event.pull_request
       && (
-        contains(fromJson('["OWNER", "MEMBER"]'), github.event.pull_request.author_association)
+        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
         || contains(github.event.pull_request.labels.*.name, 'safe-to-test')
       )
 
@@ -49,8 +46,8 @@ jobs:
     steps:
       - id: convert_distros_to_matrix
         run: |
-          echo "::set-output name=matrix_epel7::'["centos-7", "oraclelinux-7"]'"
-          echo "::set-output name=matrix_epel8::'["centos-8.4", "centos-8", "oraclelinux-8.4", "oraclelinux-8.6"]'"
+          echo "::set-output name=matrix_epel7::[\"centos-7\", \"oraclelinux-7\"]"
+          echo "::set-output name=matrix_epel8::[\"centos-8.4\", \"centos-8\", \"oraclelinux-8.4\", \"oraclelinux-8.6\"]"
 
   # Tier 0 integration tests
   call_workflow_integration_tests_epel_7_tier0:
@@ -60,7 +57,7 @@ jobs:
       copr: "epel-7-x86_64"
       copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
       tmt_plan_regex: "^(?!.*tier0)"
-      distros: ${{fromJson(needs.convert_distros_to_matrix.outputs.matrix_epel7)}}
+      distros: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel7 }}
       pull_request_status_name: "epel-7-tier0"
     secrets: inherit
 
@@ -70,7 +67,7 @@ jobs:
     with:
       copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
       tmt_plan_regex: "^(?!.*tier0)"
-      distros: ${{fromJson(needs.convert_distros_to_matrix.outputs.matrix_epel8)}}
+      distros: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel8 }}
       pull_request_status_name: "epel-8-tier0"
     secrets: inherit
 
@@ -82,7 +79,7 @@ jobs:
       copr: "epel-7-x86_64"
       copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
       tmt_plan_regex: "^(?!.*tier1)"
-      distros: ${{fromJson(needs.convert_distros_to_matrix.outputs.matrix_epel7)}}
+      distros: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel7 }}
       pull_request_status_name: "epel-7-tier1"
     secrets: inherit
 
@@ -92,6 +89,6 @@ jobs:
     with:
       copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
       tmt_plan_regex: "^(?!.*tier1)"
-      distros: ${{fromJson(needs.convert_distros_to_matrix.outputs.matrix_epel8)}}
+      distros: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel8 }}
       pull_request_status_name: "epel-8-tier1"
     secrets: inherit


### PR DESCRIPTION
The tmt pipeline was failing because of incorrect matrix setup. This
should fix the issue as it generates the matrix in the correct json
syntax.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>