### PR TITLE
[RHELC-598] Fix for check-user-response test

### DIFF
--- a/tests/integration/tier0/check-user-response/test_user_response.py
+++ b/tests/integration/tier0/check-user-response/test_user_response.py
@@ -16,13 +16,26 @@ def test_check_user_response_user_and_password(convert2rhel):
         # "Password" and raises the assertion error.
         assert c2r.expect_exact(["Username", "Password"], timeout=300) == 0
         # Provide username, expect password prompt
-        c2r.sendline(env.str("RHSM_USERNAME"))
-        c2r.expect_exact("Password: ")
-        c2r.sendline()
-        assert c2r.expect_exact(["Password", "Enter number of the chosen subscription"], timeout=300) == 0
-        # Provide password, expect successful registration and subscription prompt
-        c2r.sendline(env.str("RHSM_PASSWORD"))
-        c2r.expect_exact("Enter number of the chosen subscription: ")
+
+        retries = 0
+        while True:
+            c2r.sendline(env.str("RHSM_USERNAME"))
+            print("Sending username:", env.str("RHSM_USERNAME"))
+            c2r.expect_exact("Password: ")
+            c2r.sendline()
+            try:
+                assert c2r.expect_exact(["Password", "Enter number of the chosen subscription"], timeout=300) == 0
+                # Provide password, expect successful registration and subscription prompt
+                c2r.sendline(env.str("RHSM_PASSWORD"))
+                print("Sending password")
+                c2r.expect_exact("Enter number of the chosen subscription: ")
+                break
+            except Exception:
+                retries = retries + 1
+                if retries == 3:
+                    raise
+                continue
+
         # Due to inconsistent behavior of Ctrl+c
         # the Ctrl+d is used to terminate the process instead
         c2r.sendcontrol("d")


### PR DESCRIPTION
Signed-off-by: Preston Watson <prwatson@redhat.com>

Adds a try/expect block to retry an assertion that usually takes 3 tries to pass. The integration test was not built to handle the three retries and fails on the first try. 

[RHELC-598] https://issues.redhat.com/browse/RHELC-598
Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [ x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
