### PR TITLE
[RHELC-745] Fix conversion with "LANGUAGE" envar 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,14 @@
 minimum_pre_commit_version: "2.9.0"
 repos:
-  - repo: "https://github.com/psf/black"
-    rev: "21.12b0"
+  - repo: local
     hooks:
-      - id: "black"
-        name: "Format code (black)"
+      - id: black
+        name: black
+        entry: black
+        types: [python]
+        language: python
         language_version: "python3"
-        additional_dependencies: [click==7.1.2]
+        additional_dependencies: [click==7.1.2, black==21.12b0]
         args:
           - "--target-version=py27"
           - "--target-version=py36"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,21 +2,26 @@ minimum_pre_commit_version: "2.9.0"
 repos:
   - repo: local
     hooks:
-      - id: black
-        name: black
-        entry: black
-        types: [python]
-        language: python
-        language_version: "python3"
-        additional_dependencies: [click==7.1.2, black==21.12b0]
-        args:
-          - "--target-version=py27"
-          - "--target-version=py36"
-          - "--target-version=py37"
-          - "--target-version=py38"
-          - "--target-version=py39"
-          - "--target-version=py310"
-
+    - id: black
+      name: black
+      entry: black
+      types: [python]
+      language: python
+      language_version: "python3"
+      additional_dependencies: [click==7.1.2, black==21.12b0]
+  - repo: local
+    hooks:
+    - id: pylint
+      name: pylint
+      entry: pylint
+      types: [python]
+      language: python
+      additional_dependencies: [pylint==2.15.10]
+      args:
+        [
+          "-sn", # Don't display the score
+          "--rcfile=.pylintrc", # Link to your config file
+        ]
   - repo: "https://github.com/timothycrosley/isort"
     rev: 5.11.4
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,27 +1,20 @@
 minimum_pre_commit_version: "2.9.0"
 repos:
-  - repo: local
+  - repo: "https://github.com/psf/black"
+    rev: "21.12b0"
     hooks:
-    - id: black
-      name: black
-      entry: black
-      types: [python]
-      language: python
-      language_version: "python3"
-      additional_dependencies: [click==7.1.2, black==21.12b0]
-  - repo: local
-    hooks:
-    - id: pylint
-      name: pylint
-      entry: pylint
-      types: [python]
-      language: python
-      additional_dependencies: [pylint==2.15.10]
-      args:
-        [
-          "-sn", # Don't display the score
-          "--rcfile=.pylintrc", # Link to your config file
-        ]
+      - id: "black"
+        name: "Format code (black)"
+        language_version: "python3"
+        additional_dependencies: [click==7.1.2]
+        args:
+          - "--target-version=py27"
+          - "--target-version=py36"
+          - "--target-version=py37"
+          - "--target-version=py38"
+          - "--target-version=py39"
+          - "--target-version=py310"
+
   - repo: "https://github.com/timothycrosley/isort"
     rev: 5.11.4
     hooks:

--- a/.pylintrc
+++ b/.pylintrc
@@ -8,6 +8,10 @@ function-rgx=[a-z_][a-z0-9_]{2,50}$
 disable=
 # do not warn about pylint checks being disabled through comments in the code
  locally-disabled,
+# These are false positives because they refer to features which are unusable
+# on the versions of python we support.
+ redundant-u-string-prefix,  # Python 3.0+
+ consider-using-f-string,  # Python 3.6+
 # These are our current failures 2023-01-11.  We can go through them and either
 # fix them or add a comment to say why we are leaving it disabled.
  anomalous-backslash-in-string,

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -868,7 +868,7 @@ class DummyPopenOutput(unit_tests.MockFunction):
             return b""
 
         self.call_count += 1
-        return next_line
+        return next_line + b""
 
     def communicate(self):
         pass

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -868,7 +868,7 @@ class DummyPopenOutput(unit_tests.MockFunction):
             return b""
 
         self.call_count += 1
-        return next_line + b""
+        return next_line
 
     def communicate(self):
         pass

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -150,9 +150,10 @@ def run_subprocess(cmd, print_cmd=True, print_output=True):
     )
     output = ""
     for line in iter(process.stdout.readline, b""):
-        output += line.decode()
+        line = line.decode("utf8")
+        output += line
         if print_output:
-            loggerinst.info(line.decode().rstrip("\n"))
+            loggerinst.info(line.rstrip("\n"))
 
     # Call communicate() to wait for the process to terminate so that we can get the return code by poll().
     # It's just for py2.6, py2.7+/3 doesn't need this.
@@ -203,7 +204,11 @@ def run_cmd_in_pty(cmd, expect_script=(), print_cmd=True, print_output=True, col
     process = PexpectSpawnWithDimensions(
         cmd[0],
         cmd[1:],
-        env={"LC_ALL": i18n.SCREENSCRAPED_LOCALE, "LANG": i18n.SCREENSCRAPED_LOCALE},
+        env={
+            "LC_ALL": i18n.SCREENSCRAPED_LOCALE,
+            "LANG": i18n.SCREENSCRAPED_LOCALE,
+            "LANGUAGE": i18n.SCREENSCRAPED_LOCALE,
+        },
         timeout=None,
         dimensions=(1, columns),
     )
@@ -665,7 +670,13 @@ def set_locale():
     We need to be setting not only LC_ALL but LANG as well because subscription-manager considers LANG to have priority
     over LC_ALL even though it goes against POSIX which specifies that LC_ALL overrides LANG.
     """
-    os.environ.update({"LC_ALL": i18n.SCREENSCRAPED_LOCALE, "LANG": i18n.SCREENSCRAPED_LOCALE})
+    os.environ.update(
+        {
+            "LC_ALL": i18n.SCREENSCRAPED_LOCALE,
+            "LANG": i18n.SCREENSCRAPED_LOCALE,
+            "LANGUAGE": i18n.SCREENSCRAPED_LOCALE,
+        }
+    )
 
 
 def string_to_version(verstring):

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -150,7 +150,7 @@ def run_subprocess(cmd, print_cmd=True, print_output=True):
     )
     output = ""
     for line in iter(process.stdout.readline, b""):
-        line.decode("utf8")
+        line = line.decode("utf8")
         output += line
         if print_output:
             loggerinst.info(line.rstrip("\n"))

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -150,7 +150,7 @@ def run_subprocess(cmd, print_cmd=True, print_output=True):
     )
     output = ""
     for line in iter(process.stdout.readline, b""):
-        line = line.decode("utf8")
+        line.decode("utf8")
         output += line
         if print_output:
             loggerinst.info(line.rstrip("\n"))

--- a/tests/integration/tier1/set-locale/use_non_english_language.py
+++ b/tests/integration/tier1/set-locale/use_non_english_language.py
@@ -12,9 +12,9 @@ def test_use_non_english_language(shell):
     if "centos-8" in os or "oracle-8" in os:
         assert shell("dnf install glibc-langpack-zh -y").returncode == 0
 
-    # set LANG to Chinese
+    # set locale variables that affect translations to Chinese
     assert shell("localectl list-locales | grep zh_CN.utf8").returncode == 0
-    assert shell("localectl set-locale LANG=zh_CN.utf8").returncode == 0
+    assert shell("localectl set-locale LANG=zh_CN.utf8 LC_MESSAGES=zh_CN.utf8 LANGUAGE=zh_CN").returncode == 0
 
     # Testing farm is returning an error on CentOS7 mentioning
     # setting incompatible LC_CTYPE C.UTF-8.


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
This PR fixes the conversion when you set the "LANGUAGE" envar, because currently you would run into an traceback.

in this PR:
- utf-8 will beset as the default codec to fix the traceback
- "LANGUAGE" will be added to the set of envar alonge with "LC_ALL" and "LANG" 

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-745](https://issues.redhat.com/browse/RHELC-745)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
