### PR TITLE
[RHELC-693] test: remove unnecessary code for org and key

### DIFF
--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -313,16 +313,6 @@ class RegistrationCommand(object):
             loggerinst.info("    ... activation key detected")
             registration_attributes["activation_key"] = tool_opts.activation_key
 
-            while "org" not in registration_attributes:
-                loggerinst.info("    ... activation key requires organization")
-                # Organization is required when activation key is used
-                # TODO: Parse the output of 'subscription-manager orgs' and let the
-                # user choose from the available organizations. If there's just one,
-                # pick it automatically.
-                org = utils.prompt_user("Organization: ").strip()
-                # In case the user entered the empty string
-                if org:
-                    registration_attributes["org"] = org
         else:
             # No activation key -> username/password required
             if tool_opts.username and tool_opts.password:

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -681,11 +681,6 @@ class TestRegistrationCommand(object):
     @pytest.mark.parametrize(
         "registration_kwargs, prompt_input",
         (
-            # activation_key and not org
-            (
-                {"activation_key": "0xDEADBEEF"},
-                {"Organization: ": "Local Organization"},
-            ),
             # no activation_key no password
             (
                 {"username": "me_myself_and_i"},
@@ -720,9 +715,6 @@ class TestRegistrationCommand(object):
 
         registration_cmd = subscription.RegistrationCommand.from_tool_opts(tool_opts)
 
-        if "Organization: " in prompt_input:
-            assert registration_cmd.org == prompt_input["Organization: "]
-
         if "Password: " in prompt_input:
             assert registration_cmd.password == prompt_input["Password: "]
 
@@ -731,16 +723,6 @@ class TestRegistrationCommand(object):
 
         # assert that we prompted the user the number of times that we expected
         assert fake_prompt_user.call_count == len(prompt_input)
-
-    def test_from_tool_opts_activation_key_empty_string(self, tool_opts, monkeypatch):
-        monkeypatch.setattr(utils, "prompt_user", PromptUserLoopMocked())
-        tool_opts.activation_key = "activation_key"
-
-        registration_cmd = subscription.RegistrationCommand.from_tool_opts(tool_opts)
-
-        assert registration_cmd.activation_key == "activation_key"
-        assert registration_cmd.org == "test"
-        assert utils.prompt_user.called == {"Organization: ": 2}
 
     def test_from_tool_opts_username_empty_string(self, tool_opts, monkeypatch):
         monkeypatch.setattr(utils, "prompt_user", PromptUserLoopMocked())

--- a/tests/integration/tier0/check-user-response/test_user_response.py
+++ b/tests/integration/tier0/check-user-response/test_user_response.py
@@ -42,30 +42,6 @@ def test_check_user_response_user_and_password(convert2rhel):
     assert c2r.exitstatus != 0
 
 
-def test_check_user_response_organization(convert2rhel):
-    """
-    Run c2r registration with activation key provided and verify the organization prompt when not specified during the command call.
-    """
-    substitute_org = "foo"
-    with convert2rhel(
-        "-y --no-rpm-va --serverurl {} -k {}".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_KEY"),
-        ),
-        unregister=True,
-    ) as c2r:
-        c2r.expect_exact("activation key detected")
-        c2r.expect_exact("Organization: ")
-        c2r.sendline()
-        assert c2r.expect_exact(["Organization", "Registering the system"], timeout=300) == 0
-        c2r.sendline(substitute_org)
-        c2r.expect_exact("Registering the system using subscription-manager ...")
-        # Due to inconsistent behavior of Ctrl+c
-        # the Ctrl+d is used to terminate the process instead
-        c2r.sendcontrol("d")
-    assert c2r.exitstatus != 0
-
-
 def test_auto_attach_pool_submgr(convert2rhel):
     """
     Provide Convert2RHEL with username and password with just one subscription available.

--- a/tests/integration/tier0/test-check-rollback-handling/test_check_rollback_handling.py
+++ b/tests/integration/tier0/test-check-rollback-handling/test_check_rollback_handling.py
@@ -198,18 +198,3 @@ def test_terminate_on_subscription_prompt(convert2rhel):
     ) as c2r:
         c2r.expect("Enter number of the chosen subscription:")
         terminate_and_assert_good_rollback(c2r)
-
-
-def test_terminate_on_organization_prompt(convert2rhel):
-    """
-    Send termination signal on the user prompt for organization.
-    Verify that c2r goes successfully through the rollback.
-    """
-    with convert2rhel(
-        ("-y --no-rpm-va --serverurl {} -k {}").format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_KEY"),
-        )
-    ) as c2r:
-        c2r.expect("Organization:")
-        terminate_and_assert_good_rollback(c2r)


### PR DESCRIPTION
When #563 was merged we got a few methods that were no longer needed.
Due to forcing the user to provide key and org always now we no longer
need two integration tests either that was failing due to this change.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-693](https://issues.redhat.com/browse/RHELC-693)

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
