### PR TITLE
Move system info logs to happen after the data collection

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -88,6 +88,7 @@ def main():
         # gather system information
         loggerinst.task("Prepare: Gather system information")
         systeminfo.system_info.resolve_system_info()
+        systeminfo.system_info.print_system_information()
         breadcrumbs.breadcrumbs.collect_early_data()
 
         loggerinst.task("Prepare: Clear YUM/DNF version locks")

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -126,6 +126,11 @@ class SystemInfo(object):
         self.has_internet_access = self._check_internet_access()
         self.dbus_running = self._is_dbus_running()
 
+        self.logger.info("%-20s %s" % ("Name:", self.name))
+        self.logger.info("%-20s %d.%d" % ("OS version:", self.version.major, self.version.minor))
+        self.logger.info("%-20s %s" % ("Architecture:", self.arch))
+        self.logger.info("%-20s %s" % ("Config filename:", self.cfg_filename))
+
     @staticmethod
     def get_system_release_file_content():
         from convert2rhel import redhatrelease
@@ -135,7 +140,6 @@ class SystemInfo(object):
     def _get_system_name(self, system_release_content=None):
         content = self.system_release_file_content if not system_release_content else system_release_content
         name = re.search(r"(.+?)\s?(?:release\s?)?\d", content).group(1)
-        self.logger.info("%-20s %s" % ("Name:", name))
         return name
 
     def _get_system_version(self, system_release_content=None):
@@ -156,7 +160,6 @@ class SystemInfo(object):
             self.logger.critical("Couldn't get system version from %s" % redhatrelease.get_system_release_filepath())
         version = Version(int(match.group(1)), int(match.group(2)))
 
-        self.logger.info("%-20s %d.%d" % ("OS version:", version.major, version.minor))
         return version
 
     def _get_system_distribution_id(self, system_release_content=None):
@@ -187,7 +190,6 @@ class SystemInfo(object):
     def _get_architecture(self):
         arch, _ = utils.run_subprocess(["uname", "-i"], print_output=False)
         arch = arch.strip()  # Remove newline
-        self.logger.info("%-20s %s" % ("Architecture:", arch))
         return arch
 
     def _get_cfg_filename(self):
@@ -196,7 +198,6 @@ class SystemInfo(object):
             self.version.major,
             self.arch,
         )
-        self.logger.info("%-20s %s" % ("Config filename:", cfg_filename))
         return cfg_filename
 
     def _get_cfg_content(self):
@@ -461,12 +462,6 @@ class SystemInfo(object):
             "name": distribution_name,
             "version": "%s.%s" % (distribution_version.major, distribution_version.minor),
         }
-
-        printable_release_info = []
-        for key, value in release_info.items():
-            printable_release_info.append("%s: %s" % (key, value))
-
-        self.logger.info("Release Info: %s", " ".join(printable_release_info))
 
         return release_info
 

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -126,6 +126,8 @@ class SystemInfo(object):
         self.has_internet_access = self._check_internet_access()
         self.dbus_running = self._is_dbus_running()
 
+    def print_system_information(self):
+        """Print system related information."""
         self.logger.info("%-20s %s" % ("Name:", self.name))
         self.logger.info("%-20s %d.%d" % ("OS version:", self.version.major, self.version.minor))
         self.logger.info("%-20s %s" % ("Architecture:", self.arch))

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -443,3 +443,13 @@ def test_get_enabled_rhel_repos(
     global_tool_opts.no_rhsm = tool_opts_no_rhsm
 
     assert system_info.get_enabled_rhel_repos() == expected
+
+
+@centos8
+def test_print_system_information(pretend_os, caplog):
+    system_info.print_system_information()
+
+    assert "CentOS Linux" in caplog.records[-4].message
+    assert "8.4" in caplog.records[-3].message
+    assert "x86_64" in caplog.records[-2].message
+    assert "centos-8-x86_64.cfg" in caplog.records[-1].message


### PR DESCRIPTION
After we introduced the collection of breadcrumbs (#612) as a RHSM facts, we started to use some internal (now public) functions from the systeminfo.py module, which at first, those functions were responsible for logging out some system information, such as: Name, Version, Config file used, and so on... That change caused some duplicated lines in the Convert2RHEL log output.

This commit fixes this by moving the logs to the `resolve_system_info` function instead of placing the logs in each of the facts collection.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
