### PR TITLE
Do not use plural "packages" when there's just one

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -592,7 +592,7 @@ def check_package_updates():
             else "on repositories defined in the %s folder" % reposdir
         )
         logger.warning(
-            "The system has %s packages not updated based %s.\n"
+            "The system has %s package(s) not updated based %s.\n"
             "List of packages to update: %s.\n\n"
             "Not updating the packages may cause the conversion to fail.\n"
             "Consider stopping the conversion and update the packages before re-running convert2rhel."

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -1005,7 +1005,7 @@ def test_check_package_updates_skip_on_not_latest_ol(pretend_os, caplog):
 @pytest.mark.parametrize(
     ("packages", "exception", "expected"),
     (
-        (["package-1", "package-2"], True, "The system has {0} packages not updated"),
+        (["package-1", "package-2"], True, "The system has {0} package(s) not updated"),
         ([], False, "System is up-to-date."),
     ),
 )

--- a/tests/integration/tier1/system-up-to-date/test_system_up_to_date.py
+++ b/tests/integration/tier1/system-up-to-date/test_system_up_to_date.py
@@ -88,5 +88,5 @@ def test_system_not_updated(shell, convert2rhel):
         )
     ) as c2r:
         c2r.expect("WARNING - YUM/DNF versionlock plugin is in use. It may cause the conversion to fail.")
-        c2r.expect(r"WARNING - The system has \d+ packages not updated.")
+        c2r.expect(r"WARNING - The system has \d+ package\(s\) not updated")
     assert c2r.exitstatus == 0


### PR DESCRIPTION
The main reason for this change was a failing integration test. It had a period at the end of the expected warning message when in fact this period had been removed in
https://github.com/oamg/convert2rhel/pull/458/files#diff-cf19bc90f65d9e26e1b6fa7dcd84a18dfba097f65706e211a4f4ac71b1b467f6R504. For some strange reason the integration test for that PR passed at the time of merging.

<!-- Link to relevant Jira issue, add multiple if necessary -->
~~Jira Issue: [RHELC-]()~~ N/A

Checklist
- [ ] ~~PR meets acceptance criteria specified in the Jira issue~~ N/A
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] ~~Jira issue has been made public if possible~~ N/A
- [ ] ~~`[RHELC-]` is part of the PR title~~ N/A <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] ~~When merged: Jira issue has been updated to `Release Pending`~~ N/A
