### PR TITLE
[RHELC-645] Skip check of latest kernel on OL8.4

### DIFF
--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -389,7 +389,7 @@ class SystemInfo(object):
         :return: Whether or not the current system has a EUS correspondent in RHEL.
         :rtype: bool
         """
-        return self.releasever in EUS_MINOR_VERSIONS
+        return "%s.%s" % (self.version.major, self.version.minor) in EUS_MINOR_VERSIONS
 
     def _is_dbus_running(self):
         """

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -30,7 +30,7 @@ import pytest
 import six
 
 from convert2rhel import logger, systeminfo, unit_tests, utils  # Imports unit_tests/__init__.py
-from convert2rhel.systeminfo import RELEASE_VER_MAPPING, system_info
+from convert2rhel.systeminfo import RELEASE_VER_MAPPING, Version, system_info
 from convert2rhel.toolopts import tool_opts
 from convert2rhel.unit_tests import is_rpm_based_os
 from convert2rhel.unit_tests.conftest import all_systems, centos8
@@ -358,19 +358,20 @@ def test_get_dbus_status_in_progress(monkeypatch, states, expected):
 
 
 @pytest.mark.parametrize(
-    ("releasever", "expected"),
+    ("major", "minor", "expected"),
     (
-        ("7.9", False),
-        ("8.4", True),
-        ("8.5", False),
-        ("8.6", False),
-        ("8.7", False),
-        ("8.8", False),
-        ("8.9", False),
+        (7, 9, False),
+        (8, 4, True),
+        (8, 5, False),
+        (8, 6, False),
+        (8, 7, False),
+        (8, 8, False),
+        (8, 9, False),
     ),
 )
-def test_corresponds_to_rhel_eus_release(releasever, expected):
-    system_info.releasever = releasever
+def test_corresponds_to_rhel_eus_release(major, minor, expected):
+    version = Version(major, minor)
+    system_info.version = version
     assert system_info.corresponds_to_rhel_eus_release() == expected
 
 

--- a/tests/ansible_collections/roles/oracle-linux-specific/tasks/boot_standard_kernel_84.yml
+++ b/tests/ansible_collections/roles/oracle-linux-specific/tasks/boot_standard_kernel_84.yml
@@ -1,0 +1,12 @@
+---
+- name: Install standard kernel (Oracle Linux 8.4)
+  yum:
+    name: "https://yum.oracle.com/repo/OracleLinux/OL8/4/baseos/base/x86_64/getPackage/kernel-4.18.0-305.el8.x86_64.rpm"
+    state: present
+
+- name: Get installed kernel version (Oracle Linux 8.4)
+  shell: rpm -q --last kernel | head -1 | cut -d " " -f1 | sed 's/kernel-//'
+  register: kernel_ver
+
+- name: Set default kernel to Red Hat compatible kernel (Oracle Linux 8.4)
+  shell: "grubby --set-default /boot/vmlinuz-{{ kernel_ver.stdout }}"

--- a/tests/ansible_collections/roles/oracle-linux-specific/tasks/main.yml
+++ b/tests/ansible_collections/roles/oracle-linux-specific/tasks/main.yml
@@ -1,2 +1,9 @@
 ---
 - include: boot_standard_kernel.yml
+  when:
+    - not ansible_facts['distribution_version'] == "8.4"
+
+# For Oracle Linux 8.4 we need to install the kernel from the 8.4 repository
+- include: boot_standard_kernel_84.yml
+  when:
+    - ansible_facts['distribution_version'] == "8.4"


### PR DESCRIPTION
Skip the check on OL 8.4 because there are no available repositories.

https://issues.redhat.com/browse/RHELC-645