### PR TITLE
[RHELC-244] Verify overriding usupported kernel module inhibition

### DIFF
--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -242,9 +242,6 @@
           playbook: tests/ansible_collections/roles/reboot/main.yml
 
 /system_up_to_date:
-    # There are no minor version repositories for Oracle Linux EUS releases, so we skip the check for up-to-date system.
-    # The other distributions (including latest Oracle Linux 8) have all the necessary repositories
-    # to make the check possible.
     discover+:
         test: checks-after-conversion
     prepare+:

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -242,6 +242,9 @@
           playbook: tests/ansible_collections/roles/reboot/main.yml
 
 /system_up_to_date:
+    # There are no minor version repositories for Oracle Linux EUS releases, so we skip the check for up-to-date system.
+    # The other distributions (including latest Oracle Linux 8) have all the necessary repositories
+    # to make the check possible.
     discover+:
         test: checks-after-conversion
     prepare+:

--- a/tests/integration/tier0/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
+++ b/tests/integration/tier0/inhibit-if-kmods-is-not-supported/test_kmods_not_supported.py
@@ -51,7 +51,7 @@ def test_inhibit_if_custom_module_loaded(insert_custom_kmod, convert2rhel):
 @pytest.mark.unsupported_kmod_with_envar
 def test_envar_overrides_unsupported_module_loaded(insert_custom_kmod, convert2rhel, prompt_amount=PROMPT_AMOUNT):
     """
-    This test verifies that setting the environment variable "CONVERT2RHEL_ALLOW_UNCHECKED_KMODS"
+    This test verifies that setting the environment variable "CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS"
     will override the inhibition when there is RHEL unsupported kernel module detected.
 
     TODO(danmyway) after merging PR619 add the reference links to test metadata.
@@ -59,7 +59,7 @@ def test_envar_overrides_unsupported_module_loaded(insert_custom_kmod, convert2r
     Verifies https://github.com/oamg/convert2rhel/pull/613/
     """
     insert_custom_kmod()
-    os.environ["CONVERT2RHEL_ALLOW_UNCHECKED_KMODS"] = "1"
+    os.environ["CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS"] = "1"
 
     with convert2rhel(
         "--no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug".format(
@@ -74,14 +74,14 @@ def test_envar_overrides_unsupported_module_loaded(insert_custom_kmod, convert2r
             c2r.sendline("y")
             prompt_amount -= 1
 
-        c2r.expect("Detected 'CONVERT2RHEL_ALLOW_UNCHECKED_KMODS' environment variable")
-        c2r.expect("We will continue the conversion, with the following kernel modules")
+        c2r.expect("Detected 'CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS' environment variable")
+        c2r.expect("We will continue the conversion with the following kernel modules")
 
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("n")
     assert c2r.exitstatus != 0
 
-    del os.environ["CONVERT2RHEL_ALLOW_UNCHECKED_KMODS"]
+    del os.environ["CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS"]
 
 
 def test_do_not_inhibit_if_module_is_not_loaded(shell, convert2rhel, prompt_amount=PROMPT_AMOUNT):


### PR DESCRIPTION
* add integration test to verify the environment variable introduced overrides the inhibition
* Introduced in [PR#613](https://github.com/oamg/convert2rhel/pull/613/)

Jira Issue: [RHELC-244](https://issues.redhat.com/browse/RHELC-244)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
