### PR TITLE
[RHELC-733] Fixes the bug for converting when trying to add in an new UEFI bootloader entry for RHEL

### DIFF
--- a/convert2rhel/grub.py
+++ b/convert2rhel/grub.py
@@ -151,12 +151,24 @@ def _get_blk_device(device):
 
 
 def _get_device_number(device):
-    """Return dict with 'major' and 'minor' number of the specified device/partition."""
-    output, ecode = utils.run_subprocess(["blkid", "-p", "-s", "PART_ENTRY_NUMBER", device], print_output=False)
+    """Get the partition number of a particular device.
+
+    This method will use `blkid` to determinate what is the partition number
+    related to a particular device.
+
+    :param device: The device to be analyzed.
+    :type device: str
+    :return: The device partition number.
+    :rtype: int
+    """
+    output, ecode = utils.run_subprocess(
+        ["/usr/sbin/blkid", "-p", "-s", "PART_ENTRY_NUMBER", device], print_output=False
+    )
     if ecode:
         logger.debug("blkid output:\n-----\n%s\n-----" % output)
         raise BootloaderError("Unable to get information about the '%s' device" % device)
-    # We are spliting the partition entry number, and we are just taking that output as our desired partition number
+    # We are spliting the partition entry number, and we are just taking that
+    # output as our desired partition number
     partition_number = output.split("PART_ENTRY_NUMBER=")[-1].replace('"', "")
     return int(partition_number)
 

--- a/convert2rhel/grub.py
+++ b/convert2rhel/grub.py
@@ -157,8 +157,8 @@ def _get_device_number(device):
         logger.debug("blkid output:\n-----\n%s\n-----" % output)
         raise BootloaderError("Unable to get information about the '%s' device" % device)
     # We are spliting the partition entry number, and we are just taking that output as our desired partition number
-    parttition_number = output.split("PART_ENTRY_NUMBER=")[-1].replace('"', "")
-    return int(parttition_number)
+    partition_number = output.split("PART_ENTRY_NUMBER=")[-1].replace('"', "")
+    return int(partition_number)
 
 
 def get_grub_device():

--- a/convert2rhel/unit_tests/grub_test.py
+++ b/convert2rhel/unit_tests/grub_test.py
@@ -39,9 +39,7 @@ _SEC_STDOUT_DISABLED = "e.g. nothing..."
 LSBLK_NAME_OUTPUT = """/dev/sda
 /dev/sda
 """
-LSBLK_NUMBER_OUTPUT = """123:1
-259:0
-"""
+BLKID_NUMBER_OUTPUT = '/dev/sda1: PART_ENTRY_NUMBER="1"'
 
 
 # subproc is tuple (stdout, ecode) or None in case exception should be raised
@@ -137,8 +135,8 @@ def test__get_blk_device(monkeypatch, caplog, expected_res, device, exception, s
 @pytest.mark.parametrize(
     ("expected_res", "device", "exc", "subproc_called", "subproc"),
     (
-        ({"major": 123, "minor": 1}, "/dev/sda", False, True, (LSBLK_NUMBER_OUTPUT, 0)),
-        (None, "/dev/sda", grub.BootloaderError, True, (LSBLK_NUMBER_OUTPUT, 1)),
+        (1, "/dev/sda1", False, True, (BLKID_NUMBER_OUTPUT, 0)),
+        (None, "/dev/sda1", grub.BootloaderError, True, (BLKID_NUMBER_OUTPUT, 1)),
     ),
 )
 def test__get_device_number(monkeypatch, caplog, expected_res, device, exc, subproc_called, subproc):
@@ -152,7 +150,9 @@ def test__get_device_number(monkeypatch, caplog, expected_res, device, exc, subp
         assert grub._get_device_number(device) == expected_res
 
     if subproc_called:
-        utils.run_subprocess.assert_called_once_with(["lsblk", "-spnlo", "MAJ:MIN", device], print_output=False)
+        utils.run_subprocess.assert_called_once_with(
+            ["blkid", "-p", "-s", "PART_ENTRY_NUMBER", device], print_output=False
+        )
     else:
         utils.run_subprocess.assert_not_called()
         assert len(caplog.records) == 0
@@ -478,7 +478,7 @@ def test__is_rhel_in_boot_entries(efi_bin_path, label, expected_ret_val):
     ),
 )
 def test__add_rhel_boot_entry(efi_file_exists, exc, exc_msg, rhel_entry_exists, subproc, log_msg, monkeypatch, caplog):
-    monkeypatch.setattr("convert2rhel.grub._get_device_number", mock.Mock(return_value={"major": 252, "minor": 1}))
+    monkeypatch.setattr("convert2rhel.grub._get_device_number", mock.Mock(return_value=1))
     monkeypatch.setattr("convert2rhel.systeminfo.system_info.version", namedtuple("Version", ["major", "minor"])(8, 5))
     monkeypatch.setattr("convert2rhel.grub.get_efi_partition", mock.Mock(return_value="/dev/sda"))
     monkeypatch.setattr("convert2rhel.grub.get_grub_device", mock.Mock(return_value="/dev/sda"))

--- a/convert2rhel/unit_tests/grub_test.py
+++ b/convert2rhel/unit_tests/grub_test.py
@@ -151,7 +151,7 @@ def test__get_device_number(monkeypatch, caplog, expected_res, device, exc, subp
 
     if subproc_called:
         utils.run_subprocess.assert_called_once_with(
-            ["blkid", "-p", "-s", "PART_ENTRY_NUMBER", device], print_output=False
+            ["/usr/sbin/blkid", "-p", "-s", "PART_ENTRY_NUMBER", device], print_output=False
         )
     else:
         utils.run_subprocess.assert_not_called()

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -373,3 +373,18 @@
         - name: reboot after conversion
           how: ansible
           playbook: tests/ansible_collections/roles/reboot/main.yml
+  
+/detect_correct_boot_partition:
+   adjust:
+     enabled: true
+     when: trigger == commit
+     because: There are no UEFI images available on the Testing Farm yet.
+   discover+:
+       test: checks-after-conversion
+   prepare+:
+       - name: main conversion part
+         how: shell
+         script: pytest -svv tests/integration/tier1/detect-bootloader-partition/test_detect_correct_boot_partition.py
+       - name: reboot after conversion
+         how: ansible
+         playbook: tests/ansible_collections/roles/reboot/main.yml

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -375,10 +375,10 @@
           playbook: tests/ansible_collections/roles/reboot/main.yml
   
 /detect_correct_boot_partition:
-   adjust:
-     enabled: true
-     when: trigger == commit
-     because: There are no UEFI images available on the Testing Farm yet.
+   adjust+:
+     - enabled: false
+       when: trigger == commit
+       because: There are no UEFI images available on the Testing Farm yet.
    discover+:
        test: checks-after-conversion
    prepare+:

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -373,7 +373,7 @@
         - name: reboot after conversion
           how: ansible
           playbook: tests/ansible_collections/roles/reboot/main.yml
-  
+
 /detect_correct_boot_partition:
    adjust+:
      - enabled: false

--- a/tests/integration/tier1/detect-bootloader-partition/main.fmf
+++ b/tests/integration/tier1/detect-bootloader-partition/main.fmf
@@ -1,0 +1,17 @@
+summary: Detect correct bootloader partition
+
+description: |
+    Verify that Convert2RHEL detected the correct boot partition.
+
+    This test is supposed to be ran only on UEFI machines.
+
+tier: 1
+
+test: pytest -svv
+
+tag+:
+    - uefi
+    - bootloader
+
+link:
+    verifies: https://issues.redhat.com/browse/RHELC-733

--- a/tests/integration/tier1/detect-bootloader-partition/test_detect_correct_boot_partition.py
+++ b/tests/integration/tier1/detect-bootloader-partition/test_detect_correct_boot_partition.py
@@ -1,0 +1,82 @@
+import platform
+import subprocess
+
+from envparse import env
+
+
+EFI_BOOT_MOUNTPOINT = "/boot/efi"
+SYSTEM_RELEASE = platform.platform()
+
+# TODO(danmyway): We need to include another test case in this to verify that
+# Convert2RHEL can detect the correct partition even though it will not be in
+# the usual /dev/xxx1. We are holding https://github.com/teemtee/tmt/pull/1835
+# to get merged, as well, UEFI support in testing farm to create such case.
+
+
+def get_boot_device():
+    """Utillity function to get the device that the `EFI_BOOT_MOUNTPOINT` lives in."""
+    device = subprocess.check_output(["grub2-probe", "--target=device", EFI_BOOT_MOUNTPOINT])
+    return device.decode().strip()
+
+
+def get_device_name(device):
+    """Utillity function to get a device name only, without the partition number."""
+    name = subprocess.check_output(["lsblk", "-spnlo", "name", device])
+    return name.decode().strip()
+
+
+def get_device_partition(device):
+    """Utillity function to retrieve the boot partition for a given device."""
+    partition = subprocess.check_output(["blkid", "-p", "-s", "PART_ENTRY_NUMBER", device])
+    partition = partition.decode().strip()
+    return partition.rsplit("PART_ENTRY_NUMBER=", maxsplit=1)[-1].replace('"', "")
+
+
+def test_detect_correct_boot_partition(convert2rhel):
+    """
+    Verify that the correct arguments for disk and partition will be used
+    during the creation of a new EFI partition.
+
+    This test does a series of assertions to verify that Convert2RHEl was able
+    to correctly detect the EFI boot partition during the execution, no matter
+    what disk/partition the EFI mount will be.
+    """
+    boot_device = get_boot_device()
+    boot_device_name = get_device_name(boot_device)
+    boot_partition = get_device_partition(boot_device)
+
+    rhel_version = "7"
+
+    if "centos-8" in SYSTEM_RELEASE or "oracle-8" in SYSTEM_RELEASE:
+        rhel_version = "8"
+
+    with convert2rhel(
+        "-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug".format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        assert c2r.expect("Calling command '/usr/sbin/blkid -p -s PART_ENTRY_NUMBER %s'" % boot_device) == 0
+
+        # This assertation should always match what comes from boot_partition.
+        assert c2r.expect("Block device: %s" % boot_device_name) == 0
+        assert c2r.expect("ESP device number: %s" % boot_partition) == 0
+
+        assert c2r.expect("Adding 'Red Hat Enterprise Linux %s' UEFI bootloader entry." % rhel_version) == 0
+
+        # Only asserting half of the command as we care mostly about the
+        # `--disk` and `--part`.
+        assert (
+            c2r.expect(
+                "Calling command '/usr/sbin/efibootmgr --create --disk %s --part %s"
+                % (boot_device_name, boot_partition)
+            )
+            == 0
+        )
+        # Last assertation to make sure that it went well and we removed the
+        # old UEFI bootloader.
+        assert c2r.expect("The removal of the original, currently used UEFI bootloader") == 0
+
+    assert c2r.exitstatus == 0

--- a/tests/integration/tier1/detect-bootloader-partition/test_detect_correct_boot_partition.py
+++ b/tests/integration/tier1/detect-bootloader-partition/test_detect_correct_boot_partition.py
@@ -22,7 +22,7 @@ def get_boot_device():
 def get_device_name(device):
     """Utillity function to get a device name only, without the partition number."""
     name = subprocess.check_output(["lsblk", "-spnlo", "name", device])
-    return name.decode().strip()
+    return name.decode().strip().splitlines()[-1].strip()
 
 
 def get_device_partition(device):
@@ -75,8 +75,5 @@ def test_detect_correct_boot_partition(convert2rhel):
             )
             == 0
         )
-        # Last assertation to make sure that it went well and we removed the
-        # old UEFI bootloader.
-        assert c2r.expect("The removal of the original, currently used UEFI bootloader") == 0
 
     assert c2r.exitstatus == 0


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
This PR fixes a bug in convert2rhel. The conversion would fail when getting to the "Configure the Bootloader" step because it wasn't getting the correct partition number if the user had more than one partition on a UEFI system.

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-733](https://issues.redhat.com/browse/RHELC-733)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
