### PR TITLE
[RHELC-39] Enable NO_COLOR for tests

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -1,27 +1,29 @@
 execute:
-  how: tmt
+    how: tmt
 discover:
-  how: fmf
+    how: fmf
+environment:
+    NO_COLOR: 1
 prepare:
-  - name: main preparation step
-    how: ansible
-    playbook: tests/ansible_collections/main.yml
-  - name: reboot system after update
-    how: ansible
-    playbook: tests/ansible_collections/roles/reboot/main.yml
-  - name: install latest copr build
-    how: install
-    copr: '@oamg/convert2rhel'
-    package: convert2rhel
-    missing: fail
+    - name: main preparation step
+      how: ansible
+      playbook: tests/ansible_collections/main.yml
+    - name: reboot system after update
+      how: ansible
+      playbook: tests/ansible_collections/roles/reboot/main.yml
+    - name: install latest copr build
+      how: install
+      copr: '@oamg/convert2rhel'
+      package: convert2rhel
+      missing: fail
 
-  # We need to remove all the repositories that were used to install c2r package.
-  # The updated packages check may find that installed c2r is not latest and it then
-  # ask for one more interactive prompt to continue. This could be incosistent in some tests
-  # that are doing the interactive run of c2r.
-  - name: remove all copr repositories
-    how: shell
-    script: grep -l "copr:copr.fedorainfracloud.org:group_oamg:convert2rhel" /etc/yum.repos.d/* | xargs rm
+    # We need to remove all the repositories that were used to install c2r package.
+    # The updated packages check may find that installed c2r is not latest and it then
+    # ask for one more interactive prompt to continue. This could be incosistent in some tests
+    # that are doing the interactive run of c2r.
+    - name: remove all copr repositories
+      how: shell
+      script: grep -l "copr:copr.fedorainfracloud.org:group_oamg:convert2rhel" /etc/yum.repos.d/* | xargs rm
 
 # Commenting this out in favour of using a github actions with tft
 environment-file:


### PR DESCRIPTION
Set an environment variable NO_COLOR=1 for tests to align with changes in #622

Signed-off-by: Daniel Diblik <ddiblik@redhat.com>

Jira Issue: [RHELC-39](https://issues.redhat.com/browse/RHELC-39)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [x] When merged: Jira issue has been updated to `Release Pending`
