### PR TITLE
Re-enable testing on Oracle Linux 8.6

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -42,8 +42,9 @@ jobs:
     epel-7-x86_64:
       distros: [centos-7, oraclelinux-7]
     epel-8-x86_64:
-      # TODO add oraclelinux-8.6 when the 8.7 is officially out
-      distros: [centos-8.4, centos-8-latest]
+      # TODO switch oraclelinux-8.6 to oraclelinux-8.7,
+      # when the image is available on TF
+      distros: [centos-8.4, centos-8-latest, oraclelinux-8.6]
   use_internal_tf: True
   trigger: pull_request
   identifier: "tier0"

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -42,8 +42,9 @@ jobs:
     epel-7-x86_64:
       distros: [centos-7, oraclelinux-7]
     epel-8-x86_64:
-      # TODO switch oraclelinux-8.6 to oraclelinux-8.7,
-      # when the image is available on TF
+        #TODO bump distro context to 8.7 when the image is available on the testing farm
+        # Even though the distro context is 8.6 we are setting the SYSTEM_RELEASE to 8.7
+        # to tag the updated system correctly
       distros: [centos-8.4, centos-8-latest, oraclelinux-8.6]
   use_internal_tf: True
   trigger: pull_request

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -22,7 +22,10 @@ adjust+:
         SYSTEM_RELEASE: oracle-8.4
       when: distro == oraclelinux-8.4
     - environment+:
-        SYSTEM_RELEASE: oracle-8.6
+        #TODO bump distro context to 8.7 when the image is available on the testing farm
+        # Even though the distro context is 8.6 we are setting the SYSTEM_RELEASE to 8.7
+        # to tag the updated system correctly
+        SYSTEM_RELEASE: oracle-8.7
       when: distro == oraclelinux-8.6
 
 prepare:

--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -76,12 +76,6 @@
 /custom_kernel:
   discover+:
     test: custom-kernel
-    adjust+:
-        enabled: false
-        when: >
-            distro != centos-8-latest
-    discover+:
-        test: sub-man-rollback
 
 /log_command_verification:
   discover+:

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -367,7 +367,7 @@
     # TODO EUS Bump disabled version
     when: >
       distro != centos-8-latest and
-      distro != oraclelinux-8.7
+      distro != oraclelinux-8.6
   discover+:
     test: checks-after-conversion
   prepare+:

--- a/tests/integration/tier0/custom-kernel/test_custom_kernel.py
+++ b/tests/integration/tier0/custom-kernel/test_custom_kernel.py
@@ -5,16 +5,17 @@ import pytest
 
 SYSTEM_RELEASE = os.environ.get("SYSTEM_RELEASE")
 
-ORACLE_LATEST_ORIGINAL_KERNEL = os.popen("rpm -q --last kernel | head -1 | cut -d ' ' -f1").read()
+ORIGINAL_KERNEL = os.popen("rpm -q --last kernel | head -1 | cut -d ' ' -f1").read()
 
 DISTRO_KERNEL_MAPPING = {
     "centos-7": {
-        "original_kernel": "kernel-3.10.0-1160.80.1.el7.x86_64",
+        "original_kernel": f"{ORIGINAL_KERNEL}",
         "custom_kernel": "https://yum.oracle.com/repo/OracleLinux/OL7/latest/x86_64/getPackage/kernel-3.10.0-1160.76.1.0.1.el7.x86_64.rpm",
         "grub_substring": "CentOS Linux (3.10.0-1160.76.1.0.1.el7.x86_64) 7 (Core)",
     },
+    # We hardcode original kernel for both CentOS 8.4 and CentOS 8.5 as it won't receive any updates anymore
     "centos-8.4": {
-        "original_kernel": "kernel-core-4.18.0-305.25.1.el8_4.x86_64",
+        "original_kernel": f"kernel-core-4.18.0-305.25.1.el8_4.x86_64",
         "custom_kernel": "https://yum.oracle.com/repo/OracleLinux/OL8/4/baseos/base/x86_64/getPackage/kernel-core-4.18.0-305.el8.x86_64.rpm",
         "grub_substring": "Oracle Linux Server (4.18.0-305.el8.x86_64) 8.4",
     },
@@ -24,15 +25,13 @@ DISTRO_KERNEL_MAPPING = {
         "grub_substring": "Oracle Linux Server (4.18.0-348.el8.x86_64) 8.5",
     },
     "oracle-7": {
-        "original_kernel": "kernel-3.10.0-1160.80.1.0.1.el7.x86_64",
+        "original_kernel": f"{ORIGINAL_KERNEL}",
         "custom_kernel": "http://mirror.centos.org/centos/7/os/x86_64/Packages/kernel-3.10.0-1160.el7.x86_64.rpm",
         "grub_substring": "Oracle Linux Server 7.9, with Linux 3.10.0-1160.el7.x86_64",
     },
     # Install CentOS 8.5 kernel
-    # We need to load the original kernel value for Oracle Linux 8.7
-    # It cannot be hardcoded, because we are always installing the latest version of standard kernel
     "oracle-8.7": {
-        "original_kernel": f"{ORACLE_LATEST_ORIGINAL_KERNEL}",
+        "original_kernel": f"{ORIGINAL_KERNEL}",
         "custom_kernel": "https://vault.centos.org/centos/8.5.2111/BaseOS/x86_64/os/Packages/kernel-core-4.18.0-348.7.1.el8_5.x86_64.rpm",
         "grub_substring": "CentOS Linux (4.18.0-348.7.1.el8_5.x86_64) 8",
     },

--- a/tests/integration/tier0/custom-kernel/test_custom_kernel.py
+++ b/tests/integration/tier0/custom-kernel/test_custom_kernel.py
@@ -5,6 +5,8 @@ import pytest
 
 SYSTEM_RELEASE = os.environ.get("SYSTEM_RELEASE")
 
+ORACLE_LATEST_ORIGINAL_KERNEL = os.popen("rpm -q --last kernel | head -1 | cut -d ' ' -f1").read()
+
 DISTRO_KERNEL_MAPPING = {
     "centos-7": {
         "original_kernel": "kernel-3.10.0-1160.80.1.el7.x86_64",
@@ -26,14 +28,11 @@ DISTRO_KERNEL_MAPPING = {
         "custom_kernel": "http://mirror.centos.org/centos/7/os/x86_64/Packages/kernel-3.10.0-1160.el7.x86_64.rpm",
         "grub_substring": "Oracle Linux Server 7.9, with Linux 3.10.0-1160.el7.x86_64",
     },
-    "oracle-8.4": {
-        "original_kernel": "kernel-core-4.18.0-305.el8.x86_64",
-        "custom_kernel": " https://vault.centos.org/centos/8.4.2105/BaseOS/x86_64/os/Packages/kernel-core-4.18.0-305.25.1.el8_4.x86_64.rpm",
-        "grub_substring": "CentOS Linux (4.18.0-305.25.1.el8_4.x86_64) 8",
-    },
     # Install CentOS 8.5 kernel
-    "oracle-8.6": {
-        "original_kernel": "kernel-core-4.18.0-372.32.1.0.1.el8_6.x86_64",
+    # We need to load the original kernel value for Oracle Linux 8.7
+    # It cannot be hardcoded, because we are always installing the latest version of standard kernel
+    "oracle-8.7": {
+        "original_kernel": f"{ORACLE_LATEST_ORIGINAL_KERNEL}",
         "custom_kernel": "https://vault.centos.org/centos/8.5.2111/BaseOS/x86_64/os/Packages/kernel-core-4.18.0-348.7.1.el8_5.x86_64.rpm",
         "grub_substring": "CentOS Linux (4.18.0-348.7.1.el8_5.x86_64) 8",
     },
@@ -70,7 +69,7 @@ def clean_up_custom_kernel(shell):
 
     assert (
         shell(
-            "grubby --set-default /boot/vmlinuz-%s" % original_kernel_release,
+            "grubby --set-default /boot/vmlinuz-*%s" % original_kernel_release,
         ).returncode
         == 0
     )


### PR DESCRIPTION
* OL8.7 is officially out, re-enable 8.6 as a target to run tests on
* the target will get updated using ansible to 8.7 latest
* when 8.7 image is available on testing farm, switch target to 8.7

Signed-off-by: Daniel Diblik <ddiblik@redhat.com>
