### PR TITLE
Allow contributors to run integration tests

### DIFF
--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -30,7 +30,7 @@ jobs:
     if: |
       github.event.pull_request
       && (
-        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association)
         || contains(github.event.pull_request.labels.*.name, 'testing')
       )
 


### PR DESCRIPTION
Adding the `CONTRIBUTOR` tag to the list of allowed authors to run integration tests automatically when a PR is opened. 

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>