### PR TITLE
[RHELC-892] Finish the move of set_locale() to initialize.

### DIFF
--- a/convert2rhel/initialize.py
+++ b/convert2rhel/initialize.py
@@ -18,15 +18,18 @@
 import os
 import sys
 
+from convert2rhel import i18n
+
 
 def set_locale():
-    """Set the C locale, also known as the POSIX locale, for the main process as well as the child processes.
+    """
+    Set the C locale, also known as the POSIX locale, for the main process as well as the child processes.
 
     The reason is to get predictable output from the executables we call, not
-    influenced by non-default locale. We need to be setting not only LC_ALL but
-    LANG as well because subscription-manager considers LANG to have priority
-    over LC_ALL even though it goes against POSIX which specifies that LC_ALL
-    overrides LANG.
+    influenced by non-default locale. We need to be setting not only LC_ALL
+    and LANGUAGE but LANG as well because subscription-manager considers LANG
+    to have priority over LC_ALL even though it goes against POSIX which
+    specifies that LC_ALL overrides LANG.
 
     .. note::
         Since we introduced a new way to interact with packages that is not
@@ -37,7 +40,13 @@ def set_locale():
         overriding any user set locale in their machine, to actually being the
         ones we require during the process execution.
     """
-    os.environ.update({"LC_ALL": "C", "LANG": "C"})
+    os.environ.update(
+        {
+            "LC_ALL": i18n.SCREENSCRAPED_LOCALE,
+            "LANG": i18n.SCREENSCRAPED_LOCALE,
+            "LANGUAGE": i18n.SCREENSCRAPED_LOCALE,
+        }
+    )
 
 
 def run():

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -663,22 +663,6 @@ def find_keyid(keyfile):
     return keyid.lower()
 
 
-def set_locale():
-    """Set the C locale, also known as the POSIX locale, for the main process as well as the child processes.
-
-    The reason is to get predictable output from the executables we call, not influenced by non-default locale.
-    We need to be setting not only LC_ALL but LANG as well because subscription-manager considers LANG to have priority
-    over LC_ALL even though it goes against POSIX which specifies that LC_ALL overrides LANG.
-    """
-    os.environ.update(
-        {
-            "LC_ALL": i18n.SCREENSCRAPED_LOCALE,
-            "LANG": i18n.SCREENSCRAPED_LOCALE,
-            "LANGUAGE": i18n.SCREENSCRAPED_LOCALE,
-        }
-    )
-
-
 def string_to_version(verstring):
     """Return a tuple of (epoch, version, release) from a version string
     This function was taken from softwarefactory-project/rdopkg


### PR DESCRIPTION
When we created `initialize.set_locale()`, removing the function from its former location in `utils.py` was missed.  Subsequently, some new code was added to `utils.set_locale()` when it should have been added to `initialize` instead.  This commit merges the new changes into `initialize.set_locale()` and finishes the move by removing the duplicate from `utils.py`.

Fixes RHELC-892

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-892](https://issues.redhat.com/browse/RHELC-892)

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
