### PR TITLE
[RHELC-749] Add tmt-lint to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,8 @@ repos:
       - id: "check-toml"
       - id: "check-yaml"
       - id: "check-merge-conflict"
+
+  - repo: "https://github.com/teemtee/tmt"
+    rev: main
+    hooks:
+      - id: tmt-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,7 @@ repos:
       - id: "check-toml"
       - id: "check-yaml"
       - id: "check-merge-conflict"
-
-  - repo: "https://github.com/teemtee/tmt"
-    rev: main
+  - repo: "https://github.com/teemtee/tmt.git"
+    rev: "1.17.0"
     hooks:
       - id: tmt-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,4 +26,4 @@ repos:
   - repo: "https://github.com/teemtee/tmt.git"
     rev: "1.17.0"
     hooks:
-      - id: tmt-lint
+      - id: "tmt-tests-lint"


### PR DESCRIPTION
Add tmt-lint to verify correct fmf syntax.

For now introduce tmt-tests-lint, once we move away from GitLab hosted values, add tmt-plans-lint which is now failing due to SSL error whilst trying to reach to internal GitLab.

[RHELC-749](https://issues.redhat.com/browse/RHELC-749)

Signed-off-by: Daniel Diblik <ddiblik@redhat.com>


