### PR TITLE
chore: build GHCR images on main

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -3,8 +3,6 @@ name: build_and_publish_images
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   build_and_publish:
@@ -20,8 +18,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,11 +1,10 @@
 name: test_coverage
 
 on:
-  workflow_run:
-    workflows:
-      - build_and_publish_images
-    types:
-      - completed
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   coverage:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,11 +1,10 @@
 name: pylint
 
 on:
-  workflow_run:
-    workflows:
-      - build_and_publish_images
-    types:
-      - completed
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   linting:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,10 @@
 name: unit_tests
 
 on:
-  workflow_run:
-    workflows:
-      - build_and_publish_images
-    types:
-      - completed
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   testing:


### PR DESCRIPTION
Forks don't have permission to update the image. We also don't need to update the image for every commit in a PR, intead we can simply update the images on push to main and use that image

Caveat: with this update we won't be able to update the images and have the workflows reflect that in the PRs themselves. We can utilize workflow_dispatch together with reusable workflows and environment variables to manually trigger this in the future if we want to. But for that to work we will have to update the images from a branch on this repo instead of a fork due to permissions