### PR TITLE
[RHELC-849, RHELC-850] Inform+disable telemetry

### DIFF
--- a/convert2rhel/breadcrumbs.py
+++ b/convert2rhel/breadcrumbs.py
@@ -69,6 +69,8 @@ class Breadcrumbs(object):
         self.run_id = "null"
         # The convert2rhel package object from the yum/dnf python API for further information extraction.
         self._pkg_object = None
+        # Flag to inform the user about DISABLE_TELEMETRY. If not informed, we shouldn't save rhsm_facts.
+        self._inform_telemetry = False
 
     def collect_early_data(self):
         """Set data which is accessible before the conversion"""
@@ -87,8 +89,10 @@ class Breadcrumbs(object):
             self._set_target_os()
 
         self._set_ended()
+
         self._save_migration_results()
-        self._save_rhsm_facts()
+        if self._inform_telemetry and "CONVERT2RHEL_DISABLE_TELEMETRY" not in os.environ:
+            self._save_rhsm_facts()
 
     def _set_pkg_object(self):
         """Set pkg_object which is used to get information about installed Convert2RHEL"""
@@ -111,13 +115,13 @@ class Breadcrumbs(object):
 
     def _set_started(self):
         """Set start time of activity"""
-        self.activity_started = self._get_formated_time()
+        self.activity_started = self._get_formatted_time()
 
     def _set_ended(self):
         """Set end time of activity"""
-        self.activity_ended = self._get_formated_time()
+        self.activity_ended = self._get_formatted_time()
 
-    def _get_formated_time(self):
+    def _get_formatted_time(self):
         """Set timestamp in format YYYYMMDDHHMMZ"""
         return datetime.utcnow().isoformat() + "Z"
 
@@ -193,6 +197,28 @@ class Breadcrumbs(object):
         # we only care about dumping the facts without having multiple copies of
         # it.
         utils.write_json_object_to_file(path=RHSM_CUSTOM_FACTS_FILE, data=data)
+
+    def print_data_collection(self):
+        """Print information about telemetry and ask for acknowledge."""
+        if "CONVERT2RHEL_DISABLE_TELEMETRY" not in os.environ:
+            loggerinst.info(
+                "The convert2rhel utility uploads the following data about the system conversion"
+                " to Red Hat servers for the purpose of the utility usage analysis:\n"
+                "- The Convert2RHEL command as executed\n"
+                "- The Convert2RHEL RPM version and GPG signature\n"
+                "- Success or failure status of the conversion\n"
+                "- Conversion start and end timestamps\n"
+                "- Source OS vendor and version\n"
+                "- Target RHEL version\n"
+                "- Convert2RHEL related environment variables\n\n"
+                "To disable the data collection, use the 'CONVERT2RHEL_DISABLE_TELEMETRY=1' environment variable."
+            )
+
+            utils.ask_to_continue()
+            # User informed about CONVERT2RHEL_DISABLE_TELEMETRY environment variable
+            self._inform_telemetry = True
+        else:
+            loggerinst.info("Skipping, telemetry disabled.")
 
 
 def _write_obj_to_array_json(path, new_object, key):

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -84,10 +84,14 @@ def main():
         loggerinst.task("Prepare: Show Red Hat software EULA")
         show_eula()
 
+        loggerinst.task("Prepare: Inform about telemetry")
+        breadcrumbs.breadcrumbs.print_data_collection()
+
         # gather system information
         loggerinst.task("Prepare: Gather system information")
         systeminfo.system_info.resolve_system_info()
         systeminfo.system_info.print_system_information()
+
         breadcrumbs.breadcrumbs.collect_early_data()
 
         loggerinst.task("Prepare: Clear YUM/DNF version locks")

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -1057,6 +1057,10 @@ def update_rhsm_custom_facts():
     the conversion with the candlepin server, thus, propagating the
     "breadcrumbs" from convert2rhel as RHSM facts.
     """
+    if "CONVERT2RHEL_DISABLE_TELEMETRY" in os.environ:
+        loggerinst.info("Telemetry disabled, skipping RHSM facts upload.")
+        return
+
     if not tool_opts.no_rhsm:
         loggerinst.info("Updating RHSM custom facts collected during the conversion.")
         cmd = ["subscription-manager", "facts", "--update"]

--- a/convert2rhel/unit_tests/breadcrumbs_test.py
+++ b/convert2rhel/unit_tests/breadcrumbs_test.py
@@ -20,7 +20,7 @@ import json
 import pytest
 import six
 
-from convert2rhel import breadcrumbs, pkghandler, pkgmanager
+from convert2rhel import breadcrumbs, pkghandler, pkgmanager, utils
 from convert2rhel.unit_tests.conftest import centos7, create_pkg_obj
 
 
@@ -64,6 +64,8 @@ def test_finish_collection(pretend_os, success, monkeypatch):
 
     monkeypatch.setattr(breadcrumbs.breadcrumbs, "_save_migration_results", save_migration_results_mock)
     monkeypatch.setattr(breadcrumbs.breadcrumbs, "_save_rhsm_facts", save_rhsm_facts_mock)
+    # Set to true, pretend that user was informed about collecting data
+    monkeypatch.setattr(breadcrumbs.breadcrumbs, "_inform_telemetry", True)
 
     breadcrumbs.breadcrumbs.finish_collection(success=success)
 
@@ -268,3 +270,51 @@ def test_set_target_os(pretend_os):
         "name": "CentOS Linux",
         "version": "7.9",
     } == breadcrumbs.breadcrumbs.target_os
+
+
+@pytest.mark.parametrize(("telemetry_disabled", "telemetry_called"), [(True, 0), (False, 1)])
+def test_disable_telemetry(telemetry_disabled, telemetry_called, monkeypatch):
+    if telemetry_disabled:
+        monkeypatch.setenv("CONVERT2RHEL_DISABLE_TELEMETRY", "1")
+
+    _save_migration_results = mock.Mock()
+    _save_rhsm_facts = mock.Mock()
+
+    monkeypatch.setattr(breadcrumbs.breadcrumbs, "_save_migration_results", _save_migration_results)
+    monkeypatch.setattr(breadcrumbs.breadcrumbs, "_save_rhsm_facts", _save_rhsm_facts)
+    # Set to true, pretend that user was informed about collecting data
+    monkeypatch.setattr(breadcrumbs.breadcrumbs, "_inform_telemetry", True)
+
+    breadcrumbs.breadcrumbs.finish_collection()
+
+    assert _save_migration_results.call_count == 1
+    assert _save_rhsm_facts.call_count == telemetry_called
+
+
+def test_user_not_informed_about_telemetry(monkeypatch):
+    _save_migration_results = mock.Mock()
+    _save_rhsm_facts = mock.Mock()
+
+    monkeypatch.setattr(breadcrumbs.breadcrumbs, "_save_migration_results", _save_migration_results)
+    monkeypatch.setattr(breadcrumbs.breadcrumbs, "_save_rhsm_facts", _save_rhsm_facts)
+
+    breadcrumbs.breadcrumbs.finish_collection()
+
+    _save_migration_results.assert_called_once()
+    _save_rhsm_facts.assert_not_called()
+
+
+@pytest.mark.parametrize(("telemetry_disabled", "call_count"), [(True, 0), (False, 1)])
+def test_print_data_collection(telemetry_disabled, call_count, monkeypatch, caplog):
+    if telemetry_disabled:
+        monkeypatch.setenv("CONVERT2RHEL_DISABLE_TELEMETRY", "1")
+
+    ask_to_continue = mock.Mock()
+    monkeypatch.setattr(utils, "ask_to_continue", ask_to_continue)
+
+    breadcrumbs.breadcrumbs.print_data_collection()
+
+    ask_to_continue.call_count == call_count
+
+    if telemetry_disabled:
+        assert "Skipping, telemetry disabled." in caplog.records[-1].message

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -378,6 +378,7 @@ def test_main(monkeypatch):
     initialize_logger_mock = mock.Mock()
     toolopts_cli_mock = mock.Mock()
     show_eula_mock = mock.Mock()
+    print_data_collection_mock = mock.Mock()
     resolve_system_info_mock = mock.Mock()
     collect_early_data_mock = mock.Mock()
     clean_yum_metadata_mock = mock.Mock()
@@ -402,6 +403,7 @@ def test_main(monkeypatch):
     monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
     monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
     monkeypatch.setattr(main, "show_eula", show_eula_mock)
+    monkeypatch.setattr(breadcrumbs, "print_data_collection", print_data_collection_mock)
     monkeypatch.setattr(system_info, "resolve_system_info", resolve_system_info_mock)
     monkeypatch.setattr(breadcrumbs, "collect_early_data", collect_early_data_mock)
     monkeypatch.setattr(pkghandler, "clear_versionlock", clear_versionlock_mock)
@@ -427,6 +429,7 @@ def test_main(monkeypatch):
     assert initialize_logger_mock.call_count == 1
     assert toolopts_cli_mock.call_count == 1
     assert show_eula_mock.call_count == 1
+    assert print_data_collection_mock.call_count == 1
     assert resolve_system_info_mock.call_count == 1
     assert collect_early_data_mock.call_count == 1
     assert clean_yum_metadata_mock.call_count == 1
@@ -475,6 +478,7 @@ def test_main_rollback_pre_ponr_changes_phase(monkeypatch):
     initialize_logger_mock = mock.Mock()
     toolopts_cli_mock = mock.Mock()
     show_eula_mock = mock.Mock()
+    print_data_collection_mock = mock.Mock()
     resolve_system_info_mock = mock.Mock()
     collect_early_data_mock = mock.Mock()
     clean_yum_metadata_mock = mock.Mock()
@@ -494,6 +498,7 @@ def test_main_rollback_pre_ponr_changes_phase(monkeypatch):
     monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
     monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
     monkeypatch.setattr(main, "show_eula", show_eula_mock)
+    monkeypatch.setattr(breadcrumbs, "print_data_collection", print_data_collection_mock)
     monkeypatch.setattr(system_info, "resolve_system_info", resolve_system_info_mock)
     monkeypatch.setattr(breadcrumbs, "collect_early_data", collect_early_data_mock)
     monkeypatch.setattr(pkghandler, "clear_versionlock", clear_versionlock_mock)
@@ -512,6 +517,7 @@ def test_main_rollback_pre_ponr_changes_phase(monkeypatch):
     assert initialize_logger_mock.call_count == 1
     assert toolopts_cli_mock.call_count == 1
     assert show_eula_mock.call_count == 1
+    assert print_data_collection_mock.call_count == 1
     assert resolve_system_info_mock.call_count == 1
     assert collect_early_data_mock.call_count == 1
     assert clean_yum_metadata_mock.call_count == 1
@@ -531,6 +537,7 @@ def test_main_rollback_post_ponr_changes_phase(monkeypatch, caplog):
     initialize_logger_mock = mock.Mock()
     toolopts_cli_mock = mock.Mock()
     show_eula_mock = mock.Mock()
+    print_data_collection_mock = mock.Mock()
     resolve_system_info_mock = mock.Mock()
     collect_early_data_mock = mock.Mock()
     clean_yum_metadata_mock = mock.Mock()
@@ -552,6 +559,7 @@ def test_main_rollback_post_ponr_changes_phase(monkeypatch, caplog):
     monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
     monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
     monkeypatch.setattr(main, "show_eula", show_eula_mock)
+    monkeypatch.setattr(breadcrumbs, "print_data_collection", print_data_collection_mock)
     monkeypatch.setattr(system_info, "resolve_system_info", resolve_system_info_mock)
     monkeypatch.setattr(breadcrumbs, "collect_early_data", collect_early_data_mock)
     monkeypatch.setattr(pkghandler, "clear_versionlock", clear_versionlock_mock)
@@ -572,6 +580,7 @@ def test_main_rollback_post_ponr_changes_phase(monkeypatch, caplog):
     assert initialize_logger_mock.call_count == 1
     assert toolopts_cli_mock.call_count == 1
     assert show_eula_mock.call_count == 1
+    assert print_data_collection_mock.call_count == 1
     assert resolve_system_info_mock.call_count == 1
     assert collect_early_data_mock.call_count == 1
     assert clean_yum_metadata_mock.call_count == 1

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -1519,6 +1519,15 @@ def test_update_rhsm_custom_facts_no_rhsm(global_tool_opts, caplog, monkeypatch)
     assert "Skipping updating RHSM custom facts." in caplog.records[-1].message
 
 
+def test_update_rhsm_custom_facts_disable_telemetry(monkeypatch, caplog):
+    message = "Telemetry disabled, skipping RHSM facts upload."
+    monkeypatch.setenv("CONVERT2RHEL_DISABLE_TELEMETRY", "1")
+
+    subscription.update_rhsm_custom_facts()
+
+    assert message in caplog.records[-1].message
+
+
 MOCK_LIST_AVAILABLE_SUBS_OUTPUT = """\
 Subscription Name:   Red Hat\n
 Provides:            Test\n

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -1,6 +1,9 @@
 /activation_key:
+    adjust+:
+        - environment+:
+            CONVERT2RHEL_DISABLE_TELEMETRY: 1
     discover+:
-        filter: tag:checks-after-conversion
+        filter: tag:checks-after-conversion | tag:CONVERT2RHEL_DISABLE_TELEMETRY
     prepare+:
         - name: main conversion preparation
           how: shell
@@ -27,7 +30,7 @@
           when: >
             distro != centos-8.4
     discover+:
-      filter: tag:checks-after-conversion
+        filter: tag:checks-after-conversion
     prepare+:
         - name: main conversion preparation
           how: shell
@@ -110,10 +113,10 @@
         filter: tag:checks-after-conversion
     adjust+:
         - environment+:
-            PROMPT_AMOUNT: 2
+            PROMPT_AMOUNT: 3
           when: distro != oraclelinux-8
         - environment+:
-            PROMPT_AMOUNT: 1
+            PROMPT_AMOUNT: 2
           when: distro == oraclelinux-8
     prepare+:
         - name: test no sub manager installed

--- a/tests/integration/tier0/check-internet-connection/test_internet_connection.py
+++ b/tests/integration/tier0/check-internet-connection/test_internet_connection.py
@@ -47,6 +47,10 @@ def _restore_configuration_files():
 def test_check_if_internet_connection_is_reachable(convert2rhel):
     """Test if convert2rhel can access the internet."""
     with convert2rhel("--no-rpm-va --debug") as c2r:
+        # We need to get past the data collection acknowledgement.
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("y")
+
         c2r.expect("Checking internet connectivity using address")
         assert c2r.expect("internet connection seems to be available", timeout=300) == 0
         c2r.expect("Continue with the system conversion?")
@@ -65,6 +69,10 @@ def test_check_if_internet_connection_is_not_reachable(convert2rhel, shell):
     assert shell("systemctl enable dnsmasq && systemctl restart dnsmasq").returncode == 0
 
     with convert2rhel("--no-rpm-va --debug") as c2r:
+        # We need to get past the data collection acknowledgement.
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("y")
+
         c2r.expect("Checking internet connectivity using address")
         assert c2r.expect("There was a problem while trying to connect to", timeout=300) == 0
         c2r.expect("Continue with the system conversion?")

--- a/tests/integration/tier0/custom-kernel/test_custom_kernel.py
+++ b/tests/integration/tier0/custom-kernel/test_custom_kernel.py
@@ -87,6 +87,10 @@ def test_custom_kernel(convert2rhel, shell):
         install_custom_kernel(shell)
     elif os.environ["TMT_REBOOT_COUNT"] == "1":
         with convert2rhel("--no-rpm-va --debug") as c2r:
+            # We need to get past the data collection acknowledgement.
+            c2r.expect("Continue with the system conversion?")
+            c2r.sendline("y")
+
             c2r.expect("WARNING - Custom kernel detected. The booted kernel needs to be signed by {}".format(os_vendor))
             c2r.expect("CRITICAL - The booted kernel version is incompatible with the standard RHEL kernel.")
         assert c2r.exitstatus != 0

--- a/tests/integration/tier0/inhibit-if-kmods-is-not-supported/main.fmf
+++ b/tests/integration/tier0/inhibit-if-kmods-is-not-supported/main.fmf
@@ -6,13 +6,13 @@ adjust+:
     # TODO (danmyway) disable for epel7 due to the impossibility of force loading the kmod
     # TODO (danmyway) after the merge of the tier0 refactor disable just the force load kmod test
     - environment+:
-        PROMPT_AMOUNT: 4
+        PROMPT_AMOUNT: 5
       when: distro == centos-8
     - environment+:
-        PROMPT_AMOUNT: 3
+        PROMPT_AMOUNT: 4
       when: distro == centos-7, oraclelinux-7
     - environment+:
-        PROMPT_AMOUNT: 2
+        PROMPT_AMOUNT: 3
       when: distro == oraclelinux-8
 
 tier: 0

--- a/tests/integration/tier0/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
+++ b/tests/integration/tier0/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
@@ -90,6 +90,10 @@ def test_do_not_inhibit_if_module_is_force_loaded(shell, convert2rhel):
         assert "(FE)" in shell("cat /proc/modules").output
 
         with convert2rhel("--no-rpm-va --debug") as c2r:
+            # We need to get past the data collection acknowledgement.
+            c2r.expect("Continue with the system conversion?")
+            c2r.sendline("y")
+
             assert c2r.expect("Tainted kernel modules detected") == 0
             assert c2r.exitstatus != 0
 

--- a/tests/integration/tier0/latest-kernel-check/test_latest_kernel_check.py
+++ b/tests/integration/tier0/latest-kernel-check/test_latest_kernel_check.py
@@ -26,6 +26,10 @@ def test_verify_latest_kernel_check_passes_with_failed_repoquery(shell, convert2
 
     # Run the conversion just past the latest kernel check, if successful, end the conversion there.
     with convert2rhel("--debug --no-rpm-va") as c2r:
+        # We need to get past the data collection acknowledgement.
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("y")
+
         assert c2r.expect("Continue with the system conversion?", timeout=300) == 0
         c2r.sendline("y")
         assert (

--- a/tests/integration/tier0/test-check-rollback-handling/main.fmf
+++ b/tests/integration/tier0/test-check-rollback-handling/main.fmf
@@ -2,10 +2,10 @@ summary: check-if-rollback-is-finishing-up-properly
 
 adjust+:
     - environment+:
-        PROMPT_AMOUNT: 3
+        PROMPT_AMOUNT: 4
       when: distro == oraclelinux
     - environment+:
-        PROMPT_AMOUNT: 4
+        PROMPT_AMOUNT: 5
       when: distro == centos
       because: |
         There is one more user prompt asking for removal of python[3]?-syspurpose

--- a/tests/integration/tier1/checks-after-conversion/main.fmf
+++ b/tests/integration/tier1/checks-after-conversion/main.fmf
@@ -14,6 +14,10 @@ link:
   - https://issues.redhat.com/browse/RHELC-411
   - https://issues.redhat.com/browse/RHELC-291
 
+/disable_data_collection:
+    tag: CONVERT2RHEL_DISABLE_TELEMETRY
+    test: pytest -svv -m disable_data_collection
+
 /delete_temporary_folder:
     test: pytest -svv -m delete_temporary_folder
 

--- a/tests/integration/tier1/checks-after-conversion/test_disable_data_collection.py
+++ b/tests/integration/tier1/checks-after-conversion/test_disable_data_collection.py
@@ -1,0 +1,12 @@
+import os
+
+import pytest
+
+
+@pytest.mark.disable_data_collection
+def test_disable_data_collection():
+    """
+    Verify, that convert2rhel.facts data are not collected, when CONVERT2RHEL_DISABLE_TELEMETRY envar is set.
+    """
+    convert2rhel_facts_file = "/etc/rhsm/facts/convert2rhel.facts"
+    assert not os.path.exists(convert2rhel_facts_file)

--- a/tests/integration/tier1/method/activation_key.py
+++ b/tests/integration/tier1/method/activation_key.py
@@ -1,6 +1,9 @@
+import pytest
+
 from envparse import env
 
 
+@pytest.mark.activation_key_conversion
 def test_activation_key_conversion(convert2rhel):
     with convert2rhel(
         "-y --no-rpm-va --serverurl {} -k {} -o {} --debug".format(

--- a/tests/integration/tier1/method/custom_repos.py
+++ b/tests/integration/tier1/method/custom_repos.py
@@ -2,6 +2,8 @@ import re
 
 from collections import namedtuple
 
+import pytest
+
 
 def get_system_version(system_release_content=None):
     """Return a namedtuple with major and minor elements, both of an int type.
@@ -20,6 +22,7 @@ def get_system_version(system_release_content=None):
     return version
 
 
+@pytest.mark.custom_repos_conversion
 def test_run_conversion_using_custom_repos(shell, convert2rhel):
 
     # We need to skip check for collected rhsm custom facts after the conversion

--- a/tests/integration/tier1/method/main.fmf
+++ b/tests/integration/tier1/method/main.fmf
@@ -6,3 +6,20 @@ description: |
     Tested methods: satellite, RHSM, non-EUS RHSM, activation key and custom repos.
 
 tier: 1
+
+
+/activation_key_conversion:
+    tag+: activation-key-conversion
+    test: pytest -svv -m activation_key_conversion
+
+/custom_repos_conversion:
+    test: pytest -svv -m custom_repos_conversion
+
+/rhsm_conversion:
+    test: pytest -svv -m rhsm_conversion
+
+/rhsm_non_eus_account_conversion:
+    test: pytest -svv -m rhsm_non_eus_account_conversion
+
+/satellite_conversion:
+    test: pytest -svv -m satellite_conversion

--- a/tests/integration/tier1/method/rhsm.py
+++ b/tests/integration/tier1/method/rhsm.py
@@ -1,7 +1,10 @@
+import pytest
+
 from envparse import env
 
 
-def test_run_convertion(convert2rhel):
+@pytest.mark.rhsm_conversion
+def test_run_conversion(convert2rhel):
     with convert2rhel(
         "-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug".format(
             env.str("RHSM_SERVER_URL"),

--- a/tests/integration/tier1/method/rhsm_non_eus.py
+++ b/tests/integration/tier1/method/rhsm_non_eus.py
@@ -1,6 +1,9 @@
+import pytest
+
 from envparse import env
 
 
+@pytest.mark.rhsm_non_eus_account_conversion
 def test_rhsm_non_eus_account(convert2rhel):
     """
     Verify that Convert2RHEL is working properly when EUS repositories are not available for conversions

--- a/tests/integration/tier1/method/satellite.py
+++ b/tests/integration/tier1/method/satellite.py
@@ -1,7 +1,10 @@
+import pytest
+
 from conftest import SATELLITE_PKG_DST, SATELLITE_PKG_URL
 from envparse import env
 
 
+@pytest.mark.satellite_conversion
 def test_satellite_conversion(shell, convert2rhel):
     # Remove subscription manager if installed
     assert shell("yum remove subscription-manager -y").returncode == 0

--- a/tests/integration/tier1/remove-all-submgr-pkgs/main.fmf
+++ b/tests/integration/tier1/remove-all-submgr-pkgs/main.fmf
@@ -5,10 +5,10 @@ description: |
 
 adjust+:
     - environment+:
-        PROMPT_AMOUNT: 2
+        PROMPT_AMOUNT: 3
       when: distro != oraclelinux-8
     - environment+:
-        PROMPT_AMOUNT: 1
+        PROMPT_AMOUNT: 2
       when: distro == oraclelinux-8
 
 tier: 1

--- a/tests/integration/tier1/system-up-to-date/test_system_up_to_date.py
+++ b/tests/integration/tier1/system-up-to-date/test_system_up_to_date.py
@@ -44,6 +44,10 @@ def test_skip_kernel_check(shell, convert2rhel):
             env.str("RHSM_POOL"),
         )
     ) as c2r:
+        # We need to get past the data collection acknowledgement.
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("y")
+
         c2r.expect("Detected 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK' environment variable")
         c2r.sendcontrol("c")
     assert c2r.exitstatus != 0


### PR DESCRIPTION
The user is informed about the data we upload to Red Hat servers. They are asked to acknowledge the data collection and in case they do not like it we've added the ability to disable it.

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-849](https://issues.redhat.com/browse/RHELC-849)
Jira Issue: [RHELC-850](https://issues.redhat.com/browse/RHELC-850)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
