### PR TITLE
[RHELC-787] Fix for temporary gpg home dir race.

### DIFF
--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -410,7 +410,7 @@ class TestFindKeys:
         def __init__(self, exception, real_rmtree):
             self.called = 0
             self.exception = exception
-            self.real_rmtree =real_rmtree
+            self.real_rmtree = real_rmtree
 
         def __call__(self, *args, **kwargs):
             # Fail on the first call
@@ -514,7 +514,7 @@ class TestFindKeys:
         (
             (OSError(13, "Permission denied"), "Errno 13.*Permission denied"),
             (Exception("Unanticipated problem"), "Unanticipated problem"),
-        )
+        ),
     )
     def test_find_keyid_problem_removing_directory(self, exception, exception_msg, monkeypatch):
         real_rmtree = shutil.rmtree

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -18,6 +18,7 @@ import getpass
 import json
 import logging
 import os
+import shutil
 import sys
 import unittest
 
@@ -405,11 +406,31 @@ def test_get_rpm_header(monkeypatch):
 
 
 class TestFindKeys:
+    class MockedRmtree(object):
+        def __init__(self, exception, real_rmtree):
+            self.called = 0
+            self.exception = exception
+            self.real_rmtree =real_rmtree
+
+        def __call__(self, *args, **kwargs):
+            # Fail on the first call
+            self.called += 1
+            if self.called == 1:
+                raise self.exception
+
+            return self.real_rmtree(*args, **kwargs)
+
     gpg_key = os.path.realpath(
         os.path.join(os.path.dirname(__file__), "../data/version-independent/gpg-keys/RPM-GPG-KEY-redhat-release")
     )
 
     def test_find_keyid(self):
+        assert utils.find_keyid(self.gpg_key) == "fd431d51"
+
+    def test_find_keyid_race_in_gpg_cleanup(self, monkeypatch):
+        real_rmtree = shutil.rmtree
+        monkeypatch.setattr(shutil, "rmtree", self.MockedRmtree(OSError(2, "File not found"), real_rmtree))
+
         assert utils.find_keyid(self.gpg_key) == "fd431d51"
 
     def test_find_keyid_bad_file(self, tmpdir):
@@ -443,6 +464,30 @@ class TestFindKeys:
         ):
             utils.find_keyid(self.gpg_key)
 
+    def test_find_keyid_gpg_bad_keyring_and_race_deleting_tmp_dir(self, monkeypatch):
+        class MockedRunSubProcess(object):
+            def __init__(self):
+                self.called = 0
+
+            def __call__(self, *args, **kwargs):
+                # Fail on the second call
+                self.called += 1
+                if self.called == 2:
+                    return ("", 1)
+
+                return real_run_subprocess(*args, **kwargs)
+
+        real_run_subprocess = utils.run_subprocess
+        monkeypatch.setattr(utils, "run_subprocess", MockedRunSubProcess())
+
+        real_rmtree = shutil.rmtree
+        monkeypatch.setattr(shutil, "rmtree", self.MockedRmtree(OSError(2, "File not found"), real_rmtree))
+
+        with pytest.raises(
+            utils.ImportGPGKeyError, match="Failed to read the temporary keyring with the rpm gpg key:.*"
+        ):
+            utils.find_keyid(self.gpg_key)
+
     def test_find_keyid_no_gpg_output(self, monkeypatch):
         class MockedRunSubProcess(object):
             def __init__(self):
@@ -462,6 +507,20 @@ class TestFindKeys:
         with pytest.raises(
             utils.ImportGPGKeyError, match="Unable to determine the gpg keyid for the rpm key file: %s" % self.gpg_key
         ):
+            utils.find_keyid(self.gpg_key)
+
+    @pytest.mark.parametrize(
+        ("exception", "exception_msg"),
+        (
+            (OSError(13, "Permission denied"), "Errno 13.*Permission denied"),
+            (Exception("Unanticipated problem"), "Unanticipated problem"),
+        )
+    )
+    def test_find_keyid_problem_removing_directory(self, exception, exception_msg, monkeypatch):
+        real_rmtree = shutil.rmtree
+        monkeypatch.setattr(shutil, "rmtree", self.MockedRmtree(exception, real_rmtree))
+
+        with pytest.raises(exception.__class__, match=exception_msg):
             utils.find_keyid(self.gpg_key)
 
 


### PR DESCRIPTION
Gpg writes a temporary socket file for a gpg-agent into --homedir.  Sometimes gpg removes that socket file after rmtree has determined it should delete that file but before the deletion occurs. This will cause a FileNotFoundError (OSError on Python 2).  If we encounter that, try to run shutil.rmtree again since we should now be able to remove all the files that were left.

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-787](https://issues.redhat.com/browse/RHELC-787)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
