### PR TITLE
 [RHELC-740] Fix permissions check for certificates.

### DIFF
--- a/convert2rhel/cert.py
+++ b/convert2rhel/cert.py
@@ -35,7 +35,7 @@ class SystemCert(object):
 
     @staticmethod
     def _get_cert():
-        """Return name of certificate and his directory."""
+        """Return name of certificate and this directory."""
         cert_dir = os.path.join(utils.DATA_DIR, "rhel-certs")
         if not os.access(cert_dir, os.R_OK | os.X_OK):
             loggerinst.critical("Error: Could not access %s." % cert_dir)

--- a/convert2rhel/cert.py
+++ b/convert2rhel/cert.py
@@ -37,7 +37,7 @@ class SystemCert(object):
     def _get_cert():
         """Return name of certificate and his directory."""
         cert_dir = os.path.join(utils.DATA_DIR, "rhel-certs")
-        if not os.access(cert_dir, os.R_OK | os.W_OK):
+        if not os.access(cert_dir, os.R_OK | os.X_OK):
             loggerinst.critical("Error: Could not access %s." % cert_dir)
         pem_filename = None
         for filename in os.listdir(cert_dir):


### PR DESCRIPTION
We check whether we can access the certificate files shipped with convert2rhel prior to installing them.  The check for the directory they live in was checking whether the directory was readable and writable. We don't write to that directory, though, so the check shuld be whether the directory is readable and executable.

Note that convert2rhel should always be run by root so this bug won't be encountered in normal use.

<!-- Link to relevant Jira issue, add multiple if necessary -->
This issue mentioned in:
Jira Issue: [RHELC-740](https://issues.redhat.com/browse/RHELC-740)


Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
