### PR TITLE
[RHELC-39] fix: allow CI systems to disable color

### DIFF
--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -128,6 +128,11 @@ def setup_logger_handler(log_name, log_dir):
 
 
 def should_disable_color_output():
+    """
+    Return whether NO_COLOR exists in environment parameter and is true.
+
+    See http://no-color.org/
+    """
     if "NO_COLOR" in os.environ:
         NO_COLOR = os.environ["NO_COLOR"]
         return NO_COLOR != None and NO_COLOR != "0" and NO_COLOR.lower() != "false"

--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -113,7 +113,7 @@ def setup_logger_handler(log_name, log_dir):
     # create sys.stdout handler for info/debug
     stdout_handler = logging.StreamHandler(sys.stdout)
     formatter = CustomFormatter("%(message)s")
-    formatter.disable_colors(tool_opts.disable_colors)
+    formatter.disable_colors(should_disable_color_output())
     stdout_handler.setFormatter(formatter)
     stdout_handler.setLevel(logging.DEBUG)
     logger.addHandler(stdout_handler)
@@ -128,6 +128,13 @@ def setup_logger_handler(log_name, log_dir):
     handler.setLevel(LogLevelFile.level)
     logger.addHandler(handler)
 
+
+def should_disable_color_output():
+    if "NO_COLOR" in os.environ:
+        NO_COLOR = os.environ["NO_COLOR"]
+        return NO_COLOR != None and NO_COLOR != "0" and NO_COLOR.lower() != "false"
+
+    return False
 
 def archive_old_logger_files(log_name, log_dir):
     """Archive the old log files to not mess with multiple runs outputs.

--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -32,8 +32,6 @@ import sys
 
 from time import gmtime, strftime
 
-from convert2rhel.toolopts import tool_opts
-
 
 LOG_DIR = "/var/log/convert2rhel"
 

--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -136,6 +136,7 @@ def should_disable_color_output():
 
     return False
 
+
 def archive_old_logger_files(log_name, log_dir):
     """Archive the old log files to not mess with multiple runs outputs.
     Every time a new run begins, this method will be called to archive the previous logs

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -54,7 +54,6 @@ class ToolOpts(object):
         self.org = None
         self.arch = None
         self.no_rpm_va = False
-        self.disable_colors = False
         self.keep_rhsm = False
 
         # set True when credentials (username & password) are given through CLI
@@ -307,9 +306,6 @@ class CLI(object):
         # password from CLI has precedence and activation-key must be deleted (unused)
         if config_opts.activation_key and (parsed_opts.password or parsed_opts.password_from_file):
             tool_opts.activation_key = None
-
-        if parsed_opts.disable_colors:
-            tool_opts.disable_colors = True
 
         if parsed_opts.no_rpm_va:
             tool_opts.no_rpm_va = True

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -83,11 +83,11 @@ class CLI(object):
             "  convert2rhel [--version]\n"
             "  convert2rhel [-u username] [-p password | -c conf_file_path] [--pool pool_id | -a] [--disablerepo repoid]"
             " [--enablerepo repoid] [--serverurl url] [--keep-rhsm] [--no-rpm-va] [--debug] [--restart]"
-            " [--disable-colors] [-y]\n"
+            " [-y]\n"
             "  convert2rhel [--no-rhsm] [--disablerepo repoid]"
-            " [--enablerepo repoid] [--no-rpm-va] [--debug] [--restart] [--disable-colors] [-y]\n"
+            " [--enablerepo repoid] [--no-rpm-va] [--debug] [--restart] [-y]\n"
             "  convert2rhel [-k activation_key | -c conf_file_path] [-o organization] [--pool pool_id | -a] [--disablerepo repoid] [--enablerepo"
-            " repoid] [--serverurl url] [--keep-rhsm] [--no-rpm-va] [--debug] [--restart] [--disable-colors] [-y]"
+            " repoid] [--serverurl url] [--keep-rhsm] [--no-rpm-va] [--debug] [--restart] [-y]"
             "\n\n"
             "WARNING: The tool needs to be run under the root user"
         )
@@ -115,11 +115,6 @@ class CLI(object):
             "--debug",
             action="store_true",
             help="Print traceback in case of an abnormal exit and messages that could help find an issue.",
-        )
-        self._parser.add_option(
-            "--disable-colors",
-            action="store_true",
-            help="Disable color output",
         )
         # Importing here instead of on top of the file to avoid cyclic dependency
         from convert2rhel.systeminfo import POST_RPM_VA_LOG_FILENAME, PRE_RPM_VA_LOG_FILENAME

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -116,6 +116,7 @@ def test_archive_old_logger_files(log_name, path_exists, tmpdir, caplog):
 
     assert not os.path.exists(log_file)
 
+
 @pytest.mark.parametrize(
     ("0", True),
     ("False", True),

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -118,12 +118,15 @@ def test_archive_old_logger_files(log_name, path_exists, tmpdir, caplog):
 
 
 @pytest.mark.parametrize(
-    ("0", True),
-    ("False", True),
-    (None, True),
-    ("1", False),
-    ("True", False),
-    ("foobar", False),
+    ("no_color_value", "should_disable_color"),
+    (
+        ("0", True),
+        ("False", True),
+        (None, True),
+        ("1", False),
+        ("True", False),
+        ("foobar", False)
+    )
 )
 def test_should_disable_color_output(monkeypatch, no_color_value, should_disable_color):
     monkeypatch.setattr(os, "environ", {"NO_COLOR": no_color_value})

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -24,8 +24,8 @@ from convert2rhel import logger as logger_module
 
 
 def test_logger_handlers(monkeypatch, tmpdir, caplog, read_std, is_py2, global_tool_opts, clear_loggers):
-    """Test if the logger handlers emmits the events to the file and stdout."""
-    monkeypatch.setattr(logger_module, "tool_opts", global_tool_opts)
+    """Test if the logger handlers emits the events to the file and stdout."""
+    monkeypatch.setattr("convert2rhel.toolopts.tool_opts", global_tool_opts)
 
     # initializing the logger first
     log_fname = "convert2rhel.log"
@@ -119,7 +119,7 @@ def test_archive_old_logger_files(log_name, path_exists, tmpdir, caplog):
 
 @pytest.mark.parametrize(
     ("no_color_value", "should_disable_color"),
-    (("0", True), ("False", True), (None, True), ("1", False), ("True", False), ("foobar", False)),
+    (("0", False), ("False", False), (None, False), ("1", True), ("True", True), ("foobar", True)),
 )
 def test_should_disable_color_output(monkeypatch, no_color_value, should_disable_color):
     monkeypatch.setattr(os, "environ", {"NO_COLOR": no_color_value})

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -49,7 +49,7 @@ def test_logger_handlers(monkeypatch, tmpdir, caplog, read_std, is_py2, global_t
 
 
 def test_tools_opts_debug(monkeypatch, tmpdir, read_std, is_py2, global_tool_opts, clear_loggers):
-    monkeypatch.setattr(logger_module, "tool_opts", global_tool_opts)
+    monkeypatch.setattr("convert2rhel.toolopts.tool_opts", global_tool_opts)
     log_fname = "convert2rhel.log"
     logger_module.setup_logger_handler(log_name=log_fname, log_dir=str(tmpdir))
     logger = logging.getLogger(__name__)

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -119,14 +119,7 @@ def test_archive_old_logger_files(log_name, path_exists, tmpdir, caplog):
 
 @pytest.mark.parametrize(
     ("no_color_value", "should_disable_color"),
-    (
-        ("0", True),
-        ("False", True),
-        (None, True),
-        ("1", False),
-        ("True", False),
-        ("foobar", False)
-    )
+    (("0", True), ("False", True), (None, True), ("1", False), ("True", False), ("foobar", False)),
 )
 def test_should_disable_color_output(monkeypatch, no_color_value, should_disable_color):
     monkeypatch.setattr(os, "environ", {"NO_COLOR": no_color_value})

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -115,3 +115,15 @@ def test_archive_old_logger_files(log_name, path_exists, tmpdir, caplog):
             assert archive_f.read() == test_data
 
     assert not os.path.exists(log_file)
+
+@pytest.mark.parametrize(
+    ("0", True),
+    ("False", True),
+    (None, True),
+    ("1", False),
+    ("True", False),
+    ("foobar", False),
+)
+def test_should_disable_color_output(monkeypatch, no_color_value, should_disable_color):
+    monkeypatch.setattr(os, "environ", {"NO_COLOR": no_color_value})
+    assert logger_module.should_disable_color_output() == should_disable_color


### PR DESCRIPTION
We had an issue before where we couldn't disable color output for systems that don't have color functionality. This meant output could look very cluttered

With this change we reimplement it using `NO_COLOR` environment variable
http://no-color.org/

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-39](https://issues.redhat.com/browse/RHELC-39)

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
