### PR TITLE
[RHELC-784] Allow but warn about deprecated env var

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -156,7 +156,16 @@ def check_convert2rhel_latest():
     # and latest_available_version respectively, to compare **just** the version field.
     ver_compare = rpm.labelCompare(("0", installed_convert2rhel_version, "0"), ("0", latest_available_version[1], "0"))
     if ver_compare < 0:
-        if "CONVERT2RHEL_ALLOW_OLDER_VERSION" in os.environ:
+        # Current and deprecated env var names
+        allow_older_envvar_names = ("CONVERT2RHEL_ALLOW_OLDER_VERSION", "CONVERT2RHEL_UNSUPPORTED_VERSION")
+        if any(envvar in os.environ for envvar in allow_older_envvar_names):
+            if "CONVERT2RHEL_ALLOW_OLDER_VERSION" not in os.environ:
+                logger.warning(
+                    "You are using the deprecated 'CONVERT2RHEL_UNSUPPORTED_VERSION'"
+                    " environment variable.  Please switch to 'CONVERT2RHEL_ALLOW_OLDER_VERSION'"
+                    " instead."
+                )
+
             logger.warning(
                 "You are currently running %s and the latest version of Convert2RHEL is %s.\n"
                 "'CONVERT2RHEL_ALLOW_OLDER_VERSION' environment variable detected, continuing conversion"

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -200,7 +200,6 @@ class TestCheckConvert2rhelLatest(object):
         global_system_info.has_internet_access = False
         checks.check_convert2rhel_latest()
 
-        convert2rhel_latest_version_test
         log_msg = "Skipping the check because no internet connection has been detected."
         assert log_msg in caplog.text
 


### PR DESCRIPTION
We've renamed CONVERT2RHEL_UNSUPPORTED_VERSION to CONVERT2RHEL_ALLOW_OLDER_VERSION.  Allow the old env var name to be used but emit a deprecation warning in the log.

Add unittests to show the deprecation message is emitted when we use the old env var rather than the new one to allow the conversion to continue.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Followup to changes introduced for: #566
Jira Issue: [RHELC-784](https://issues.redhat.com/browse/RHELC-784)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
