### PR TITLE
[RHELC-635] Fix git_ref in reusable workflows

### DIFF
--- a/.github/workflows/reuse-int-tests.yml
+++ b/.github/workflows/reuse-int-tests.yml
@@ -64,6 +64,10 @@ on:
         type: string
         required: false
         default: "true"
+      git_ref:
+        type: string
+        required: false
+        default: "main"
 
 jobs:
   reusable_workflow_job:
@@ -81,7 +85,7 @@ jobs:
           api_url: ${{ secrets.TF_ENDPOINT }}
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: "https://github.com/oamg/convert2rhel"
-          git_ref: "refs/pull/${{ github.event.issue.number }}/head"
+          git_ref: ${{ inputs.git_ref }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # optional
           tf_scope: "private"

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -59,6 +59,7 @@ jobs:
       tmt_plan_regex: "^(?!.*tier0)"
       distros: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel7 }}
       pull_request_status_name: "epel-7-tier0"
+      git_ref: "refs/pull/${{ github.event.issue.number }}/head"
     secrets: inherit
 
   call_workflow_integration_tests_epel_8_tier0:
@@ -69,6 +70,7 @@ jobs:
       tmt_plan_regex: "^(?!.*tier0)"
       distros: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel8 }}
       pull_request_status_name: "epel-8-tier0"
+      git_ref: "refs/pull/${{ github.event.issue.number }}/head"
     secrets: inherit
 
   # Tier 1 integration tests
@@ -81,6 +83,7 @@ jobs:
       tmt_plan_regex: "^(?!.*tier1)"
       distros: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel7 }}
       pull_request_status_name: "epel-7-tier1"
+      git_ref: "refs/pull/${{ github.event.issue.number }}/head"
     secrets: inherit
 
   call_workflow_integration_tests_epel_8_tier1:
@@ -91,4 +94,5 @@ jobs:
       tmt_plan_regex: "^(?!.*tier1)"
       distros: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel8 }}
       pull_request_status_name: "epel-8-tier1"
+      git_ref: "refs/pull/${{ github.event.issue.number }}/head"
     secrets: inherit


### PR DESCRIPTION
The `git_ref` property was missing the PR number because inside the
reusable workflow we didn't have the reference that holds the pull
request number.

This commit changes that behavior to get the issue number outside the
reusable workflow and pass it as a input.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>