### PR TITLE
Remove deprecated `include`

### DIFF
--- a/tests/ansible_collections/roles/hardcode-minor-version-repos/tasks/main.yml
+++ b/tests/ansible_collections/roles/hardcode-minor-version-repos/tasks/main.yml
@@ -1,2 +1,2 @@
 ---
-- include: centos-repos.yml
+- include_tasks: centos-repos.yml

--- a/tests/ansible_collections/roles/oracle-linux-specific/tasks/main.yml
+++ b/tests/ansible_collections/roles/oracle-linux-specific/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
-- include: boot_standard_kernel.yml
+- include_tasks: boot_standard_kernel.yml
   when:
     - not ansible_facts['distribution_version'] == "8.4"
 
 # For Oracle Linux 8.4 we need to install the kernel from the 8.4 repository
-- include: boot_standard_kernel_84.yml
+- include_tasks: boot_standard_kernel_84.yml
   when:
     - ansible_facts['distribution_version'] == "8.4"

--- a/tests/ansible_collections/roles/packaging/tasks/main.yml
+++ b/tests/ansible_collections/roles/packaging/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- include: build_rpm.yml
+- include_tasks: build_rpm.yml
   when: build_rpm == true
-- include: install_rpm_from_local_build.yml
+- include_tasks: install_rpm_from_local_build.yml
   when: (rpm_provider == "local") and
         (build_rpm == true)
-- include: install_rpm_from_url.yml
+- include_tasks: install_rpm_from_url.yml
   when: (rpm_provider == "url")

--- a/tests/ansible_collections/roles/update-system/tasks/main.yml
+++ b/tests/ansible_collections/roles/update-system/tasks/main.yml
@@ -2,6 +2,6 @@
 # We can't update Oracle Linux 8.4 to the latest 8.4 packages because there are no public Oracle Linux 8.4 repositories available.
 # The CentOS Linux 8.4 can be updated using this role because the repositories on the system image has been
 # tweaked to point to the CentOS Linux 8.4 repositories in the Vault.
-- include: update-system.yml
+- include_tasks: update-system.yml
   when:
     - not (ansible_facts['distribution_version'] == "8.4" and ansible_facts['distribution'] == "OracleLinux")


### PR DESCRIPTION
* using `include` in ansible to import tasks shows the following: `[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead.`
* change to suggested

Signed-off-by: Daniel Diblik <ddiblik@redhat.com>
