### PR TITLE
[RHELC-750, RHELC-1005] Rewrite the log messages in download_pkg() to not use "unsupported"

### DIFF
--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -294,6 +294,7 @@ class Convert2rhelLatest(actions.Action):
 
         logger.info("Latest available convert2rhel version is installed.")
 
+
 def _format_EVR(epoch, version, release):
     return "%s:%s-%s" % (epoch, version, release)
 

--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -114,25 +114,6 @@ class Convert2rhelLatest(actions.Action):
 
         raw_output_convert2rhel_versions = _extract_convert2rhel_versions(raw_output_convert2rhel_versions)
 
-        # temp_raw_output = []
-
-        # # We are expecting an repoquery output to be similar to this:
-        # # C2R convert2rhel-0:0.17-1.el7.noarch
-        # # We need the `C2R` identifier to be present on the line so we can know for
-        # # sure that the line we are working with is the a line that contains
-        # # relevant repoquery information to our check, otherwise, we just log the
-        # # information as debug and do nothing with it.
-        # for raw_version in raw_output_convert2rhel_versions:
-        #     if "C2R" in raw_version:
-        #         temp_raw_output.append(raw_version.lstrip("C2R "))
-        #     else:
-        #         # Mainly for debugging purposes to see what is happening if we got
-        #         # anything else that does not have the C2R identifier at the start
-        #         # of the line.
-        #         logger.debug("Got a line without the C2R identifier: %s" % raw_version)
-        # raw_output_convert2rhel_versions = temp_raw_output
-        # print(raw_output_convert2rhel_versions)
-
         latest_available_version = ("0", "0.00", "0")
         convert2rhel_versions = []
 
@@ -223,7 +204,7 @@ class Convert2rhelLatest(actions.Action):
         # and latest_available_version respectively, to compare **just** the version field.
         ver_compare = rpm.labelCompare(precise_convert2rhel_version, precise_available_version)
 
-        formatted_conver2rhel_version = _format_EVR(*precise_convert2rhel_version)
+        formatted_convert2rhel_version = _format_EVR(*precise_convert2rhel_version)
         formatted_available_version = _format_EVR(*precise_available_version)
 
         if ver_compare < 0:
@@ -248,7 +229,7 @@ class Convert2rhelLatest(actions.Action):
                 diagnosis = (
                     "You are currently running %s and the latest version of convert2rhel is %s.\n"
                     "'CONVERT2RHEL_ALLOW_OLDER_VERSION' environment variable detected, continuing conversion"
-                    % (formatted_conver2rhel_version, formatted_available_version)
+                    % (formatted_convert2rhel_version, formatted_available_version)
                 )
                 logger.warning(diagnosis)
                 self.add_message(

--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -201,6 +201,8 @@ class Convert2rhelLatest(actions.Action):
 
         formatted_convert2rhel_version = _format_EVR(*precise_convert2rhel_version)
         formatted_available_version = _format_EVR(*precise_available_version)
+        print("Formatted convert2rhel version: %s" % formatted_convert2rhel_version)
+        print("Formatted avaliable version: %s" % formatted_available_version)
 
         if ver_compare < 0:
             # Current and deprecated env var names
@@ -272,7 +274,7 @@ class Convert2rhelLatest(actions.Action):
 
 
 def _format_EVR(epoch, version, release):
-    return "%s:%s-%s" % (epoch, version, release)
+    return "%s" % (version)
 
 
 def _extract_convert2rhel_versions(raw_versions):

--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -172,7 +172,10 @@ class Convert2rhelLatest(actions.Action):
         else:
             running_convert2rhel_NEVRA = running_convert2rhel_NEVRA[0]
             # Run `rpm -V <convert2rhel pkg NEVRA>` to make sure the user hasn't installed a different convert2rhel version on top of a previously installed rpm package through other means than rpm (e.g. pip install from GitHub)
-            rpm_convert2rhel_verify, return_code = utils.run_subprocess(["rpm", "-V", running_convert2rhel_NEVRA])
+            rpm_convert2rhel_verify, return_code = utils.run_subprocess(
+                ["rpm", "-V", running_convert2rhel_NEVRA],
+                print_output=False,
+            )
 
             # If the files aren't what shipped in the rpm, we print a warning that we could not determine the rpm release and use convert2rhel.__version__ to compare with the latest packaged version
             if return_code != 0:

--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -244,7 +244,7 @@ class Convert2rhelLatest(actions.Action):
                     logger.warning(
                         "You are currently running %s and the latest version of convert2rhel is %s.\n"
                         "We encourage you to update to the latest version."
-                        % (formatted_conver2rhel_version, formatted_available_version)
+                        % (formatted_convert2rhel_version, formatted_available_version)
                     )
                     self.add_message(
                         level="WARNING",
@@ -254,7 +254,7 @@ class Convert2rhelLatest(actions.Action):
                         diagnosis=(
                             "You are currently running %s and the latest version of convert2rhel is %s.\n"
                             "We encourage you to update to the latest version."
-                            % (formatted_conver2rhel_version, formatted_available_version)
+                            % (formatted_convert2rhel_version, formatted_available_version)
                         ),
                     )
 
@@ -267,7 +267,7 @@ class Convert2rhelLatest(actions.Action):
                         diagnosis=(
                             "You are currently running %s and the latest version of convert2rhel is %s.\n"
                             "Only the latest version is supported for conversion."
-                            % (formatted_conver2rhel_version, formatted_available_version)
+                            % (formatted_convert2rhel_version, formatted_available_version)
                         ),
                         remediation="If you want to ignore this check, then set the environment variable 'CONVERT2RHEL_ALLOW_OLDER_VERSION=1' to continue.",
                     )

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -766,6 +766,7 @@ class TestCheckConvert2rhelLatest:
                 return ("C2R convert2rhel-0:0.18.0-1.el7.noarch", 0)
             elif "-V" in cmd:
                 return ("", 1)
+            return ("", 0)
 
         monkeypatch.setattr(
             utils,
@@ -834,6 +835,7 @@ class TestCheckConvert2rhelLatest:
                 return ("C2R convert2rhel-0:0.18.0-1.el7.noarch", 0)
             elif "--qf" in cmd:
                 return ("", 1)
+            return ("", 0)
 
         monkeypatch.setattr(
             utils,
@@ -918,7 +920,7 @@ def extract_convert2rhel_versions_generator():
 
 class Test_ExtractConvert2rhelVersions:
     @pytest.mark.parametrize(
-        ("precise_raw_version", "expected_versions"),
+        ("raw_versions", "expected_versions"),
         (
             (
                 "C2R convert2rhel-0:0.18.0-1.el7.noarch\n",
@@ -982,7 +984,7 @@ class Test_ExtractConvert2rhelVersions:
             ),
         ),
     )
-    def test_extract_convert2rhel_version(self, precise_raw_version, expected_versions):
-        list_of_versions = convert2rhel_latest._extract_convert2rhel_versions(precise_raw_version)
+    def test_extract_convert2rhel_version(self, raw_versions, expected_versions):
+        list_of_versions = convert2rhel_latest._extract_convert2rhel_versions(raw_versions)
 
         assert list_of_versions == expected_versions

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -850,6 +850,71 @@ class TestCheckConvert2rhelLatest:
         )
 
         assert log_msg in caplog.text
+        
+    @pytest.mark.parametrize(
+    ("convert2rhel_latest_version_test",),
+    (
+        [
+            {
+                "local_version": "0.19.0",
+                "package_version_repoquery": "C2R convert2rhel-0:0.18.0-1.el7.noarch\nNot a NEVRA that we was not filtered due to a bug\nC2R convert2rhel-0:0.20.0-1.el7.noarch",
+                "package_version_qf": "C2R convert2rhel-0:0.19.0-1.el7.noarch",
+                "package_version_V": 0,
+                "pmajor": "8",
+                "running_version": "0:0.19.0-1.el7",
+                "latest_version": "0:0.20-1.el7",
+            }
+        ],
+    ),
+    indirect=True,
+    )
+    def test_bad_NEVRA_to_parse_pkg_string(
+        self,
+        convert2rhel_latest_action,
+        convert2rhel_latest_version_test,
+        monkeypatch,
+    ):
+        generator = extract_convert2rhel_versions_generator()
+
+        monkeypatch.setattr(
+            convert2rhel_latest,
+            "_extract_convert2rhel_versions",
+            mock.Mock(spec=convert2rhel_latest._extract_convert2rhel_versions, return_value=next(generator)),
+        )
+
+        convert2rhel_latest_action.run()
+
+        running_version, latest_version = convert2rhel_latest_version_test
+
+        unit_tests.assert_actions_result(
+            convert2rhel_latest_action,
+            level="ERROR",
+            id="OUT_OF_DATE",
+            title="Outdated convert2rhel version detected",
+            description="An outdated convert2rhel version has been detected",
+            diagnosis=(
+                "You are currently running %s and the latest version of convert2rhel is %s.\n"
+                "Only the latest version is supported for conversion." % (running_version, latest_version)
+            ),
+            remediation="If you want to ignore this check, then set the environment variable 'CONVERT2RHEL_ALLOW_OLDER_VERSION=1' to continue.",
+        )
+
+
+def extract_convert2rhel_versions_generator():
+    # Yield bad output
+    yield [
+        "convert2rhel-0:0.18.0-1.el7.noarch",
+        "Not a NEVRA that we was not filtered due to a bug",
+        "convert2rhel-0:0.20.0-1.el7.noarch",
+    ]
+
+    # Yield good output
+    yield [
+        "convert2rhel-0:0.18.0-1.el7.noarch",
+        "convert2rhel-0:0.19.0-1.el7.noarch",
+        "convert2rhel-0:0.20.0-1.el7.noarch",
+    ]
+
 
 
 class Test_ExtractConvert2rhelVersions:
@@ -922,3 +987,5 @@ class Test_ExtractConvert2rhelVersions:
         list_of_versions = convert2rhel_latest._extract_convert2rhel_versions(precise_raw_version)
 
         assert list_of_versions == expected_versions
+
+    

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -850,3 +850,75 @@ class TestCheckConvert2rhelLatest:
         )
 
         assert log_msg in caplog.text
+
+
+class Test_ExtractConvert2rhelVersions:
+    @pytest.mark.parametrize(
+        ("precise_raw_version", "expected_versions"),
+        (
+            (
+                "C2R convert2rhel-0:0.18.0-1.el7.noarch\n",
+                [
+                    "convert2rhel-0:0.18.0-1.el7.noarch",
+                ],
+            ),
+            (
+                "C2R convert2rhel-1:1.0-99.el8.noarch\n",
+                [
+                    "convert2rhel-1:1.0-99.el8.noarch",
+                ],
+            ),
+            (
+                "C2R convert2rhel-0:0.18.0-1.el7.noarch\nC2R convert2rhel-0:0.17.0-1.el7.noarch\nC2R convert2rhel-0:0.20.0-1.el7.noarch",
+                [
+                    "convert2rhel-0:0.18.0-1.el7.noarch",
+                    "convert2rhel-0:0.17.0-1.el7.noarch",
+                    "convert2rhel-0:0.20.0-1.el7.noarch",
+                ],
+            ),
+            (
+                "C2R convert2rhel-0:0.18.0-1.el7.noarch\nC2R convert2rhel-0:0.17.0-1.el7.noarch\nC2R convert2rhel-0:0.20.0-1.el7.noarch\nconvert2rhel-0:0.21-1.el7.noarch",
+                [
+                    "convert2rhel-0:0.18.0-1.el7.noarch",
+                    "convert2rhel-0:0.17.0-1.el7.noarch",
+                    "convert2rhel-0:0.20.0-1.el7.noarch",
+                ],
+            ),
+            (
+                "C2R convert2rhel-0:0.18.0-1.el7.noarch\nconvert2rhel-0:0.21-1.el7.noarch\nC2R convert2rhel-0:0.17.0-1.el7.noarch\nC2R convert2rhel-0:0.20.0-1.el7.noarch\n",
+                [
+                    "convert2rhel-0:0.18.0-1.el7.noarch",
+                    "convert2rhel-0:0.17.0-1.el7.noarch",
+                    "convert2rhel-0:0.20.0-1.el7.noarch",
+                ],
+            ),
+            (
+                "convert2rhel-0:0.21-1.el7.noarch\nC2R convert2rhel-0:0.18.0-1.el7.noarch\nC2R convert2rhel-0:0.17.0-1.el7.noarch\nC2R convert2rhel-0:0.20.0-1.el7.noarch\n",
+                [
+                    "convert2rhel-0:0.18.0-1.el7.noarch",
+                    "convert2rhel-0:0.17.0-1.el7.noarch",
+                    "convert2rhel-0:0.20.0-1.el7.noarch",
+                ],
+            ),
+            (
+                "convert2rhel-0:0.21-1.el7.noarch\nC2R convert2rhel-0:0.18.0-1.el7.noarch\nC2R convert2rhel-0:0.17.0-1.el7.noarch\nconvert2rhel-1:2.27-9.el8.noarch\nC2R convert2rhel-0:0.20.0-1.el7.noarch\n",
+                [
+                    "convert2rhel-0:0.18.0-1.el7.noarch",
+                    "convert2rhel-0:0.17.0-1.el7.noarch",
+                    "convert2rhel-0:0.20.0-1.el7.noarch",
+                ],
+            ),
+            (
+                "",
+                [],
+            ),
+            (
+                "Output\nfrom repoquery where\nno strings were for\npackages",
+                [],
+            ),
+        )
+    )
+    def test_extract_convert2rhel_version(self, precise_raw_version, expected_versions):
+        list_of_versions = convert2rhel_latest._extract_convert2rhel_versions(precise_raw_version)
+
+        assert list_of_versions == expected_versions

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -916,7 +916,7 @@ class Test_ExtractConvert2rhelVersions:
                 "Output\nfrom repoquery where\nno strings were for\npackages",
                 [],
             ),
-        )
+        ),
     )
     def test_extract_convert2rhel_version(self, precise_raw_version, expected_versions):
         list_of_versions = convert2rhel_latest._extract_convert2rhel_versions(precise_raw_version)

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -306,48 +306,6 @@ class TestCheckConvert2rhelLatest:
     @pytest.mark.parametrize(
         ("convert2rhel_latest_version_test",),
         (
-            [{"local_version": "0.21", "package_version": "C2R convert2rhel-0:0.22-1.el7.noarch", "pmajor": "6"}],
-            [{"local_version": "0.21", "package_version": "C2R convert2rhel-0:1.10-1.el7.noarch", "pmajor": "6"}],
-            [{"local_version": "1.21.0", "package_version": "C2R convert2rhel-0:1.21.1-1.el7.noarch", "pmajor": "6"}],
-            [{"local_version": "1.21", "package_version": "C2R convert2rhel-0:1.21.1-1.el7.noarch", "pmajor": "6"}],
-            [{"local_version": "1.21.1", "package_version": "C2R convert2rhel-0:1.22-1.el7.noarch", "pmajor": "6"}],
-        ),
-        indirect=True,
-    )
-    def test_convert2rhel_latest_action_outdated_version(
-        self, convert2rhel_latest_action, convert2rhel_latest_version_test
-    ):
-        convert2rhel_latest_action.run()
-
-        local_version, package_version = convert2rhel_latest_version_test
-        if len(package_version) > 36:
-
-            package_version = package_version[19:25]
-        else:
-            package_version = package_version[19:23]
-
-        expected = set(
-            (
-                actions.ActionMessage(
-                    level="WARNING",
-                    id="OUTDATED_CONVERT2RHEL_VERSION",
-                    title="Outdated convert2rhel version detected",
-                    description="An outdated convert2rhel version has been detected",
-                    diagnosis=(
-                        "You are currently running %s and the latest version of convert2rhel is %s.\n"
-                        "We encourage you to update to the latest version." % (local_version, package_version)
-                    ),
-                    remediation=None,
-                    variables={},
-                ),
-            )
-        )
-        assert expected.issuperset(convert2rhel_latest_action.messages)
-        assert expected.issubset(convert2rhel_latest_action.messages)
-
-    @pytest.mark.parametrize(
-        ("convert2rhel_latest_version_test",),
-        (
             [
                 {
                     "local_version": "0.18.0",

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -144,8 +144,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.21-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "7",
-                    "running_version": "0:0.21-1.el7",
-                    "latest_version": "0:0.22-1.el7",
+                    "running_version": "0.21",
+                    "latest_version": "0.22",
                 }
             ],
             [
@@ -156,8 +156,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.21-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "7",
-                    "running_version": "0:0.21-1.el7",
-                    "latest_version": "0:1.10-1.el7",
+                    "running_version": "0.21",
+                    "latest_version": "1.10",
                 }
             ],
             [
@@ -168,8 +168,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:1.21.0-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "7",
-                    "running_version": "0:1.21.0-1.el7",
-                    "latest_version": "0:1.21.1-1.el7",
+                    "running_version": "1.21.0",
+                    "latest_version": "1.21.1",
                 }
             ],
             [
@@ -180,8 +180,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:1.21-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "7",
-                    "running_version": "0:1.21-1.el7",
-                    "latest_version": "0:1.21.1-1.el7",
+                    "running_version": "1.21",
+                    "latest_version": "1.21.1",
                 }
             ],
             [
@@ -192,8 +192,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:1.21.1-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "7",
-                    "running_version": "0:1.21.1-1.el7",
-                    "latest_version": "0:1.22-1.el7",
+                    "running_version": "1.21.1",
+                    "latest_version": "1.22",
                 }
             ],
         ),
@@ -228,8 +228,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.21-1.el7.noarch",
                     "package_version_V": " ",
                     "pmajor": "6",
-                    "running_version": "0:0.21-1.el7",
-                    "latest_version": "0:0.22-1.el7",
+                    "running_version": "0.21",
+                    "latest_version": "0.22",
                 }
             ],
             [
@@ -240,8 +240,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.21-1.el7.noarch",
                     "package_version_V": " ",
                     "pmajor": "6",
-                    "running_version": "0:0.21-1.el7",
-                    "latest_version": "0:1.10-1.el7",
+                    "running_version": "0.21",
+                    "latest_version": "1.10",
                 }
             ],
             [
@@ -252,8 +252,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:1.21.0-1.el7.noarch",
                     "package_version_V": " ",
                     "pmajor": "6",
-                    "running_version": "0:1.21.0-1.el7",
-                    "latest_version": "0:1.21.1-1.el7",
+                    "running_version": "1.21.0",
+                    "latest_version": "1.21.1",
                 }
             ],
             [
@@ -264,8 +264,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:1.21-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "6",
-                    "running_version": "0:1.21-1.el7",
-                    "latest_version": "0:1.21.1-1.el7",
+                    "running_version": "1.21",
+                    "latest_version": "1.21.1",
                 }
             ],
             [
@@ -276,8 +276,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:1.21.1-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "6",
-                    "running_version": "0:1.21.1-1.el7",
-                    "latest_version": "0:1.22-1.el7",
+                    "running_version": "1.21.1",
+                    "latest_version": "1.22",
                 }
             ],
         ),
@@ -320,8 +320,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_V": 0,
                     "pmajor": "6",
                     "enset": "1",
-                    "running_version": "0:0.18.0-1.el7",
-                    "latest_version": "0:0.22.0-1.el7",
+                    "running_version": "0.18.0",
+                    "latest_version": "0.22.0",
                 }
             ],
             [
@@ -333,8 +333,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_V": 0,
                     "pmajor": "7",
                     "enset": "1",
-                    "running_version": "0:0.18.1-1.el7",
-                    "latest_version": "0:0.22.0-1.el7",
+                    "running_version": "0.18.1",
+                    "latest_version": "0.22.0",
                 }
             ],
             [
@@ -346,8 +346,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_V": 0,
                     "pmajor": "8",
                     "enset": "1",
-                    "running_version": "0:0.18.3-1.el7",
-                    "latest_version": "0:0.22.1-1.el7",
+                    "running_version": "0.18.3",
+                    "latest_version": "0.22.1",
                 }
             ],
             [
@@ -359,8 +359,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_V": 0,
                     "pmajor": "8",
                     "enset": "1",
-                    "running_version": "0:0.18-1.el7",
-                    "latest_version": "0:1.10.2-1.el7",
+                    "running_version": "0.18",
+                    "latest_version": "1.10.2",
                 }
             ],
             [
@@ -372,8 +372,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_V": 0,
                     "pmajor": "8",
                     "enset": "1",
-                    "running_version": "0:0.18.0-1.el7",
-                    "latest_version": "0:1.10-1.el7",
+                    "running_version": "0.18.0",
+                    "latest_version": "1.10",
                 }
             ],
         ),
@@ -589,8 +589,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.19.0-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "8",
-                    "running_version": "0:0.19.0-1.el7",
-                    "latest_version": "0:0.20.0-1.el7",
+                    "running_version": "0.19.0",
+                    "latest_version": "0.20.0",
                 }
             ],
             [
@@ -601,8 +601,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.19-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "8",
-                    "running_version": "0:0.19-1.el7",
-                    "latest_version": "0:0.20.0-1.el7",
+                    "running_version": "0.19",
+                    "latest_version": "0.20.0",
                 }
             ],
             [
@@ -613,8 +613,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.19.0-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "8",
-                    "running_version": "0:0.19.0-1.el7",
-                    "latest_version": "0:0.20-1.el7",
+                    "running_version": "0.19.0",
+                    "latest_version": "0.20",
                 }
             ],
         ),
@@ -649,8 +649,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.17.0-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "8",
-                    "running_version": "0:0.17.0-1.el7",
-                    "latest_version": "0:0.18.0-1.el7",
+                    "running_version": "0.17.0",
+                    "latest_version": "0.18.0",
                 }
             ],
             [
@@ -661,8 +661,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.17-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "8",
-                    "running_version": "0:0.17-1.el7",
-                    "latest_version": "0:0.18.0-1.el7",
+                    "running_version": "0.17",
+                    "latest_version": "0.18.0",
                 }
             ],
             [
@@ -673,8 +673,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.17.0-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "8",
-                    "running_version": "0:0.17.0-1.el7",
-                    "latest_version": "0:0.18-1.el7",
+                    "running_version": "0.17.0",
+                    "latest_version": "0.18",
                 }
             ],
         ),
@@ -868,8 +868,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.19.0-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "8",
-                    "running_version": "0:0.19.0-1.el7",
-                    "latest_version": "0:0.20.0-1.el7",
+                    "running_version": "0.19.0",
+                    "latest_version": "0.20.0",
                 }
             ],
         ),

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -19,6 +19,8 @@ __metaclass__ = type
 
 import os
 
+from unittest import mock
+
 import pytest
 
 from convert2rhel import actions, systeminfo, unit_tests, utils

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -19,9 +19,12 @@ __metaclass__ = type
 
 import os
 
-from unittest import mock
-
 import pytest
+import six
+
+
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
 
 from convert2rhel import actions, systeminfo, unit_tests, utils
 from convert2rhel.actions.system_checks import convert2rhel_latest

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -850,23 +850,23 @@ class TestCheckConvert2rhelLatest:
         )
 
         assert log_msg in caplog.text
-        
+
     @pytest.mark.parametrize(
-    ("convert2rhel_latest_version_test",),
-    (
-        [
-            {
-                "local_version": "0.19.0",
-                "package_version_repoquery": "C2R convert2rhel-0:0.18.0-1.el7.noarch\nNot a NEVRA that we was not filtered due to a bug\nC2R convert2rhel-0:0.20.0-1.el7.noarch",
-                "package_version_qf": "C2R convert2rhel-0:0.19.0-1.el7.noarch",
-                "package_version_V": 0,
-                "pmajor": "8",
-                "running_version": "0:0.19.0-1.el7",
-                "latest_version": "0:0.20-1.el7",
-            }
-        ],
-    ),
-    indirect=True,
+        ("convert2rhel_latest_version_test",),
+        (
+            [
+                {
+                    "local_version": "0.19.0",
+                    "package_version_repoquery": "C2R convert2rhel-0:0.18.0-1.el7.noarch\nNot a NEVRA that we was not filtered due to a bug\nC2R convert2rhel-0:0.20.0-1.el7.noarch",
+                    "package_version_qf": "C2R convert2rhel-0:0.19.0-1.el7.noarch",
+                    "package_version_V": 0,
+                    "pmajor": "8",
+                    "running_version": "0:0.19.0-1.el7",
+                    "latest_version": "0:0.20.0-1.el7",
+                }
+            ],
+        ),
+        indirect=True,
     )
     def test_bad_NEVRA_to_parse_pkg_string(
         self,
@@ -876,10 +876,10 @@ class TestCheckConvert2rhelLatest:
     ):
         generator = extract_convert2rhel_versions_generator()
 
-        monkeypatch.setattr(
-            convert2rhel_latest,
-            "_extract_convert2rhel_versions",
-            mock.Mock(spec=convert2rhel_latest._extract_convert2rhel_versions, return_value=next(generator)),
+        # Use mock.patch with side_effect set to the generator
+        mock.patch(
+            "convert2rhel_latest._extract_convert2rhel_versions",
+            side_effect=generator,
         )
 
         convert2rhel_latest_action.run()
@@ -914,7 +914,6 @@ def extract_convert2rhel_versions_generator():
         "convert2rhel-0:0.19.0-1.el7.noarch",
         "convert2rhel-0:0.20.0-1.el7.noarch",
     ]
-
 
 
 class Test_ExtractConvert2rhelVersions:
@@ -987,5 +986,3 @@ class Test_ExtractConvert2rhelVersions:
         list_of_versions = convert2rhel_latest._extract_convert2rhel_versions(precise_raw_version)
 
         assert list_of_versions == expected_versions
-
-    


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
Convert2RHEL is moving away from using the word unsupported, and we will gradually go away from using this terminology. This PR also goes through the log message to better explain how the conversion can fail.
* Add sanity test to verify the deprecated `CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK` envar is still allowed


<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issues: 
- [RHELC-750](https://issues.redhat.com/browse/RHELC-750)
- [RHELC-1005](https://issues.redhat.com/browse/RHELC-1005)

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
