### PR TITLE
[RHELC-888] Make RHSM organization and username a secret

### DIFF
--- a/convert2rhel/breadcrumbs.py
+++ b/convert2rhel/breadcrumbs.py
@@ -98,8 +98,7 @@ class Breadcrumbs(object):
 
     def _set_executed(self):
         """Set how was Convert2RHEL executed"""
-        cli_options_to_sanitize = frozenset(("--password", "-p", "--activationkey", "-k"))
-        self.executed = " ".join(utils.hide_secrets(args=sys.argv, secret_args=cli_options_to_sanitize))
+        self.executed = " ".join(utils.hide_secrets(args=sys.argv))
 
     def _set_nevra(self):
         """Set NEVRA of installed Convert2RHEL"""

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -334,9 +334,6 @@ class RegistrationCommand(object):
                 loggerinst.info("    ... password detected")
                 password = tool_opts.password
             else:
-                if tool_opts.username:
-                    # Hint user for which username they need to enter pswd
-                    loggerinst.info("Username: %s", username)  # lgtm[py/clear-text-logging-sensitive-data]
                 password = ""
                 while not password:
                     password = utils.prompt_user("Password: ", password=True)
@@ -422,9 +419,9 @@ class RegistrationCommand(object):
             try:
                 if self.password:
                     if self.org:
-                        loggerinst.info("Organization: %s", self.org)
-                    loggerinst.info("Username: %s", self.username)
-                    loggerinst.info("Password: %s", "*" * 5)
+                        loggerinst.info("Organization: %s", utils.OBFUSCATION_STRING)
+                    loggerinst.info("Username: %s", utils.OBFUSCATION_STRING)
+                    loggerinst.info("Password: %s", utils.OBFUSCATION_STRING)
                     loggerinst.info("Connection Options: %s", self.connection_opts)
                     loggerinst.info("Locale settings: %s", i18n.SUBSCRIPTION_MANAGER_LOCALE)
                     args = (
@@ -446,8 +443,8 @@ class RegistrationCommand(object):
                     )
 
                 else:
-                    loggerinst.info("Organization: %s", self.org)
-                    loggerinst.info("Activation Key: %s", "*" * 5)
+                    loggerinst.info("Organization: %s", utils.OBFUSCATION_STRING)
+                    loggerinst.info("Activation Key: %s", utils.OBFUSCATION_STRING)
                     loggerinst.info("Connection Options: %s", self.connection_opts)
                     loggerinst.info("Locale settings: %s", i18n.SUBSCRIPTION_MANAGER_LOCALE)
                     args = (

--- a/convert2rhel/unit_tests/breadcrumbs_test.py
+++ b/convert2rhel/unit_tests/breadcrumbs_test.py
@@ -87,11 +87,11 @@ def test_finish_collection(pretend_os, success, monkeypatch):
                 "--username=test",
                 "--password=nicePassword",
             ],
-            "/usr/bin/convert2rhel --username=test --password=*****",
+            "/usr/bin/convert2rhel --username=***** --password=*****",
         ),
         (
             ["/usr/bin/convert2rhel", "-u=test", "-p=nicePassword"],
-            "/usr/bin/convert2rhel -u=test -p=*****",
+            "/usr/bin/convert2rhel -u=***** -p=*****",
         ),
         (
             [
@@ -100,11 +100,11 @@ def test_finish_collection(pretend_os, success, monkeypatch):
                 "--org=1234",
                 "-y",
             ],
-            "/usr/bin/convert2rhel --activationkey=***** --org=1234 -y",
+            "/usr/bin/convert2rhel --activationkey=***** --org=***** -y",
         ),
         (
             ["/usr/bin/convert2rhel", "-k=test", "-o=1234", "-y"],
-            "/usr/bin/convert2rhel -k=***** -o=1234 -y",
+            "/usr/bin/convert2rhel -k=***** -o=***** -y",
         ),
     ),
 )

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -781,7 +781,7 @@ class TestRegistrationCommand(object):
                 None,
                 "RegisterWithActivationKeys",
                 "sasa{sv}a{sv}s",
-                "Organization: Local Organization",
+                "Organization: *****",
             ),
             (
                 "Local Organization",
@@ -790,7 +790,7 @@ class TestRegistrationCommand(object):
                 "pass_word",
                 "Register",
                 "sssa{sv}a{sv}s",
-                "Organization: Local Organization",
+                "Organization: *****",
             ),
             (None, None, "user_name", "pass_word", "Register", "sssa{sv}a{sv}s", None),
         ),

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -479,17 +479,17 @@ def test_validate_serverurl_parsing(url_parts, message):
 def test__log_command_used(caplog, monkeypatch):
     obfuscation_string = "*" * 5
     input_command = mock_cli_arguments(
-        ["--username", "uname", "--password", "123", "--activationkey", "456", "--token", "789"]
+        ["--username", "uname", "--password", "123", "--activationkey", "456", "--org", "789"]
     )
     expected_command = mock_cli_arguments(
         [
             "--username",
-            "uname",
+            obfuscation_string,
             "--password",
             obfuscation_string,
             "--activationkey",
             obfuscation_string,
-            "--token",
+            "--org",
             obfuscation_string,
         ]
     )
@@ -503,7 +503,7 @@ def test__log_command_used(caplog, monkeypatch):
     ("argv", "message"),
     (
         # The message is a log of used command
-        (mock_cli_arguments(["-o", "org", "-k", "key"]), "-o org -k *****"),
+        (mock_cli_arguments(["-o", "org", "-k", "key"]), "-o ***** -k *****"),
         (
             mock_cli_arguments(["-o", "org"]),
             "Either the --organization or the --activationkey option is missing. You can't use one without the other.",

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -748,8 +748,7 @@ def hide_secrets(
 
     if hide_next:
         loggerinst.debug(
-            "Passed arguments had an option, '{0}', without an expected"
-            " secret parameter".format(sanitized_list[-1])  # lgtm[py/clear-text-logging-sensitive-data]
+            "Passed arguments had an option, '{0}', without an expected secret parameter".format(sanitized_list[-1])
         )
 
     return sanitized_list

--- a/tests/integration/tier0/log-command/test_log_command.py
+++ b/tests/integration/tier0/log-command/test_log_command.py
@@ -1,4 +1,8 @@
+import json
+
+
 C2R_LOG = "/var/log/convert2rhel/convert2rhel.log"
+C2R_FACTS = "/etc/rhsm/facts/convert2rhel.facts"
 
 
 def test_verify_logfile_starts_with_command(shell):
@@ -10,14 +14,13 @@ def test_verify_logfile_starts_with_command(shell):
     username = "jdoe"
     password = "foobar"
     activationkey = "a-map-of-a-key"
+    organization = "SoMe_NumberS-8_a_lettER"
 
-    command_long = (
-        "convert2rhel --debug --no-rpm-va --serverurl {} --username {} --password {} --activationkey {}".format(
-            serverurl, username, password, activationkey
-        )
+    command_long = "convert2rhel --debug --no-rpm-va --serverurl {} --username {} --password {} --activationkey {} --org {}".format(
+        serverurl, username, password, activationkey, organization
     )
-    command_short = "convert2rhel --debug --no-rpm-va --serverurl {} -u {} -p {} -k {}".format(
-        serverurl, username, password, activationkey
+    command_short = "convert2rhel --debug --no-rpm-va --serverurl {} -u {} -p {} -k {} -o {}".format(
+        serverurl, username, password, activationkey, organization
     )
 
     command_verification = "convert2rhel --debug --no-rpm-va --serverurl {}".format(serverurl)
@@ -41,3 +44,14 @@ def test_verify_logfile_starts_with_command(shell):
             assert command_verification in command_line
             assert password not in command_line
             assert activationkey not in command_line
+            assert username not in command_line
+            assert organization not in command_line
+
+        with open(C2R_FACTS, "r") as breadcrumbs:
+            data = json.load(breadcrumbs)
+            command = data.get("conversions.executed")
+
+            assert password not in command
+            assert activationkey not in command
+            assert username not in command
+            assert organization not in command

--- a/tests/integration/tier0/test-check-rollback-handling/test_check_rollback_handling.py
+++ b/tests/integration/tier0/test-check-rollback-handling/test_check_rollback_handling.py
@@ -78,7 +78,7 @@ def terminate_and_assert_good_rollback(c2r):
     # Verify the last step of the rollback is present in the log file
     with open("/var/log/convert2rhel/convert2rhel.log", "r") as logfile:
         for line in logfile:
-            assert "Rollback: Removing installed RHSM certificate" not in line
+            assert "Rollback: Remove installed RHSM certificate" not in line
 
 
 def test_proper_rhsm_clean_up(shell, convert2rhel):


### PR DESCRIPTION
Until now we've been recording and collecting the RHSM username and organization in their plain text form in the convert2rhel log files and the breadcrumbs files:
- /var/log/convert2rhel/convert2rhel.log
- /var/log/convert2rhel/archive/convert2rhel-*.log
- /etc/migration-results
- /etc/rhsm/facts/convert2rhel.facts

Users might perceive those values as sensitive or private information. Red Hat doesn't need this information for anything so it's better to not collect it at all.

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-888](https://issues.redhat.com/browse/RHELC-888)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-888]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
