### PR TITLE
Revert "Fix codecov checks by passing a token"

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,6 +39,5 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           env_vars: OS,PYTHON
-          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           files: ./coverage.xml


### PR DESCRIPTION
Reverts oamg/convert2rhel#593. 

Since PRs from forks can't access the token we're getting errors overall where it tries to upload with an empty token