### PR TITLE
Use a local repo for black.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,21 @@
 minimum_pre_commit_version: "2.9.0"
 repos:
-  - repo: "https://github.com/psf/black"
-    rev: "22.10.0"
-    hooks:
-      - id: "black"
-        name: "Format code (black)"
-        language_version: "python3"
+  -   repo: local
+      hooks:
+      -   id: black
+          name: black
+          entry: black
+          types: [python]
+          language: python
+          language_version: "python3"
+          additional_dependencies: [click==7.1.2, black==21.12b0]
+          args:
+            - "--target-version=py27"
+            - "--target-version=py36"
+            - "--target-version=py37"
+            - "--target-version=py38"
+            - "--target-version=py39"
+            - "--target-version=py310"
 
   - repo: "https://github.com/timothycrosley/isort"
     rev: 5.10.1

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -435,7 +435,7 @@ class SystemInfo(object):
 
             # Wait for 1 second, 2 seconds, and then 4 seconds for dbus to be running
             # (In case it was started before convert2rhel but it is slow to start)
-            time.sleep(2**retries)
+            time.sleep(2 ** retries)
             retries += 1
 
         else:  # while-else


### PR DESCRIPTION
This will let us pin the version of black without getting PRs from pre-commit that there is an updated version of black.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist
- [N/A] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [N/A] Jira issue has been made public if possible
- [N/A] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [N/A] When merged: Jira issue has been updated to `Release Pending`
