### PR TITLE
[RHELC-876] Cleanup pylint errors for object inheritance and enable consider-using-with

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,6 @@
+[MASTER]
+ignore=
+
 [BASIC]
 
 # Regular expression matching correct function names
@@ -18,11 +21,7 @@ disable=
  arguments-renamed,
  attribute-defined-outside-init,
  broad-except,
- consider-using-dict-items,
- consider-using-f-string,
- consider-using-with,
  cyclic-import,
- deprecated-module,
  duplicate-code,
  empty-docstring,
  expression-not-assigned,
@@ -81,8 +80,6 @@ disable=
  unused-argument,
  unused-import,
  unused-variable,
- useless-else-on-loop,
- useless-object-inheritance,
  useless-option-value,
  useless-return,
  useless-suppression,

--- a/convert2rhel/__init__.py
+++ b/convert2rhel/__init__.py
@@ -1,1 +1,2 @@
+__metaclass__ = type
 __version__ = "1.4.1"

--- a/convert2rhel/actions/pre_ponr_changes/__init__.py
+++ b/convert2rhel/actions/pre_ponr_changes/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/actions/system_checks/__init__.py
+++ b/convert2rhel/actions/system_checks/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/backup.py
+++ b/convert2rhel/backup.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import abc
 import logging
 import os
@@ -32,7 +34,7 @@ from convert2rhel.utils import BACKUP_DIR, download_pkg, remove_orphan_folders, 
 loggerinst = logging.getLogger(__name__)
 
 # Note: Currently the only use case for this is package removals
-class ChangedRPMPackagesController(object):
+class ChangedRPMPackagesController:
     """Keep control of installed/removed RPM pkgs for backup/restore."""
 
     def __init__(self):
@@ -121,7 +123,7 @@ class ChangedRPMPackagesController(object):
         self._install_removed_pkgs()
 
 
-class BackupController(object):
+class BackupController:
     """
     Controls backup and restore for all restorable types.
 
@@ -258,7 +260,7 @@ class BackupController(object):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class RestorableChange(object):
+class RestorableChange:
     """
     Interface definition for types which can be restored.
     """
@@ -339,7 +341,7 @@ class RestorableRpmKey(RestorableChange):
         super(RestorableRpmKey, self).restore()
 
 
-class RestorableFile(object):
+class RestorableFile:
     def __init__(self, filepath):
         self.filepath = filepath
 
@@ -392,7 +394,7 @@ class RestorableFile(object):
 
 # Over time we want to replace this with pkghandler.RestorablePackageSet
 # Right now, this is still used for removed packages.  Installed packages are handled by pkghandler.RestorablePackageSet
-class RestorablePackage(object):
+class RestorablePackage:
     def __init__(self, pkgname):
         self.name = pkgname
         self.path = None

--- a/convert2rhel/breadcrumbs.py
+++ b/convert2rhel/breadcrumbs.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import json
 import logging
 import os
@@ -40,7 +42,7 @@ RHSM_CUSTOM_FACTS_NAMESPACE = "conversions"
 loggerinst = logging.getLogger(__name__)
 
 
-class Breadcrumbs(object):
+class Breadcrumbs:
     """The so-called breadcrumbs data is a collection of basic information about the convert2rhel execution.
 
     This data is to be stored in a specific file in a machine-readable format which can be collected by various

--- a/convert2rhel/cert.py
+++ b/convert2rhel/cert.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import errno
 import logging
 import os

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -13,6 +13,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import logging
 import os
 

--- a/convert2rhel/grub.py
+++ b/convert2rhel/grub.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import logging
 import os
 import re
@@ -182,7 +184,7 @@ def get_grub_device():
     return _get_blk_device(partition)
 
 
-class EFIBootLoader(object):
+class EFIBootLoader:
     """Representation of an UEFI boot loader entry."""
 
     def __init__(self, boot_number, label, active, efi_bin_source):
@@ -243,7 +245,7 @@ class EFIBootLoader(object):
         return EFIBootLoader._efi_path_to_canonical(match.groups("path")[0])
 
 
-class EFIBootInfo(object):
+class EFIBootInfo:
     """Data about the current UEFI boot configuration.
 
     Raise BootloaderError when unable to obtain info about the UEFI configuration.
@@ -311,8 +313,8 @@ class EFIBootInfo(object):
         msg = "Bootloader setup:"
         msg += "\nCurrent boot: %s" % self.current_bootnum
         msg += "\nBoot order: %s\nBoot entries:" % ", ".join(self.boot_order)
-        for bootnum in self.entries:
-            msg += "\n- %s: %s" % (bootnum, self.entries[bootnum].label.rstrip())
+        for bootnum, entry in self.entries.items():
+            msg += "\n- %s: %s" % (bootnum, entry.label.rstrip())
         logger.debug(msg)
 
 

--- a/convert2rhel/i18n.py
+++ b/convert2rhel/i18n.py
@@ -22,6 +22,8 @@ module provides a single place to keep that information.  If we decide to locali
 the future, this file should point us towards all the locations that we may need to change.
 """
 
+__metaclass__ = type
+
 #
 # Display locales
 #

--- a/convert2rhel/initialize.py
+++ b/convert2rhel/initialize.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import logging
 import os
 

--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -26,6 +26,9 @@ DEBUG     (10)    Prints debug message (using date/time)
 FILE      (5)     CUSTOM LABEL - Outputs with the DEBUG label but only to a file
                   handle (using date/time)
 """
+
+__metaclass__ = type
+
 import logging
 import os
 import shutil
@@ -37,12 +40,12 @@ from time import gmtime, strftime
 LOG_DIR = "/var/log/convert2rhel"
 
 
-class LogLevelTask(object):
+class LogLevelTask:
     level = 15
     label = "TASK"
 
 
-class LogLevelFile(object):
+class LogLevelFile:
     level = 5
     # Label messages DEBUG as it is contains the same messages as debug, just that they always go
     # to the log file.
@@ -193,12 +196,9 @@ def colorize(message, color="OKGREEN"):
     return "".join((getattr(bcolors, color), message, bcolors.ENDC))
 
 
-class CustomFormatter(logging.Formatter, object):
-    """Custom formatter to handle different logging formats based on logging level
-
-    Python 2.6 workaround - logging.Formatter class does not use new-style
-        class and causes 'TypeError: super() argument 1 must be type, not
-        classobj' so we use multiple inheritance to get around the problem.
+class CustomFormatter(logging.Formatter):
+    """
+    Custom formatter to handle different logging formats based on logging level.
     """
 
     color_disabled = False

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import logging
 import os
 import sys
@@ -33,7 +35,7 @@ class _AnalyzeExit(Exception):
     pass
 
 
-class ConversionPhase(object):
+class ConversionPhase:
     INIT = 0
     POST_CLI = 1
     # PONR means Point Of No Return

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import glob
 import logging
 import os
@@ -451,9 +453,9 @@ def get_rpm_header(pkg_obj):
             #  separately, but there's a bug: https://bugzilla.redhat.com/show_bug.cgi?id=1876885.
 
             return rpm_hdr
-    else:
-        # Package not found in the rpm db
-        loggerinst.critical("Unable to find package '%s' in the rpm database." % pkg_obj.name)
+
+    # Package not found in the rpm db
+    loggerinst.critical("Unable to find package '%s' in the rpm database." % pkg_obj.name)
 
 
 def get_installed_pkg_objects(name=None, version=None, release=None, arch=None):

--- a/convert2rhel/pkgmanager/__init__.py
+++ b/convert2rhel/pkgmanager/__init__.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import logging
 
 from contextlib import contextmanager

--- a/convert2rhel/pkgmanager/handlers/__init__.py
+++ b/convert2rhel/pkgmanager/handlers/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/pkgmanager/handlers/base.py
+++ b/convert2rhel/pkgmanager/handlers/base.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import abc
 
 import six

--- a/convert2rhel/pkgmanager/handlers/dnf/__init__.py
+++ b/convert2rhel/pkgmanager/handlers/dnf/__init__.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import logging
 
 from convert2rhel import pkgmanager

--- a/convert2rhel/pkgmanager/handlers/dnf/callback.py
+++ b/convert2rhel/pkgmanager/handlers/dnf/callback.py
@@ -58,6 +58,8 @@
 #   License above taken from the original code at:
 #
 #       https://github.com/rpm-software-management/dnf/blob/4.7.0/dnf/cli/output.py
+__metaclass__ = type
+
 import logging
 
 from convert2rhel import pkgmanager

--- a/convert2rhel/pkgmanager/handlers/yum/callback.py
+++ b/convert2rhel/pkgmanager/handlers/yum/callback.py
@@ -55,7 +55,9 @@
 #   License above taken from the original code at:
 #
 #       https://github.com/rpm-software-management/yum/blob/master/yum/callbacks.py
-#
+
+__metaclass__ = type
+
 import logging
 
 from convert2rhel import pkgmanager
@@ -66,7 +68,7 @@ loggerinst = logging.getLogger(__name__)
 
 # We need to double inherit here, both from the callback class and the base
 # object class, just to initialize properly with `super`
-class PackageDownloadCallback(pkgmanager.DownloadProgress, object):
+class PackageDownloadCallback(pkgmanager.DownloadProgress, object):  # pylint: disable=useless-object-inheritance
     """Package download callback for YUM transaction."""
 
     def __init__(self):
@@ -111,7 +113,7 @@ class PackageDownloadCallback(pkgmanager.DownloadProgress, object):
         self.last_package_seen = name
 
 
-class TransactionDisplayCallback(pkgmanager.TransactionDisplay, object):
+class TransactionDisplayCallback(pkgmanager.TransactionDisplay, object):  # pylint: disable=useless-object-inheritance
     """Transaction display callback for YUM transaction."""
 
     def __init__(self):

--- a/convert2rhel/redhatrelease.py
+++ b/convert2rhel/redhatrelease.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import logging
 import os
 import re
@@ -60,7 +62,7 @@ def get_system_release_content():
         loggerinst.critical("%s\n%s file is essential for running this tool." % (err, filepath))
 
 
-class YumConf(object):
+class YumConf:
     _yum_conf_path = "/etc/yum.conf"
 
     def __init__(self):
@@ -87,11 +89,8 @@ class YumConf(object):
             self._yum_conf_content = re.sub(r"\n(distroverpkg=).*", r"\n#\1", self._yum_conf_content)
 
     def _write_altered_yum_conf(self):
-        file_to_write = open(self._yum_conf_path, "w")
-        try:
+        with open(self._yum_conf_path, "w") as file_to_write:
             file_to_write.write(self._yum_conf_content)
-        finally:
-            file_to_write.close()
 
     @staticmethod
     def get_yum_conf_filepath():

--- a/convert2rhel/repo.py
+++ b/convert2rhel/repo.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import logging
 import os
 import shutil

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import logging
 import os
 import re
@@ -231,7 +233,7 @@ def _stop_rhsm():
     loggerinst.info("RHSM service stopped.")
 
 
-class RegistrationCommand(object):
+class RegistrationCommand:
     def __init__(
         self,
         activation_key=None,

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -14,6 +14,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
 import difflib
 import logging
 import os
@@ -54,7 +57,7 @@ EUS_MINOR_VERSIONS = ["8.6"]
 Version = namedtuple("Version", ["major", "minor"])
 
 
-class SystemInfo(object):
+class SystemInfo:
     def __init__(self):
         # Operating system name (e.g. Oracle Linux)
         self.name = None
@@ -374,8 +377,11 @@ class SystemInfo(object):
             CHECK_INTERNET_CONNECTION_ADDRESS,
         )
         try:
+            # urlopen as a context manager is only available in Python-3.0+
+            # pylint: disable=consider-using-with
             response = urllib.request.urlopen(CHECK_INTERNET_CONNECTION_ADDRESS)
             response.close()
+            # pylint: enable=consider-using-with
             self.logger.info(
                 "Successfully connected to address '%s', internet connection seems to be available."
                 % CHECK_INTERNET_CONNECTION_ADDRESS

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+__metaclass__ = type
 
 import argparse
 import copy
@@ -64,7 +65,7 @@ PRE_RPM_VA_LOG_FILENAME = "rpm_va.log"
 POST_RPM_VA_LOG_FILENAME = "rpm_va_after_conversion.log"
 
 
-class ToolOpts(object):
+class ToolOpts:
     def __init__(self):
         self.debug = False
         self.username = None
@@ -97,7 +98,7 @@ class ToolOpts(object):
                 setattr(self, key, value)
 
 
-class CLI(object):
+class CLI:
     def __init__(self):
         self._parser = self._get_argparser()
         self._shared_options_parser = argparse.ArgumentParser(add_help=False)

--- a/convert2rhel/unit_tests/__init__.py
+++ b/convert2rhel/unit_tests/__init__.py
@@ -64,8 +64,8 @@ def create_pkg_information(
     return pkg_info
 
 
-class TestPkgObj(object):
-    class PkgObjHdr(object):
+class TestPkgObj:
+    class PkgObjHdr:
         def sprintf(self, *args, **kwargs):
             return "RSA/SHA256, Sun Feb  7 18:35:40 2016, Key ID 73bde98381b46521"
 
@@ -83,7 +83,7 @@ def create_pkg_obj(
     manager="yum",
     vendor=None,
 ):
-    class DumbObj(object):
+    class DumbObj:
         pass
 
     obj = TestPkgObj()
@@ -593,8 +593,8 @@ def run_subprocess_side_effect(*stubs):
         for kws, result in stubs:
             if all(kw in args[0] for kw in kws):
                 return result
-        else:
-            return run_subprocess(*args, **kwargs)
+
+        return run_subprocess(*args, **kwargs)
 
     return factory
 

--- a/convert2rhel/unit_tests/actions/__init__.py
+++ b/convert2rhel/unit_tests/actions/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/actions/data/__init__.py
+++ b/convert2rhel/unit_tests/actions/data/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/actions/data/aliased_action_name/__init__.py
+++ b/convert2rhel/unit_tests/actions/data/aliased_action_name/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/actions/data/aliased_action_name/test.py
+++ b/convert2rhel/unit_tests/actions/data/aliased_action_name/test.py
@@ -1,3 +1,5 @@
+__metaclass__ = type
+
 from convert2rhel.actions import Action as Foo
 
 

--- a/convert2rhel/unit_tests/actions/data/extraneous_files/__init__.py
+++ b/convert2rhel/unit_tests/actions/data/extraneous_files/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/actions/data/extraneous_files/test.py
+++ b/convert2rhel/unit_tests/actions/data/extraneous_files/test.py
@@ -1,3 +1,5 @@
+__metaclass__ = type
+
 from convert2rhel import actions
 
 

--- a/convert2rhel/unit_tests/actions/data/ignore__init__/__init__.py
+++ b/convert2rhel/unit_tests/actions/data/ignore__init__/__init__.py
@@ -1,3 +1,5 @@
+__metaclass__ = type
+
 from convert2rhel import actions
 
 

--- a/convert2rhel/unit_tests/actions/data/ignore__init__/test.py
+++ b/convert2rhel/unit_tests/actions/data/ignore__init__/test.py
@@ -1,3 +1,5 @@
+__metaclass__ = type
+
 from convert2rhel import actions
 
 

--- a/convert2rhel/unit_tests/actions/data/multiple_actions_multiple_files/__init__.py
+++ b/convert2rhel/unit_tests/actions/data/multiple_actions_multiple_files/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/actions/data/multiple_actions_multiple_files/test1.py
+++ b/convert2rhel/unit_tests/actions/data/multiple_actions_multiple_files/test1.py
@@ -1,3 +1,5 @@
+__metaclass__ = type
+
 from convert2rhel import actions
 
 

--- a/convert2rhel/unit_tests/actions/data/multiple_actions_multiple_files/test2.py
+++ b/convert2rhel/unit_tests/actions/data/multiple_actions_multiple_files/test2.py
@@ -1,3 +1,5 @@
+__metaclass__ = type
+
 from convert2rhel import actions
 
 

--- a/convert2rhel/unit_tests/actions/data/multiple_actions_one_file/__init__.py
+++ b/convert2rhel/unit_tests/actions/data/multiple_actions_one_file/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/actions/data/multiple_actions_one_file/test.py
+++ b/convert2rhel/unit_tests/actions/data/multiple_actions_one_file/test.py
@@ -1,3 +1,5 @@
+__metaclass__ = type
+
 from convert2rhel import actions
 
 

--- a/convert2rhel/unit_tests/actions/data/not_action_itself/__init__.py
+++ b/convert2rhel/unit_tests/actions/data/not_action_itself/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/actions/data/not_action_itself/test.py
+++ b/convert2rhel/unit_tests/actions/data/not_action_itself/test.py
@@ -1,3 +1,5 @@
+__metaclass__ = type
+
 from convert2rhel import actions
 
 

--- a/convert2rhel/unit_tests/actions/data/only_subclasses_of_action/__init__.py
+++ b/convert2rhel/unit_tests/actions/data/only_subclasses_of_action/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/actions/data/only_subclasses_of_action/test.py
+++ b/convert2rhel/unit_tests/actions/data/only_subclasses_of_action/test.py
@@ -1,3 +1,5 @@
+__metaclass__ = type
+
 from convert2rhel import actions
 
 
@@ -8,7 +10,7 @@ class RealTest(actions.Action):
         pass
 
 
-class NotAction(object):
+class NotAction:
     pass
 
 

--- a/convert2rhel/unit_tests/actions/data/stage_tests/__init__.py
+++ b/convert2rhel/unit_tests/actions/data/stage_tests/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/actions/data/stage_tests/action_exceptions/__init__.py
+++ b/convert2rhel/unit_tests/actions/data/stage_tests/action_exceptions/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/actions/data/stage_tests/action_exceptions/test.py
+++ b/convert2rhel/unit_tests/actions/data/stage_tests/action_exceptions/test.py
@@ -1,3 +1,5 @@
+__metaclass__ = type
+
 import logging
 
 from convert2rhel import actions

--- a/convert2rhel/unit_tests/actions/data/stage_tests/all_status_actions/__init__.py
+++ b/convert2rhel/unit_tests/actions/data/stage_tests/all_status_actions/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/actions/data/stage_tests/all_status_actions/test.py
+++ b/convert2rhel/unit_tests/actions/data/stage_tests/all_status_actions/test.py
@@ -1,3 +1,5 @@
+__metaclass__ = type
+
 from convert2rhel import actions
 
 

--- a/convert2rhel/unit_tests/actions/data/stage_tests/bad_deps1/__init__.py
+++ b/convert2rhel/unit_tests/actions/data/stage_tests/bad_deps1/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/actions/data/stage_tests/bad_deps1/test.py
+++ b/convert2rhel/unit_tests/actions/data/stage_tests/bad_deps1/test.py
@@ -1,3 +1,5 @@
+__metaclass__ = type
+
 from convert2rhel import actions
 
 

--- a/convert2rhel/unit_tests/actions/data/stage_tests/deps_on_1/__init__.py
+++ b/convert2rhel/unit_tests/actions/data/stage_tests/deps_on_1/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/actions/data/stage_tests/deps_on_1/test.py
+++ b/convert2rhel/unit_tests/actions/data/stage_tests/deps_on_1/test.py
@@ -1,3 +1,5 @@
+__metaclass__ = type
+
 from convert2rhel import actions
 
 

--- a/convert2rhel/unit_tests/actions/data/stage_tests/good_deps1/__init__.py
+++ b/convert2rhel/unit_tests/actions/data/stage_tests/good_deps1/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/actions/data/stage_tests/good_deps1/test.py
+++ b/convert2rhel/unit_tests/actions/data/stage_tests/good_deps1/test.py
@@ -1,3 +1,5 @@
+__metaclass__ = type
+
 from convert2rhel import actions
 
 

--- a/convert2rhel/unit_tests/actions/data/stage_tests/good_deps_failed_actions/__init__.py
+++ b/convert2rhel/unit_tests/actions/data/stage_tests/good_deps_failed_actions/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/actions/data/stage_tests/good_deps_failed_actions/test.py
+++ b/convert2rhel/unit_tests/actions/data/stage_tests/good_deps_failed_actions/test.py
@@ -1,3 +1,5 @@
+__metaclass__ = type
+
 from convert2rhel import actions
 
 

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/__init__.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/actions/system_checks/__init__.py
+++ b/convert2rhel/unit_tests/actions/system_checks/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/applock_test.py
+++ b/convert2rhel/unit_tests/applock_test.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+__metaclass__ = type
 
 import os
 import subprocess

--- a/convert2rhel/unit_tests/breadcrumbs_test.py
+++ b/convert2rhel/unit_tests/breadcrumbs_test.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import json
 
 import pytest

--- a/convert2rhel/unit_tests/cert_test.py
+++ b/convert2rhel/unit_tests/cert_test.py
@@ -14,6 +14,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
 import os
 import shutil
 

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+__metaclass__ = type
 
 import pytest
 import six

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -1,3 +1,5 @@
+__metaclass__ = type
+
 import logging
 import os
 import sys

--- a/convert2rhel/unit_tests/example_test.py
+++ b/convert2rhel/unit_tests/example_test.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 """
 This is an example test file containing a simple test.
 """

--- a/convert2rhel/unit_tests/grub_test.py
+++ b/convert2rhel/unit_tests/grub_test.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import copy
 import os
 

--- a/convert2rhel/unit_tests/initialize_test.py
+++ b/convert2rhel/unit_tests/initialize_test.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import os
 
 import pytest

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import logging
 import os
 

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import os
 
 from collections import OrderedDict

--- a/convert2rhel/unit_tests/other_test.py
+++ b/convert2rhel/unit_tests/other_test.py
@@ -14,6 +14,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
 import re
 
 from convert2rhel import __version__, logger, pkghandler, utils

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -2299,6 +2299,6 @@ def test_get_package_repositories_repoquery_failure(pretend_os, monkeypatch, cap
     result = pkghandler._get_package_repositories(packages)
 
     assert "Repoquery exited with return code 1 and with output: failed" in caplog.records[-1].message
-    for package in result:
+    for package, repo in result.items():
         assert package in packages
-        assert result[package] == "N/A"
+        assert repo == "N/A"

--- a/convert2rhel/unit_tests/pkgmanager/__init__.py
+++ b/convert2rhel/unit_tests/pkgmanager/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/pkgmanager/handlers/__init__.py
+++ b/convert2rhel/unit_tests/pkgmanager/handlers/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/pkgmanager/handlers/dnf/__init__.py
+++ b/convert2rhel/unit_tests/pkgmanager/handlers/dnf/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/pkgmanager/handlers/dnf/callback_test.py
+++ b/convert2rhel/unit_tests/pkgmanager/handlers/dnf/callback_test.py
@@ -1,3 +1,5 @@
+__metaclass__ = type
+
 import pytest
 
 from convert2rhel import pkgmanager

--- a/convert2rhel/unit_tests/pkgmanager/handlers/dnf/dnf_test.py
+++ b/convert2rhel/unit_tests/pkgmanager/handlers/dnf/dnf_test.py
@@ -14,6 +14,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+__metaclass__ = type
+
 import pytest
 import six
 

--- a/convert2rhel/unit_tests/pkgmanager/handlers/yum/__init__.py
+++ b/convert2rhel/unit_tests/pkgmanager/handlers/yum/__init__.py
@@ -1,0 +1,1 @@
+__metaclass__ = type

--- a/convert2rhel/unit_tests/pkgmanager/handlers/yum/callback_test.py
+++ b/convert2rhel/unit_tests/pkgmanager/handlers/yum/callback_test.py
@@ -1,3 +1,5 @@
+__metaclass__ = type
+
 import pytest
 
 from convert2rhel import pkgmanager
@@ -8,7 +10,7 @@ from convert2rhel.pkgmanager.handlers.yum.callback import PackageDownloadCallbac
     pkgmanager.TYPE != "yum",
     reason="No yum module detected on the system, skipping it.",
 )
-class TestPackageDownloadCallback(object):
+class TestPackageDownloadCallback:
     @pytest.mark.parametrize(
         ("name", "frac", "fread", "ftime", "expected"),
         (
@@ -51,7 +53,7 @@ class TestPackageDownloadCallback(object):
     pkgmanager.TYPE != "yum",
     reason="No yum module detected on the system, skipping it.",
 )
-class TestTransactionDisplayCallback(object):
+class TestTransactionDisplayCallback:
     def test_event(self, caplog):
         instance = TransactionDisplayCallback()
         instance.event(

--- a/convert2rhel/unit_tests/pkgmanager/handlers/yum/yum_test.py
+++ b/convert2rhel/unit_tests/pkgmanager/handlers/yum/yum_test.py
@@ -14,6 +14,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+__metaclass__ = type
+
+import six
+
+
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
 import os
 
 import pytest
@@ -90,7 +96,7 @@ SYSTEM_PACKAGES = [
     pkgmanager.TYPE != "yum",
     reason="No yum module detected on the system, skipping it.",
 )
-class TestYumTransactionHandler(object):
+class TestYumTransactionHandler:
     @pytest.fixture
     def _mock_yum_api_calls(self, monkeypatch):
         """ """

--- a/convert2rhel/unit_tests/pkgmanager/pkgmanager_test.py
+++ b/convert2rhel/unit_tests/pkgmanager/pkgmanager_test.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
 
 import pytest
 import six

--- a/convert2rhel/unit_tests/redhatrelease_test.py
+++ b/convert2rhel/unit_tests/redhatrelease_test.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import os
 
 import pytest

--- a/convert2rhel/unit_tests/repo_test.py
+++ b/convert2rhel/unit_tests/repo_test.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import os
 
 import pytest

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -357,7 +357,7 @@ def test_install_rhel_subsription_manager(monkeypatch):
 
 
 @pytest.mark.usefixtures("tool_opts", scope="function")
-class TestAttachSubscription(object):
+class TestAttachSubscription:
     def test_attach_subscription_sca_enabled(self, monkeypatch):
         monkeypatch.setattr(
             utils,
@@ -384,7 +384,7 @@ class TestAttachSubscription(object):
         assert caplog.records[-1].levelname == "CRITICAL"
 
 
-class TestRegisterSystem(object):
+class TestRegisterSystem:
     @pytest.mark.parametrize(
         ("unregister_system_mock", "stop_rhsm_mock", "expected_log_messages"),
         (
@@ -501,7 +501,7 @@ class TestRegisterSystem(object):
             subscription._stop_rhsm()
 
 
-class TestRegistrationCommand(object):
+class TestRegistrationCommand:
     @pytest.mark.parametrize(
         "registration_kwargs",
         (
@@ -890,7 +890,7 @@ class TestRegistrationCommand(object):
             reg_cmd()
 
 
-class TestUnregisteringSystem(object):
+class TestUnregisteringSystem:
     @pytest.mark.parametrize(
         ("output", "ret_code", "expected"),
         (("", 0, "System unregistered successfully."),),

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 import logging
 import os
 import time

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+__metaclass__ = type
 
 import os
 import sys
@@ -39,7 +40,7 @@ def mock_cli_arguments(args):
     return sys.argv[0:1] + args
 
 
-class TestTooloptsParseFromCLI(object):
+class TestTooloptsParseFromCLI:
     def test_cmdline_interactive_username_without_passwd(self, monkeypatch, global_tool_opts):
         monkeypatch.setattr(sys, "argv", mock_cli_arguments(["--username", "uname"]))
         convert2rhel.toolopts.CLI()

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -14,6 +14,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
 import getpass
 import json
 import logging
@@ -305,7 +308,7 @@ def test_get_rpm_header(monkeypatch):
 
 
 class TestFindKeys:
-    class MockedRmtree(object):
+    class MockedRmtree:
         def __init__(self, exception, real_rmtree):
             self.called = 0
             self.exception = exception

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -54,7 +54,7 @@ class ImportGPGKeyError(Exception):
     """Raised for failures during the rpm import of gpg keys."""
 
 
-class Color(object):
+class Color:
     PURPLE = "\033[95m"
     CYAN = "\033[96m"
     DARKCYAN = "\033[36m"
@@ -303,11 +303,8 @@ def get_file_content(filename, as_list=False):
         if not as_list:
             return ""
         return lines
-    file_to_read = open(filename, "r")
-    try:
+    with open(filename, "r") as file_to_read:
         lines = file_to_read.readlines()
-    finally:
-        file_to_read.close()
     if as_list:
         # remove newline character from each line
         return [x.strip() for x in lines]
@@ -359,7 +356,8 @@ def run_subprocess(cmd, print_cmd=True, print_output=True):
     if print_cmd:
         loggerinst.debug("Calling command '%s'" % " ".join(cmd))
 
-    process = subprocess.Popen(
+    process = subprocess.Popen(  # pylint: disable=consider-using-with
+        # Popen is only a context manager in Python-3.2+
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/setup.py
+++ b/setup.py
@@ -65,5 +65,8 @@ setup(
             "convert2rhel = convert2rhel.initialize:run",
         ]
     },
+    install_requires=[
+        "six",
+    ],
     include_package_data=True,
 )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -43,6 +43,8 @@ def shell(tmp_path):
             "\nExecuting a command:\n{}\n\n".format(command),
             color="green",
         )
+        # pylint: disable=consider-using-with
+        # Popen is a context-manager in python-3.2+
         process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         output = ""
         for line in iter(process.stdout.readline, b""):


### PR DESCRIPTION
* Evaluate consider-using-f-string: this can only be enabled when we move support up to python-3.6+
* Enable consider-using-with.  Python context managers are used via the with keyword.  these automatcally clean up resources when a context's scope is exited.  Fix the places where we can use existing context managers (file open) to use them and note where we have to wait to drop support for old Python versions to the other places.
* Enable useless-object-inheritance.  Python originally had separate data structures for builtin types and user defined classes.  This changed in Python-2.2 and the new user defined classes were known as new-style classes.  A user defined class had to explicitly inherit from object (`class Foo(object):`) to be a new-style class.  In Python 3, old-style classes were dropped and the simpler syntax which had been reserved for old-style classes now works creates new-style classes (`class Foo:`). This syntax can also be used in Python 2 if the file specifies `__metaclass__ = type` at the top of the file.

  This commit add `__metaclass__ = type` to all of our python files (in case classes are added to any of them in the future) and the class definitions are ported to the simpler syntax.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-876](https://issues.redhat.com/browse/RHELC-876)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
