### PR TITLE
Debug Testing Farm GH Action permissions

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -1,0 +1,14 @@
+name: Debug
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  debug:
+    name: Author Association
+    runs-on: ubuntu-latest
+    steps:
+      - name: What is your author association?
+        run: |
+          echo ${{ github.event.pull_request.author_association }}


### PR DESCRIPTION
Currently the Testing Farm GitHub action is being skipped. We think it might be related to a PR authorship/permissions.