### PR TITLE
Remove black args from pre-commit-config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,19 +9,11 @@ repos:
           language: python
           language_version: "python3"
           additional_dependencies: [click==7.1.2, black==21.12b0]
-          args:
-            - "--target-version=py27"
-            - "--target-version=py36"
-            - "--target-version=py37"
-            - "--target-version=py38"
-            - "--target-version=py39"
-            - "--target-version=py310"
 
   - repo: "https://github.com/timothycrosley/isort"
     rev: 5.11.4
     hooks:
       - id: isort
-        language_version: "python3"
         additional_dependencies: [toml]
 
   - repo: "https://github.com/pre-commit/pre-commit-hooks"

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -77,7 +77,6 @@ def main():
 
     # handle command line arguments
     toolopts.CLI()
-
     try:
         process_phase = ConversionPhase.POST_CLI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length=120
-target-version=["py38"]
+target-version=["py27", "py36", "py37", "py38", "py39", "py310"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
We had pre-commit-config settings the args for black and the
pyproject.toml file as also setting some properties for the tool.

It seems that black override those properties from pyproject.toml since
we used the CLI args for it, but in any case, we should rely only on one
configuration file to tell the tool what property it should override.

Also removed the unnecessary property in pre-commit-config for `isort`.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
