### PR TITLE
[RHELC-724] Move adding of NullHandler to the root logger.

### DIFF
--- a/convert2rhel/initialize.py
+++ b/convert2rhel/initialize.py
@@ -15,10 +15,24 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import logging
 import os
 import sys
 
 from convert2rhel import i18n
+
+
+def initialize_logging():
+    """
+    Initialize root logger before dbus is imported.
+
+    We need to initialize the root logger with the NullHandler before dbus is
+    imported. Otherwise, dbus will install Handlers on the root logger which
+    can end up printing our log messages an additional time.  Additionally,
+    bad user data could end up causing the dbus logging to log rhsm passwords
+    and other credentials.
+    """
+    logging.getLogger().addHandler(logging.NullHandler())
 
 
 def set_locale():
@@ -57,6 +71,9 @@ def run():
     """
     # prepare environment
     set_locale()
+
+    # Initialize logging to stop duplicate messages.
+    initialize_logging()
 
     from convert2rhel import main
 

--- a/convert2rhel/initialize.py
+++ b/convert2rhel/initialize.py
@@ -22,9 +22,9 @@ import sys
 from convert2rhel import i18n
 
 
-def initialize_logging():
+def disable_root_logger():
     """
-    Initialize root logger before dbus is imported.
+    Set the root logger to not output before dbus is imported.
 
     We need to initialize the root logger with the NullHandler before dbus is
     imported. Otherwise, dbus will install Handlers on the root logger which
@@ -73,7 +73,7 @@ def run():
     set_locale()
 
     # Initialize logging to stop duplicate messages.
-    initialize_logging()
+    disable_root_logger()
 
     from convert2rhel import main
 

--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -37,45 +37,6 @@ from time import gmtime, strftime
 LOG_DIR = "/var/log/convert2rhel"
 
 
-#
-# Pre-dbus import initialization
-#
-
-# We need to initialize the root logger with the NullHandler before dbus is imported.
-# Otherwise, dbus will install Handlers on the root logger which can end up printing
-# our log messages an additional time.  Additionally, bad user data could end up
-# causing the dbus logging to log rhsm passwords and other credentials.
-#
-# Right now we do this here, at the toplevel of logger.py.  In the future we should
-# have a dedicated module for initializing convert2rhel prior to importing other
-# libraries and we can do this step there.
-
-if hasattr(logging, "NullHandler"):
-    NullHandler = logging.NullHandler
-else:
-    # Python 2.6 compatibility.
-    # This code is copied from Pthon-3.10's logging module,
-    # licensed under the Python Software Foundation License, version 2
-    class NullHandler(logging.Handler):
-        def handle(self, record):
-            """Stub."""
-
-        def emit(self, record):
-            """Stub."""
-
-        def createLock(self):
-            self.lock = None
-
-        def _at_fork_reinit(self):
-            pass
-
-    # End of PSF Licensed code
-
-logging.getLogger().addHandler(NullHandler())
-
-# End pre-DBus initialization code
-
-
 class LogLevelTask(object):
     level = 15
     label = "TASK"


### PR DESCRIPTION
@r0x0d added initialize.py for steps that need to be taken early to initialize various subsystems.  Adding of the NullHandler to the root logger (to avoid some libraries initializing themselves in a way that ends up outputting messages multiple times) needs to be done very early. So moving it to initialize.py is the logical choice.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-724](https://issues.redhat.com/browse/RHELC-724)

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [X] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
