### PR TITLE
[RHELC-729] Do not show output from systemctl show during systeminfo gathering.

### DIFF
--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -419,7 +419,12 @@ def _is_systemd_managed_dbus_running():
     # Reloading, activating, etc will return None which means to retry
     running = None
 
-    output, ret_code = utils.run_subprocess(["/usr/bin/systemctl", "show", "-p", "ActiveState", "dbus"])
+    output, ret_code = utils.run_subprocess(["/usr/bin/systemctl",
+                                             "show",
+                                             "-p",
+                                             "ActiveState",
+                                             "dbus"],
+                                            print_output=False)
     for line in output.splitlines():
         # Note: systemctl seems to always emit an ActiveState line (ActiveState=inactive if
         # the service doesn't exist).  So this check is just defensive coding.

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -419,12 +419,9 @@ def _is_systemd_managed_dbus_running():
     # Reloading, activating, etc will return None which means to retry
     running = None
 
-    output, ret_code = utils.run_subprocess(["/usr/bin/systemctl",
-                                             "show",
-                                             "-p",
-                                             "ActiveState",
-                                             "dbus"],
-                                            print_output=False)
+    output, ret_code = utils.run_subprocess(
+        ["/usr/bin/systemctl", "show", "-p", "ActiveState", "dbus"], print_output=False
+    )
     for line in output.splitlines():
         # Note: systemctl seems to always emit an ActiveState line (ActiveState=inactive if
         # the service doesn't exist).  So this check is just defensive coding.


### PR DESCRIPTION
We use systemctl to tell us whether dbus is running on the system. When we do so, we don't want to directly emit the output of the systemctl command to the log as it is cryptic for the end user.

Fixes https://issues.redhat.com/browse/RHELC-729

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-729](https://issues.redhat.com/browse/RHELC-729)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
