### PR TITLE
[RHELC-689] Verification test - Latest kernel check: Handle unsuccessful repoquery call

### DIFF
--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -62,5 +62,8 @@
     test: check-internet-connection
 
 /latest_kernel_check_failed_repoquery:
-  discover+:
-    test: verify-latest-kernel-check-with-failed-repoquery
+    adjust+:
+        enabled: false
+        when: distro == oraclelinux-8.4
+    discover+:
+        test: verify-latest-kernel-check-with-failed-repoquery

--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -60,3 +60,10 @@
 /check_internet_connection:
   discover+:
     test: check-internet-connection
+
+/latest_kernel_check_failed_repoquery:
+  discover+:
+    test: verify-latest-kernel-check-with-failed-repoquery
+  adjust:
+    enabled: false
+    when: distro == oraclelinux-8.4

--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -64,6 +64,3 @@
 /latest_kernel_check_failed_repoquery:
   discover+:
     test: verify-latest-kernel-check-with-failed-repoquery
-  adjust:
-    enabled: false
-    when: distro == oraclelinux-8.4

--- a/tests/integration/tier0/verify-latest-kernel-check-with-failed-repoquery/files/broken_repo.repo
+++ b/tests/integration/tier0/verify-latest-kernel-check-with-failed-repoquery/files/broken_repo.repo
@@ -1,0 +1,5 @@
+[broken_repo]
+name=Broken repository for verification test purposes
+baseurl=http://download.eng.bos.redhat.com/beakerrepos/client/Fedor36/
+enabled=1
+gpgcheck=0

--- a/tests/integration/tier0/verify-latest-kernel-check-with-failed-repoquery/main.fmf
+++ b/tests/integration/tier0/verify-latest-kernel-check-with-failed-repoquery/main.fmf
@@ -4,7 +4,14 @@ tier: 0
 
 tag+:
   - kernel
-  - repo
+  - repository
 
-test: |
-  pytest -svv
+adjust+:
+    enabled: false
+    when: distro == oraclelinux-8.4
+
+/latest_kernel_check_with_failed_repoquery:
+    tag+:
+        - latest_kernel_check_with_failed_repoquery
+    test: |
+        pytest -svv -m latest_kernel_check_with_failed_repoquery

--- a/tests/integration/tier0/verify-latest-kernel-check-with-failed-repoquery/main.fmf
+++ b/tests/integration/tier0/verify-latest-kernel-check-with-failed-repoquery/main.fmf
@@ -1,0 +1,10 @@
+summary: Verify that failed repoquery call does not cause latest kernel check call.
+
+tier: 0
+
+tag+:
+  - kernel
+  - repo
+
+test: |
+  pytest -svv

--- a/tests/integration/tier0/verify-latest-kernel-check-with-failed-repoquery/main.fmf
+++ b/tests/integration/tier0/verify-latest-kernel-check-with-failed-repoquery/main.fmf
@@ -6,10 +6,6 @@ tag+:
   - kernel
   - repository
 
-adjust+:
-    enabled: false
-    when: distro == oraclelinux-8.4
-
 /latest_kernel_check_with_failed_repoquery:
     tag+:
         - latest_kernel_check_with_failed_repoquery

--- a/tests/integration/tier0/verify-latest-kernel-check-with-failed-repoquery/test_verify_kernel_check_passes.py
+++ b/tests/integration/tier0/verify-latest-kernel-check-with-failed-repoquery/test_verify_kernel_check_passes.py
@@ -1,3 +1,5 @@
+import platform
+
 import pytest
 
 
@@ -8,15 +10,16 @@ def test_verify_latest_kernel_check_passes_with_failed_repoquery(shell, convert2
     Failed repoquery subsequently caused the latest kernel check to fail.
     Introduced fixes should get the process past the latest kernel check.
     """
-
-    repopath = "/etc/yum.repos.d/tainted_repo.repo"
-    tainted_repo_setup = "[tainted-repo]\nname=Tainted repository\nbaseurl=http://download.eng.bos.redhat.com/beakerrepos/client/Fedor36/\nenabled=1\ngpgcheck=0"
+    get_system_release = platform.platform()
+    repofile = "broken_repo"
 
     # Add a tainted repository with intentionally bad baseurl so the repoquery fails successfully.
-    with open(repopath, "w") as tainted_repo:
-        tainted_repo.write(tainted_repo_setup)
-
-    assert shell(f"cat {repopath}").output == tainted_repo_setup
+    # For CentOS EUS we are working with hardcoded repos in /usr/share/convert2rhel/repos/
+    # We are skipping (at the test metadata level) the test for Oracle Linux EUS version,
+    # as the repositories are not available at all
+    if "centos-8.4" in get_system_release:
+        shell(f"cp -r files/{repofile}.repo /usr/share/convert2rhel/repos/")
+    shell(f"cp -r files/{repofile}.repo /etc/yum.repos.d/")
 
     # Run the conversion just past the latest kernel check, if successful, end the conversion there.
     with convert2rhel("--debug --no-rpm-va") as c2r:
@@ -34,4 +37,6 @@ def test_verify_latest_kernel_check_passes_with_failed_repoquery(shell, convert2
     assert c2r.exitstatus != 0
 
     # Cleanup the tainted repository.
-    assert shell(f"rm -f {repopath}").returncode == 0
+    if "centos-8.4" in get_system_release:
+        assert shell(f"rm -f /usr/share/convert2rhel/repos/{repofile}.repo") == 0
+    assert shell(f"rm -f /etc/yum.repos.d/{repofile}.repo").returncode == 0

--- a/tests/integration/tier0/verify-latest-kernel-check-with-failed-repoquery/test_verify_kernel_check_passes.py
+++ b/tests/integration/tier0/verify-latest-kernel-check-with-failed-repoquery/test_verify_kernel_check_passes.py
@@ -12,13 +12,19 @@ def test_verify_latest_kernel_check_passes_with_failed_repoquery(shell, convert2
     """
     get_system_release = platform.platform()
     repofile = "broken_repo"
+    centos_custom_reposdir = "/usr/share/convert2rhel/repos/"
 
     # Add a tainted repository with intentionally bad baseurl so the repoquery fails successfully.
-    # For CentOS EUS we are working with hardcoded repos in /usr/share/convert2rhel/repos/
+    # For CentOS we are working with hardcoded repos in /usr/share/convert2rhel/repos/centos-8.{4,5}
     # We are skipping (at the test metadata level) the test for Oracle Linux EUS version,
     # as the repositories are not available at all
+
+    # TODO after the #619 gets merged, squash condition to centos-8 only
+    # TODO and copy to {centos_custom_reposdir}/{get_system_release}/
     if "centos-8.4" in get_system_release:
-        shell(f"cp -r files/{repofile}.repo /usr/share/convert2rhel/repos/")
+        shell(f"cp -r files/{repofile}.repo {centos_custom_reposdir}/centos-8.4/")
+    elif "centos-8.5" in get_system_release:
+        shell(f"cp -r files/{repofile}.repo {centos_custom_reposdir}/centos-8.5/")
     shell(f"cp -r files/{repofile}.repo /etc/yum.repos.d/")
 
     # Run the conversion just past the latest kernel check, if successful, end the conversion there.
@@ -38,5 +44,7 @@ def test_verify_latest_kernel_check_passes_with_failed_repoquery(shell, convert2
 
     # Cleanup the tainted repository.
     if "centos-8.4" in get_system_release:
-        assert shell(f"rm -f /usr/share/convert2rhel/repos/{repofile}.repo") == 0
+        assert shell(f"rm -f {centos_custom_reposdir}/centos-8.4/{repofile}.repo").returncode == 0
+    if "centos-8.5" in get_system_release:
+        assert shell(f"rm -f {centos_custom_reposdir}/centos-8.5/{repofile}.repo").returncode == 0
     assert shell(f"rm -f /etc/yum.repos.d/{repofile}.repo").returncode == 0

--- a/tests/integration/tier0/verify-latest-kernel-check-with-failed-repoquery/test_verify_kernel_check_passes.py
+++ b/tests/integration/tier0/verify-latest-kernel-check-with-failed-repoquery/test_verify_kernel_check_passes.py
@@ -1,0 +1,27 @@
+def test_verify_latest_kernel_check_passes_with_failed_repoquery(shell, convert2rhel):
+    """
+    This test verifies, that failed repoquery is handled correctly.
+    Failed repoquery subsequently caused the latest kernel check to fail.
+    Introduced fixes should get the process past the latest kernel check.
+    """
+
+    repopath = "/etc/yum.repos.d/beaker.repo"
+
+    # Add a tainted repository with intentionally bad baseurl so the repoquery fails successfully.
+    assert shell(f"touch {repopath}").returncode == 0
+    assert (
+        shell(
+            "printf '[beaker-client]\nname=Beaker Client - Fedora36\nbaseurl=http://download.eng.bos.redhat.com/\nenabled=1\ngpgcheck=0' > /etc/yum.repos.d/beaker.repo"
+        )
+    ).returncode == 0
+
+    # Run the conversion just past the latest kernel check, if successful, end the conversion there.
+    with convert2rhel("--debug --no-rpm-va") as c2r:
+        assert c2r.expect("Continue with the system conversion?", timeout=300) == 0
+        c2r.sendline("y")
+        assert c2r.expect("Continue with the system conversion?", timeout=300) == 0
+        c2r.sendline("n")
+    assert c2r.exitstatus != 0
+
+    # Cleanup the tainted repository.
+    assert shell(f"rm -f {repopath}").returncode == 0

--- a/tests/integration/tier0/verify-latest-kernel-check-with-failed-repoquery/test_verify_kernel_check_passes.py
+++ b/tests/integration/tier0/verify-latest-kernel-check-with-failed-repoquery/test_verify_kernel_check_passes.py
@@ -1,3 +1,7 @@
+import pytest
+
+
+@pytest.mark.latest_kernel_check_with_failed_repoquery
 def test_verify_latest_kernel_check_passes_with_failed_repoquery(shell, convert2rhel):
     """
     This test verifies, that failed repoquery is handled correctly.
@@ -5,20 +9,26 @@ def test_verify_latest_kernel_check_passes_with_failed_repoquery(shell, convert2
     Introduced fixes should get the process past the latest kernel check.
     """
 
-    repopath = "/etc/yum.repos.d/beaker.repo"
+    repopath = "/etc/yum.repos.d/tainted_repo.repo"
+    tainted_repo_setup = "[tainted-repo]\nname=Tainted repository\nbaseurl=http://download.eng.bos.redhat.com/beakerrepos/client/Fedor36/\nenabled=1\ngpgcheck=0"
 
     # Add a tainted repository with intentionally bad baseurl so the repoquery fails successfully.
-    assert shell(f"touch {repopath}").returncode == 0
-    assert (
-        shell(
-            "printf '[beaker-client]\nname=Beaker Client - Fedora36\nbaseurl=http://download.eng.bos.redhat.com/\nenabled=1\ngpgcheck=0' > /etc/yum.repos.d/beaker.repo"
-        )
-    ).returncode == 0
+    with open(repopath, "w") as tainted_repo:
+        tainted_repo.write(tainted_repo_setup)
+
+    assert shell(f"cat {repopath}").output == tainted_repo_setup
 
     # Run the conversion just past the latest kernel check, if successful, end the conversion there.
     with convert2rhel("--debug --no-rpm-va") as c2r:
         assert c2r.expect("Continue with the system conversion?", timeout=300) == 0
         c2r.sendline("y")
+        assert (
+            c2r.expect(
+                "Couldn't fetch the list of the most recent kernels available in the repositories. Skipping the loaded kernel check.",
+                timeout=300,
+            )
+            == 0
+        )
         assert c2r.expect("Continue with the system conversion?", timeout=300) == 0
         c2r.sendline("n")
     assert c2r.exitstatus != 0


### PR DESCRIPTION
Add a verification test with intentionally tainted repository to verify handling unsuccessful repoquery.

Signed-off-by: Daniel Diblik <ddiblik@redhat.com>

* add verification test for #557
* tested with old build and build for PR#557

Jira Issue: [RHELC-689](https://issues.redhat.com/browse/RHELC-689)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
