### PR TITLE
[RHELC-784] Fix the format of message about unavailable kernel modules.

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -361,17 +361,15 @@ def ensure_compatibility_of_kmods():
         logger.debug("All loaded kernel modules are available in RHEL.")
     else:
         not_supported_kmods = "\n".join(
-            map(
-                lambda kmod: "/lib/modules/{kver}/{kmod}".format(kver=system_info.booted_kernel, kmod=kmod),
-                unsupported_kmods,
-            )
+            "/lib/modules/{kver}/{kmod}".format(kver=system_info.booted_kernel, kmod=kmod)
+            for kmod in unsupported_kmods
         )
         logger.critical(
             "The following loaded kernel modules are not available in RHEL:\n{0}\n"
             "First, make sure you have updated the kernel to the latest available version and rebooted the system.\n"
             "If this message appears again after doing the above, prevent the modules from loading by following {1}"
             " and run convert2rhel again to continue with the conversion.".format(
-                "\n".join(not_supported_kmods), LINK_PREVENT_KMODS_FROM_LOADING
+                not_supported_kmods, LINK_PREVENT_KMODS_FROM_LOADING
             )
         )
 

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -361,8 +361,7 @@ def ensure_compatibility_of_kmods():
         logger.debug("All loaded kernel modules are available in RHEL.")
     else:
         not_supported_kmods = "\n".join(
-            "/lib/modules/{kver}/{kmod}".format(kver=system_info.booted_kernel, kmod=kmod)
-            for kmod in unsupported_kmods
+            "/lib/modules/{kver}/{kmod}".format(kver=system_info.booted_kernel, kmod=kmod) for kmod in unsupported_kmods
         )
         logger.critical(
             "The following loaded kernel modules are not available in RHEL:\n{0}\n"


### PR DESCRIPTION
In #469, one of the cleanups ended up calling `"\n".join()` on a list of kernel modules twice.  The first time changes the list into a string with each entry separated by a newline but the second time changes the string into another string with each chatacter separated by a newline. Fixed that by removing the second `str.join()`.

This also refactors away a call to `map()` and use of `lambda`.  In modern python, any uses of `map()` or `filter()` can be replaced with either a generator expression or list comprehension.

Related to #469

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-784](RHELC-784)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
