### PR TITLE
[RHELC-637, RHELC-742] Improve internet connection check

### DIFF
--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -384,9 +384,9 @@ class SystemInfo(object):
             return True
         except urllib.error.URLError as err:
             self.logger.warning(
-                "There was a problem while trying to connect to '%s' to check internet connectivity, "
-                "it seems that the host appears to be offline or not responding. Convert2RHEL will continue the conversion "
-                "but without support for online resources.",
+                "There was a problem while trying to connect to '%s' to check internet connectivity. "
+                "This could be due to the host being offline, or the network blocking access to the endpoint... "
+                "Some checks and actions will be skipped.",
                 CHECK_INTERNET_CONNECTION_ADDRESS,
             )
             self.logger.debug("Failed to retrieve data from host, reason: %s", err.reason)

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -389,7 +389,7 @@ class SystemInfo(object):
                 "but without support for online resources.",
                 CHECK_INTERNET_CONNECTION_ADDRESS,
             )
-            self.logger.debug("Faild to retrieve data from host, reason: %s", err.reason)
+            self.logger.debug("Failed to retrieve data from host, reason: %s", err.reason)
             return False
 
     def corresponds_to_rhel_eus_release(self):

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -18,7 +18,6 @@ import difflib
 import logging
 import os
 import re
-import socket
 import time
 
 from collections import namedtuple

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -354,9 +354,8 @@ class SystemInfo(object):
 
         This method will try to retrieve a web page on the Red Hat network that
         we know to exist (http://static.redhat.com/test/rhel-networkmanager.txt).
-        If we can successfully retrieve that page, validate that the status_code
-        is 200, and assert that the content of the response is the string 'OK',
-        then we decide we are connected to the internet.
+        If we can successfully access that page, then we decide we are connected
+        to the internet.
 
         We check a web page because we will need working https to retrieve
         packages from Red Hat infrastructure during the conversion.

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -377,14 +377,19 @@ class SystemInfo(object):
         try:
             response = urllib.request.urlopen(CHECK_INTERNET_CONNECTION_ADDRESS)
             response.close()
-            self.logger.info("Internet connection available.")
+            self.logger.info(
+                "Successfully connected to address '%s', internet connection seems to be available."
+                % CHECK_INTERNET_CONNECTION_ADDRESS
+            )
             return True
         except urllib.error.URLError as err:
-            self.logger.debug("Faild to retrieve data from host, reason: %s", err.reason)
             self.logger.warning(
-                "Couldn't connect to the address '%s', assuming no internet connection is present.",
+                "There was a problem while trying to connect to '%s' to check internet connectivity, "
+                "it seems that the host appears to be offline or not responding. Convert2RHEL will continue the conversion "
+                "but without support for online resources.",
                 CHECK_INTERNET_CONNECTION_ADDRESS,
             )
+            self.logger.debug("Faild to retrieve data from host, reason: %s", err.reason)
             return False
 
     def corresponds_to_rhel_eus_release(self):

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -274,7 +274,7 @@ def pretend_os(request, pkg_root, monkeypatch):
         value=lambda: True,
     )
 
-    # We won't dependon a test environment having internet connection, so we
+    # We won't depend on a test environment having an internet connection, so we
     # need to disable the mock this return value for all tests
     monkeypatch.setattr(
         system_info,

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -275,7 +275,7 @@ def pretend_os(request, pkg_root, monkeypatch):
     )
 
     # We won't depend on a test environment having an internet connection, so we
-    # need to disable the mock this return value for all tests
+    # need to mock _check_internet_access() for all tests
     monkeypatch.setattr(
         system_info,
         "_check_internet_access",

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -274,6 +274,14 @@ def pretend_os(request, pkg_root, monkeypatch):
         value=lambda: True,
     )
 
+    # We won't dependon a test environment having internet connection, so we
+    # need to disable the mock this return value for all tests
+    monkeypatch.setattr(
+        system_info,
+        "_check_internet_access",
+        value=lambda: True,
+    )
+
     system_info.resolve_system_info()
 
 

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -264,8 +264,8 @@ def test_get_release_ver_other(
 @pytest.mark.parametrize(
     ("side_effect", "expected", "message"),
     (
-        (urllib.error.URLError(reason="fail"), False, "Couldn't connect to the address"),
-        (None, True, "Internet connection available."),
+        (urllib.error.URLError(reason="fail"), False, "Faild to retrieve data from host"),
+        (None, True, "internet connection seems to be available"),
     ),
 )
 def test_check_internet_access(side_effect, expected, message, monkeypatch, caplog):

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -264,7 +264,7 @@ def test_get_release_ver_other(
 @pytest.mark.parametrize(
     ("side_effect", "expected", "message"),
     (
-        (urllib.error.URLError(reason="fail"), False, "Faild to retrieve data from host"),
+        (urllib.error.URLError(reason="fail"), False, "Failed to retrieve data from host"),
         (None, True, "internet connection seems to be available"),
     ),
 )

--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -56,3 +56,7 @@
   - name: install subscription manager
     how: ansible
     playbook: tests/ansible_collections/roles/install-submgr/main.yml
+
+/check_internet_connection:
+  discover+:
+    test: check-internet-connection

--- a/tests/integration/tier0/check-internet-connection/main.fmf
+++ b/tests/integration/tier0/check-internet-connection/main.fmf
@@ -1,6 +1,20 @@
-summary: internet connection checks
+summary: Internet connection checks
+description: |
+    Verify, that internet connection check works as expected for both available and unavailable connection.
 
 tier: 0
 
-test: |
-  pytest -svv
+tag+:
+    - internet-connection
+
+/available_connection:
+    tag+:
+        - available_connection
+    test: |
+        pytest -svv -m available_connection
+
+/unavailable_connection:
+    tag+:
+        - unavailable-connection
+    test: |
+        pytest -svv -m unavailable_connection

--- a/tests/integration/tier0/check-internet-connection/main.fmf
+++ b/tests/integration/tier0/check-internet-connection/main.fmf
@@ -1,6 +1,6 @@
 summary: internet connection checks
 
-tier: 1
+tier: 0
 
 test: |
   pytest -svv

--- a/tests/integration/tier0/check-internet-connection/main.fmf
+++ b/tests/integration/tier0/check-internet-connection/main.fmf
@@ -1,0 +1,6 @@
+summary: internet connection checks
+
+tier: 1
+
+test: |
+  pytest -svv

--- a/tests/integration/tier0/check-internet-connection/test_internet_connection.py
+++ b/tests/integration/tier0/check-internet-connection/test_internet_connection.py
@@ -23,12 +23,12 @@ def _modify_configuration_files():
     shutil.copy(DNSMASQ_CONF_FILE, DNSMASQ_CONF_BACKUP_FILE)
     shutil.copy(RESOLV_CONF_FILE, RESOLV_CONF_BACKUP_FILE)
 
-    with open("/etc/dnsmasq.conf", "a") as f:
-        # Everything else is resolved to localhost
-        f.write("address=/#/127.0.0.1\n")
+    with open(DNSMASQ_CONF_FILE, "a") as f:
+        # Everything is resolved to localhost
+        f.write("address=/#/127.0.0.1")
 
-    with open("/etc/resolv.conf", "a") as f:
-        f.write("nameserver 127.0.0.1\n")
+    with open(RESOLV_CONF_FILE, "a") as f:
+        f.write("nameserver 127.0.0.1")
 
 
 def _restore_configuration_files():
@@ -44,35 +44,28 @@ def _restore_configuration_files():
 
 def test_check_if_internet_connection_is_reachable(convert2rhel):
     """Test if convert2rhel can access the internet."""
-    with convert2rhel(
-        ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
-        )
-    ) as c2r:
+    with convert2rhel(("--no-rpm-va --debug")) as c2r:
         c2r.expect("Checking internet connectivity using address")
         assert c2r.expect_exact("Internet connection available.") == 0
-        c2r.send(chr(3))
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("n")
 
     assert c2r.exitstatus == 1
 
 
-def test_check_if_internet_connection_is_not_reachable(convert2rhel):
+def test_check_if_internet_connection_is_not_reachable(convert2rhel, shell):
     """Test a case where the internet connection is not reachable by any means."""
+    assert shell("yum install dnsmasq -y").returncode == 0
+
     _modify_configuration_files()
-    with convert2rhel(
-        ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
-        )
-    ) as c2r:
+
+    assert shell("systemctl enable dnsmasq && systemctl restart dnsmasq").returncode == 0
+
+    with convert2rhel(("--no-rpm-va --debug")) as c2r:
         c2r.expect("Checking internet connectivity using address")
-        c2r.expect("assuming no internet connection is present.")
-        c2r.send(chr(3))
+        c2r.expect("Couldn't connect to the address")
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("n")
 
     _restore_configuration_files()
     assert c2r.exitstatus == 1

--- a/tests/integration/tier0/check-internet-connection/test_internet_connection.py
+++ b/tests/integration/tier0/check-internet-connection/test_internet_connection.py
@@ -27,7 +27,8 @@ def _modify_configuration_files():
         # Everything is resolved to localhost
         f.write("address=/#/127.0.0.1")
 
-    with open(RESOLV_CONF_FILE, "a") as f:
+    # Overwrite the file instead of appending a new line.
+    with open(RESOLV_CONF_FILE, "w") as f:
         f.write("nameserver 127.0.0.1")
 
 

--- a/tests/integration/tier0/check-internet-connection/test_internet_connection.py
+++ b/tests/integration/tier0/check-internet-connection/test_internet_connection.py
@@ -1,0 +1,61 @@
+from envparse import env
+
+
+def _modify_dnsmasq():
+    with open("/etc/dnsmasq.conf", "a") as f:
+        # Everything else is resolved to localhost
+        f.write("address=/#/127.0.0.1")
+
+    with open("/etc/resolv.conf", "w") as f:
+        f.write("nameserver 127.0.0.1")
+
+
+def _remove_changes_from_dnsmasq():
+    """Delete only the last line that was appended to both files."""
+    with open("/etc/dnsmas.conf", "r+") as f:
+        lines = f.readlines()
+        f.seek(0)
+        f.truncate()
+        f.writelines(lines[1:])
+
+    with open("/etc/resolv.conf", "w") as f:
+        lines = f.readlines()
+        f.seek(0)
+        f.truncate()
+        f.writelines(lines[1:])
+
+
+def test_check_if_internet_connection_is_reachable(convert2rhel):
+    """Test if convert2rhel can access the internet."""
+    with convert2rhel(
+        ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        c2r.expect("Checking internet connectivity using address")
+        assert c2r.expect_exact("Internet connection available.") == 0
+        c2r.send(chr(3))
+
+    assert c2r.exitstatus == 1
+
+
+def test_check_if_internet_connection_is_not_reachable(convert2rhel):
+    """Test a case where the internet connection is not reachable by any means."""
+    _modify_dnsmasq()
+    with convert2rhel(
+        ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        c2r.expect("Checking internet connectivity using address")
+        c2r.expect("assuming no internet connection is present.")
+        c2r.send(chr(3))
+
+    _remove_changes_from_dnsmasq()
+    assert c2r.exitstatus == 1

--- a/tests/integration/tier0/check-internet-connection/test_internet_connection.py
+++ b/tests/integration/tier0/check-internet-connection/test_internet_connection.py
@@ -1,28 +1,45 @@
+import os
+import shutil
+
 from envparse import env
 
 
-def _modify_dnsmasq():
+# The original dnsmasq.conf file
+DNSMASQ_CONF_FILE = "/etc/dnsmasq.conf"
+
+# The original resolv.conf file
+RESOLV_CONF_FILE = "/etc/resolv.conf"
+
+# The backup file for dnsmasq, should be /etc/dnsmasq.conf.bk
+DNSMASQ_CONF_BACKUP_FILE = "{0}.bk".format(DNSMASQ_CONF_FILE)
+
+# The backup file for resolv, should be /etc/resolv.conf.bk
+RESOLV_CONF_BACKUP_FILE = "{0}.bk".format(RESOLV_CONF_FILE)
+
+
+def _modify_configuration_files():
+    """Modify the configuration files and backup the original ones."""
+    # Backup the dnsmasq and resolv files
+    shutil.copy(DNSMASQ_CONF_FILE, DNSMASQ_CONF_BACKUP_FILE)
+    shutil.copy(RESOLV_CONF_FILE, RESOLV_CONF_BACKUP_FILE)
+
     with open("/etc/dnsmasq.conf", "a") as f:
         # Everything else is resolved to localhost
-        f.write("address=/#/127.0.0.1")
+        f.write("address=/#/127.0.0.1\n")
 
-    with open("/etc/resolv.conf", "w") as f:
-        f.write("nameserver 127.0.0.1")
+    with open("/etc/resolv.conf", "a") as f:
+        f.write("nameserver 127.0.0.1\n")
 
 
-def _remove_changes_from_dnsmasq():
-    """Delete only the last line that was appended to both files."""
-    with open("/etc/dnsmas.conf", "r+") as f:
-        lines = f.readlines()
-        f.seek(0)
-        f.truncate()
-        f.writelines(lines[1:])
+def _restore_configuration_files():
+    """Restore the original files and remove the modified ones."""
+    if os.path.exists(DNSMASQ_CONF_FILE):
+        os.remove(DNSMASQ_CONF_FILE)
+        shutil.move(DNSMASQ_CONF_BACKUP_FILE, DNSMASQ_CONF_FILE)
 
-    with open("/etc/resolv.conf", "w") as f:
-        lines = f.readlines()
-        f.seek(0)
-        f.truncate()
-        f.writelines(lines[1:])
+    if os.path.exists(RESOLV_CONF_FILE):
+        os.remove(RESOLV_CONF_FILE)
+        shutil.copy(RESOLV_CONF_BACKUP_FILE, RESOLV_CONF_FILE)
 
 
 def test_check_if_internet_connection_is_reachable(convert2rhel):
@@ -44,7 +61,7 @@ def test_check_if_internet_connection_is_reachable(convert2rhel):
 
 def test_check_if_internet_connection_is_not_reachable(convert2rhel):
     """Test a case where the internet connection is not reachable by any means."""
-    _modify_dnsmasq()
+    _modify_configuration_files()
     with convert2rhel(
         ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
             env.str("RHSM_SERVER_URL"),
@@ -57,5 +74,5 @@ def test_check_if_internet_connection_is_not_reachable(convert2rhel):
         c2r.expect("assuming no internet connection is present.")
         c2r.send(chr(3))
 
-    _remove_changes_from_dnsmasq()
+    _restore_configuration_files()
     assert c2r.exitstatus == 1

--- a/tests/integration/tier1/convert-offline-systems/prepare_system.py
+++ b/tests/integration/tier1/convert-offline-systems/prepare_system.py
@@ -35,7 +35,7 @@ def configure_connection():
 
 
 def test_prepare_system(shell):
-    assert shell("yum install dnsmasq wget iptables -y").returncode == 0
+    assert shell("yum install dnsmasq wget -y").returncode == 0
 
     # Install katello package
     pkg_url = "https://dogfood.sat.engineering.redhat.com/pub/katello-ca-consumer-latest.noarch.rpm"
@@ -46,10 +46,6 @@ def test_prepare_system(shell):
     replace_urls_rhsm()
 
     configure_connection()
-
-    # c2r checks the internet connectivity against the 8.8.8.8 DNS server
-    # pinging specific IP address is still possible so we need to block this as well
-    assert shell("iptables -I OUTPUT -d 8.8.8.8 -j DROP").returncode == 0
 
     assert shell("systemctl enable dnsmasq && systemctl restart dnsmasq").returncode == 0
 


### PR DESCRIPTION
This check was introduced in PR #458 as a quick way to validate if the internet
connectionw as up or not. The way that it was introduced was not very robust,
as it was checking for a public Google DNS that may be blocked on some
machines/servers as not essential.

This commit tries to improve it by, instead of checking Google Public DNS, we
check a static file hosted by Red Hat. That should be a little more robust
since `*.redhat.com` is supposed to be reachable from the customer servers when
running convert2rhel.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>