### PR TITLE
Fix codecov checks by passing a token

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,5 +40,6 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           env_vars: OS,PYTHON
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           files: ./coverage.xml


### PR DESCRIPTION
Codecov checks were failing with this message:
"No token specified or token is empty"

Related:
https://github.com/codecov/codecov-action/issues/557#issuecomment-1225464370