### PR TITLE
[RHELC-882] Change the label for FILE output to DEBUG.

### DIFF
--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -82,7 +82,9 @@ class LogLevelTask(object):
 
 class LogLevelFile(object):
     level = 5
-    label = "FILE"
+    # Label messages DEBUG as it is contains the same messages as debug, just that they always go
+    # to the log file.
+    label = "DEBUG"
 
 
 def setup_logger_handler(log_name, log_dir):

--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -23,7 +23,8 @@ WARNING   (30)    Prints warning message using date/time
 INFO      (20)    Prints info message (no date/time, just plain message)
 TASK      (15)    CUSTOM LABEL - Prints a task header message (using asterisks)
 DEBUG     (10)    Prints debug message (using date/time)
-FILE      (5)     CUSTOM LABEL - Prints only to file handler (using date/time)
+FILE      (5)     CUSTOM LABEL - Outputs with the DEBUG label but only to a file
+                  handle (using date/time)
 """
 import logging
 import os

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -799,7 +799,7 @@ def test_hide_secret_unexpected_input(caplog):
         "--activationkey",
     ]
     assert len(caplog.records) == 1
-    assert caplog.records[-1].levelname == "FILE"
+    assert caplog.records[-1].levelname == "DEBUG"
     assert "Passed arguments had unexpected secret argument," " '--activationkey', without a secret" in caplog.text
 
 


### PR DESCRIPTION
The contents of FILE are the same as DEBUG.  The only difference is that FILE outputs to the log file whereas DEBUG goes to the terminal and the log file.  This means, in the log file, when we run convert2rhel with the --debug flag, the log messages are labelled with DEBUG.  When we run without --debug, the same messages end up in the log file but they have the label FILE.  Changing the label of LogLevelFile to DEBUG will keep the label the same for both of these cases.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-882](https://issues.redhat.com/browse/RHELC-882)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
