### PR TITLE
chore: remove download artifact

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,12 +24,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: convert2rhel-centos${{ matrix.centos_ver }}
-          path: /tmp
-
       - name: Run pytest coverage
         run: |
           docker run --name pytest-container ghcr.io/${{ github.repository_owner }}/convert2rhel-centos${{ matrix.centos_ver }} pytest --cov --cov-report xml --cov-report term

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -23,12 +23,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: convert2rhel-centos${{ matrix.centos_ver }}
-          path: /tmp
-
       - name: Run command
         run: |
           docker run ghcr.io/${{ github.repository_owner }}/convert2rhel-centos${{ matrix.centos_ver }} bash -c "scripts/run_lint.sh"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,12 +23,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: convert2rhel-centos${{ matrix.centos_ver }}
-          path: /tmp
-
       - name: Run command
         run: |
           docker run ghcr.io/${{ github.repository_owner }}/convert2rhel-centos${{ matrix.centos_ver }} pytest


### PR DESCRIPTION
We don't create an artifact for the container builds so the workflows don't pass

This should still be relatively fast I believe