### PR TITLE
Fix yum transaction for RHEL6 targets

### DIFF
--- a/convert2rhel/pkgmanager/handlers/yum.py
+++ b/convert2rhel/pkgmanager/handlers/yum.py
@@ -298,10 +298,10 @@ class YumTransactionHandler(TransactionHandlerBase):
 
         self._process_transaction(validate_transaction)
 
-        # Because we call the same thing multiple times, the rpm database is
-        # not properly closed at the end.
-        # This cause problems because we have another special operation that
-        # happen in the middle of all of this, that is preserving the rhel
-        # kernel. In the YumBase() class there is a special __del__() method
-        # that resolves all of the locks that it places during the transaction.
+        # Because we call the same thing multiple times, the rpm database is not
+        # properly closed at the end of it, thus, having the need to call
+        # `self._base.close()` explicitly before we delete the object. If we use
+        # only `del self._base`, it seems that yum is not able to properly clean
+        # everything in the database.
+        self._base.close()
         del self._base


### PR DESCRIPTION
The yum transaction handler was not closing the rpmdb properly after the validation phase, thus, leaving the rpmdb opened and causing an traceback in the next step before replacing the packages on the system.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
