### PR TITLE
[RHELC-635] Update concurrency group to prevent interference

### DIFF
--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -13,8 +13,8 @@ on:
 # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
 # This will ensure that only one commit will be running tests at a time on each PR.
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   wait_for_rpm_builds:


### PR DESCRIPTION
With our current concurrency group, the PRs are conflicting with each other, if one PR is executing the tmt-tests.yml workflow, and then another PR receives an update and trigger the same workflow, the first one will stop executing as canceled.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-635](https://issues.redhat.com/browse/RHELC-635)

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
