### PR TITLE
fix: remove leftover .env file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ endif
 
 all: clean images tests
 
-install: .install .build-images .env .pre-commit
+install: .install .build-images .pre-commit
 
 .install:
 	virtualenv --system-site-packages --python $(PYTHON) $(VENV); \


### PR DESCRIPTION
There was a leftover .env in #634 we didn't spot. This removes that so it
no longer errors out

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: N/A

Checklist
- [ ] ~~PR meets acceptance criteria specified in the Jira issue~~
- [ ] ~~PR has been tested manually in a VM (either author or reviewer)~~
- [ ] ~~Jira issue has been made public if possible~~
- [ ] ~~`[RHELC-]` is part of the PR title~~ <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] ~~When merged: Jira issue has been updated to `Release Pending`~~