### PR TITLE
Remove a unit_test dependency on having internet.

### DIFF
--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -1201,6 +1201,9 @@ def test_is_loaded_kernel_latest_eus_system(
 ):
     fake_reposdir_path = str(tmpdir)
     monkeypatch.setattr(checks, "get_hardcoded_repofiles_dir", value=lambda: fake_reposdir_path)
+
+    monkeypatch.setattr(checks.system_info, "has_internet_access", True)
+
     run_subprocess_mocked = mock.Mock(
         spec=run_subprocess,
         side_effect=run_subprocess_side_effect(


### PR DESCRIPTION
unit_tests should be designed to work even when there isn't an internet connection (for security of downstream build systems).  Mock out system_info.has_internet_access since we are also mocking out the repoquery call which would require internet access to exist.

<!-- Write a description of what the PR solves and how -->
This is an extremely simple patch that just adjusts a unit test to not need internet access to function.

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-]()

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
