### PR TITLE
chore(codecov): remove token and add more arguments

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,6 +39,8 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           env_vars: OS,PYTHON
-          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: centos${{ matrix.centos_ver }}
+          name: coverage-centos
           fail_ci_if_error: true
           files: ./coverage.xml
+          verbose: true # optional (default = false)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           env_vars: OS,PYTHON
-          flags: centos${{ matrix.centos_ver }}
+          flags: centos-linux-${{ matrix.centos_ver }}
           name: coverage-centos
           fail_ci_if_error: true
           files: ./coverage.xml


### PR DESCRIPTION
Token is removed as fork PRs can't access it - making it useless for our project. It also creates errors or simply assumes the fault is the token when it errors

Flags argument is added to separate the coverage for the three centos machines

Name is added to assign a name to the code coverage