### PR TITLE
Update URL_GET_PIP in CentOS6 dockerfile

### DIFF
--- a/Dockerfiles/centos6.Dockerfile
+++ b/Dockerfiles/centos6.Dockerfile
@@ -4,7 +4,7 @@ ENV PYTHON python2
 ENV PIP pip2
 ENV PYTHONDONTWRITEBYTECODE 1
 
-ENV URL_GET_PIP "https://fedora-archive.ip-connect.vn.ua/epel/6/x86_64/Packages/p/python-pip-7.1.0-2.el6.noarch.rpm"
+ENV URL_GET_PIP "https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/Packages/p/python-pip-7.1.0-2.el6.noarch.rpm"
 ENV APP_DEV_DEPS "requirements/centos6.requirements.txt"
 ENV APP_PRE_DEV_DEPS "requirements/centos6_pre.requirements.txt"
 ENV PREP_PIP_DEPS "scripts/centos6_pip_prep.sh"


### PR DESCRIPTION
The old URL we were using seems to be returning 404 when we try to access it. Since we can't retrieve the package from that URL, it was causing the image to not be built.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
