### PR TITLE
[RHELC-889] Make TASK log messages consistent

### DIFF
--- a/convert2rhel/backup.py
+++ b/convert2rhel/backup.py
@@ -67,12 +67,12 @@ class ChangedRPMPackagesController(object):
 
     def _remove_installed_pkgs(self):
         """For each package installed during conversion remove it."""
-        loggerinst.task("Rollback: Removing installed packages")
+        loggerinst.task("Rollback: Remove installed packages")
         remove_pkgs(self.installed_pkgs, backup=False, critical=False)
 
     def _install_removed_pkgs(self):
         """For each package removed during conversion install it."""
-        loggerinst.task("Rollback: Installing removed packages")
+        loggerinst.task("Rollback: Install removed packages")
         pkgs_to_install = []
         for restorable_pkg in self.removed_pkgs:
             if restorable_pkg.path is None:
@@ -301,7 +301,7 @@ class RestorableFile(object):
         """Restore a previously backed up file"""
         backup_filepath = os.path.join(BACKUP_DIR, os.path.basename(self.filepath))
         if rollback:
-            loggerinst.task("Rollback: Restoring %s from backup" % self.filepath)
+            loggerinst.task("Rollback: Restore %s from backup" % self.filepath)
         else:
             loggerinst.info("Restoring %s from backup" % self.filepath)
 

--- a/convert2rhel/cert.py
+++ b/convert2rhel/cert.py
@@ -68,7 +68,7 @@ class SystemCert(object):
 
     def remove(self):
         """Remove certificate (.pem), which was copied to system's cert dir."""
-        loggerinst.task("Rollback: Removing installed RHSM certificate")
+        loggerinst.task("Rollback: Remove installed RHSM certificate")
 
         try:
             os.remove(self._target_cert_path)

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -136,7 +136,7 @@ def perform_pre_ponr_checks():
 
 def check_convert2rhel_latest():
     """Make sure that we are running the latest downstream version of convert2rhel"""
-    logger.task("Prepare: Checking if this is the latest version of Convert2RHEL")
+    logger.task("Prepare: Check if this is the latest version of Convert2RHEL")
 
     if not system_info.has_internet_access:
         logger.warning("Skipping the check because no internet connection has been detected.")
@@ -234,7 +234,7 @@ def check_convert2rhel_latest():
 
 def check_efi():
     """Inhibit the conversion when we are not able to handle UEFI."""
-    logger.task("Prepare: Checking the firmware interface type (BIOS/UEFI)")
+    logger.task("Prepare: Check the firmware interface type (BIOS/UEFI)")
     if not grub.is_efi():
         logger.info("BIOS detected.")
         return
@@ -283,7 +283,7 @@ def check_tainted_kmods():
         system76_io 16384 0 - Live 0x0000000000000000 (OE)  <<<<<< Tainted
         system76_acpi 16384 0 - Live 0x0000000000000000 (OE) <<<<<< Tainted
     """
-    logger.task("Prepare: Checking if loaded kernel modules are not tainted")
+    logger.task("Prepare: Check if loaded kernel modules are not tainted")
     unsigned_modules, _ = run_subprocess(["grep", "(", "/proc/modules"])
     module_names = "\n  ".join([mod.split(" ")[0] for mod in unsigned_modules.splitlines()])
     if unsigned_modules:
@@ -305,7 +305,7 @@ def check_readonly_mounts():
     Having /mnt/ and /sys/ read-only causes the installation of the filesystem package to
     fail (https://bugzilla.redhat.com/show_bug.cgi?id=1887513, https://github.com/oamg/convert2rhel/issues/123).
     """
-    logger.task("Prepare: Checking /mnt and /sys are read-write")
+    logger.task("Prepare: Check /mnt and /sys are read-write")
 
     mounts = get_file_content("/proc/mounts", as_list=True)
     for line in mounts:
@@ -335,7 +335,7 @@ def check_custom_repos_are_valid():
     - YUM/DNF is able to find the repoids (to rule out a typo)
     - the repository "baseurl" is accessible and contains repository metadata
     """
-    logger.task("Prepare: Checking if --enablerepo repositories are accessible")
+    logger.task("Prepare: Check if --enablerepo repositories are accessible")
 
     if not tool_opts.no_rhsm:
         logger.info("Skipping the check of repositories due to the use of RHSM for the conversion.")
@@ -391,7 +391,7 @@ def ensure_compatibility_of_kmods():
 
 def validate_package_manager_transaction():
     """Validate the package manager transaction is passing the tests."""
-    logger.task("Validate the %s transaction", pkgmanager.TYPE)
+    logger.task("Prepare: Validate the %s transaction", pkgmanager.TYPE)
     transaction_handler = pkgmanager.create_transaction_handler()
     transaction_handler.run_transaction(
         validate_transaction=True,
@@ -655,7 +655,7 @@ def _bad_kernel_substring(kernel_release):
 
 def check_package_updates():
     """Ensure that the system packages installed are up-to-date."""
-    logger.task("Prepare: Checking if the installed packages are up-to-date")
+    logger.task("Prepare: Check if the installed packages are up-to-date")
 
     if system_info.id == "oracle" and system_info.corresponds_to_rhel_eus_release():
         logger.info(
@@ -706,7 +706,7 @@ def check_package_updates():
 
 def is_loaded_kernel_latest():
     """Check if the loaded kernel is behind or of the same version as in yum repos."""
-    logger.task("Prepare: Checking if the loaded kernel version is the most recent")
+    logger.task("Prepare: Check if the loaded kernel version is the most recent")
 
     if system_info.id == "oracle" and system_info.corresponds_to_rhel_eus_release():
         logger.info(

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -123,10 +123,10 @@ def main():
         process_phase = ConversionPhase.POST_PONR_CHANGES
         post_ponr_conversion()
 
-        loggerinst.task("Final: RPM files modified by the conversion")
+        loggerinst.task("Final: Show RPM files modified by the conversion")
         systeminfo.system_info.modified_rpm_files_diff()
 
-        loggerinst.task("Final: Updating GRUB2 configuration")
+        loggerinst.task("Final: Update GRUB2 configuration")
         grub.update_grub_after_conversion()
 
         loggerinst.task("Final: Remove temporary folder %s" % utils.TMP_DIR)
@@ -134,7 +134,7 @@ def main():
 
         breadcrumbs.breadcrumbs.finish_collection(success=True)
 
-        loggerinst.task("Final: Updating RHSM custom facts")
+        loggerinst.task("Final: Update RHSM custom facts")
         subscription.update_rhsm_custom_facts()
 
         loggerinst.info("\nConversion successful!\n")

--- a/tests/integration/tier0/backup-release/test_backup_release.py
+++ b/tests/integration/tier0/backup-release/test_backup_release.py
@@ -100,7 +100,7 @@ def test_backup_os_release_wrong_registartion(shell, convert2rhel):
 
     with convert2rhel("-y --no-rpm-va -k wrong_key -o rUbBiSh_pWd --debug --keep-rhsm") as c2r:
         c2r.expect("Unable to register the system through subscription-manager.")
-        c2r.expect("Restoring /etc/os-release from backup")
+        c2r.expect("Restore /etc/os-release from backup")
 
     assert shell("find /etc/os-release").returncode == 0
 

--- a/tests/integration/tier0/latest-kernel-check/test_latest_kernel_check.py
+++ b/tests/integration/tier0/latest-kernel-check/test_latest_kernel_check.py
@@ -81,7 +81,7 @@ def test_latest_kernel_check_with_exclude_kernel_option(shell, convert2rhel):
     # Run the conversion and verify, that it goes past the latest kernel check
     # if so, inhibit the conversion
     with convert2rhel("-y --debug --no-rpm-va") as c2r:
-        c2r.expect("Prepare: Checking if the loaded kernel version is the most recent")
+        c2r.expect("Prepare: Check if the loaded kernel version is the most recent")
         assert c2r.expect("Convert: List third-party packages", timeout=300) == 0
         c2r.sendcontrol("c")
 


### PR DESCRIPTION
Some of the log messages were using continous tense, some present tense. There was more of the messages with the present tense so this commit transforms all the messages to the present tense.

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-889](https://issues.redhat.com/browse/RHELC-889)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-889]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
