### PR TITLE
[RHELC-760] Increase the line length in a pseudo-terminal

### DIFF
--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -156,7 +156,7 @@ def run_subprocess(cmd, print_cmd=True, print_output=True):
     return output, return_code
 
 
-def run_cmd_in_pty(cmd, expect_script=(), print_cmd=True, print_output=True, columns=120):
+def run_cmd_in_pty(cmd, expect_script=(), print_cmd=True, print_output=True, columns=150):
     """Similar to run_subprocess(), but the command is executed in a pseudo-terminal.
 
     The pseudo-terminal can be useful when a command prints out a different output with or without an active terminal


### PR DESCRIPTION
The name of the rpm we download during a package backup can be so long that the length of the line of 120 characters we set in the pseudo-terminal may not be sufficient. If the downloaded package file name (NEVRA.rpm) is too long, the yumdownloader truncates it and then our output parsing fails. That leads to not tracking the downloaded package and, more importantly, not installing the package back during a rollback.

Real world example of a truncated rpm name:
`libvirt-daemon-driver-storage-core-8.0.0-5.4.0.1.module+el8.6.0+20743+999ad699.x86_64.r 326 kB/s | 253 kB     00:00`

Jira Issue: [RHELC-760](https://issues.redhat.com/browse/RHELC-760)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
