### PR TITLE
[RHELC-779] Remove unused function call_yum_cmd_w_downgrades

### DIFF
--- a/convert2rhel/pkgmanager/handlers/dnf.py
+++ b/convert2rhel/pkgmanager/handlers/dnf.py
@@ -53,7 +53,19 @@ class DnfTransactionHandler(TransactionHandlerBase):
         self._base = None
 
     def _set_up_base(self):
-        """Create a new instance of the dnf.Base() class."""
+        """Create a new instance of the dnf.Base() class
+
+        We create a new instance of the Base() inside this internal method
+        with the intention of being able to re-initialize the base class
+        whenever we need during the class workflow.
+
+        .. note::
+            Since we need have to delete the base class at the end of the
+            `run_transaction` workflow so we can close the RPM database, preventing
+            leaks or transaction mismatches between the validation and replacement
+            of the packages, we use this internal method to make it easier to
+            re-initialize it again.
+        """
         self._base = pkgmanager.Base()
         self._base.conf.substitutions["releasever"] = system_info.releasever
         self._base.conf.module_platform_id = "platform:el8"
@@ -138,8 +150,8 @@ class DnfTransactionHandler(TransactionHandlerBase):
         """
 
         if validate_transaction:
-            self._base.conf.tsflags.append("test")
             loggerinst.info("Validating the dnf transaction set, no modifications to the system will happen this time.")
+            self._base.conf.tsflags.append("test")
         else:
             loggerinst.info("Replacing %s packages. This process may take some time to finish." % system_info.name)
 
@@ -161,8 +173,8 @@ class DnfTransactionHandler(TransactionHandlerBase):
         """Run the dnf transaction.
 
         Perform the transaction. If the `validate_transaction` parameter set to
-        true, it means the transaction will not be executed, but rather verify everything
-        and do an early return.
+        true, it means the transaction will not be executed, but rather verify
+        everything and do an early return.
 
         :param validate_transaction: Determines if the transaction needs to be
         validated or not.

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -35,7 +35,7 @@ from convert2rhel.pkghandler import (
 from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts
 from convert2rhel.unit_tests import GetLoggerMocked, is_rpm_based_os, run_subprocess_side_effect
-from convert2rhel.unit_tests.conftest import TestPkgObj, all_systems, centos7, centos8, create_pkg_obj
+from convert2rhel.unit_tests.conftest import TestPkgObj, all_systems, centos8, create_pkg_obj
 
 
 six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
@@ -1314,7 +1314,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         pkghandler.fix_default_kernel()
         self.assertTrue(len(pkghandler.logging.getLogger.info_msgs), 2)
         self.assertTrue(any("Boot kernel validated." in message for message in pkghandler.logging.getLogger.debug_msgs))
-        self.assertTrue(len(pkghandler.logging.getLogger.warning_msgs) == 0)
+        self.assertEqual(len(pkghandler.logging.getLogger.warning_msgs), 0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
After merging the #528, we left behind a few comments to be addressed in a future PR as they were mostly about comments/logs that could be improved.

In this PR, there is also a removal of one unused function that was marked as a TODO in #528.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-779](https://issues.redhat.com/browse/RHELC-779)

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`

---
# Blocker

- [x] Probably it is best to merge this after #668 as it removes codes that this PR is intended to remove too.