### PR TITLE
Disable up to date test

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -41,7 +41,7 @@ jobs:
     epel-7-x86_64:
       distros: [centos-7, oraclelinux-7]
     epel-8-x86_64:
-      distros: [centos-8.4, centos-8, oraclelinux-8.4, oraclelinux-8.6]
+      distros: [centos-8.4, centos-8-latest, oraclelinux-8.4, oraclelinux-8.6]
   use_internal_tf: True
   trigger: pull_request
 - <<: *tests

--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -62,8 +62,10 @@
     test: check-internet-connection
 
 /latest_kernel_check_failed_repoquery:
-    adjust+:
+    adjust:
         enabled: false
-        when: distro == oraclelinux-8.4
+        # TODO EUS Bump disabled version
+        when: >
+            distro == oraclelinux-8.4, oraclelinux-8.6
     discover+:
         test: verify-latest-kernel-check-with-failed-repoquery

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -251,7 +251,7 @@
   adjust:
     enabled: false
     when: >
-      distro == oraclelinux-8.4
+      distro == oraclelinux-8.4, oraclelinux-8.6
   discover+:
     test: checks-after-conversion
   prepare+:

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -23,9 +23,11 @@
 /rhsm_non_eus:
   adjust:
     enabled: false
+    # TODO EUS Bump disabled version
     when: >
       distro != centos-8.4 and
-      distro != oraclelinux-8.4
+      distro != oraclelinux-8.4 and
+      distro != oraclelinux-8.6
   discover+:
     test: checks-after-conversion
   prepare+:
@@ -245,17 +247,18 @@
     playbook: tests/ansible_collections/roles/reboot/main.yml
 
 /system_up_to_date:
-  # On Oracle Linux 8.4 we do not have minor version repositories so we skip the check for up-to-date system.
+  # There are no minor version repositories for Oracle Linux EUS releases, so we skip the check for up-to-date system.
   # The other distributions (including latest Oracle Linux 8 ) have all the necessary repositories
   # to make the check possible.
   adjust:
     enabled: false
+    # TODO EUS Bump disabled version
     when: >
       distro == oraclelinux-8.4, oraclelinux-8.6
   discover+:
     test: checks-after-conversion
   prepare+:
-  - name: preapre non latest kernel
+  - name: prepare non latest kernel
     how: shell
     script: pytest -svv tests/integration/tier1/system-up-to-date/install_non_latest_kernel.py
   - name: reboot machine
@@ -278,7 +281,7 @@
   adjust:
     enabled: false
     when: >
-      distro != centos-8
+      distro != centos-8-latest
   discover+:
     test: checks-after-conversion
   prepare+:
@@ -318,7 +321,7 @@
   adjust:
       enabled: false
       when: >
-        distro != centos-8
+        distro != centos-8-latest
   discover+:
     test: checks-after-conversion
   prepare+:
@@ -368,9 +371,10 @@
 /single_yum_transaction_mismatch_errors:
   adjust:
     enabled: false
+    # TODO EUS Bump disabled version
     when: >
-      distro != centos-8 and
-      distro != oraclelinux-8.6
+      distro != centos-8-latest and
+      distro != oraclelinux-8.7
   discover+:
     test: checks-after-conversion
   prepare+:

--- a/tests/integration/tier0/verify-latest-kernel-check-with-failed-repoquery/main.fmf
+++ b/tests/integration/tier0/verify-latest-kernel-check-with-failed-repoquery/main.fmf
@@ -1,6 +1,15 @@
-summary: Verify that failed repoquery call does not cause latest kernel check call.
+summary: Latest kernel check with failed repoquery
+description: |
+    Verify that failed repoquery call does not cause the latest kernel check to fail.
+
 
 tier: 0
+
+adjust+:
+    enabled: false
+    # TODO EUS Bump disabled version
+    when: >
+        distro == oraclelinux-8.4, oraclelinux-8.6
 
 tag+:
   - kernel
@@ -8,6 +17,6 @@ tag+:
 
 /latest_kernel_check_with_failed_repoquery:
     tag+:
-        - latest_kernel_check_with_failed_repoquery
+        - latest-kernel-check-with-failed-repoquery
     test: |
         pytest -svv -m latest_kernel_check_with_failed_repoquery

--- a/tests/integration/tier1/removed-pkgs-centos-85/main.fmf
+++ b/tests/integration/tier1/removed-pkgs-centos-85/main.fmf
@@ -2,9 +2,4 @@ summary: Removed pkgs from CentOS 8.5
 
 tier: 1
 
-adjust:
-  enabled: false
-  when: >
-    distro != centos-8
-
 test: pytest -svv


### PR DESCRIPTION
* disable for Oracle Linux 8.6 as it is now listed as EUS

Signed-off-by: Daniel Diblik <ddiblik@redhat.com>

