### PR TITLE
[RHELC-744] Install the redhat-uep.pem certificate if it is needed.

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -750,11 +750,14 @@ def is_loaded_kernel_latest():
         # appears in the repoquery output. If it does, we ignore it.
         # This later check is supposed to avoid duplicate repofiles being defined in the system,
         # this is a super corner case and should not happen everytime, but if it does, we are aware now.
-        packages = [
+        packages = (
             tuple(str(line).replace('"', "").split("\t"))
             for line in repoquery_output.split("\n")
             if (line.strip() and "listed more than once in the configuration" not in line.lower())
-        ]
+        )
+        # Filter out any error messages (things that do not have the three
+        # fields which we expect)
+        packages = [pkg for pkg in packages if len(pkg) == 3]
 
         # Sort out for the most recent kernel with reverse order
         # In case `repoquery` returns more than one kernel in the output

--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -69,7 +69,8 @@
   adjust:
     enabled: false
     when: >
-      distro != centos-8-latest
+      distro != centos-8-latest and
+      distro != centos-8.4
   discover+:
       test: sub-man-rollback
 


### PR DESCRIPTION
We need this certificate for the convert2rhel repo if the user installed using the convert2rhel.repo file:

https://ftp.redhat.com/redhat/convert2rhel/8/convert2rhel.repo

This is a workaround for https://issues.redhat.com/browse/RHELC-744 When we make uninstalling and reinstalling the RHEL subscription-manager packages a single step process, we will no longer need this as there will always be a redhat-uep.pem available from an rpm package.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-744](https://issues.redhat.com/browse/RHELC-744)

TODO:
- [x] unit tests
- [x] integration test

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
