### PR TITLE
chore: fix duplicated path in logs

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -369,15 +369,12 @@ def ensure_compatibility_of_kmods():
     if not unsupported_kmods:
         logger.debug("All loaded kernel modules are available in RHEL.")
     else:
-        not_supported_kmods = "\n".join(
-            "/lib/modules/{kver}/{kmod}".format(kver=system_info.booted_kernel, kmod=kmod) for kmod in unsupported_kmods
-        )
         logger.critical(
             "The following loaded kernel modules are not available in RHEL:\n{0}\n"
             "First, make sure you have updated the kernel to the latest available version and rebooted the system.\n"
             "If this message appears again after doing the above, prevent the modules from loading by following {1}"
             " and run convert2rhel again to continue with the conversion.".format(
-                not_supported_kmods, LINK_PREVENT_KMODS_FROM_LOADING
+                "\n".join(unsupported_kmods), LINK_PREVENT_KMODS_FROM_LOADING
             )
         )
 


### PR DESCRIPTION
The unsupported_kmods variable already formatted
the list to contain the path to lib/modules. Thus the
second joining duplicated the path to include
/lib/modules path twice

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
