### PR TITLE
[DRAFT][RHELC-753] Add tier1 sanity test

### DIFF
--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -328,3 +328,7 @@
   - name: reboot after conversion
     how: ansible
     playbook: tests/ansible_collections/roles/reboot/main.yml
+
+/sanity:
+    discover+:
+        test: sanity

--- a/tests/integration/tier1/sanity/main.fmf
+++ b/tests/integration/tier1/sanity/main.fmf
@@ -1,0 +1,11 @@
+summary: Conversion sanity test
+description: Verify basic conversion with no preparation phase as a sanity test.
+
+tier: 1
+
+tag+:
+    - sanity
+    - basic-conversion
+
+test: |
+    pytest -svv

--- a/tests/integration/tier1/sanity/test_sanity_conversion.py
+++ b/tests/integration/tier1/sanity/test_sanity_conversion.py
@@ -1,0 +1,20 @@
+from envparse import env
+
+
+def test_sanity_conversion(convert2rhel, shell):
+    """
+    Sanity only.
+    Verify successful full conversion.
+    No preparation or adjustments.
+    """
+
+    with convert2rhel(
+        ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        c2r.expect("Conversion successful!")
+    assert c2r.exitstatus == 0


### PR DESCRIPTION
* add a test for basic conversion just to verify sanity

Signed-off-by: Daniel Diblik <ddiblik@redhat.com>

* Test to verify sanity of a full conversion.
* To be possible to run locally 
  * `tmt run -a provision -h connect -g {vm-machine-ip} plans --name /plans/tier1/sanity`
  * `tmt run -a provision -h connect -g {vm-machine-ip} tests --filter 'tier: 1' --filter 'tag: sanity'`

Jira Issue: [RHELC-753](https://issues.redhat.com/browse/RHELC-753)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
