### PR TITLE
[RHELC-862] chore: Separate make fetch-images 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@ SRPMS/
 system_tests/vmdefs/centos*/.vagrant/
 *.copr.conf
 .venv/*
-.build-images
+.build-image7
+.build-image8
 .install
 .pre-commit
 .rpms/*


### PR DESCRIPTION
This makes it so that if you want to run just tests for centos7 using
make tests7 it will now only build an image for centos7 instead of all
images at once.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-862](https://issues.redhat.com/browse/RHELC-862)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
