### PR TITLE
[RHELC-864] chore: fix GitHub workflow with container

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -2,7 +2,7 @@ name: build_and_publish_images
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build_and_publish:
@@ -34,7 +34,7 @@ jobs:
         with:
           push: true
           context: .
-          file: ./Dockerfiles/centos${{ matrix.centos_ver }}.Dockerfile
+          file: ./Containerfiles/centos${{ matrix.centos_ver }}.Containerfile
           tags: ghcr.io/${{ github.repository_owner }}/convert2rhel-centos${{ matrix.centos_ver }}:latest
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/convert2rhel-centos${{ matrix.centos_ver }}:latest
           cache-to: type=inline


### PR DESCRIPTION
We forgot to rename the build_images workflow to use Containerfile

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-864](https://issues.redhat.com/browse/RHELC-864)

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
