### PR TITLE
[RHELC-886] Always print the RHSM rollback task "title"

### DIFF
--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -947,12 +947,12 @@ def rollback():
     """Rollback subscription related changes"""
     # Systems using Satellite 6.10 need to stay registered otherwise admins
     # will lose remote access from the Satellite server.
+    loggerinst.task("Rollback: RHSM-related actions")
     if tool_opts.keep_rhsm:
         loggerinst.info("Skipping due to the use of --keep-rhsm.")
         return
 
     try:
-        loggerinst.task("Rollback: RHSM-related actions")
         unregister_system()
     except UnregisterError as e:
         loggerinst.warning(str(e))


### PR DESCRIPTION
The terminal output was confusing when the --keep-rhsm option was used because the only thing that the user was seeing was the message "Skipping due to the use of --keep-rhsm." They had no clue what activity this message relates to, i.e. what is being skipped.

Example of the old output:
```
WARNING - Abnormal exit! Performing rollback ...
Skipping due to the use of --keep-rhsm.
 
[01/05/2023 12:56:47] TASK - [Rollback: Removing installed packages] ****************************
```

Jira Issue: [RHELC-886](https://issues.redhat.com/browse/RHELC-886)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`