### PR TITLE
[RHELC-667] Improve package version comparison

### DIFF
--- a/convert2rhel/pkgmanager/__init__.py
+++ b/convert2rhel/pkgmanager/__init__.py
@@ -43,7 +43,6 @@ except ImportError as e:
     from dnf import *  # pylint: disable=import-error
     from dnf.callback import Depsolve, DownloadProgress
 
-
     # This is added here to prevent a generic try-except in the
     # `check_package_updates()` function.
     from dnf.exceptions import RepoError

--- a/convert2rhel/pkgmanager/__init__.py
+++ b/convert2rhel/pkgmanager/__init__.py
@@ -23,6 +23,8 @@ from convert2rhel import utils
 loggerinst = logging.getLogger(__name__)
 
 try:
+    # this is used in pkghandler.py to parse version strings in the _parse_pkg_with_yum function
+    from rpmUtils.miscutils import splitFilename
     from yum import *
     from yum.callbacks import DownloadBaseCallback as DownloadProgress
 
@@ -32,9 +34,15 @@ try:
     from yum.rpmtrans import SimpleCliCallBack as TransactionDisplay
 
     TYPE = "yum"
+
+# WARNING: if there is a bug in the yum import section, we might try to import dnf incorrectly
 except ImportError as e:
-    from dnf import *
+
+    import hawkey
+
+    from dnf import *  # pylint: disable=import-error
     from dnf.callback import Depsolve, DownloadProgress
+
 
     # This is added here to prevent a generic try-except in the
     # `check_package_updates()` function.

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -645,6 +645,13 @@ def test_get_rhel_supported_kmods(
         ),
         (
             (
+                "kmod-core-0:10.18.0-240.10.1.el8_3.x86_64",
+                "kmod-core-0:9.18.0-240.15.1.el8_3.x86_64",
+            ),
+            ("kmod-core-0:10.18.0-240.10.1.el8_3.x86_64",),
+        ),
+        (
+            (
                 "not-expected-core-0:4.18.0-240.10.1.el8_3.x86_64",
                 "kmod-core-0:4.18.0-240.15.1.el8_3.x86_64",
             ),
@@ -1166,6 +1173,7 @@ class TestIsLoadedKernelLatest:
                 "3.10.0-1160.42.2.el7.x86_64",
                 0,
                 "kernel-core",
+
             ),
         ),
     )

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -1173,7 +1173,6 @@ class TestIsLoadedKernelLatest:
                 "3.10.0-1160.42.2.el7.x86_64",
                 0,
                 "kernel-core",
-
             ),
         ),
     )

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -545,28 +545,6 @@ def test_prompt_user(question, is_password, response, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    ("string_version", "nevra"),
-    (
-        ("5.14.15-300.fc35", ("0", "5.14.15", "300.fc35")),
-        ("0.17-9.fc35", ("0", "0.17", "9.fc35")),
-        ("2.34.1-2.fc35", ("0", "2.34.1", "2.fc35")),
-        (
-            "0.9.1-2.20210420git36391559.fc35",
-            ("0", "0.9.1", "2.20210420git36391559.fc35"),
-        ),
-        ("2:8.2.3568-1.fc35", ("2", "8.2.3568", "1.fc35")),
-        (
-            "4.6~pre16262021g84ef6bd9-3.fc35",
-            ("0", "4.6~pre16262021g84ef6bd9", "3.fc35"),
-        ),
-    ),
-)
-def test_string_to_version(string_version, nevra):
-    nevra_version = utils.string_to_version(string_version)
-    assert nevra_version == nevra
-
-
-@pytest.mark.parametrize(
     ("path_exists", "list_dir", "expected"),
     (
         (True, ["dir-1", "dir-2"], 0),

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -664,27 +664,6 @@ def find_keyid(keyfile):
     return keyid.lower()
 
 
-def string_to_version(verstring):
-    """Return a tuple of (epoch, version, release) from a version string
-    This function was taken from softwarefactory-project/rdopkg
-    (https://github.com/softwarefactory-project/rdopkg/blob/1.4.0/rdopkg/utils/specfile.py)
-    """
-
-    # is there an epoch?
-    components = verstring.split(":")
-    if len(components) > 1:
-        epoch = components[0]
-        components.pop(0)
-    else:
-        epoch = "0"
-
-    remaining = components[:2][0].split("-")
-    version = remaining[0]
-    release = remaining[1]
-
-    return (epoch, version, release)
-
-
 def remove_orphan_folders():
     """Even after removing redhat-release-* package, some of its folders are
     still present, are empty, and that blocks us from installing centos-release


### PR DESCRIPTION
This is a WIP PR for RHELC-667. It aims to improve the current package version comparison with the addition of being able to parse NEVRA, NEVR, NVRA, NVR, ENVRA and ENVR formats. The PR will also separate the current package version comparison and parsing function into two separate functions. 

Jira Issue: [RHELC-667](https://issues.redhat.com/browse/RHELC-667)


Signed-off-by: Preston Watson <prwatson@redhat.com>

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
