### PR TITLE
[RHELC-635] Fix integration tests on github actions

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -21,13 +21,11 @@ jobs:
             ## **Thank you for contributing to the Convert2RHEL project!**
             👋 Hello @${{ github.actor }}, thank you for submitting a PR 🚀!
             Please note that every PR needs to comply with the [Convert2RHEL Guidelines](https://github.com/oamg/convert2rhel/blob/main/CONTRIBUTING.md) and must pass all tests in order to be mergable.
-            If you want to rebuild a package in copr, you can use following commands as a comment:
-            - **/packit copr-build** to trigger a copr build using packit
+            If you want to rebuild a package in [Fedora Copr](https://copr.fedorainfracloud.org/coprs/g/oamg/convert2rhel/), you can use the following command as a comment:
+            - **/packit copr-build** to trigger a copr build using [packit](https://packit.dev/)
 
-            To launch regression testing public members of oamg organization don't need any extra step. The automation kicks that off for you!
+            To execute integration tests, members of [the oamg organization](https://github.com/oamg/) don't need any extra step. The automation kicks that off for you!
 
-            If you're an external collaborator (Meaning that you're not part of oamg), ping the `@oamg/convert2rhel-developers` group to assign the testing label to your pr.
-
-            Please [open ticket](https://github.com/oamg/convert2rhel/issues) in case you experience technical problem with the CI.
+            If you're an external collaborator (Meaning that you're not part of oamg organization), wait for somebody from the `@oamg/convert2rhel-developers` group to add the `testing` label to the PR to trigger the tests.
 
             **Note:** In case there are problems with tests not being triggered automatically on new PR/commit or pending for a long time, please tag `@oamg/convert2rhel-developers` in the pr comments.

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -22,7 +22,7 @@ jobs:
             👋 Hello @${{ github.actor }}, thank you for submitting a PR 🚀!
             Please note that every PR needs to comply with the [Convert2RHEL Guidelines](https://github.com/oamg/convert2rhel/blob/main/CONTRIBUTING.md) and must pass all tests in order to be mergable.
             If you want to rebuild a package in copr, you can use following commands as a comment:
-            - **/packit copr-build** to submit a public copr build using packit
+            - **/packit copr-build** to trigger a copr build using packit
 
             To launch regression testing public members of oamg organization don't need any extra step. The automation kicks that off for you!
 

--- a/.github/workflows/reuse-int-tests.yml
+++ b/.github/workflows/reuse-int-tests.yml
@@ -57,7 +57,7 @@ on:
         type: string
         required: false
         default: "epel-8-x86_64"
-      distros:
+      matrix:
         type: string
         required: true
       update_pull_request_status:
@@ -74,8 +74,7 @@ jobs:
     name: Schedule integration tests on Testing Farm
     strategy:
       fail-fast: false
-      matrix:
-        distro: ${{ fromJson(inputs.distros) }}
+      matrix: ${{ fromJson(inputs.matrix) }}
     runs-on: ubuntu-latest
     steps:
       - name: Schedule integration testing for ${{ inputs.pull_request_status_name }}
@@ -91,13 +90,13 @@ jobs:
           tf_scope: "private"
           create_issue_comment: "true"
           update_pull_request_status: ${{ inputs.update_pull_request_status }}
+          pull_request_status_name: ${{ inputs.pull_request_status_name }}/${{ matrix.distro }}
           tmt_plan_regex: ${{ inputs.tmt_plan_regex }}
-          compose: ${{ matrix.distro }}
+          compose: ${{ matrix.compose }}
           arch: ${{ inputs.arch }}
           copr: ${{ inputs.copr }}
           copr_artifacts: ${{ inputs.copr_artifacts }}
-          debug: ${{ secrets.DEBUG }}
+          debug: "true"
           tmt_context: "distro=${{ matrix.distro }}"
-          pull_request_status_name: ${{ inputs.pull_request_status_name }}/${{ matrix.distro }}
           environment_settings: ${{ inputs.environment_settings }}
           secrets: "DEBUG=${{ secrets.DEBUG }};RHSM_KEY=${{ secrets.RHSM_KEY }};RHSM_ORG=${{ secrets.RHSM_ORG }};RHSM_PASSWORD=${{ secrets.RHSM_PASSWORD }};RHSM_POOL=${{ secrets.RHSM_POOL }};RHSM_SERVER_URL=${{ secrets.RHSM_SERVER_URL }};RHSM_SINGLE_SUB_PASSWORD=${{ secrets.RHSM_SINGLE_SUB_PASSWORD }};RHSM_SINGLE_SUB_POOL=${{ secrets.RHSM_SINGLE_SUB_PASSWORD }};RHSM_SINGLE_SUB_USERNAME=${{ secrets.RHSM_SINGLE_SUB_PASSWORD }};RHSM_USERNAME=${{ secrets.RHSM_USERNAME }};SATELLITE_KEY=${{ secrets.SATELLITE_KEY }};SATELLITE_KEY_EUS=${{ secrets.SATELLITE_KEY_EUS }};SATELLITE_ORG=${{ secrets.SATELLITE_ORG }}"

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -46,8 +46,8 @@ jobs:
     steps:
       - id: convert_distros_to_matrix
         run: |
-          echo "::set-output name=matrix_epel7::[\"centos-7\", \"oraclelinux-7\"]"
-          echo "::set-output name=matrix_epel8::[\"centos-8.4\", \"centos-8\", \"oraclelinux-8.4\", \"oraclelinux-8.6\"]"
+          echo "::set-output name=matrix_epel7::{\"include\":[{\"compose\": \"CentOS-7-latest\", \"distro\": \"centos-7\"},{\"compose\": \"Oracle-Linux-7.9\", \"distro\": \"oraclelinux-7\"}]}"
+          echo "::set-output name=matrix_epel8::{\"include\":[{\"compose\": \"CentOS-8.4\", \"distro\": \"centos-8.4\"},{\"compose\": \"CentOS-8-latest\", \"distro\": \"centos-8\"},{\"compose\": \"Oracle-Linux-8.4\", \"distro\": \"oraclelinux-8.4\"},{\"compose\": \"Oracle-Linux-8.6\", \"distro\": \"oraclelinux-8.6\"}]}"
 
   # Tier 0 integration tests
   call_workflow_integration_tests_epel_7_tier0:
@@ -56,10 +56,10 @@ jobs:
     with:
       copr: "epel-7-x86_64"
       copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*tier0)"
-      distros: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel7 }}
+      tmt_plan_regex: "^(.*tier0)"
+      matrix: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel7 }}
       pull_request_status_name: "epel-7-tier0"
-      git_ref: "refs/pull/${{ github.event.issue.number }}/head"
+      git_ref: "refs/pull/${{ github.event.number }}/head"
     secrets: inherit
 
   call_workflow_integration_tests_epel_8_tier0:
@@ -67,10 +67,10 @@ jobs:
     uses: ./.github/workflows/reuse-int-tests.yml
     with:
       copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*tier0)"
-      distros: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel8 }}
+      tmt_plan_regex: "^(.*tier0)"
+      matrix: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel8 }}
       pull_request_status_name: "epel-8-tier0"
-      git_ref: "refs/pull/${{ github.event.issue.number }}/head"
+      git_ref: "refs/pull/${{ github.event.number }}/head"
     secrets: inherit
 
   # Tier 1 integration tests
@@ -80,10 +80,10 @@ jobs:
     with:
       copr: "epel-7-x86_64"
       copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*tier1)"
-      distros: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel7 }}
+      tmt_plan_regex: "^(.*tier1)"
+      matrix: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel7 }}
       pull_request_status_name: "epel-7-tier1"
-      git_ref: "refs/pull/${{ github.event.issue.number }}/head"
+      git_ref: "refs/pull/${{ github.event.number }}/head"
     secrets: inherit
 
   call_workflow_integration_tests_epel_8_tier1:
@@ -91,8 +91,8 @@ jobs:
     uses: ./.github/workflows/reuse-int-tests.yml
     with:
       copr_artifacts: ${{ needs.call_workflow_get_copr_id.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*tier1)"
-      distros: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel8 }}
+      tmt_plan_regex: "^(.*tier1)"
+      matrix: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel8 }}
       pull_request_status_name: "epel-8-tier1"
-      git_ref: "refs/pull/${{ github.event.issue.number }}/head"
+      git_ref: "refs/pull/${{ github.event.number }}/head"
     secrets: inherit

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -31,7 +31,7 @@ jobs:
       github.event.pull_request
       && (
         contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
-        || contains(github.event.pull_request.labels.*.name, 'safe-to-test')
+        || contains(github.event.pull_request.labels.*.name, 'testing')
       )
 
   call_workflow_get_copr_id:


### PR DESCRIPTION
This commit introduces the fix to the github actions that requests the
integration tests through a custom GitHub Actions.

# Related PRs

- https://github.com/oamg/convert2rhel/pull/584
- https://github.com/oamg/convert2rhel/pull/582
- https://github.com/oamg/convert2rhel/pull/577
- https://github.com/oamg/convert2rhel/pull/574

# Changes that are worth to mention

The wait time for feedback is way less than with packit, that's because we are sending lots of requests to the tft API to run the tiers for each operating system we want. This way, we have the following matrix for our tests: 

| Tier 0     | Tier 1     |
|------------|------------|
| OL 7       | OL 7       |
| OL 8.4     | OL 8.4     |
| OL 8.6     | OL 8.6     |
| CentOS 7   | CentOS 7   |
| CentOS 8.4 | CentOS 8.4 |
| CentOS 8.5 | CentOS 8.5 |

You can check the wait time for each of them here: https://github.com/r0x0d/convert2rhel/runs/8000210821?check_suite_focus=true. Keep in mind that some tests in tier1 seems fast enough, but that's because I was using the wrong credentials/secrets, so it may be because it failed fast rather succeeded fast.

# Leftover TODO from #577 

- [ ] Check with QE if it's okay for them the way I'm setting up the tests
- [ ] Check if the link is correct for opening issues about our CI (Maybe use jira for that instead of github issues?)

# Proof of that the action is working as expected

https://github.com/r0x0d/convert2rhel/pull/65

It is good to keep in mind that even if the integration tests fails, the `check` in the list will appear as a green check.

# Suggestions to use this workflow

It would be nice to have a label to place after a reviewer/qe checks that the integration tests pass without problems. Maybe, something like `integration-tests-passes` or `ready-to-merge`.

# List of files that have been added/changed from the PRs

```
.github/workflows/greetings.yml
.github/workflows/reuse-int-tests.yml
.github/workflows/tmt-tests.yml
.github/workflows/reuse-get-copr-id.yml
plans/main.fmf
scripts/get_copr_build_id.py
```
# ❗❗Important notes❗❗

Any reviews should be posted under this PR to simplify the visualization, tracking, and progress. Please, do not post reviews on the closed PRs, as GitHub won't update the changes properly. 

If the reviewer prefer, pull this branch locally, make code changes in the listed files above, generate a diff for me, and I can apply that diff without an issue. 

Steps for that: 

1. Checkout this remote/branch locally
2. Do code changes
3. git diff > review.diff
4. Upload here the diff

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>