### PR TITLE
[RHELC-738] Add RHEL 8.6 among the supported EUS minor versions

### DIFF
--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -56,7 +56,7 @@ PRE_RPM_VA_LOG_FILENAME = "rpm_va.log"
 POST_RPM_VA_LOG_FILENAME = "rpm_va_after_conversion.log"
 
 # List of EUS minor versions supported
-EUS_MINOR_VERSIONS = ["8.4"]
+EUS_MINOR_VERSIONS = ["8.4", "8.6"]
 
 Version = namedtuple("Version", ["major", "minor"])
 

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -378,10 +378,11 @@ def test_get_dbus_status_in_progress(monkeypatch, states, expected):
         ("7.9", False),
         ("8.4", True),
         ("8.5", False),
-        ("8.6", False),
+        ("8.6", True),
         ("8.7", False),
         ("8.8", False),
         ("8.9", False),
+        ("8.10", False),
     ),
 )
 def test_corresponds_to_rhel_eus_release(releasever, expected):

--- a/tests/ansible_collections/roles/add-custom-repos/main.yml
+++ b/tests/ansible_collections/roles/add-custom-repos/main.yml
@@ -9,4 +9,4 @@
 - import_playbook: rhel8-repos.yml
   when: ansible_facts['distribution_version'] == "8.5" or ansible_facts['distribution_version'] == "8.6"
 - import_playbook: rhel8-eus-repos.yml
-  when: ansible_facts['distribution_version'] == "8.4"
+  when: ansible_facts['distribution_version'] == "8.4" or ansible_facts['distribution_version'] == "8.6"

--- a/tests/integration/tier0/backup-release/test_backup_release.py
+++ b/tests/integration/tier0/backup-release/test_backup_release.py
@@ -33,7 +33,7 @@ def test_backup_os_release_no_envar(shell, convert2rhel):
     assert shell("mv /etc/yum.repos.d/* /tmp/s_backup/").returncode == 0
 
     # EUS version use hardoced repos from c2r as well
-    if "centos-8" in system or "oracle-8.4" in system:
+    if "centos-8" in system:
         assert shell("mkdir /tmp/s_backup_eus").returncode == 0
         assert shell("mv /usr/share/convert2rhel/repos/* /tmp/s_backup_eus/").returncode == 0
 
@@ -83,7 +83,7 @@ def test_backup_os_release_with_envar(shell, convert2rhel):
     # Return repositories to their original location
     assert shell("mv /tmp/s_backup/* /etc/yum.repos.d/").returncode == 0
 
-    if "centos-8" in system or "oracle-8.4" in system:
+    if "centos-8" in system:
         assert shell("mv /tmp/s_backup_eus/* /usr/share/convert2rhel/repos/").returncode == 0
 
     # Clean up

--- a/tests/integration/tier0/check-custom-repo/test_custom_repos.py
+++ b/tests/integration/tier0/check-custom-repo/test_custom_repos.py
@@ -34,13 +34,13 @@ def test_good_convertion_without_rhsm(shell, convert2rhel):
         if system_version.major == 7:
             enable_repo_opt = "--enablerepo rhel-7-server-rpms --enablerepo rhel-7-server-optional-rpms --enablerepo rhel-7-server-extras-rpms"
         elif system_version.major == 8:
-            if system_version.minor != 4:
-                enable_repo_opt = (
-                    "--enablerepo rhel-8-for-x86_64-baseos-rpms --enablerepo rhel-8-for-x86_64-appstream-rpms"
-                )
-            elif system_version.minor == 4:
+            if system_version.minor in (4, 6):
                 enable_repo_opt = (
                     "--enablerepo rhel-8-for-x86_64-baseos-eus-rpms --enablerepo rhel-8-for-x86_64-appstream-eus-rpms"
+                )
+            else:
+                enable_repo_opt = (
+                    "--enablerepo rhel-8-for-x86_64-baseos-rpms --enablerepo rhel-8-for-x86_64-appstream-rpms"
                 )
 
     with convert2rhel("-y --no-rpm-va --disable-submgr {} --debug".format(enable_repo_opt)) as c2r:

--- a/tests/integration/tier1/checks-after-conversion/test_enabled_repositories.py
+++ b/tests/integration/tier1/checks-after-conversion/test_enabled_repositories.py
@@ -3,24 +3,39 @@ import platform
 from os.path import exists
 
 
+def _check_enabled_repos_rhel8(enabled_repos):
+    """Helper function to assert RHEL repositories."""
+    baseos_repo = "rhel-8-for-x86_64-baseos-rpms"
+    appstream_repo = "rhel-8-for-x86_64-appstream-rpms"
+
+    assert baseos_repo in enabled_repos
+    assert appstream_repo in enabled_repos
+
+
+def _check_eus_enabled_repos_rhel8(enabled_repos):
+    """Helper function to assert EUS repositories."""
+    baseos_repo = "rhel-8-for-x86_64-baseos-eus-rpms"
+    appstream_repo = "rhel-8-for-x86_64-appstream-eus-rpms"
+
+    assert baseos_repo in enabled_repos
+    assert appstream_repo in enabled_repos
+
+
 def test_enabled_repositories(shell):
     """Testing, if the EUS repostitories are enabled after conversion"""
     system_version = platform.platform()
     enabled_repos = shell("yum repolist").output
 
-    # Once we will decide to use EUS 8.6 we have to add them here as well
     try:
-        if "redhat-8.4" in system_version:
-            # Handle the special test case scenario where we do not use the premium account with EUS repositories
+        if "redhat-8.4" in system_version or "redhat-8.6" in system_version:
+            # Handle the special test case scenario where we do not use the
+            # premium account with EUS repositories
             if exists("/non_eus_repos_used"):
-                assert "rhel-8-for-x86_64-baseos-rpms" in enabled_repos
-                assert "rhel-8-for-x86_64-appstream-rpms" in enabled_repos
+                _check_enabled_repos_rhel8(enabled_repos)
             else:
-                assert "rhel-8-for-x86_64-appstream-eus-rpms" in enabled_repos
-                assert "rhel-8-for-x86_64-baseos-eus-rpms" in enabled_repos
-        elif "redhat-8.5" in system_version or "redhat-8.6" in system_version:
-            assert "rhel-8-for-x86_64-baseos-rpms" in enabled_repos
-            assert "rhel-8-for-x86_64-appstream-rpms" in enabled_repos
+                _check_eus_enabled_repos_rhel8(enabled_repos)
+        elif "redhat-8.5" in system_version:
+            _check_enabled_repos_rhel8(enabled_repos)
         elif "redhat-7.9" in system_version:
             assert "rhel-7-server-rpms/7Server/x86_64" in enabled_repos
     finally:

--- a/tests/integration/tier1/method/custom_repos.py
+++ b/tests/integration/tier1/method/custom_repos.py
@@ -33,14 +33,13 @@ def test_run_conversion_using_custom_repos(shell, convert2rhel):
         if system_version.major == 7:
             enable_repo_opt = "--enablerepo rhel-7-server-rpms --enablerepo rhel-7-server-optional-rpms --enablerepo rhel-7-server-extras-rpms"
         elif system_version.major == 8:
-            if system_version.minor != 4:
-                enable_repo_opt = (
-                    "--enablerepo rhel-8-for-x86_64-baseos-rpms --enablerepo rhel-8-for-x86_64-appstream-rpms"
-                )
-            # for the future releases we will have to enable this also for the 8.6 versions
-            elif system_version.minor == 4:
+            if system_version.minor in (4, 6):
                 enable_repo_opt = (
                     "--enablerepo rhel-8-for-x86_64-baseos-eus-rpms --enablerepo rhel-8-for-x86_64-appstream-eus-rpms"
+                )
+            else:
+                enable_repo_opt = (
+                    "--enablerepo rhel-8-for-x86_64-baseos-rpms --enablerepo rhel-8-for-x86_64-appstream-rpms"
                 )
 
     with convert2rhel("-y --no-rpm-va --disable-submgr {} --debug".format(enable_repo_opt)) as c2r:
@@ -53,8 +52,9 @@ def test_run_conversion_using_custom_repos(shell, convert2rhel):
             "--enable rhel-7-server-rpms --enable rhel-7-server-optional-rpms --enable rhel-7-server-extras-rpms"
         )
     elif system_version.major == 8:
-        if system_version.minor != 4:
-            enable_repo_opt = "--enable rhel-8-for-x86_64-baseos-rpms --enable rhel-8-for-x86_64-appstream-rpms"
-        elif system_version.minor == 4:
+        if system_version.minor in (4, 6):
             enable_repo_opt = "--enable rhel-8-for-x86_64-baseos-eus-rpms --enable rhel-8-for-x86_64-appstream-eus-rpms"
+        else:
+            enable_repo_opt = "--enable rhel-8-for-x86_64-baseos-rpms --enable rhel-8-for-x86_64-appstream-rpms"
+
     shell("yum-config-manager {}".format(enable_repo_opt))

--- a/tests/integration/tier1/satellite_non_eus_repos/satellite_non_eus_repos.py
+++ b/tests/integration/tier1/satellite_non_eus_repos/satellite_non_eus_repos.py
@@ -1,0 +1,31 @@
+from envparse import env
+
+
+def test_missing_os_release(shell, convert2rhel):
+    """
+    This test case verify that it's possible to do full conversion when /etc/os-release
+    file is not present on the system.
+    """
+
+    # Mark the system so the check for the enabled repos after the conversion handles this special case
+    assert shell("touch /non_eus_repos_used").returncode == 0
+
+    # Remove subscription manager if installed
+    assert shell("yum remove subscription-manager -y").returncode == 0
+
+    assert shell("yum install wget -y").returncode == 0
+
+    # Install katello package
+    pkg_url = "https://satellite.sat.engineering.redhat.com/pub/katello-ca-consumer-latest.noarch.rpm"
+    pkg_dst = "/usr/share/convert2rhel/subscription-manager/katello-ca-consumer-latest.noarch.rpm"
+    assert shell("wget --no-check-certificate --output-document {} {}".format(pkg_dst, pkg_url)).returncode == 0
+
+    with convert2rhel(
+        ("-y --no-rpm-va -k {} -o {} --debug").format(
+            env.str("SATELLITE_KEY"),
+            env.str("SATELLITE_ORG"),
+        )
+    ) as c2r:
+        c2r.expect("WARNING - rhel-8-for-x86_64-baseos-eus-rpms repository is not available")
+        c2r.expect("WARNING - rhel-8-for-x86_64-appstream-eus-rpms repository is not available")
+    assert c2r.exitstatus == 0


### PR DESCRIPTION
When RHEL 8.7 is released, RHEL 8.6 will transition into the Extended Update Support. Our next release will happen post RHEL 8.7 GA so this is to make sure we then correctly detect 8.6 as EUS.

Some integration may be failing now as:
- they don't expect 8.6 to be EUS
- different RHEL repos are being enabled
- some checks during the conversion are being skipped if converting to EUS, namely loaded kernel currency check and system up-to-date check on Oracle Linux (because Oracle does not make repos of older minor versions available)
- the convert2rhel will start locking to the minor version through RHSM

Jira Issue: [RHELC-738](https://issues.redhat.com/browse/RHELC-738)

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-738]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
