### PR TITLE
[RHELC-854] Man/help page to mention config file location

### DIFF
--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -199,10 +199,14 @@ class CLI(object):
         group.add_option(
             "-c",
             "--config-file",
-            help="A configuration file to safely provide either a user password or an activation key for registering"
-            " the system through subscription-manager. Alternatively, passing these values through the"
-            " --activationkey or --password option would leak them through a list of running processes."
-            " Example of this file in /etc/convert2rhel.ini",
+            help="The configuration file is an optional way to safely pass either a user password or an activation key"
+            " to the subscription-manager to register the system. This is more secure than passing these values"
+            " through the --activationkey or --password option, which might leak the values"
+            " through a list of running processes."
+            " You can edit the pre-installed configuration file template at /etc/convert2rhel.ini or create a new"
+            " configuration file at ~/.convert2rhel.ini. The convert2rhel utility loads the configuration from either"
+            " of those locations, the latter having preference over the former. Alternatively, you can specify a path"
+            " to the configuration file using the --config-file option to override other configurations.",
         )
         group.add_option(
             "-a",


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
Small improvement of docustring of `--config-file` option.
<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [[RHELC-854](https://issues.redhat.com/browse/RHELC-854)]

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
