### PR TITLE
[hotfix] Remove workaround from convert_offline_systems test

### DIFF
--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -221,12 +221,6 @@
   discover+:
     test: checks-after-conversion
   prepare+:
-  - name: workaround_kernel
-    how: shell
-    script: "yum install kernel-3.10.0-1160.76.1.el7 -y && yum remove kernel-3.10.0-1160.80.1.el7 -y"
-  - name: reboot machine
-    how: ansible
-    playbook: tests/ansible_collections/roles/reboot/main.yml
   - name: install subscription manager
     how: ansible
     playbook: tests/ansible_collections/roles/install-submgr/main.yml


### PR DESCRIPTION
* Previously the Satellite repository was out of sync, therefore we needed to install older kernel to match the latest available in the repository
* the satellite repository is now synced weekly, the workaround is not needed anymore

Signed-off-by: Daniel Diblik <ddiblik@redhat.com>


