### PR TITLE
chore: add pre-commit.ci command to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,10 @@ Check Yaml...............................................................Passed
 Check for merge conflicts................................................Passed
 ```
 
+We automatically run `pre-commit` as part of our CI infrastructure as well. If you have a PR it will run and see if everything passes. Sometimes there may be an outage or unexpected result from `pre-commit`, if that happens you can create a new comment on the PR saying:
+
+> pre-commit.ci run 
+
 Install `pre-commit` hooks to automatically run when doing `git commit`.
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ Check for merge conflicts................................................Passed
 
 We automatically run `pre-commit` as part of our CI infrastructure as well. If you have a PR it will run and see if everything passes. Sometimes there may be an outage or unexpected result from `pre-commit`, if that happens you can create a new comment on the PR saying:
 
-> pre-commit.ci run 
+> pre-commit.ci run
 
 Install `pre-commit` hooks to automatically run when doing `git commit`.
 


### PR DESCRIPTION
We did not have a documented command to run if pre-commit itself has an issue. This is taken from the docs and will rerun the GitHub action for us

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
