### PR TITLE
[RHELC-744, RHELC-762] Backup all CentOS subscription-manager packages

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -41,7 +41,7 @@ jobs:
     epel-7-x86_64:
       distros: [centos-7, oraclelinux-7]
     epel-8-x86_64:
-      distros: [centos-8.4, centos-8, oraclelinux-8.4, oraclelinux-8.6]
+      distros: [centos-8.4, centos-8-latest, oraclelinux-8.4, oraclelinux-8.6]
   use_internal_tf: True
   trigger: pull_request
 - <<: *tests

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -592,6 +592,10 @@ def remove_original_subscription_manager():
     loggerinst.info("Removing installed subscription-manager/katello-ca-consumer packages.")
     # python3-subscription-manager-rhsm, dnf-plugin-subscription-manager, subscription-manager-rhsm-certificates, etc.
     submgr_pkgs = pkghandler.get_installed_pkg_objects("*subscription-manager*")
+    # The python-syspurpose, python3-syspurpose, and python3-cloud-what packages are also built out of
+    # the subscription-manager SRPM.
+    submgr_pkgs += pkghandler.get_installed_pkg_objects("python*-syspurpose")
+    submgr_pkgs += pkghandler.get_installed_pkg_objects("python3-cloud-what")
     # Satellite-server related package
     submgr_pkgs += pkghandler.get_installed_pkg_objects("katello-ca-consumer*")
     if not submgr_pkgs:

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -919,6 +919,7 @@ def download_rhsm_pkgs():
         loggerinst.info("Skipping due to the use of --keep-rhsm.")
         return
     utils.mkdir_p(_RHSM_TMP_DIR)
+
     pkgs_to_download = [
         "subscription-manager",
         "subscription-manager-rhsm-certificates",
@@ -948,9 +949,20 @@ def download_rhsm_pkgs():
 
 
 def _download_rhsm_pkgs(pkgs_to_download, repo_path, repo_content):
+    _log_rhsm_download_directory_contents(SUBMGR_RPMS_DIR, "before RHEL rhsm packages download")
+
     utils.store_content_to_file(filename=repo_path, content=repo_content)
     paths = utils.download_pkgs(pkgs_to_download, dest=SUBMGR_RPMS_DIR, reposdir=_RHSM_TMP_DIR)
+
+    _log_rhsm_download_directory_contents(SUBMGR_RPMS_DIR, "after RHEL rhsm packages download")
     exit_on_failed_download(paths)
+
+
+def _log_rhsm_download_directory_contents(directory, when_message):
+    pkgs = ["<download directory does not exist>"]
+    if os.path.isdir(SUBMGR_RPMS_DIR):
+        pkgs = os.listdir(SUBMGR_RPMS_DIR)
+    loggerinst.debug("Contents of %s directory %s:\n%s", SUBMGR_RPMS_DIR, when_message, "\n".join(pkgs))
 
 
 def exit_on_failed_download(paths):

--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -67,3 +67,11 @@
         when: distro == oraclelinux-8.4
     discover+:
         test: verify-latest-kernel-check-with-failed-repoquery
+
+/sub_man_rollback:
+    adjust+:
+        enabled: false
+        when: >
+            distro != centos-8-latest
+    discover+:
+        test: sub-man-rollback

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -278,7 +278,7 @@
   adjust:
     enabled: false
     when: >
-      distro != centos-8
+      distro != centos-8-latest
   discover+:
     test: checks-after-conversion
   prepare+:
@@ -318,7 +318,7 @@
   adjust:
       enabled: false
       when: >
-        distro != centos-8
+        distro != centos-8-latest
   discover+:
     test: checks-after-conversion
   prepare+:

--- a/tests/integration/tier0/check-cve-2022-1662/test_cve_fixes.py
+++ b/tests/integration/tier0/check-cve-2022-1662/test_cve_fixes.py
@@ -21,7 +21,7 @@ def test_passing_password_to_submrg(convert2rhel):
     """
     username = "testname"
     password = "EXAMPLE&hTYGHKPvU7Ewd"
-    with convert2rhel(f"-y --no-rpm-va -u {username} -p {password}") as c2r:
+    with convert2rhel(f"-y --no-rpm-va -u {username} -p {password} --debug") as c2r:
         # Just to be sure, try to run through all three tries
         # of the registration process in case the race condition applies
         for subscription_try in range(2):
@@ -41,7 +41,7 @@ def test_passing_activation_key_to_submrg(convert2rhel):
     """
     organization = "testorg"
     activation_key = "mfaop90a23f_2%"
-    with convert2rhel(f"-y --no-rpm-va -k {activation_key} -o {organization}") as c2r:
+    with convert2rhel(f"-y --no-rpm-va -k {activation_key} -o {organization} --debug") as c2r:
         # Just to be sure, try to run through all three tries
         # of the registration process in case the race condition applies
         for subscription_try in range(2):

--- a/tests/integration/tier0/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
+++ b/tests/integration/tier0/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
@@ -55,10 +55,8 @@ def test_do_not_inhibit_if_module_is_not_loaded(shell, convert2rhel):
     """
     assert shell("modprobe -r -v bonding").returncode == 0
 
-    if "oracle-7" in system_version:
+    if "oracle-7" in system_version or "centos-7" in system_version:
         prompt_amount = 3
-    elif "centos-7" in system_version:
-        prompt_amount = 4
     elif "oracle-8" in system_version:
         prompt_amount = 2
     elif "centos-8" in system_version:

--- a/tests/integration/tier0/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
+++ b/tests/integration/tier0/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
@@ -55,12 +55,14 @@ def test_do_not_inhibit_if_module_is_not_loaded(shell, convert2rhel):
     """
     assert shell("modprobe -r -v bonding").returncode == 0
 
-    if "oracle-7" in system_version or "centos-7" in system_version:
+    if "oracle-7" in system_version:
         prompt_amount = 3
+    elif "centos-7" in system_version:
+        prompt_amount = 4
     elif "oracle-8" in system_version:
         prompt_amount = 2
     elif "centos-8" in system_version:
-        prompt_amount = 3
+        prompt_amount = 4
     # If custom module is not loaded the conversion is not inhibited.
     with convert2rhel(
         "--no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug".format(

--- a/tests/integration/tier0/sub-man-rollback/main.fmf
+++ b/tests/integration/tier0/sub-man-rollback/main.fmf
@@ -1,0 +1,20 @@
+summary: Rollback of the removed subscription-manager packages
+description: |
+    When the subscription-manager package is installed from the BaseOS repository prior to running convert2rhel, it is
+    removed during the conversion run. This test makes sure that subscription-manager and its dependencies are correctly
+    backed up and re-installed during the rollback together with the certificate.
+
+tier: 0
+
+tag+:
+    - certificate
+    - subscription-manager
+
+require:
+    - subscription-manager
+
+/sub_man_rollback:
+    tag+:
+        - sub-man-rollback
+    test: |
+      pytest -svv -m sub_man_rollback

--- a/tests/integration/tier0/sub-man-rollback/test_sub_man_rollback.py
+++ b/tests/integration/tier0/sub-man-rollback/test_sub_man_rollback.py
@@ -1,0 +1,49 @@
+import os.path
+
+import pytest
+
+from envparse import env
+
+
+@pytest.mark.sub_man_rollback
+def test_sub_man_rollback(convert2rhel, shell):
+    """
+    Verify that convert2rhel removes and backs up the original vendor subscription-manager packages, including
+    python3-syspurpose and python3-cloud-what which are also built out of the subscription-manager SRPM.
+
+    Not removing and backing up the python3-syspurpose and python3-cloud-what packages on CentOS Linux 8.5 was causing
+    a rollback failure when an older version of these two packages was installed.
+
+    The rollback failure caused the following issues during the subsequent second run of convert2rhel:
+    1. when the rollback happened before removing the centos-linux-release package, the removed
+      subscription-manager-rhsm-certificates was not re-installed back during the rollback leading to a missing
+      /etc/rhsm/ca/redhat-uep.pem file which is necessary for accessing the official convert2rhel repo on CDN
+      (https://issues.redhat.com/browse/RHELC-744)
+    2. when the rollback happened before removing the centos-linux-release package, this package was not re-installed
+      back during the rollback and that lead to the $releasever variable being undefined, ultimately causing a traceback
+      when using the DNF python API (https://issues.redhat.com/browse/RHELC-762)
+    """
+    assert shell("rpm -qi subscription-manager").returncode == 0
+    # The following repository requires the redhat-uep.pem certificate. convert2rhel will try accessing the repo and
+    # by running convert2rhel twice makes sure that the rollback of the first run correctly reinstalled the certificate
+    # when installing subscription-manager-rhsm-certificates.
+    assert (
+        shell(
+            "curl -o /etc/yum.repos.d/convert2rhel.repo https://ftp.redhat.com/redhat/convert2rhel/8/convert2rhel.repo"
+        ).returncode
+        == 0
+    )
+    assert os.path.exists("/etc/yum.repos.d/convert2rhel.repo") is True
+
+    for run in range(2):
+        with convert2rhel(
+            ("-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug").format(
+                env.str("RHSM_SERVER_URL"),
+                env.str("RHSM_USERNAME"),
+                env.str("RHSM_PASSWORD"),
+                env.str("RHSM_POOL"),
+            )
+        ) as c2r:
+            assert c2r.expect("Validate the dnf transaction") == 0
+            # At this point the centos-linux-release package is already installed
+            c2r.sendcontrol("c")

--- a/tests/integration/tier0/test-check-rollback-handling/test_check_rollback_handling.py
+++ b/tests/integration/tier0/test-check-rollback-handling/test_check_rollback_handling.py
@@ -87,12 +87,16 @@ def test_proper_rhsm_clean_up(shell, convert2rhel):
     Verify that usermode, rhn-setup and os-release packages are not removed.
     """
     install_pkg(shell)
-    if "oracle-7" in booted_os or "centos-7" in booted_os:
+    if "oracle-7" in booted_os:
         prompt_amount = 3
+    elif "centos-7" in booted_os:
+        # additional question about the removal of python-syspurpose
+        prompt_amount = 4
     elif "oracle-8" in booted_os:
         prompt_amount = 3
     elif "centos-8" in booted_os:
-        prompt_amount = 3
+        # additional question about the removal of python3-syspurpose
+        prompt_amount = 4
 
     with convert2rhel(
         ("--serverurl {} --username {} --password {} --pool {} --debug --no-rpm-va").format(

--- a/tests/integration/tier1/remove-all-submgr-pkgs/test_no_submgr_pkg_installed.py
+++ b/tests/integration/tier1/remove-all-submgr-pkgs/test_no_submgr_pkg_installed.py
@@ -9,7 +9,7 @@ def test_no_sub_manager_installed(shell, convert2rhel):
     is able to get to the last point of the rollback.
     """
 
-    assert shell("yum remove -y subscription-manager").returncode == 0
+    assert shell("yum remove -y subscription-manager python3-syspurpose").returncode == 0
     system_version = platform.platform()
     if "oracle-7" in system_version or "centos-7" in system_version:
         prompt_amount = 2

--- a/tests/integration/tier1/single-yum-transaction/test_single_yum_transaction.py
+++ b/tests/integration/tier1/single-yum-transaction/test_single_yum_transaction.py
@@ -25,7 +25,7 @@ def test_single_yum_transaction(convert2rhel, shell):
             env.str("RHSM_POOL"),
         )
     ) as c2r:
-        c2r.expect("no modifications to the system will happen this time.", timeout=900)
+        c2r.expect("no modifications to the system will happen this time.", timeout=1200)
         c2r.expect("Successfully validated the %s transaction set." % pkgmanager, timeout=600)
         c2r.expect("This process may take some time to finish.", timeout=300)
         c2r.expect("System packages replaced successfully.", timeout=900)


### PR DESCRIPTION
Not removing and backing up the python3-syspurpose and python3-cloud-what packages, which are also built out of the subscription-manager SRPM, was causing a rollback failure on CentOS Linux 8.5 when an older version of these two packages was installed.

The rollback failure caused the following issues during the subsequent second run of convert2rhel:
 1. when the rollback happened before removing the centos-linux-release package, the removed subscription-manager-rhsm-certificates was not re-installed back during the rollback leading to a missing /etc/rhsm/ca/redhat-uep.pem file which is necessary for accessing the official convert2rhel repo on CDN
 2. when the rollback happened before removing the centos-linux-release package, this package was not re-installed back during the rollback and that lead to the $releasever variable being undefined, ultimately causing a traceback when using the DNF python API

Replaces https://github.com/oamg/convert2rhel/pull/642.

Jira Issue: [RHELC-744](https://issues.redhat.com/browse/RHELC-744), [RHELC-762](https://issues.redhat.com/browse/RHELC-762)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-744]` and `[RHELC-762]` are part of the PR title
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
