### PR TITLE
[RHELC-750] Rewrite the log messages using the word "unsupported"  in is_loaded_kernel_latest()

### DIFF
--- a/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
+++ b/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
@@ -77,21 +77,36 @@ class IsLoadedKernelLatest(actions.Action):
         # Append the package name as the last item on the list
         cmd.append(package_to_check)
 
-        unsupported_skip = os.environ.get("CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK", None)
+        # Repoquery failed to detected any kernel or kernel-core packages in it's repositories
+        # we allow the user to provide a environment variable to override the functionality and proceed
+        # with the conversion, otherwise, we just throw an critical logging to them.
+        allow_older_envvar_names = (
+            "CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK",
+            "CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK",
+        )
+        # This check is to see which environment variable is set, To allow users in the next version
+        # to adjust their environmental variable names. This check will be removed in the future and
+        # will only have the 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' environment variable
+        if any(envvar in os.environ for envvar in allow_older_envvar_names):
+            if "CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK" in os.environ:
+                logger.warning(
+                    "You are using the deprecated 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK'"
+                    " environment variable. Please switch to 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK'"
+                    " instead."
+                )
 
-        # Skip the kernel package check and print a warning if the user used the special environment variable for it
-        if unsupported_skip:
             logger.warning(
-                "Detected 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip "
+                "Detected 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip "
                 "the %s comparison.\n"
                 "Beware, this could leave your system in a broken state." % package_to_check
             )
+
             self.add_message(
                 level="WARNING",
                 id="UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK_DETECTED",
                 title="Skipping the kernel currency check",
                 description=(
-                    "Detected 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip "
+                    "Detected 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip "
                     "the %s comparison.\n"
                     "Beware, this could leave your system in a broken state." % package_to_check
                 ),

--- a/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
+++ b/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
@@ -79,7 +79,7 @@ class IsLoadedKernelLatest(actions.Action):
 
         # Repoquery failed to detected any kernel or kernel-core packages in it's repositories
         # we allow the user to provide a environment variable to override the functionality and proceed
-        # with the conversion, otherwise, we just throw an critical logging to them.
+        # with the conversion, otherwise, we just throw a critical logging to them.
         allow_older_envvar_names = (
             "CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK",
             "CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK",

--- a/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
@@ -385,6 +385,7 @@ class TestIsLoadedKernelLatest:
             "repoquery_stdout",
             "return_code",
             "unsupported_skip",
+            "skip_check",
             "level",
             "id",
             "title",
@@ -396,6 +397,7 @@ class TestIsLoadedKernelLatest:
             pytest.param(
                 "",
                 0,
+                "0",
                 "1",
                 "WARNING",
                 "UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK_DETECTED",
@@ -409,12 +411,13 @@ class TestIsLoadedKernelLatest:
             ),
         ),
     )
-    def test_is_loaded_kernel_latest_unsupported_skip_warnings(
+    def test_is_loaded_kernel_latest_skip_warnings(
         self,
         pretend_os,
         repoquery_stdout,
         return_code,
         unsupported_skip,
+        skip_check,
         level,
         id,
         title,
@@ -454,6 +457,11 @@ class TestIsLoadedKernelLatest:
             "environ",
             {"CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK": unsupported_skip},
         )
+        monkeypatch.setattr(
+            os,
+            "environ",
+            {"CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK": skip_check},
+        )
 
         expected_set = set(
             (
@@ -469,6 +477,112 @@ class TestIsLoadedKernelLatest:
         )
         is_loaded_kernel_latest_action.run()
         assert description in caplog.records[-1].message
+        assert expected_set.issuperset(is_loaded_kernel_latest_action.messages)
+        assert expected_set.issubset(is_loaded_kernel_latest_action.messages)
+
+    @centos8
+    @pytest.mark.parametrize(
+        (
+            "repoquery_stdout",
+            "return_code",
+            "unsupported_skip",
+            "latest_skip",
+            "level",
+            "id",
+            "title",
+            "description",
+            "unsupported_message",
+            "diagnosis",
+            "remediation",
+        ),
+        (
+            pytest.param(
+                "",
+                0,
+                "1",
+                "0",
+                "WARNING",
+                "UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK_DETECTED_1",
+                "Skipping the kernel currency check",
+                (
+                    "Detected 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip the kernel-core comparison.\nBeware, this could leave your system in a broken state."
+                ),
+                (
+                    "You are using the deprecated 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK' environment variable. Please switch to 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' instead."
+                ),
+                None,
+                None,
+                id="Unsupported skip with environment var set to 1",
+            ),
+        ),
+    )
+    def test_is_loaded_kernel_latest_unsupported_skip_warning(
+        self,
+        pretend_os,
+        repoquery_stdout,
+        return_code,
+        unsupported_skip,
+        latest_skip,
+        level,
+        id,
+        title,
+        description,
+        unsupported_message,
+        diagnosis,
+        remediation,
+        monkeypatch,
+        caplog,
+        is_loaded_kernel_latest_action,
+    ):
+        run_subprocess_mocked = mock.Mock(
+            spec=run_subprocess,
+            side_effect=run_subprocess_side_effect(
+                (
+                    (
+                        "repoquery",
+                        "--setopt=exclude=",
+                        "--quiet",
+                        "--qf",
+                        "C2R\\t%{BUILDTIME}\\t%{VERSION}-%{RELEASE}\\t%{REPOID}",
+                        "kernel-core",
+                    ),
+                    (
+                        repoquery_stdout,
+                        return_code,
+                    ),
+                ),
+            ),
+        )
+        monkeypatch.setattr(
+            is_loaded_kernel_latest,
+            "run_subprocess",
+            value=run_subprocess_mocked,
+        )
+        monkeypatch.setattr(
+            os,
+            "environ",
+            {"CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK": unsupported_skip},
+        )
+        monkeypatch.setattr(
+            os,
+            "environ",
+            {"CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK": latest_skip},
+        )
+
+        expected_set = set(
+            (
+                actions.ActionMessage(
+                    level=level,
+                    id=id,
+                    title=title,
+                    description=description,
+                    diagnosis=diagnosis,
+                    remediation=remediation,
+                ),
+            )
+        )
+        is_loaded_kernel_latest_action.run()
+        assert unsupported_message in caplog.records[-1].message
         assert expected_set.issuperset(is_loaded_kernel_latest_action.messages)
         assert expected_set.issubset(is_loaded_kernel_latest_action.messages)
 

--- a/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
@@ -502,7 +502,7 @@ class TestIsLoadedKernelLatest:
                 "1",
                 "0",
                 "WARNING",
-                "UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK_DETECTED_1",
+                "UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK_DETECTED",
                 "Skipping the kernel currency check",
                 (
                     "Detected 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip the kernel-core comparison.\nBeware, this could leave your system in a broken state."
@@ -563,11 +563,6 @@ class TestIsLoadedKernelLatest:
             "environ",
             {"CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK": unsupported_skip},
         )
-        monkeypatch.setattr(
-            os,
-            "environ",
-            {"CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK": latest_skip},
-        )
 
         expected_set = set(
             (
@@ -582,7 +577,7 @@ class TestIsLoadedKernelLatest:
             )
         )
         is_loaded_kernel_latest_action.run()
-        assert unsupported_message in caplog.records[-1].message
+        assert unsupported_message in caplog.records[-2].message
         assert expected_set.issuperset(is_loaded_kernel_latest_action.messages)
         assert expected_set.issubset(is_loaded_kernel_latest_action.messages)
 

--- a/tests/integration/tier0/non-destructive/system-release-backup/main.fmf
+++ b/tests/integration/tier0/non-destructive/system-release-backup/main.fmf
@@ -16,7 +16,7 @@ tag+:
         description+: |
             Install subscription-manager and katello package from the Satellite.
             Remove all repositories from the system.
-            Set the "CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK" envar to bypass kernel check.
+            Set the "CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK" envar to bypass kernel check.
             Verify that the /etc/os-release file is restored after the rollback.
         /backup_os_release_no_envar:
             summary+: |

--- a/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
+++ b/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
@@ -79,12 +79,12 @@ def kernel_check_envar(shell):
     to skip the kernel currency check.
     """
     # Since we are moving all repos away, we need to bypass kernel check
-    os.environ["CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK"] = "1"
+    os.environ["CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK"] = "1"
 
     yield
 
     # Remove the envar skipping the kernel check
-    del os.environ["CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK"]
+    del os.environ["CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK"]
 
 
 @pytest.mark.test_unsuccessful_satellite_registration

--- a/tests/integration/tier1/destructive/kernel-check-skip/main.fmf
+++ b/tests/integration/tier1/destructive/kernel-check-skip/main.fmf
@@ -5,7 +5,7 @@ description+: |
     Verify that it's possible to run the full conversion with older kernel,
     than available in the RHEL repositories.
         1/ Install older kernel on the system
-        2/ Make sure the `CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK` is in place
+        2/ Make sure the `CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK` is in place
             * doing that we also verify, the deprecated envar is still allowed
         3/ Enable *just* the rhel-7-server-rpms repository
         4/ Run conversion verifying the conversion is not inhibited and completes successfully

--- a/tests/integration/tier1/destructive/kernel-check-skip/test_latest_kernel_check_skip.py
+++ b/tests/integration/tier1/destructive/kernel-check-skip/test_latest_kernel_check_skip.py
@@ -50,8 +50,7 @@ def test_skip_kernel_check(shell, convert2rhel):
         )
     ) as c2r:
         # Verify that using the deprecated environment variable is still allowed and continues the conversion
-        # TODO(danmyway) uncomment in #684
-        # assert c2r.expect("You are using the deprecated 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK'") == 0
+        assert c2r.expect("You are using the deprecated 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK'") == 0
         # Make sure the kernel comparison is skipped
         c2r_expect_index = c2r.expect(
             [

--- a/tests/integration/tier1/destructive/one-kernel-scenario/run_conversion.py
+++ b/tests/integration/tier1/destructive/one-kernel-scenario/run_conversion.py
@@ -33,7 +33,7 @@ def test_run_conversion_using_custom_repos(shell, convert2rhel):
         shell("rm /etc/yum.repos.d/copr_build-convert2rhel-1.repo")
 
     os.environ["CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK"] = "1"
-    os.environ["CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK"] = "1"
+    os.environ["CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK"] = "1"
     # Unavailable kmods may be present on the system due to the kernel package
     # not being updated. Mitigate the issues by exporting CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS.
     os.environ["CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS"] = "1"

--- a/tests/integration/tier1/destructive/system-up-to-date/test_system_up_to_date.py
+++ b/tests/integration/tier1/destructive/system-up-to-date/test_system_up_to_date.py
@@ -24,7 +24,24 @@ def test_skip_kernel_check(shell, convert2rhel):
     os.environ["CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK"] = "1"
 
     with convert2rhel(
-        "--serverurl {} --username {} --password {} --pool {} --debug".format(
+        "-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug".format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        if SYSTEM_RELEASE_ENV in ("centos-7", "oracle-7"):
+            c2r.expect("Could not find any kernel from repositories to compare against the loaded kernel.")
+        else:
+            c2r.expect("Could not find any kernel-core from repositories to compare against the loaded kernel.")
+    assert c2r.exitstatus != 0
+
+    os.environ["CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK"] = "1"
+
+    with convert2rhel(
+        "--no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug".format(
             env.str("RHSM_SERVER_URL"),
             env.str("RHSM_USERNAME"),
             env.str("RHSM_PASSWORD"),
@@ -35,7 +52,7 @@ def test_skip_kernel_check(shell, convert2rhel):
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("y")
 
-        c2r.expect("Detected 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK' environment variable")
+        c2r.expect("Detected 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' environment variable")
         c2r.sendcontrol("c")
     assert c2r.exitstatus != 0
 

--- a/tests/integration/tier1/destructive/system-up-to-date/test_system_up_to_date.py
+++ b/tests/integration/tier1/destructive/system-up-to-date/test_system_up_to_date.py
@@ -27,7 +27,6 @@ def test_skip_kernel_check(shell, convert2rhel):
         "-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug".format(
             env.str("RHSM_SERVER_URL"),
             env.str("RHSM_USERNAME"),
-            env.str("RHSM_USERNAME"),
             env.str("RHSM_PASSWORD"),
             env.str("RHSM_POOL"),
         )


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
Convert2RHEL is moving away from using the word unsupported, and we will gradually go away from using this terminology. This PR also goes through the log message to better explain how the conversion can fail.

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-750](https://issues.redhat.com/browse/RHELC-750)

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
