### PR TITLE
Add a few exceptions class for yum transaction handler

### DIFF
--- a/convert2rhel/pkgmanager/handlers/yum.py
+++ b/convert2rhel/pkgmanager/handlers/yum.py
@@ -216,14 +216,21 @@ class YumTransactionHandler(TransactionHandlerBase):
 
         try:
             self._base.processTransaction()
-        except (
-            pkgmanager.Errors.YumRPMCheckError,
-            pkgmanager.Errors.YumTestTransactionError,
-            pkgmanager.Errors.YumRPMTransError,
-            pkgmanager.Errors.YumDownloadError,
-            pkgmanager.Errors.YumBaseError,
-            pkgmanager.Errors.YumGPGCheckError,
-        ) as e:
+        except pkgmanager.Errors.YumBaseError as e:
+            # We are catching only `pkgmanager.Errors.YumBaseError` as the base
+            # exception here because all of the other exceptions that can be
+            # raised during the transaction process inherit it from
+            # YumBaseError.
+
+            # The following exceptions is the ones we are actually looking for,
+            # but simplified to only catch the YumBaseError:
+            #  - pkgmanager.Errors.YumRPMCheckError
+            #  - pkgmanager.Errors.YumTestTransactionError
+            #  - pkgmanager.Errors.YumRPMTransError
+            #  - pkgmanager.Errors.YumDownloadError
+            #  - pkgmanager.Errors.YumBaseError
+            #  - pkgmanager.Errors.YumGPGCheckError
+
             loggerinst.debug("Got the following exception message: %s", e)
             loggerinst.critical("Failed to validate the yum transaction.")
 

--- a/convert2rhel/pkgmanager/handlers/yum.py
+++ b/convert2rhel/pkgmanager/handlers/yum.py
@@ -220,6 +220,9 @@ class YumTransactionHandler(TransactionHandlerBase):
             pkgmanager.Errors.YumRPMCheckError,
             pkgmanager.Errors.YumTestTransactionError,
             pkgmanager.Errors.YumRPMTransError,
+            pkgmanager.Errors.YumDownloadError,
+            pkgmanager.Errors.YumBaseError,
+            pkgmanager.Errors.YumGPGCheckError,
         ) as e:
             loggerinst.debug("Got the following exception message: %s", e)
             loggerinst.critical("Failed to validate the yum transaction.")

--- a/convert2rhel/unit_tests/pkgmanager/handlers/yum_test.py
+++ b/convert2rhel/unit_tests/pkgmanager/handlers/yum_test.py
@@ -180,6 +180,9 @@ class TestYumTransactionHandler(object):
             pkgmanager.Errors.YumRPMCheckError,
             pkgmanager.Errors.YumTestTransactionError,
             pkgmanager.Errors.YumRPMTransError,
+            pkgmanager.Errors.YumDownloadError,
+            pkgmanager.Errors.YumBaseError,
+            pkgmanager.Errors.YumGPGCheckError,
         )
         instance = YumTransactionHandler()
         instance._set_up_base()

--- a/convert2rhel/unit_tests/pkgmanager/handlers/yum_test.py
+++ b/convert2rhel/unit_tests/pkgmanager/handlers/yum_test.py
@@ -176,14 +176,7 @@ class TestYumTransactionHandler(object):
 
     @centos7
     def test_process_transaction_with_exceptions(self, pretend_os, _mock_yum_api_calls, caplog):
-        side_effects = (
-            pkgmanager.Errors.YumRPMCheckError,
-            pkgmanager.Errors.YumTestTransactionError,
-            pkgmanager.Errors.YumRPMTransError,
-            pkgmanager.Errors.YumDownloadError,
-            pkgmanager.Errors.YumBaseError,
-            pkgmanager.Errors.YumGPGCheckError,
-        )
+        side_effects = pkgmanager.Errors.YumBaseError
         instance = YumTransactionHandler()
         instance._set_up_base()
         pkgmanager.YumBase.processTransaction.side_effect = side_effects


### PR DESCRIPTION
We discovered that we were missing a few exception classes to catch during the package download. We went ahead and added a couple of exceptions to catch gpg checks and mirror exceptions too.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
