### PR TITLE
Update tmt-tests workflow to pass the SHA from PR event

### DIFF
--- a/.github/workflows/reuse-int-tests.yml
+++ b/.github/workflows/reuse-int-tests.yml
@@ -71,7 +71,6 @@ on:
       pr_head_sha:
         type: string
         required: true
-        default: ''
 
 jobs:
   reusable_workflow_job:

--- a/.github/workflows/reuse-int-tests.yml
+++ b/.github/workflows/reuse-int-tests.yml
@@ -68,6 +68,10 @@ on:
         type: string
         required: false
         default: "main"
+      pr_head_sha:
+        type: string
+        required: true
+        default: ''
 
 jobs:
   reusable_workflow_job:
@@ -78,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Schedule integration testing for ${{ inputs.pull_request_status_name }}
-        uses: sclorg/testing-farm-as-github-action@v1.2.11
+        uses: sclorg/testing-farm-as-github-action@v1.2.13
         with:
           # required
           api_url: ${{ secrets.TF_ENDPOINT }}
@@ -86,9 +90,10 @@ jobs:
           git_url: "https://github.com/oamg/convert2rhel"
           git_ref: ${{ inputs.git_ref }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_head_sha: ${{ inputs.pr_head_sha }}
           # optional
           tf_scope: "private"
-          create_issue_comment: "true"
+          create_issue_comment: "false"
           update_pull_request_status: ${{ inputs.update_pull_request_status }}
           pull_request_status_name: ${{ inputs.pull_request_status_name }}/${{ matrix.distro }}
           tmt_plan_regex: ${{ inputs.tmt_plan_regex }}

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -25,7 +25,7 @@ jobs:
         uses: r0x0d/wait-for-ci-checks@main
         id: status_check
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: "${{ github.event.pull_request.head.sha }}"
           checkNames: "rpm-build:epel-7-x86_64;rpm-build:epel-8-x86_64"
     if: |
       github.event.pull_request
@@ -60,6 +60,7 @@ jobs:
       matrix: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel7 }}
       pull_request_status_name: "epel-7-tier0"
       git_ref: "refs/pull/${{ github.event.number }}/head"
+      pr_head_sha: "${{ github.event.pull_request.head.sha }}"
     secrets: inherit
 
   call_workflow_integration_tests_epel_8_tier0:
@@ -71,6 +72,7 @@ jobs:
       matrix: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel8 }}
       pull_request_status_name: "epel-8-tier0"
       git_ref: "refs/pull/${{ github.event.number }}/head"
+      pr_head_sha: "${{ github.event.pull_request.head.sha }}"
     secrets: inherit
 
   # Tier 1 integration tests
@@ -84,6 +86,7 @@ jobs:
       matrix: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel7 }}
       pull_request_status_name: "epel-7-tier1"
       git_ref: "refs/pull/${{ github.event.number }}/head"
+      pr_head_sha: "${{ github.event.pull_request.head.sha }}"
     secrets: inherit
 
   call_workflow_integration_tests_epel_8_tier1:
@@ -95,4 +98,5 @@ jobs:
       matrix: ${{ needs.convert_distros_to_matrix.outputs.matrix_epel8 }}
       pull_request_status_name: "epel-8-tier1"
       git_ref: "refs/pull/${{ github.event.number }}/head"
+      pr_head_sha: "${{ github.event.pull_request.head.sha }}"
     secrets: inherit


### PR DESCRIPTION
This commit introduces an update to the `tmt-tests.yml` workflow to pass the HEAD sha to the `testing-farm-as-github-action` as an input.

It also pins the version to the latest commit introduced in this action in order to be able to use it right away.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>