### PR TITLE
Fix Makefile: .images no longer exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 .PHONY: \
-	force-rebuild \
 	install \
 	tests-locally \
 	lint-locally \
@@ -57,7 +56,7 @@ endif
 
 all: clean images tests
 
-install: .install .images .env .pre-commit
+install: .install .build-images .env .pre-commit
 
 .install:
 	virtualenv --system-site-packages --python $(PYTHON) $(VENV); \


### PR DESCRIPTION
The `.images` target was changed to `.build-images` in https://github.com/oamg/convert2rhel/commit/7512287598a36ca80eab328c91a1e7b9cacc5f9c#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L66 and the `install` target should have been updated accordingly.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
~~Jira Issue: [RHELC-]()~~ N/A

Checklist
- [ ] ~~PR meets acceptance criteria specified in the Jira issue~~ N/A
- [ ] ~~PR has been tested manually in a VM (either author or reviewer)~~ N/A
- [ ] ~~Jira issue has been made public if possible~~ N/A
- [ ] ~~`[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->~~ N/A
- [ ] ~~Code and tests are documented properly~~ N/A
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] ~~When merged: Jira issue has been updated to `Release Pending`~~ N/A
