### PR TITLE
[RHELC-16] Do not disable RHSM repos before pkg backup

### DIFF
--- a/convert2rhel/backup.py
+++ b/convert2rhel/backup.py
@@ -328,8 +328,8 @@ class RestorableFile(object):
         try:
             os.remove(self.filepath)
             loggerinst.debug("File %s removed." % self.filepath)
-        except (OSError, IOError, TypeError):
-            loggerinst.debug("Could't remove restored file %s" % self.filepath)
+        except (OSError, IOError):
+            loggerinst.debug("Couldn't remove restored file %s" % self.filepath)
 
 
 class RestorablePackage(object):

--- a/convert2rhel/backup.py
+++ b/convert2rhel/backup.py
@@ -298,10 +298,13 @@ class RestorableFile(object):
         else:
             loggerinst.info("Can't find %s.", self.filepath)
 
-    def restore(self):
+    def restore(self, rollback=True):
         """Restore a previously backed up file"""
         backup_filepath = os.path.join(BACKUP_DIR, os.path.basename(self.filepath))
-        loggerinst.task("Rollback: Restoring %s from backup" % self.filepath)
+        if rollback:
+            loggerinst.task("Rollback: Restoring %s from backup" % self.filepath)
+        else:
+            loggerinst.info("Restoring %s from backup" % self.filepath)
 
         if not os.path.isfile(backup_filepath):
             loggerinst.info("%s hasn't been backed up." % self.filepath)
@@ -314,7 +317,19 @@ class RestorableFile(object):
             # IOError for py2 and OSError for py3
             loggerinst.warning("Error(%s): %s" % (err.errno, err.strerror))
             return
-        loggerinst.info("File %s restored." % self.filepath)
+
+        if rollback:
+            loggerinst.info("File %s restored." % self.filepath)
+        else:
+            loggerinst.debug("File %s restored." % self.filepath)
+
+    def remove(self):
+        """Remove restored file from original place, backup isn't removed"""
+        try:
+            os.remove(self.filepath)
+            loggerinst.debug("File %s removed." % self.filepath)
+        except (OSError, IOError, TypeError):
+            loggerinst.debug("Could't remove restored file %s" % self.filepath)
 
 
 class RestorablePackage(object):

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -222,6 +222,14 @@ def pre_ponr_conversion():
         loggerinst.task("Convert: Install RHEL certificates for RHSM")
         system_cert = cert.SystemCert()
         system_cert.install()
+
+    # remove non-RHEL packages containing repofiles or affecting variables in the repofiles
+    # This needs to be before attempt to unregister the system because after unregistration can be lost
+    # access to repositories needed for backuping removed packages
+    loggerinst.task("Convert: Remove packages containing .repo files")
+    pkghandler.remove_repofile_pkgs()
+
+    if not toolopts.tool_opts.no_rhsm:
         loggerinst.task("Convert: Subscription Manager - Subscribe system")
         subscription.subscribe_system()
         loggerinst.task("Convert: Get RHEL repository IDs")
@@ -230,10 +238,6 @@ def pre_ponr_conversion():
         subscription.check_needed_repos_availability(rhel_repoids)
         loggerinst.task("Convert: Subscription Manager - Disable all repositories")
         subscription.disable_repos()
-
-    # remove non-RHEL packages containing repofiles or affecting variables in the repofiles
-    loggerinst.task("Convert: Remove packages containing .repo files")
-    pkghandler.remove_repofile_pkgs()
 
     # we need to enable repos after removing repofile pkgs, otherwise we don't get backups
     # to restore from on a rollback

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -30,6 +30,7 @@ import dbus.exceptions
 from six.moves import urllib
 
 from convert2rhel import backup, i18n, pkghandler, utils
+from convert2rhel.redhatrelease import os_release_file
 from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts
 
@@ -185,7 +186,15 @@ def register_system():
         registration_cmd = RegistrationCommand.from_tool_opts(tool_opts)
 
         try:
+            # The file /etc/os-release is needed for subscribing the system and is being removed with
+            # <system-name>-release package in one of the steps before
+            # RHELC-16
+            os_release_file.restore(rollback=False)
             registration_cmd()
+            # Need to remove the file, if it would stay there would be leftover /etc/os-release.rpmorig
+            # after conversion
+            # RHELC-16
+            os_release_file.remove()
             loggerinst.info("System registration succeeded.")
         except KeyboardInterrupt:
             # When the user hits Control-C to exit, we shouldn't retry

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -24,7 +24,7 @@ from collections import namedtuple
 
 from six.moves import configparser, urllib
 
-from convert2rhel import logger, pkgmanager, utils
+from convert2rhel import logger, utils
 from convert2rhel.toolopts import tool_opts
 from convert2rhel.utils import run_subprocess
 
@@ -472,6 +472,8 @@ class SystemInfo(object):
 
 def _get_original_releasever():
     """Get the original value for releasever using either YUM or DNF."""
+    from convert2rhel import pkgmanager
+
     original_releasever = ""
     if pkgmanager.TYPE == "yum":
         yb = pkgmanager.YumBase()

--- a/convert2rhel/unit_tests/backup_test.py
+++ b/convert2rhel/unit_tests/backup_test.py
@@ -662,3 +662,26 @@ class TestRestorableRpmKey:
 )
 def test_remove_epoch_from_yum_nevra_notation(pkg_nevra, nvra_without_epoch):
     assert backup.remove_epoch_from_yum_nevra_notation(pkg_nevra) == nvra_without_epoch
+
+
+@pytest.mark.parametrize(
+    ("file", "filepath", "message"),
+    (
+        (False, None, "Could't remove restored file"),
+        (False, "/invalid/path", "Could't remove restored file /invalid/path"),
+        (True, "filename", "File %s removed."),
+    ),
+)
+def test_restorable_file_remove(tmpdir, caplog, file, filepath, message):
+    if file:
+        path = tmpdir.join(filepath)
+        path.write("content")
+        path = str(path)
+        message = message % path
+    else:
+        path = filepath
+
+    restorable_file = backup.RestorableFile(path)
+    restorable_file.remove()
+
+    assert message in caplog.text

--- a/convert2rhel/unit_tests/backup_test.py
+++ b/convert2rhel/unit_tests/backup_test.py
@@ -667,8 +667,7 @@ def test_remove_epoch_from_yum_nevra_notation(pkg_nevra, nvra_without_epoch):
 @pytest.mark.parametrize(
     ("file", "filepath", "message"),
     (
-        (False, None, "Could't remove restored file"),
-        (False, "/invalid/path", "Could't remove restored file /invalid/path"),
+        (False, "/invalid/path", "Couldn't remove restored file /invalid/path"),
         (True, "filename", "File %s removed."),
     ),
 )

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -209,11 +209,12 @@ class TestMain(unittest.TestCase):
         intended_call_order["replace_subscription_manager"] = 1
         intended_call_order["verify_rhsm_installed"] = 1
         intended_call_order["install"] = 1
+        intended_call_order["remove_repofile_pkgs"] = 1
         intended_call_order["subscribe_system"] = 1
         intended_call_order["get_rhel_repoids"] = 1
         intended_call_order["check_needed_repos_availability"] = 1
         intended_call_order["disable_repos"] = 1
-        intended_call_order["remove_repofile_pkgs"] = 1
+
         intended_call_order["enable_repos"] = 1
         intended_call_order["perform_pre_ponr_checks"] = 1
         intended_call_order["perform_system_checks"] = 1
@@ -313,12 +314,14 @@ class TestMain(unittest.TestCase):
         intended_call_order["replace_subscription_manager"] = 0
         intended_call_order["verify_rhsm_installed"] = 0
         intended_call_order["install"] = 0
+
+        intended_call_order["remove_repofile_pkgs"] = 1
+
+        # Do not expect this one to be called - related to RHSM
         intended_call_order["subscribe_system"] = 0
         intended_call_order["get_rhel_repoids"] = 0
         intended_call_order["check_needed_repos_availability"] = 0
         intended_call_order["disable_repos"] = 0
-
-        intended_call_order["remove_repofile_pkgs"] = 1
 
         intended_call_order["enable_repos"] = 0
 

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -314,7 +314,6 @@ class TestMain(unittest.TestCase):
         intended_call_order["replace_subscription_manager"] = 0
         intended_call_order["verify_rhsm_installed"] = 0
         intended_call_order["install"] = 0
-
         intended_call_order["remove_repofile_pkgs"] = 1
 
         # Do not expect this one to be called - related to RHSM
@@ -322,9 +321,7 @@ class TestMain(unittest.TestCase):
         intended_call_order["get_rhel_repoids"] = 0
         intended_call_order["check_needed_repos_availability"] = 0
         intended_call_order["disable_repos"] = 0
-
         intended_call_order["enable_repos"] = 0
-
         intended_call_order["perform_pre_ponr_checks"] = 1
 
         # Merge the two together like a zipper, creates a tuple which we can assert with - including method call order!

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -26,11 +26,11 @@ from collections import namedtuple
 import pytest
 import six
 
-from convert2rhel import logger, systeminfo, unit_tests, utils  # Imports unit_tests/__init__.py
+from convert2rhel import logger, pkgmanager, systeminfo, unit_tests, utils  # Imports unit_tests/__init__.py
 from convert2rhel.systeminfo import RELEASE_VER_MAPPING, Version, system_info
 from convert2rhel.toolopts import tool_opts
 from convert2rhel.unit_tests import is_rpm_based_os
-from convert2rhel.unit_tests.conftest import all_systems, centos8
+from convert2rhel.unit_tests.conftest import all_systems, centos7, centos8
 
 
 six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -236,6 +236,12 @@
   discover+:
     test: checks-after-conversion
   prepare+:
+  - name: workaround_kernel
+    how: shell
+    script: "yum install kernel-3.10.0-1160.76.1.el7 -y && yum remove kernel-3.10.0-1160.80.1.el7 -y"
+  - name: reboot machine
+    how: ansible
+    playbook: tests/ansible_collections/roles/reboot/main.yml
   - name: install subscription manager
     how: ansible
     playbook: tests/ansible_collections/roles/install-submgr/main.yml

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -228,6 +228,11 @@
     playbook: tests/ansible_collections/roles/reboot/main.yml
 
 /convert_offline_systems:
+  # At the moment we have only CentOS7 repos available on Satellite server
+  adjust:
+    enabled: false
+    when: >
+      distro != centos-7
   discover+:
     test: checks-after-conversion
   prepare+:

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -205,7 +205,7 @@
     script: pytest -svv tests/integration/tier1/os-release-removal/remove_os_release.py
   - name: main conversion preparation
     how: shell
-    script: pytest -svv tests/integration/tier1/method/satellite.py
+    script: pytest -svv tests/integration/tier1/method/rhsm.py
   - name: reboot after conversion
     how: ansible
     playbook: tests/ansible_collections/roles/reboot/main.yml

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,7 +26,7 @@ env.read_envfile(str(Path(__file__).parents[2] / ".env"))
 logging.basicConfig(level="DEBUG" if env.str("DEBUG") else "INFO", stream=sys.stderr)
 logger = logging.getLogger(__name__)
 
-SATELLITE_URL = "dogfood-sat.hosts.prod.upshift.rdu2.redhat.com"
+SATELLITE_URL = "satellite.sat.engineering.redhat.com"
 SATELLITE_PKG_URL = "https://satellite.sat.engineering.redhat.com/pub/katello-ca-consumer-latest.noarch.rpm"
 SATELLITE_PKG_DST = "/usr/share/convert2rhel/subscription-manager/katello-ca-consumer-latest.noarch.rpm"
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,7 +26,7 @@ env.read_envfile(str(Path(__file__).parents[2] / ".env"))
 logging.basicConfig(level="DEBUG" if env.str("DEBUG") else "INFO", stream=sys.stderr)
 logger = logging.getLogger(__name__)
 
-SATELLITE_URL = "satellite.sat.engineering.redhat.com"
+SATELLITE_URL = "dogfood-sat.hosts.prod.upshift.rdu2.redhat.com"
 SATELLITE_PKG_URL = "https://satellite.sat.engineering.redhat.com/pub/katello-ca-consumer-latest.noarch.rpm"
 SATELLITE_PKG_DST = "/usr/share/convert2rhel/subscription-manager/katello-ca-consumer-latest.noarch.rpm"
 

--- a/tests/integration/tier0/backup-release/main.fmf
+++ b/tests/integration/tier0/backup-release/main.fmf
@@ -1,4 +1,4 @@
-summary: variant help message
+summary: Verify that c2r correctly restores the os-release file during different scenarios.
 
 tier: 0
 

--- a/tests/integration/tier0/backup-release/test_backup_release.py
+++ b/tests/integration/tier0/backup-release/test_backup_release.py
@@ -91,6 +91,20 @@ def test_backup_os_release_with_envar(shell, convert2rhel):
     del os.environ["CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK"]
 
 
+def test_backup_os_release_wrong_registartion(shell, convert2rhel):
+    """
+    Verify that the os-release file is restored when the satellite registartion fails.
+    Refrence issue: RHELC-51
+    """
+    assert shell("find /etc/os-release").returncode == 0
+
+    with convert2rhel("-y --no-rpm-va -k wrong_key -o rUbBiSh_pWd --debug --keep-rhsm") as c2r:
+        c2r.expect("Unable to register the system through subscription-manager.")
+        c2r.expect("Restoring /etc/os-release from backup")
+
+    assert shell("find /etc/os-release").returncode == 0
+
+
 def test_missing_system_release(shell, convert2rhel):
     """
     It is required to have /etc/system-release file present on the system.

--- a/tests/integration/tier1/convert-offline-systems/main.fmf
+++ b/tests/integration/tier1/convert-offline-systems/main.fmf
@@ -1,4 +1,6 @@
-summary: Convert systems that have no access to the Internet
+summary: |
+    Convert systems that have no access to the Internet. This test require having the repositories of original
+    distro available in the satellite server. As of now we only have CentOS7 repositories available.
 
 tier: 1
 

--- a/tests/integration/tier1/convert-offline-systems/prepare_system.py
+++ b/tests/integration/tier1/convert-offline-systems/prepare_system.py
@@ -5,6 +5,21 @@ from conftest import SATELLITE_PKG_DST, SATELLITE_PKG_URL, SATELLITE_URL
 from envparse import env
 
 
+# Replace urls in rhsm.conf file to the satellite server
+# Without doing this we get obsolete dogfood server as source of repositories
+def replace_urls_rhsm():
+    with open("/etc/rhsm/rhsm.conf", "r+") as f:
+        file = f.read()
+        # Replacing the urls
+        file = re.sub("hostname = .*", "hostname = {}".format(SATELLITE_URL), file)
+        file = re.sub("baseurl = .*", "baseurl = https://{}/pulp/repos".format(SATELLITE_URL), file)
+
+        # Setting the position to the top of the page to insert data
+        f.seek(0)
+        f.write(file)
+        f.truncate()
+
+
 # Configure and limit connection to the satellite server only
 def configure_connection():
     satellite_ip = socket.gethostbyname(SATELLITE_URL)
@@ -32,12 +47,15 @@ def test_prepare_system(shell):
     )
     assert shell("rpm -i {}".format(SATELLITE_PKG_DST)).returncode == 0
 
+    replace_urls_rhsm()
     shell("rm -rf /etc/yum.repos.d/*")
 
     # Subscribe system
     assert (
         shell(
-            ("subscription-manager register --org={} --activationkey={}").format(env.str("SATELLITE_ORG"), "centos7")
+            ("subscription-manager register --org={} --activationkey={}").format(
+                env.str("SATELLITE_ORG"), env.str("SATELLITE_KEY_CENTOS7")
+            )
         ).returncode
         == 0
     )

--- a/tests/integration/tier1/convert-offline-systems/run_conversion.py
+++ b/tests/integration/tier1/convert-offline-systems/run_conversion.py
@@ -6,9 +6,6 @@ from envparse import env
 def test_convert_offline_systems(convert2rhel):
     """Test converting systems not connected to the Internet but requiring sub-mgr (e.g. managed by Satellite)."""
 
-    # TODO: Remove once the repos of CentOS7 are synced with the latest packages
-    os.environ["CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK"] = "1"
-
     with convert2rhel(
         ("-y --no-rpm-va -k {} -o {} --keep-rhsm --debug").format(
             env.str("SATELLITE_KEY"),

--- a/tests/integration/tier1/convert-offline-systems/run_conversion.py
+++ b/tests/integration/tier1/convert-offline-systems/run_conversion.py
@@ -1,8 +1,13 @@
+import os
+
 from envparse import env
 
 
 def test_convert_offline_systems(convert2rhel):
     """Test converting systems not connected to the Internet but requiring sub-mgr (e.g. managed by Satellite)."""
+
+    # TODO: Remove once the repos of CentOS7 are synced with the latest packages
+    os.environ["CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK"] = "1"
 
     with convert2rhel(
         ("-y --no-rpm-va -k {} -o {} --keep-rhsm --debug").format(

--- a/tests/integration/tier1/convert-offline-systems/run_conversion.py
+++ b/tests/integration/tier1/convert-offline-systems/run_conversion.py
@@ -1,13 +1,8 @@
-import os
-
 from envparse import env
 
 
 def test_convert_offline_systems(convert2rhel):
     """Test converting systems not connected to the Internet but requiring sub-mgr (e.g. managed by Satellite)."""
-
-    os.environ["CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK"] = "1"
-    os.environ["CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK"] = "1"
 
     with convert2rhel(
         ("-y --no-rpm-va -k {} -o {} --keep-rhsm --debug").format(

--- a/tests/integration/tier1/os-release-removal/remove_os_release.py
+++ b/tests/integration/tier1/os-release-removal/remove_os_release.py
@@ -2,6 +2,10 @@ def test_missing_os_release(shell):
     """
     This test case verify that it's possible to do full conversion when /etc/os-release
     file is not present on the system.
+    The reference PR: https://github.com/oamg/convert2rhel/pull/384
+
+    Note that using the satellite as a mathod of conversion is not
+    supported at the moment and will fail during the registration process.
     """
     assert shell("rm /etc/os-release").returncode == 0
     assert shell("find /etc/os-release").returncode == 1


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
There is a problem with backing up the packages on systems which use satellite server. During the conversion is system unregistered from previous subscription - in that step we lose access to the CentOS repositories. And then we need to backup packages, which could come from CentOS. 

So the step with backup and remove the package is moved before the unregistration. With that show up another problem - the backed up and then removed package remove `os-release` file too. The file is needed for subscribing the system, so it is restored from backup and then removed (if it won't be removed, the file would stay there after conversion as  `os-release.rpmorig`)

Jira Issue: [RHELC-16](https://issues.redhat.com/browse/RHELC-16)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
