### PR TITLE
[RHELC-772] checks: Omit exclude= options from repoquery

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -620,7 +620,7 @@ def is_loaded_kernel_latest():
         logger.warning("Skipping the check as no internet connection has been detected.")
         return
 
-    cmd = ["repoquery", "--quiet", "--qf", '"%{BUILDTIME}\\t%{VERSION}-%{RELEASE}\\t%{REPOID}"']
+    cmd = ["repoquery", '--setopt=exclude=""', "--quiet", "--qf", '"%{BUILDTIME}\\t%{VERSION}-%{RELEASE}\\t%{REPOID}"']
 
     # If the reposdir variable is not empty, meaning that it detected the hardcoded repofiles, we should use that
     # instead of the system repositories located under /etc/yum.repos.d


### PR DESCRIPTION
In is_loaded_kernel_latest(), repoquery is subject to exclude= in /etc/yum.conf. If there is "exclude=kernel", the conversion can fail with the following:

	CRITICAL - Could not find any kernel from repositories to compare against the loaded kernel.

This patch resolves that condition by explicitly disabling all "exclude" options with:

	--setopt=exclude""

Signed-off-by: John Castranio <jcastran@redhat.com>

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-772](https://issues.redhat.com/browse/RHELC-772)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
