### PR TITLE
[RHELC-823] chore: add devcontainer

### DIFF
--- a/.devcontainer/.bashrc
+++ b/.devcontainer/.bashrc
@@ -1,0 +1,14 @@
+#!/usr/bin/bash
+
+alias python='python3'
+alias ll='ls -lh'
+alias la='ls -lah'
+alias cd..='cd ..'
+alias rm='rm -I'
+
+# set a fancy prompt (non-color, unless we know we "want" color)
+case "$TERM" in
+    xterm-color|*-256color) color_prompt=yes;;
+esac
+PS1='\[\033[01;34m\]\u\[\033[38;5;124m\](container)\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+unset color_prompt force_color_prompt

--- a/.devcontainer/centos8-development.Dockerfile
+++ b/.devcontainer/centos8-development.Dockerfile
@@ -1,0 +1,45 @@
+FROM centos:8 as base
+
+ENV PODMAN_USERNS=keep-id
+ENV PYTHON python3
+ENV PIP pip3
+ENV PYTHONDONTWRITEBYTECODE 1
+
+ENV URL_GET_PIP "https://bootstrap.pypa.io/pip/3.6/get-pip.py"
+ENV APP_DEV_DEPS ".devcontainer/centos8.requirements.txt"
+ENV APP_MAIN_DEPS \
+    python3 \
+    python3-six \
+    python3-dbus \
+    python3-pexpect \
+    git
+
+ENV USERNAME=vscode
+ENV USER_UID=1000
+ENV USER_GID=$USER_UID
+
+WORKDIR /workspaces/convert2rhel
+
+FROM base as install_main_deps
+
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
+RUN dnf update -y && dnf install -y $APP_MAIN_DEPS && dnf clean all
+
+FROM install_main_deps as install_dev_deps
+
+RUN curl $URL_GET_PIP | $PYTHON
+COPY $APP_DEV_DEPS $APP_DEV_DEPS
+RUN $PIP install -r $APP_DEV_DEPS
+
+FROM install_dev_deps as install_application
+
+RUN groupadd --gid=$USER_GID -r $USERNAME && \
+    useradd --uid=$USER_UID --home /home/$USERNAME --gid=$USER_GID -m $USERNAME
+
+RUN chown -R $USERNAME:$USERNAME .
+COPY --chown=$USERNAME:$USERNAME . .
+
+COPY .devcontainer/.bashrc /home/$USERNAME
+USER $USERNAME:$USERNAME

--- a/.devcontainer/centos8.requirements.txt
+++ b/.devcontainer/centos8.requirements.txt
@@ -1,0 +1,6 @@
+pylint==2.13.4
+astroid==2.11.7
+pre-commit==2.17.0
+pytest==7.0.1
+pytest-cov==3.0.0
+coverage[toml]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,46 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/docker-existing-dockerfile
+{
+	"name": "CentOS Linux 8",
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": "..",
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "centos8-development.Dockerfile",
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	"postCreateCommand": "pre-commit install",
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--security-opt", "label=disable" ],
+	"runArgs": [
+		"--userns=keep-id"
+	],
+	// Need to mount manually as we run into SELinux issues otherwise
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/${localWorkspaceFolderBasename},type=bind,Z",
+	// Need to change home to avoid errors in Podman
+	"containerEnv": {
+		"HOME": "/home/vscode"
+	},
+	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+	// Uncommented to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root
+	"remoteUser": "vscode",
+	"containerUser": "vscode",
+	"settings": {
+		"extensions.autoUpdate": false,
+		"extensions.autoCheckUpdates": false
+	},
+	// Extensions that are handy when developing
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.vscode-pylance",
+				"eamodio.gitlens",
+				"GitHub.vscode-pull-request-github",
+				"Cameron.vscode-pytest",
+				"njpwerner.autodocstring",
+				"ms-python.python@2022.8.1"
+			]
+		}
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ SRPMS/
 *.pyc
 system_tests/vmdefs/centos*/.vagrant/
 *.copr.conf
-.vscode/*
 .venv/*
 .build-images
 .install
@@ -17,3 +16,5 @@ system_tests/vmdefs/centos*/.vagrant/
 .srpms/*
 .idea/
 .cache/
+.pytest_cache/*
+.mypy_cache/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,14 +25,17 @@ repos:
         additional_dependencies: [toml]
 
   - repo: "https://github.com/pre-commit/pre-commit-hooks"
-    rev: "v4.3.0"
+    rev: "v4.1.0"
     hooks:
       - id: "end-of-file-fixer"
       - id: "trailing-whitespace"
-      - id: "check-json"
       - id: "check-toml"
       - id: "check-yaml"
       - id: "check-merge-conflict"
+  - repo: "https://gitlab.com/bmares/check-json5"
+    rev: "v1.0.0"
+    hooks:
+      - id: "check-json5"
   - repo: "https://github.com/teemtee/tmt.git"
     rev: "1.19.0"
     hooks:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "python.linting.pylintEnabled": true,
+  "python.linting.enabled": true,
+  "python.testing.pytestEnabled": true
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,41 @@ requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-reque
 
 ## Getting started with development
 
+### Develop in a container through VS Code
+
+> **Note**
+>
+> This likely does not work with Docker as it has been exclusively tested with Podman
+
+For an easy setup where you can get up and running within a minute, we have a dedicated development container setup with
+VS Code. This creates a container with extensions and allows you to run convert2rhel and tests without drawbacks.
+
+This does not work with VSCodium as Dev Container is deliberately limited to only work with Microsoft VS Code binaries.
+This also might not work with Docker as it has fixes for Podman that might not exist in Docker.
+
+Note: we need to run tests in a container as convert2rhel is volatile, a small mistake in tests can make modifications
+on your system.
+
+To get started with a Dev Container, you need to install the [Dev Container extensions in VS Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers). You can follow the link or install this ID
+```
+ms-vscode-remote.remote-containers
+```
+
+Once the extension is installed, all you need to do is open up the repository inside a container, pressing `F1` or
+`Ctrl-Shift-P` and starting the following will open up the container for you
+```
+Dev Containers: Open Folder in Container
+```
+
+You are now inside a container as indicated by the bottom left box. There is an extension for tests in the left
+navigation that auto-discovers tests that you can run. This will be much faster than developing using `make tests`
+
+#### Known issues
+##### Debugging just loads and does nothing
+Versions newer than `2022.8.1` of extension `ms-python.python` will not work when debugging code. We have pinned the version but VS Code might auto-update the extension.
+
+To work around this, go to extensions tab and select Ignore Updates on the extension, thereafter select install a new version and install `2022.8.1`. It will prompt to reload the window, make sure the right version is installed after reload. Now debugging should work
+
 ### Dependencies for local development
 
 We have some required dependencies you should have installed on your system
@@ -69,8 +104,7 @@ Optional dependencies:
 ### Setting up the environment
 
 The commands below will create a python3 virtual environment with all the
-necessary dependencies installed, images built, `.env` file created, and setup
-`pre-commit` hooks.
+necessary dependencies installed, images built, and setup `pre-commit` hooks.
 
 Beware this command can take a while to finish, depending on your internet
 connection.


### PR DESCRIPTION
Since convert2rhel is a volatile tool to run on our own machines without
prior understanding that the tests we are running are mocked out
correctly. We may break our machine. It is better to run within a
container but we then get into issues where debugging, testing, and so
on isn't as integrated with existing tools as we'd like.

This is the first step to adding devcontainer using VSCode Remote
Development which will show VSCode as normal but within a container,
making it much easier to run tests and debug

---

I believe most things work at the moment but there are some tasks that need to be done. This also assumes a Podman environment, I do not think it will work with Docker
- [x] Cannot create files in project root (likely SELinux as project root isn't owned by container user)
- [x] Clean-up development Containerfile

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-823](https://issues.redhat.com/browse/RHELC-823) 

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
