### PR TITLE
[RHELC-836] Improve release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  exclude:
+    labels:
+      - no-changelog
+    authors:
+      - dependabot
+      - pre-commit-ci
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: Enhancements 🎉
+      labels:
+        - enhancement
+        - "*"
+    - title: Security Hardening 🔒
+      labels:
+        - security-hardening
+    - title: Bug Fixes 🐛
+      labels:
+        - bug-fix


### PR DESCRIPTION
When generating release docs we want to split the PRs into different
categories more easily. This will spllit it into several categories and
ignore some labels and bots

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-836](https://issues.redhat.com/browse/RHELC-836)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
