### PR TITLE
[RHELC-890] Deduplicate log messages about imported keys

### DIFF
--- a/convert2rhel/backup.py
+++ b/convert2rhel/backup.py
@@ -251,7 +251,6 @@ class RestorableRpmKey(RestorableChange):
                 raise utils.ImportGPGKeyError("Failed to import the GPG key %s: %s" % (self.keyfile, output))
 
             self.previously_installed = False
-            loggerinst.info("GPG key %s imported", self.keyid)
 
         else:
             self.previously_installed = True

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -229,7 +229,7 @@ def check_convert2rhel_latest():
                 )
 
     else:
-        logger.info("Latest available Convert2RHEL version is installed.\n" "Continuing conversion.")
+        logger.info("Latest available Convert2RHEL version is installed.")
 
 
 def check_efi():

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -316,7 +316,7 @@ class TestCheckConvert2rhelLatest(object):
         checks.check_convert2rhel_latest()
 
         local_version, dummy_ = convert2rhel_latest_version_test
-        log_msg = "Latest available Convert2RHEL version is installed.\n" "Continuing conversion."
+        log_msg = "Latest available Convert2RHEL version is installed."
         assert log_msg in caplog.text
 
     @pytest.mark.parametrize(

--- a/tests/integration/tier0/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/basic-sanity-checks/test_basic_sanity_checks.py
@@ -73,7 +73,6 @@ def test_c2r_latest_newer(convert2rhel):
 
     with convert2rhel(f"--no-rpm-va --debug") as c2r:
         assert c2r.expect("Latest available Convert2RHEL version is installed.", timeout=300) == 0
-        assert c2r.expect("Continuing conversion.", timeout=300) == 0
 
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("n")


### PR DESCRIPTION
There were two info-level log message printed with basically the same information:
```
[02/03/2023 19:08:44] TASK - [Convert: Import Red Hat GPG keys] *********************************
GPG key 37017186 imported
GPG key /usr/share/convert2rhel/gpg-keys/RPM-GPG-KEY-redhat-legacy-release imported successfuly.
GPG key fd431d51 imported
GPG key /usr/share/convert2rhel/gpg-keys/RPM-GPG-KEY-redhat-release imported successfuly.
```

Also, the message `Continuing conversion.` was giving users no real value. To be consistent, we'd need to have it at the end of each passed check.
```
[02/03/2023 19:41:01] TASK - [Prepare: Check if this is the latest version of Convert2RHEL] *****
Latest available Convert2RHEL version is installed.
Continuing conversion.
```
--------------------

How it's going to look like after this PR:
```
[02/03/2023 19:45:28] TASK - [Prepare: Checking if this is the latest version of Convert2RHEL] **
Latest available Convert2RHEL version is installed.

...
[02/03/2023 19:47:15] TASK - [Convert: Import Red Hat GPG keys] *********************************
GPG key /usr/share/convert2rhel/gpg-keys/RPM-GPG-KEY-redhat-legacy-release imported successfuly.
GPG key /usr/share/convert2rhel/gpg-keys/RPM-GPG-KEY-redhat-release imported successfuly.
```
-------------------------

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-890](https://issues.redhat.com/browse/RHELC-890)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-890]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
