### PR TITLE
[RHELC-244] allowing the overriding of kmod inhibitors

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -410,7 +410,7 @@ def validate_package_manager_transaction():
                 "Make sure you have updated the kernel to the latest available version and rebooted the system. "
                 "Only kernel modules supported in RHEL are preferred for conversion, if you want to ignore this "
                 " check, set the environment variable 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS=1' to continue".format(
-                    kmods=not_supported_kmods, system=system_info.name
+                    kmods=not_supported_kmods
                 )
             )
 

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -379,8 +379,8 @@ def ensure_compatibility_of_kmods():
 
         if "CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS" in os.environ:
             logger.warning(
-                "The following kernel modules are not supported in RHEL:\n{kmods}\n"
-                "'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable detected, continuing conversion.".format(
+                "Detected 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable."
+                " We will continue the conversion, with the following kernel modules that are not supported:\n{kmods}\n".format(
                     kmods=not_supported_kmods
                 )
             )

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -373,9 +373,9 @@ def ensure_compatibility_of_kmods():
 
         unsupported_kmods = get_unsupported_kmods(host_kmods, rhel_supported_kmods)
 
-        if "CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS" in os.environ:
+        if "CONVERT2RHEL_ALLOW_UNCHECKED_KMODS" in os.environ:
             logger.warning(
-                "Detected 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable."
+                "Detected 'CONVERT2RHEL_ALLOW_UNCHECKED_KMODS' environment variable."
                 " We will continue the conversion, with the following kernel modules:\n{kmods}\n".format(
                     kmods="\n".join(unsupported_kmods)
                 )

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -385,14 +385,16 @@ def ensure_compatibility_of_kmods():
                 )
             )
 
-        logger.critical(
-            "The following loaded kernel modules are not available in RHEL:\n{0}\n"
-            "First, make sure you have updated the kernel to the latest available version and rebooted the system.\n"
-            "If this message appears again after doing the above, prevent the modules from loading by following {1}"
-            " and run convert2rhel again to continue with the conversion.".format(
-                "\n".join(unsupported_kmods), LINK_PREVENT_KMODS_FROM_LOADING
+        else:
+            logger.critical(
+                "The following loaded kernel modules are not available in RHEL:\n{0}\n"
+                "First, make sure you have updated the kernel to the latest available version and rebooted the system.\n"
+                "If this message appears again after doing the above, prevent the modules from loading by following {1}"
+                " and run convert2rhel again to continue with the conversion.".format(
+                    "\n".join(not_supported_kmods), LINK_PREVENT_KMODS_FROM_LOADING
+                )
             )
-        )
+
 
 def validate_package_manager_transaction():
     """Validate the package manager transaction is passing the tests."""
@@ -401,21 +403,7 @@ def validate_package_manager_transaction():
     transaction_handler.run_transaction(
         validate_transaction=True,
     )
-                "Only kernel modules supported in RHEL are preferd for conversion, if you want to ignor this "
-                " check, set the environment variable 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' to continue"
-            ).format(kmods=not_supported_kmods, system=system_info.name)
-        else:
-            logger.critical(
-                "The following kernel modules are not supported in RHEL:\n{kmods}\n"
-                "Make sure you have updated the kernel to the latest available version and rebooted the system. "
-                "Only kernel modules supported in RHEL are preferred for conversion, if you want to ignore this "
-                " check, set the environment variable 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS=1' to continue".format(
-                    kmods=not_supported_kmods
-                )
-            )
 
-    else:
-        logger.info("Kernel modules are compatible.")
 
 def get_loaded_kmods():
     """Get a set of kernel modules loaded on host.

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -371,27 +371,33 @@ def ensure_compatibility_of_kmods():
         logger.debug("All loaded kernel modules are available in RHEL.")
     else:
         not_supported_kmods = "\n".join(
-            map(
-                lambda kmod: "/lib/modules/{kver}/{kmod}".format(kver=system_info.booted_kernel, kmod=kmod),
-                unsupported_kmods,
+            "/lib/modules/{kver}/{kmod}".format(kver=system_info.booted_kernel, kmod=kmod) for kmod in unsupported_kmods
+        )
+
+        logger.critical(
+            "The following loaded kernel modules are not available in RHEL:\n{0}\n"
+            "First, make sure you have updated the kernel to the latest available version and rebooted the system.\n"
+            "If this message appears again after doing the above, prevent the modules from loading by following {1}"
+            " and run convert2rhel again to continue with the conversion.".format(
+                not_supported_kmods, LINK_PREVENT_KMODS_FROM_LOADING
             )
         )
 
         if "CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS" in os.environ:
             logger.warning(
-                "Detected 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable."
-                " We will continue the conversion, with the following kernel modules that are not supported:\n{kmods}\n".format(
+                "The following kernel modules are not supported in RHEL:\n{kmods}\n"
+                "'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable detected, continuing conversion.".format(
                     kmods=not_supported_kmods
                 )
             )
 
         else:
             logger.critical(
-                "The following loaded kernel modules are not available in RHEL:\n{0}\n"
-                "First, make sure you have updated the kernel to the latest available version and rebooted the system.\n"
-                "If this message appears again after doing the above, prevent the modules from loading by following {1}"
-                " and run convert2rhel again to continue with the conversion.".format(
-                    "\n".join(not_supported_kmods), LINK_PREVENT_KMODS_FROM_LOADING
+                "The following kernel modules are not supported in RHEL:\n{kmods}\n"
+                "Make sure you have updated the kernel to the latest available version and rebooted the system. "
+                "Only kernel modules supported in RHEL are preferred for conversion, if you want to ignore this "
+                " check, set the environment variable 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS=1' to continue".format(
+                    kmods=not_supported_kmods, system=system_info.name
                 )
             )
 

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -370,9 +370,6 @@ def ensure_compatibility_of_kmods():
     if not unsupported_kmods:
         logger.debug("All loaded kernel modules are available in RHEL.")
     else:
-
-        unsupported_kmods = get_unsupported_kmods(host_kmods, rhel_supported_kmods)
-
         if "CONVERT2RHEL_ALLOW_UNCHECKED_KMODS" in os.environ:
             logger.warning(
                 "Detected 'CONVERT2RHEL_ALLOW_UNCHECKED_KMODS' environment variable."
@@ -380,7 +377,6 @@ def ensure_compatibility_of_kmods():
                     kmods="\n".join(unsupported_kmods)
                 )
             )
-
         else:
             logger.critical(
                 "The following loaded kernel modules are not available in RHEL:\n{0}\n"

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -374,6 +374,14 @@ def ensure_compatibility_of_kmods():
             "/lib/modules/{kver}/{kmod}".format(kver=system_info.booted_kernel, kmod=kmod) for kmod in unsupported_kmods
         )
 
+        if "CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS" in os.environ:
+            logger.warning(
+                "The following kernel modules are not supported in RHEL:\n{kmods}\n"
+                "'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable detected, continuing conversion.".format(
+                    kmods=not_supported_kmods
+                )
+            )
+
         logger.critical(
             "The following loaded kernel modules are not available in RHEL:\n{0}\n"
             "First, make sure you have updated the kernel to the latest available version and rebooted the system.\n"
@@ -383,25 +391,6 @@ def ensure_compatibility_of_kmods():
             )
         )
 
-        if "CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS" in os.environ:
-            logger.warning(
-                "The following kernel modules are not supported in RHEL:\n{kmods}\n"
-                "'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable detected, continuing conversion.".format(
-                    kmods=not_supported_kmods
-                )
-            )
-
-        else:
-            logger.critical(
-                "The following kernel modules are not supported in RHEL:\n{kmods}\n"
-                "Make sure you have updated the kernel to the latest available version and rebooted the system. "
-                "Only kernel modules supported in RHEL are preferred for conversion, if you want to ignore this "
-                " check, set the environment variable 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS=1' to continue".format(
-                    kmods=not_supported_kmods, system=system_info.name
-                )
-            )
-
-
 def validate_package_manager_transaction():
     """Validate the package manager transaction is passing the tests."""
     logger.task("Validate the %s transaction", pkgmanager.TYPE)
@@ -409,7 +398,12 @@ def validate_package_manager_transaction():
     transaction_handler.run_transaction(
         validate_transaction=True,
     )
+                "Only kernel modules supported in RHEL are preferd for conversion, if you want to ignor this "
+                " check, set the environment variable 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' to continue"
+            ).format(kmods=not_supported_kmods, system=system_info.name)
 
+    else:
+        logger.info("Kernel modules are compatible.")
 
 def get_loaded_kmods():
     """Get a set of kernel modules loaded on host.

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -370,9 +370,6 @@ def ensure_compatibility_of_kmods():
     if not unsupported_kmods:
         logger.debug("All loaded kernel modules are available in RHEL.")
     else:
-        not_supported_kmods = "\n".join(
-            "/lib/modules/{kver}/{kmod}".format(kver=system_info.booted_kernel, kmod=kmod) for kmod in unsupported_kmods
-        )
 
         if "CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS" in os.environ:
             logger.warning(

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -376,8 +376,8 @@ def ensure_compatibility_of_kmods():
 
         if "CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS" in os.environ:
             logger.warning(
-                "The following kernel modules are not supported in RHEL:\n{kmods}\n"
-                "'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable detected, continuing conversion.".format(
+                "Detected 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable."
+                " We will continue the conversion, with the following kernel modules that are not supported:\n{kmods}\n".format(
                     kmods=not_supported_kmods
                 )
             )

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -370,6 +370,13 @@ def ensure_compatibility_of_kmods():
     if not unsupported_kmods:
         logger.debug("All loaded kernel modules are available in RHEL.")
     else:
+        not_supported_kmods = "\n".join(
+            map(
+                lambda kmod: "/lib/modules/{kver}/{kmod}".format(kver=system_info.booted_kernel, kmod=kmod),
+                unsupported_kmods,
+            )
+        )
+
         logger.critical(
             "The following loaded kernel modules are not available in RHEL:\n{0}\n"
             "First, make sure you have updated the kernel to the latest available version and rebooted the system.\n"
@@ -378,6 +385,24 @@ def ensure_compatibility_of_kmods():
                 "\n".join(unsupported_kmods), LINK_PREVENT_KMODS_FROM_LOADING
             )
         )
+
+        if "CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS" in os.environ:
+            logger.warning(
+                "The following kernel modules are not supported in RHEL:\n{kmods}\n"
+                "'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable detected, continuing conversion.".format(
+                    kmods=not_supported_kmods
+                )
+            )
+
+        else:
+            logger.critical(
+                "The following kernel modules are not supported in RHEL:\n{kmods}\n"
+                "Make sure you have updated the kernel to the latest available version and rebooted the system. "
+                "Only kernel modules supported in RHEL are preferred for conversion, if you want to ignore this "
+                " check, set the environment variable 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS=1' to continue".format(
+                    kmods=not_supported_kmods, system=system_info.name
+                )
+            )
 
 
 def validate_package_manager_transaction():

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -377,6 +377,14 @@ def ensure_compatibility_of_kmods():
             )
         )
 
+        if "CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS" in os.environ:
+            logger.warning(
+                "The following kernel modules are not supported in RHEL:\n{kmods}\n"
+                "'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable detected, continuing conversion.".format(
+                    kmods=not_supported_kmods
+                )
+            )
+
         logger.critical(
             "The following loaded kernel modules are not available in RHEL:\n{0}\n"
             "First, make sure you have updated the kernel to the latest available version and rebooted the system.\n"
@@ -386,25 +394,6 @@ def ensure_compatibility_of_kmods():
             )
         )
 
-        if "CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS" in os.environ:
-            logger.warning(
-                "The following kernel modules are not supported in RHEL:\n{kmods}\n"
-                "'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable detected, continuing conversion.".format(
-                    kmods=not_supported_kmods
-                )
-            )
-
-        else:
-            logger.critical(
-                "The following kernel modules are not supported in RHEL:\n{kmods}\n"
-                "Make sure you have updated the kernel to the latest available version and rebooted the system. "
-                "Only kernel modules supported in RHEL are preferred for conversion, if you want to ignore this "
-                " check, set the environment variable 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS=1' to continue".format(
-                    kmods=not_supported_kmods, system=system_info.name
-                )
-            )
-
-
 def validate_package_manager_transaction():
     """Validate the package manager transaction is passing the tests."""
     logger.task("Validate the %s transaction", pkgmanager.TYPE)
@@ -412,7 +401,12 @@ def validate_package_manager_transaction():
     transaction_handler.run_transaction(
         validate_transaction=True,
     )
+                "Only kernel modules supported in RHEL are preferd for conversion, if you want to ignor this "
+                " check, set the environment variable 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' to continue"
+            ).format(kmods=not_supported_kmods, system=system_info.name)
 
+    else:
+        logger.info("Kernel modules are compatible.")
 
 def get_loaded_kmods():
     """Get a set of kernel modules loaded on host.

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -371,21 +371,24 @@ def ensure_compatibility_of_kmods():
         logger.debug("All loaded kernel modules are available in RHEL.")
     else:
 
+        unsupported_kmods = get_unsupported_kmods(host_kmods, rhel_supported_kmods)
+
         if "CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS" in os.environ:
             logger.warning(
                 "Detected 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable."
-                " We will continue the conversion, with the following kernel modules that are not supported:\n{kmods}\n".format(
-                    kmods=not_supported_kmods
+                " We will continue the conversion, with the following kernel modules:\n{kmods}\n".format(
+                    kmods="\n".join(unsupported_kmods)
                 )
             )
 
         else:
             logger.critical(
                 "The following loaded kernel modules are not available in RHEL:\n{0}\n"
-                "First, make sure you have updated the kernel to the latest available version and rebooted the system.\n"
-                "If this message appears again after doing the above, prevent the modules from loading by following {1}"
-                " and run convert2rhel again to continue with the conversion.".format(
-                    not_supported_kmods, LINK_PREVENT_KMODS_FROM_LOADING
+                "Kernel modules need to be up-to-date to minimize the risk for issues occurring related to first-party kernel modules.\n"
+                "Ensure you have updated the kernel to the latest available version and rebooted the system.\n"
+                "If this message persists, you can prevent the modules from loading by following {1} and rerun convert2rhel.\n"
+                "To circumvent this check and allow the risk you can set environment variable 'CONVERT2RHEL_ALLOW_UNCHECKED_KMODS=1'.".format(
+                    "\n".join(unsupported_kmods), LINK_PREVENT_KMODS_FROM_LOADING
                 )
             )
 

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -401,6 +401,15 @@ def validate_package_manager_transaction():
                 "Only kernel modules supported in RHEL are preferd for conversion, if you want to ignor this "
                 " check, set the environment variable 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' to continue"
             ).format(kmods=not_supported_kmods, system=system_info.name)
+        else:
+            logger.critical(
+                "The following kernel modules are not supported in RHEL:\n{kmods}\n"
+                "Make sure you have updated the kernel to the latest available version and rebooted the system. "
+                "Only kernel modules supported in RHEL are preferred for conversion, if you want to ignore this "
+                " check, set the environment variable 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS=1' to continue".format(
+                    kmods=not_supported_kmods, system=system_info.name
+                )
+            )
 
     else:
         logger.info("Kernel modules are compatible.")

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -382,14 +382,25 @@ def ensure_compatibility_of_kmods():
                 )
             )
 
+<<<<<<< HEAD
         logger.critical(
             "The following loaded kernel modules are not available in RHEL:\n{0}\n"
             "First, make sure you have updated the kernel to the latest available version and rebooted the system.\n"
             "If this message appears again after doing the above, prevent the modules from loading by following {1}"
             " and run convert2rhel again to continue with the conversion.".format(
                 not_supported_kmods, LINK_PREVENT_KMODS_FROM_LOADING
+=======
+        else:
+            logger.critical(
+                "The following loaded kernel modules are not available in RHEL:\n{0}\n"
+                "First, make sure you have updated the kernel to the latest available version and rebooted the system.\n"
+                "If this message appears again after doing the above, prevent the modules from loading by following {1}"
+                " and run convert2rhel again to continue with the conversion.".format(
+                    "\n".join(not_supported_kmods), LINK_PREVENT_KMODS_FROM_LOADING
+                )
+>>>>>>> cab81a7 (Changed the added code that came from my PR)
             )
-        )
+
 
 def validate_package_manager_transaction():
     """Validate the package manager transaction is passing the tests."""
@@ -398,21 +409,7 @@ def validate_package_manager_transaction():
     transaction_handler.run_transaction(
         validate_transaction=True,
     )
-                "Only kernel modules supported in RHEL are preferd for conversion, if you want to ignor this "
-                " check, set the environment variable 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' to continue"
-            ).format(kmods=not_supported_kmods, system=system_info.name)
-        else:
-            logger.critical(
-                "The following kernel modules are not supported in RHEL:\n{kmods}\n"
-                "Make sure you have updated the kernel to the latest available version and rebooted the system. "
-                "Only kernel modules supported in RHEL are preferred for conversion, if you want to ignore this "
-                " check, set the environment variable 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS=1' to continue".format(
-                    kmods=not_supported_kmods
-                )
-            )
 
-    else:
-        logger.info("Kernel modules are compatible.")
 
 def get_loaded_kmods():
     """Get a set of kernel modules loaded on host.

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -404,6 +404,15 @@ def validate_package_manager_transaction():
                 "Only kernel modules supported in RHEL are preferd for conversion, if you want to ignor this "
                 " check, set the environment variable 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' to continue"
             ).format(kmods=not_supported_kmods, system=system_info.name)
+        else:
+            logger.critical(
+                "The following kernel modules are not supported in RHEL:\n{kmods}\n"
+                "Make sure you have updated the kernel to the latest available version and rebooted the system. "
+                "Only kernel modules supported in RHEL are preferred for conversion, if you want to ignore this "
+                " check, set the environment variable 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS=1' to continue".format(
+                    kmods=not_supported_kmods, system=system_info.name
+                )
+            )
 
     else:
         logger.info("Kernel modules are compatible.")

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -382,23 +382,14 @@ def ensure_compatibility_of_kmods():
                 )
             )
 
-<<<<<<< HEAD
-        logger.critical(
-            "The following loaded kernel modules are not available in RHEL:\n{0}\n"
-            "First, make sure you have updated the kernel to the latest available version and rebooted the system.\n"
-            "If this message appears again after doing the above, prevent the modules from loading by following {1}"
-            " and run convert2rhel again to continue with the conversion.".format(
-                not_supported_kmods, LINK_PREVENT_KMODS_FROM_LOADING
-=======
         else:
             logger.critical(
                 "The following loaded kernel modules are not available in RHEL:\n{0}\n"
                 "First, make sure you have updated the kernel to the latest available version and rebooted the system.\n"
                 "If this message appears again after doing the above, prevent the modules from loading by following {1}"
                 " and run convert2rhel again to continue with the conversion.".format(
-                    "\n".join(not_supported_kmods), LINK_PREVENT_KMODS_FROM_LOADING
+                    not_supported_kmods, LINK_PREVENT_KMODS_FROM_LOADING
                 )
->>>>>>> cab81a7 (Changed the added code that came from my PR)
             )
 
 

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -407,7 +407,7 @@ def validate_package_manager_transaction():
                 "Make sure you have updated the kernel to the latest available version and rebooted the system. "
                 "Only kernel modules supported in RHEL are preferred for conversion, if you want to ignore this "
                 " check, set the environment variable 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS=1' to continue".format(
-                    kmods=not_supported_kmods, system=system_info.name
+                    kmods=not_supported_kmods
                 )
             )
 

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -462,11 +462,10 @@ def test_ensure_compatibility_of_kmods_check_env(
 
     checks.ensure_compatibility_of_kmods()
     should_be_in_logs = (
-        "The following kernel modules are not supported in RHEL:\n{kmods}\n"
-        "'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable detected, continuing conversion."
+        ".*Detected 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable."
+        " We will continue the conversion, with the following kernel modules that are not supported:.*"
     )
-    
-    assert should_be_in_logs in caplog.records[-1].message
+    assert re.match(should_be_in_logs in caplog.records[-1].message, re.MULTILINE, re.DOTALL)
 
 @pytest.mark.parametrize(
     (

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -438,7 +438,22 @@ def test_ensure_compatibility_of_kmods(
         assert shouldnt_be_in_logs not in caplog.records[-1].message
 
 
-def test_validate_package_manager_transaction(monkeypatch, caplog):
+@centos8
+def test_ensure_compatibility_of_kmods_check_env(
+    monkeypatch,
+    pretend_os,
+    caplog,
+):
+
+    monkeypatch.setattr(os, "environ", {"CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS": "1"})
+    monkeypatch.setattr(checks, "get_loaded_kmods", mock.Mock(return_value=HOST_MODULES_STUB_BAD))
+    run_subprocess_mock = mock.Mock(
+        side_effect=run_subprocess_side_effect(
+            (("uname",), ("5.8.0-7642-generic\n", 0)),
+            (("repoquery", "-f"), (REPOQUERY_F_STUB_GOOD, 0)),
+            (("repoquery", "-l"), (REPOQUERY_L_STUB_GOOD, 0)),
+        )
+    )
     monkeypatch.setattr(
         checks.pkgmanager,
         "create_transaction_handler",

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -446,7 +446,7 @@ def test_ensure_compatibility_of_kmods_check_env(
     caplog,
 ):
 
-    monkeypatch.setattr(os, "environ", {"CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS": "1"})
+    monkeypatch.setattr(os, "environ", {"CONVERT2RHEL_ALLOW_UNCHECKED_KMODS": "1"})
     monkeypatch.setattr(checks, "get_loaded_kmods", mock.Mock(return_value=HOST_MODULES_STUB_BAD))
     run_subprocess_mock = mock.Mock(
         side_effect=run_subprocess_side_effect(

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -466,7 +466,7 @@ def test_ensure_compatibility_of_kmods_check_env(
         ".*Detected 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable."
         " We will continue the conversion, with the following kernel modules that are not supported:.*"
     )
-    assert re.match(should_be_in_logs in caplog.records[-1].message, re.MULTILINE, re.DOTALL)
+    assert re.match(pattern=should_be_in_logs, string=caplog.records[-1].message, flags=re.MULTILINE | re.DOTALL)
 
 
 @pytest.mark.parametrize(

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -438,7 +438,6 @@ def test_ensure_compatibility_of_kmods(
     if shouldnt_be_in_logs:
         assert shouldnt_be_in_logs not in caplog.records[-1].message
 
-
 @centos8
 def test_ensure_compatibility_of_kmods_check_env(
     monkeypatch,
@@ -463,11 +462,11 @@ def test_ensure_compatibility_of_kmods_check_env(
 
     checks.ensure_compatibility_of_kmods()
     should_be_in_logs = (
-        ".*Detected 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable."
-        " We will continue the conversion, with the following kernel modules that are not supported:.*"
+        "The following kernel modules are not supported in RHEL:\n{kmods}\n"
+        "'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable detected, continuing conversion."
     )
-    assert re.match(should_be_in_logs in caplog.records[-1].message, re.MULTILINE, re.DOTALL)
-
+    
+    assert should_be_in_logs in caplog.records[-1].message
 
 @pytest.mark.parametrize(
     (

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -438,10 +438,7 @@ def test_ensure_compatibility_of_kmods(
     if shouldnt_be_in_logs:
         assert shouldnt_be_in_logs not in caplog.records[-1].message
 
-<<<<<<< HEAD
-=======
 
->>>>>>> f6871e0 (Changed the log messages for the envar case)
 @centos8
 def test_ensure_compatibility_of_kmods_check_env(
     monkeypatch,
@@ -470,6 +467,7 @@ def test_ensure_compatibility_of_kmods_check_env(
         " We will continue the conversion, with the following kernel modules that are not supported:.*"
     )
     assert re.match(should_be_in_logs in caplog.records[-1].message, re.MULTILINE, re.DOTALL)
+
 
 @pytest.mark.parametrize(
     (

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -463,7 +463,7 @@ def test_ensure_compatibility_of_kmods_check_env(
 
     checks.ensure_compatibility_of_kmods()
     should_be_in_logs = (
-        ".*Detected 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable."
+        ".*Detected 'CONVERT2RHEL_ALLOW_UNCHECKED_KMODS' environment variable."
         " We will continue the conversion, with the following kernel modules:.*"
     )
     assert re.match(pattern=should_be_in_logs, string=caplog.records[-1].message, flags=re.MULTILINE | re.DOTALL)

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -464,7 +464,7 @@ def test_ensure_compatibility_of_kmods_check_env(
     checks.ensure_compatibility_of_kmods()
     should_be_in_logs = (
         ".*Detected 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable."
-        " We will continue the conversion, with the following kernel modules that are not supported:.*"
+        " We will continue the conversion, with the following kernel modules:.*"
     )
     assert re.match(pattern=should_be_in_logs, string=caplog.records[-1].message, flags=re.MULTILINE | re.DOTALL)
 

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -437,7 +437,6 @@ def test_ensure_compatibility_of_kmods(
     if shouldnt_be_in_logs:
         assert shouldnt_be_in_logs not in caplog.records[-1].message
 
-
 @centos8
 def test_ensure_compatibility_of_kmods_check_env(
     monkeypatch,
@@ -455,13 +454,18 @@ def test_ensure_compatibility_of_kmods_check_env(
         )
     )
     monkeypatch.setattr(
-        checks.pkgmanager,
-        "create_transaction_handler",
-        value=mock.Mock(),
+        checks,
+        "run_subprocess",
+        value=run_subprocess_mock,
     )
 
-    checks.validate_package_manager_transaction()
-
+    checks.ensure_compatibility_of_kmods()
+    should_be_in_logs = (
+        "The following kernel modules are not supported in RHEL:\n{kmods}\n"
+        "'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable detected, continuing conversion."
+    )
+    
+    assert should_be_in_logs in caplog.records[-1].message
 
 @pytest.mark.parametrize(
     (

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -438,6 +438,10 @@ def test_ensure_compatibility_of_kmods(
     if shouldnt_be_in_logs:
         assert shouldnt_be_in_logs not in caplog.records[-1].message
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> f6871e0 (Changed the log messages for the envar case)
 @centos8
 def test_ensure_compatibility_of_kmods_check_env(
     monkeypatch,

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import os
+import re
 import unittest
 
 from collections import namedtuple
@@ -461,11 +462,10 @@ def test_ensure_compatibility_of_kmods_check_env(
 
     checks.ensure_compatibility_of_kmods()
     should_be_in_logs = (
-        "The following kernel modules are not supported in RHEL:\n{kmods}\n"
-        "'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable detected, continuing conversion."
+        ".*Detected 'CONVERT2RHEL_UNSUPPORTED_UNCHECKED_KMODS' environment variable."
+        " We will continue the conversion, with the following kernel modules that are not supported:.*"
     )
-    
-    assert should_be_in_logs in caplog.records[-1].message
+    assert re.match(should_be_in_logs in caplog.records[-1].message, re.MULTILINE, re.DOTALL)
 
 @pytest.mark.parametrize(
     (


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
This PR allows the user to convert using kmods that are not signed by Red Hat, though this conversion would not be supported. 

In this PR the code has been changed to add an environment variable, as well as a case for when the user has activated the envar. The original log message has been changed as well to reflect this. The unit test has been added for this as well.

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-244](https://issues.redhat.com/browse/RHELC-244)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
