### PR TITLE
[RHELC-839] Port the cert unittests to use pytest instead of unittest.

### DIFF
--- a/convert2rhel/unit_tests/cert_test.py
+++ b/convert2rhel/unit_tests/cert_test.py
@@ -18,7 +18,6 @@ import os
 import shutil
 
 import pytest
-import six
 
 from convert2rhel import cert, unit_tests, utils
 from convert2rhel.systeminfo import system_info

--- a/convert2rhel/unit_tests/cert_test.py
+++ b/convert2rhel/unit_tests/cert_test.py
@@ -48,7 +48,7 @@ def cert_dir(monkeypatch, request):
 
     # Remove the temporary directory tree if we created it earlier
     if request.param["data_dir"] is not None:
-        shutil.rmtree(os.path.join(utils.DATA_DIR, "rhel-certs"))
+        shutil.rmtree(data_dir)
 
 
 @pytest.mark.parametrize(
@@ -95,10 +95,8 @@ def test_get_cert_path_missing_cert(message, caplog, cert_dir):
     ),
 )
 def test_get_cert_path(arch, rhel_version, pem, monkeypatch):
-    monkeypatch.setattr(utils, "DATA_DIR", unit_tests.TMP_DIR)
+    monkeypatch.setattr(utils, "DATA_DIR", os.path.join(BASE_DATA_DIR, rhel_version, arch))
     # Check there are certificates for all the supported RHEL variants
-    utils.DATA_DIR = os.path.join(BASE_DATA_DIR, rhel_version, arch)
-
     system_cert = cert.SystemCert()
 
     cert_path = system_cert._source_cert_path

--- a/convert2rhel/unit_tests/cert_test.py
+++ b/convert2rhel/unit_tests/cert_test.py
@@ -58,21 +58,21 @@ def cert_dir(monkeypatch, request):
         "cert_dir",
     ),
     (
-        # Missing certificate
-        (
+        pytest.param(
             "Error: System certificate (.pem) not found in %(cert_dir)s.",
             {
                 "data_dir": unit_tests.TMP_DIR,
                 "arch": "arch",
             },
+            id="missing-certificate",
         ),
-        # Missing cert dir
-        (
+        pytest.param(
             "Error: Could not access %(cert_dir)s.",
             {
                 "data_dir": None,
                 "arch": "nonexisting_arch",
             },
+            id="missing-cert-dir",
         ),
     ),
     indirect=("cert_dir",),


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-839](https://issues.redhat.com/browse/RHELC-839)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
