### PR TITLE
Build images locally as default option

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run pytest coverage
         run: |
-          make tests${{ matrix.centos_ver }} PYTEST_ARGS="--cov --cov-report xml --cov-report term" KEEP_TEST_CONTAINER=1
+          make tests${{ matrix.centos_ver }} PYTEST_ARGS="--cov --cov-report xml --cov-report term" KEEP_TEST_CONTAINER=1 BUILD_IMAGES=0
           podman cp pytest-container:/data/coverage.xml .
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,4 +31,4 @@ jobs:
 
       - name: Run command
         run: |
-          make tests${{ matrix.centos_ver }}
+          make tests${{ matrix.centos_ver }} BUILD_IMAGES=0

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 cover/
 .coverage
+coverage.xml
 dist/
 SRPMS/
 *.egg-info/
@@ -9,6 +10,7 @@ system_tests/vmdefs/centos*/.vagrant/
 *.copr.conf
 .vscode/*
 .venv/*
+.build-images
 .install
 .images
 .pre-commit

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ VENV ?= .venv3
 PRE_COMMIT ?= pre-commit
 SHOW_CAPTURE ?= no
 PYTEST_ARGS ?=
+BUILD_IMAGES ?= 1
 
 ifdef KEEP_TEST_CONTAINER
   DOCKER_RM_CONTAINER =
@@ -83,7 +84,7 @@ clean:
 	@find . -name '*.pyc' -exec rm -f {} +
 	@find . -name '*.pyo' -exec rm -f {} +
 
-ifdef BUILD_IMAGES
+ifeq ($(BUILD_IMAGES), 1)
 images: .build-images
 IMAGE=$(IMAGE_ORG)/$(IMAGE_PREFIX)
 else


### PR DESCRIPTION
Turning the `BUILD_IMAGES=1` to be the default option when running make commands locally, and turning this setting off when running inside the CI.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-]()

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
