### PR TITLE
Fix CodeQL warnings

### DIFF
--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -318,8 +318,8 @@ def get_installed_pkg_objects(name=None, version=None, release=None, arch=None):
     """
     if pkgmanager.TYPE == "yum":
         return _get_installed_pkg_objects_yum(name, version, release, arch)
-    elif pkgmanager.TYPE == "dnf":
-        return _get_installed_pkg_objects_dnf(name, version, release, arch)
+
+    return _get_installed_pkg_objects_dnf(name, version, release, arch)
 
 
 def _get_installed_pkg_objects_yum(name=None, version=None, release=None, arch=None):
@@ -515,14 +515,14 @@ def get_pkg_nevra(pkg_obj):
             pkg_obj.release,
             pkg_obj.arch,
         )
-    elif pkgmanager.TYPE == "dnf":
-        return "%s-%s%s-%s.%s" % (
-            pkg_obj.name,
-            "" if str(pkg_obj.epoch) == "0" else str(pkg_obj.epoch) + ":",
-            pkg_obj.version,
-            pkg_obj.release,
-            pkg_obj.arch,
-        )
+
+    return "%s-%s%s-%s.%s" % (
+        pkg_obj.name,
+        "" if str(pkg_obj.epoch) == "0" else str(pkg_obj.epoch) + ":",
+        pkg_obj.version,
+        pkg_obj.release,
+        pkg_obj.arch,
+    )
 
 
 def get_packager(pkg_obj):

--- a/convert2rhel/pkgmanager/__init__.py
+++ b/convert2rhel/pkgmanager/__init__.py
@@ -65,10 +65,10 @@ def create_transaction_handler():
         from convert2rhel.pkgmanager.handlers.yum import YumTransactionHandler
 
         return YumTransactionHandler()
-    elif TYPE == "dnf":
-        from convert2rhel.pkgmanager.handlers.dnf import DnfTransactionHandler
 
-        return DnfTransactionHandler()
+    from convert2rhel.pkgmanager.handlers.dnf import DnfTransactionHandler
+
+    return DnfTransactionHandler()
 
 
 def clean_yum_metadata():

--- a/convert2rhel/pkgmanager/handlers/base.py
+++ b/convert2rhel/pkgmanager/handlers/base.py
@@ -41,10 +41,10 @@ class TransactionHandlerBase:
         self._enabled_repos = []
 
     @abc.abstractmethod
-    def run_transaction(self, test_transaction=False):
+    def run_transaction(self, validate_transaction=False):
         """Run the actual transaction for the base class.
 
-        :param test_transaction: Determines if the transaction needs to be tested or not.
-        :type test_transaction: bool
+        :param validate_transaction: Determines if the transaction needs to be tested or not.
+        :type validate_transaction: bool
         """
         pass

--- a/convert2rhel/redhatrelease.py
+++ b/convert2rhel/redhatrelease.py
@@ -29,14 +29,16 @@ OS_RELEASE_FILEPATH = "/etc/os-release"
 
 
 def get_release_pkg_name():
-    """For RHEL 6 and 7 the release package name is redhat-release-server.
+    """For RHEL 7 the release package name is redhat-release-server.
 
     For RHEL 8, the name is redhat-release.
     """
-    if system_info.version.major in [6, 7]:
-        return "redhat-release-server"
-    elif system_info.version.major == 8:
-        return "redhat-release"
+    release_pkg_name = "redhat-release-server"
+
+    if system_info.version.major == 8:
+        release_pkg_name = "redhat-release"
+
+    return release_pkg_name
 
 
 def get_system_release_filepath():

--- a/convert2rhel/unit_tests/backup_test.py
+++ b/convert2rhel/unit_tests/backup_test.py
@@ -1,13 +1,12 @@
 import collections
 import os
-import sys
 import unittest
 
 import pytest
 import six
 
 from convert2rhel import backup, repo, unit_tests, utils  # Imports unit_tests/__init__.py
-from convert2rhel.unit_tests.conftest import all_systems, centos8
+from convert2rhel.unit_tests.conftest import centos8
 
 
 six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
@@ -589,7 +588,6 @@ class TestRestorableRpmKey:
 
     def test_enable_already_installed(self, run_subprocess_with_empty_rpmdb, rpm_key):
         utils.run_subprocess(["rpm", "--import", self.gpg_key], print_output=False)
-        previous_number_of_calls = len(run_subprocess_with_empty_rpmdb.called_with)
         rpm_key.enable()
 
         # Check that we did not call rpm to import the key

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -793,11 +793,11 @@ def _gen_version(major, minor):
 class TestEFIChecks(unittest.TestCase):
     def _check_efi_detection_log(self, efi_detected=True):
         if efi_detected:
-            self.assertFalse("BIOS detected." in checks.logger.info_msgs)
-            self.assertTrue("UEFI detected." in checks.logger.info_msgs)
+            self.assertNotIn("BIOS detected.", checks.logger.info_msgs)
+            self.assertIn("UEFI detected.", checks.logger.info_msgs)
         else:
-            self.assertTrue("BIOS detected." in checks.logger.info_msgs)
-            self.assertFalse("UEFI detected." in checks.logger.info_msgs)
+            self.assertIn("BIOS detected.", checks.logger.info_msgs)
+            self.assertNotIn("UEFI detected.", checks.logger.info_msgs)
 
     @unit_tests.mock(grub, "is_efi", lambda: False)
     @unit_tests.mock(checks, "logger", GetLoggerMocked())
@@ -810,7 +810,7 @@ class TestEFIChecks(unittest.TestCase):
     def _check_efi_critical(self, critical_msg):
         self.assertRaises(SystemExit, checks.check_efi)
         self.assertEqual(len(checks.logger.critical_msgs), 1)
-        self.assertTrue(critical_msg in checks.logger.critical_msgs)
+        self.assertIn(critical_msg, checks.logger.critical_msgs)
         self._check_efi_detection_log(True)
 
     @unit_tests.mock(grub, "is_efi", lambda: True)
@@ -864,7 +864,7 @@ class TestEFIChecks(unittest.TestCase):
             "The conversion with secure boot is currently not possible.\n"
             "To disable it, follow the instructions available in this article: https://access.redhat.com/solutions/6753681"
         )
-        self.assertTrue("Secure boot detected." in checks.logger.info_msgs)
+        self.assertIn("Secure boot detected.", checks.logger.info_msgs)
 
     @unit_tests.mock(grub, "is_efi", lambda: True)
     @unit_tests.mock(grub, "is_secure_boot", lambda: False)
@@ -894,7 +894,7 @@ class TestEFIChecks(unittest.TestCase):
             "The current UEFI bootloader '0002' is not referring to any binary UEFI file located on local"
             " EFI System Partition (ESP)."
         )
-        self.assertTrue(warn_msg in checks.logger.warning_msgs)
+        self.assertIn(warn_msg, checks.logger.warning_msgs)
 
     @unit_tests.mock(grub, "is_efi", lambda: True)
     @unit_tests.mock(grub, "is_secure_boot", lambda: False)
@@ -1052,8 +1052,8 @@ class TestReadOnlyMountsChecks(unittest.TestCase):
         checks.check_readonly_mounts()
         self.assertEqual(len(checks.logger.critical_msgs), 0)
         self.assertEqual(len(checks.logger.debug_msgs), 2)
-        self.assertTrue("/mnt mount point is not read-only." in checks.logger.debug_msgs)
-        self.assertTrue("/sys mount point is not read-only." in checks.logger.debug_msgs)
+        self.assertIn("/mnt mount point is not read-only.", checks.logger.debug_msgs)
+        self.assertIn("/sys mount point is not read-only.", checks.logger.debug_msgs)
 
     @unit_tests.mock(checks, "logger", GetLoggerMocked())
     @unit_tests.mock(
@@ -1070,13 +1070,9 @@ class TestReadOnlyMountsChecks(unittest.TestCase):
     def test_mounted_are_readonly(self):
         self.assertRaises(SystemExit, checks.check_readonly_mounts)
         self.assertEqual(len(checks.logger.critical_msgs), 1)
-        self.assertTrue(
-            "Stopping conversion due to read-only mount to /mnt directory" in checks.logger.critical_msgs[0]
-        )
-        self.assertTrue(
-            "Stopping conversion due to read-only mount to /sys directory" not in checks.logger.critical_msgs[0]
-        )
-        self.assertTrue("/sys mount point is not read-only." in checks.logger.debug_msgs[0])
+        self.assertIn("Stopping conversion due to read-only mount to /mnt directory", checks.logger.critical_msgs[0])
+        self.assertNotIn("Stopping conversion due to read-only mount to /sys directory", checks.logger.critical_msgs[0])
+        self.assertIn("/sys mount point is not read-only.", checks.logger.debug_msgs[0])
 
     class CallYumCmdMocked(unit_tests.MockFunction):
         def __init__(self, ret_code, ret_string):
@@ -1107,8 +1103,8 @@ class TestReadOnlyMountsChecks(unittest.TestCase):
         checks.check_custom_repos_are_valid()
         self.assertEqual(len(checks.logger.info_msgs), 1)
         self.assertEqual(len(checks.logger.debug_msgs), 1)
-        self.assertTrue(
-            "The repositories passed through the --enablerepo option are all accessible." in checks.logger.info_msgs
+        self.assertIn(
+            "The repositories passed through the --enablerepo option are all accessible.", checks.logger.info_msgs
         )
 
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
@@ -1123,7 +1119,7 @@ class TestReadOnlyMountsChecks(unittest.TestCase):
         self.assertRaises(SystemExit, checks.check_custom_repos_are_valid)
         self.assertEqual(len(checks.logger.critical_msgs), 1)
         self.assertEqual(len(checks.logger.info_msgs), 0)
-        self.assertTrue("Unable to access the repositories passed through " in checks.logger.critical_msgs[0])
+        self.assertIn("Unable to access the repositories passed through ", checks.logger.critical_msgs[0])
 
 
 @oracle8

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -16,29 +16,6 @@ if sys.version_info[:2] <= (2, 7):
 else:
     from unittest import mock  # pylint: disable=no-name-in-module
 
-try:
-    from pytest_catchlog import CompatLogCaptureFixture
-
-    class SubCompatLogCaptureFixture(CompatLogCaptureFixture):
-        @property
-        def messages(self):
-            return [r.getMessage() for r in self.records]
-
-    @pytest.fixture
-    def caplog(request):
-        """Access and control log capturing.
-        Captured logs are available through the following properties/methods::
-        * caplog.messages        -> list of format-interpolated log messages
-        * caplog.text            -> string containing formatted log output
-        * caplog.records         -> list of logging.LogRecord instances
-        * caplog.record_tuples   -> list of (logger_name, level, message) tuples
-        * caplog.clear()         -> clear captured records and formatted log output string
-        """
-        return SubCompatLogCaptureFixture(request.node)
-
-except ImportError:
-    pass
-
 # We are injecting a instance of `mock.Mock()` for `Depsolve` class and
 # `callback` module, as when we run the tests under CentOS 7, it fails by saying
 # that `pkgmanager.callback.Depsolve` can't be imported as it is an import from

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -103,7 +103,8 @@ def test_archive_old_logger_files(log_name, path_exists, tmpdir, caplog):
     test_data = "test data\n"
 
     if path_exists:
-        open(log_file, "w").write(test_data)
+        with open(log_file, mode="w") as handler:
+            handler.write(test_data)
 
     logger_module.archive_old_logger_files(log_name, tmpdir)
 

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -204,7 +204,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
     @unit_tests.mock(os.path, "isfile", IsFileMocked(is_file=False))
     @unit_tests.mock(os.path, "getsize", GetSizeMocked(file_size=0))
     def test_clear_versionlock_plugin_not_enabled(self):
-        self.assertFalse(pkghandler.clear_versionlock())
+        pkghandler.clear_versionlock()
         self.assertEqual(len(pkghandler.loggerinst.info_msgs), 1)
         self.assertEqual(
             pkghandler.loggerinst.info_msgs,
@@ -1219,7 +1219,7 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
     def test_list_third_party_pkgs_no_pkgs(self):
         pkghandler.list_third_party_pkgs()
 
-        self.assertTrue("No third party packages installed" in pkghandler.loggerinst.info_msgs[0])
+        self.assertIn("No third party packages installed", pkghandler.loggerinst.info_msgs[0])
 
     @unit_tests.mock(
         pkghandler,
@@ -1233,14 +1233,14 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         pkghandler.list_third_party_pkgs()
 
         self.assertEqual(len(pkghandler.print_pkg_info.pkgs), 3)
-        self.assertTrue("Only packages signed by" in pkghandler.loggerinst.warning_msgs[0])
+        self.assertIn("Only packages signed by", pkghandler.loggerinst.warning_msgs[0])
 
     @unit_tests.mock(tool_opts, "disablerepo", ["*", "rhel-7-extras-rpm"])
     @unit_tests.mock(tool_opts, "enablerepo", ["rhel-7-extras-rpm"])
     @unit_tests.mock(pkghandler, "loggerinst", GetLoggerMocked())
     def test_is_disable_and_enable_repos_has_same_repo(self):
         pkghandler.has_duplicate_repos_across_disablerepo_enablerepo_options()
-        self.assertTrue("Duplicate repositories were found" in pkghandler.loggerinst.warning_msgs[0])
+        self.assertIn("Duplicate repositories were found", pkghandler.loggerinst.warning_msgs[0])
 
     @unit_tests.mock(tool_opts, "disablerepo", ["*"])
     @unit_tests.mock(tool_opts, "enablerepo", ["rhel-7-extras-rpm"])
@@ -1263,24 +1263,24 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         pkghandler.fix_default_kernel()
         self.assertTrue(len(pkghandler.logging.getLogger.info_msgs), 1)
         self.assertTrue(len(pkghandler.logging.getLogger.warning_msgs), 1)
-        self.assertTrue(
-            "Detected leftover boot kernel, changing to RHEL kernel" in pkghandler.logging.getLogger.warning_msgs[0]
+        self.assertIn(
+            "Detected leftover boot kernel, changing to RHEL kernel", pkghandler.logging.getLogger.warning_msgs[0]
         )
-        self.assertTrue("/etc/sysconfig/kernel", utils.store_content_to_file.filename)
-        self.assertTrue("DEFAULTKERNEL=kernel" in utils.store_content_to_file.content)
-        self.assertFalse("DEFAULTKERNEL=kernel-uek" in utils.store_content_to_file.content)
-        self.assertFalse("DEFAULTKERNEL=kernel-core" in utils.store_content_to_file.content)
+        self.assertIn("/etc/sysconfig/kernel", utils.store_content_to_file.filename)
+        self.assertIn("DEFAULTKERNEL=kernel", utils.store_content_to_file.content)
+        self.assertNotIn("DEFAULTKERNEL=kernel-uek", utils.store_content_to_file.content)
+        self.assertNotIn("DEFAULTKERNEL=kernel-core", utils.store_content_to_file.content)
 
         system_info.name = "Oracle Linux Server release 8.1"
         system_info.version = namedtuple("Version", ["major", "minor"])(8, 1)
         pkghandler.fix_default_kernel()
         self.assertTrue(len(pkghandler.logging.getLogger.info_msgs), 1)
         self.assertTrue(len(pkghandler.logging.getLogger.warning_msgs), 1)
-        self.assertTrue(
-            "Detected leftover boot kernel, changing to RHEL kernel" in pkghandler.logging.getLogger.warning_msgs[0]
+        self.assertIn(
+            "Detected leftover boot kernel, changing to RHEL kernel", pkghandler.logging.getLogger.warning_msgs[0]
         )
-        self.assertTrue("DEFAULTKERNEL=kernel" in utils.store_content_to_file.content)
-        self.assertFalse("DEFAULTKERNEL=kernel-uek" in utils.store_content_to_file.content)
+        self.assertIn("DEFAULTKERNEL=kernel", utils.store_content_to_file.content)
+        self.assertNotIn("DEFAULTKERNEL=kernel-uek", utils.store_content_to_file.content)
 
     @unit_tests.mock(system_info, "name", "CentOS Plus Linux Server release 7.9")
     @unit_tests.mock(system_info, "arch", "x86_64")
@@ -1297,8 +1297,8 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         self.assertTrue(len(pkghandler.logging.getLogger.info_msgs), 1)
         self.assertTrue(len(pkghandler.logging.getLogger.warning_msgs), 1)
         self.assertTrue("/etc/sysconfig/kernel", utils.store_content_to_file.filename)
-        self.assertTrue("DEFAULTKERNEL=kernel" in utils.store_content_to_file.content)
-        self.assertFalse("DEFAULTKERNEL=kernel-plus" in utils.store_content_to_file.content)
+        self.assertIn("DEFAULTKERNEL=kernel", utils.store_content_to_file.content)
+        self.assertNotIn("DEFAULTKERNEL=kernel-plus", utils.store_content_to_file.content)
 
     @unit_tests.mock(system_info, "name", "CentOS Plus Linux Server release 7.9")
     @unit_tests.mock(system_info, "arch", "x86_64")

--- a/convert2rhel/unit_tests/pkgmanager/pkgmanager_test.py
+++ b/convert2rhel/unit_tests/pkgmanager/pkgmanager_test.py
@@ -19,7 +19,7 @@
 import pytest
 import six
 
-from convert2rhel import pkgmanager, utils
+from convert2rhel import pkgmanager
 from convert2rhel.unit_tests import run_subprocess_side_effect
 
 

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -223,17 +223,17 @@ class TestSubscription(unittest.TestCase):
     @unit_tests.mock(subscription, "get_avail_repos", lambda: ["rhel_x", "rhel_y"])
     def test_check_needed_repos_availability(self):
         subscription.check_needed_repos_availability(["rhel_x"])
-        self.assertTrue("Needed RHEL repositories are available." in logging.Logger.info.msg)
+        self.assertIn("Needed RHEL repositories are available.", logging.Logger.info.msg)
 
         subscription.check_needed_repos_availability(["rhel_z"])
-        self.assertTrue("rhel_z repository is not available" in logging.Logger.warning.msg)
+        self.assertIn("rhel_z repository is not available", logging.Logger.warning.msg)
 
     @unit_tests.mock(logging.Logger, "warning", LogMocked())
     @unit_tests.mock(utils, "ask_to_continue", PromptUserMocked())
     @unit_tests.mock(subscription, "get_avail_repos", lambda: [])
     def test_check_needed_repos_availability_no_repo_available(self):
         subscription.check_needed_repos_availability(["rhel"])
-        self.assertTrue("rhel repository is not available" in logging.Logger.warning.msg)
+        self.assertIn("rhel repository is not available", logging.Logger.warning.msg)
 
     @unit_tests.mock(pkghandler, "get_installed_pkg_objects", lambda _: [namedtuple("Pkg", ["name"])("submgr")])
     @unit_tests.mock(pkghandler, "print_pkg_info", lambda x: None)
@@ -264,9 +264,7 @@ class TestSubscription(unittest.TestCase):
         subscription.remove_original_subscription_manager()
 
         self.assertEqual(len(subscription.loggerinst.info_msgs), 2)
-        self.assertTrue(
-            "No packages related to subscription-manager installed." in subscription.loggerinst.info_msgs[-1]
-        )
+        self.assertIn("No packages related to subscription-manager installed.", subscription.loggerinst.info_msgs[-1])
 
 
 @pytest.fixture
@@ -624,7 +622,7 @@ class TestRegistrationCommand(object):
     def test_instantiate_failures(self, registration_kwargs, error_message):
         """Test various failures instantiating RegistrationCommand."""
         with pytest.raises(ValueError, match=error_message):
-            cmd = subscription.RegistrationCommand(**registration_kwargs)
+            subscription.RegistrationCommand(**registration_kwargs)
 
     @pytest.mark.parametrize(
         "registration_kwargs",

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -26,7 +26,7 @@ from collections import namedtuple
 import pytest
 import six
 
-from convert2rhel import logger, pkgmanager, systeminfo, unit_tests, utils  # Imports unit_tests/__init__.py
+from convert2rhel import logger, systeminfo, unit_tests, utils  # Imports unit_tests/__init__.py
 from convert2rhel.systeminfo import RELEASE_VER_MAPPING, Version, system_info
 from convert2rhel.toolopts import tool_opts
 from convert2rhel.unit_tests import is_rpm_based_os
@@ -163,7 +163,7 @@ class TestSysteminfo(unittest.TestCase):
         # Check that rpm -Va is executed (default) and stored into the specific file.
         tool_opts.no_rpm_va = False
         system_info.generate_rpm_va()
-        self.assertTrue(utils.run_subprocess.called > 0)
+        self.assertGreater(utils.run_subprocess.called, 0)
         self.assertEqual(utils.run_subprocess.used_args[0][0], ["rpm", "-Va"])
         self.assertTrue(os.path.isfile(self.rpmva_output_file))
         self.assertEqual(utils.get_file_content(self.rpmva_output_file), "rpmva\n")
@@ -404,7 +404,7 @@ def test_get_system_distribution_id(system_release_content, expected):
 
 @centos8
 def test_get_system_distribution_id_default_system_release_content(pretend_os):
-    assert system_info._get_system_distribution_id() == None
+    assert system_info._get_system_distribution_id() is None
 
 
 @pytest.mark.parametrize(

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -26,7 +26,6 @@ from collections import namedtuple
 import pytest
 import six
 
-import convert2rhel.toolopts
 import convert2rhel.utils
 
 from convert2rhel.toolopts import tool_opts
@@ -92,9 +91,9 @@ class TestTooloptsParseFromCLI(object):
     def test_no_serverurl(self, monkeypatch, global_tool_opts):
         monkeypatch.setattr(sys, "argv", mock_cli_arguments([]))
         convert2rhel.toolopts.CLI()
-        assert global_tool_opts.rhsm_hostname == None
-        assert global_tool_opts.rhsm_port == None
-        assert global_tool_opts.rhsm_prefix == None
+        assert global_tool_opts.rhsm_hostname is None
+        assert global_tool_opts.rhsm_port is None
+        assert global_tool_opts.rhsm_prefix is None
 
     @pytest.mark.parametrize(
         "serverurl",

--- a/man/build_manpage.py
+++ b/man/build_manpage.py
@@ -142,9 +142,8 @@ class build_manpage(Command):
         manpage.append(self._write_header())
         manpage.append(self._write_options())
         manpage.append(self._write_footer())
-        stream = open(self.output, "w")
-        stream.write("".join(manpage))
-        stream.close()
+        with open(self.output, mode="w") as stream:
+            stream.write("".join(manpage))
 
 
 class ManPageFormatter(optparse.HelpFormatter):

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,11 @@ from setuptools import find_packages, setup
 from man.build_manpage import build_manpage
 
 
-# Utility function to read content of a file.
 def read(fname):
-    return open(os.path.join(os.path.dirname(os.path.abspath(__file__)), fname)).read()
+    """Utility function to read the contents of a file."""
+    filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), fname)
+    with open(filepath, mode="r") as handler:
+        return handler.read()
 
 
 def get_version():

--- a/tests/integration/tier0/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/basic-sanity-checks/test_basic_sanity_checks.py
@@ -1,8 +1,6 @@
 import os
 import subprocess
 
-from os import getenv
-
 import pytest
 
 
@@ -218,7 +216,7 @@ def test_data_collection_acknowledgement(shell, convert2rhel):
     # Remove facts from previous runs.
     shell(f"rm -f {CONVERT2RHEL_FACTS_FILE}")
     # Remove envar disabling telemetry just in case.
-    if getenv("CONVERT2RHEL_DISABLE_TELEMETRY"):
+    if os.getenv("CONVERT2RHEL_DISABLE_TELEMETRY"):
         del os.environ["CONVERT2RHEL_DISABLE_TELEMETRY"]
 
     with convert2rhel("--no-rpm-va --debug") as c2r:

--- a/tests/integration/tier0/single-yum-transaction-validation/test_single_yum_transaction_validation.py
+++ b/tests/integration/tier0/single-yum-transaction-validation/test_single_yum_transaction_validation.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 
 import pytest
 

--- a/tests/integration/tier1/checks-after-conversion/test_flag_system_as_converted.py
+++ b/tests/integration/tier1/checks-after-conversion/test_flag_system_as_converted.py
@@ -9,11 +9,8 @@ def _load_json_schema(path):
     """Load the JSON schema from the system."""
     assert os.path.exists(path)
 
-    # Python2 doesn't have the nice `with` syntax.
-    handler = open(path, "r")
-    data = json.load(handler)
-    handler.close()
-    return data
+    with open(path, mode="r") as handler:
+        return json.load(handler)
 
 
 C2R_MIGRATION_RESULTS_SCHEMA = _load_json_schema(path="artifacts/c2r_migration_results_schema.json")

--- a/tests/integration/tier1/config-file/test_config_file.py
+++ b/tests/integration/tier1/config-file/test_config_file.py
@@ -10,9 +10,9 @@ Config = namedtuple("Config", "path content")
 
 def create_files(config):
     for cfg in config:
-        f = open(os.path.expanduser(cfg.path), "w")
-        f.write(cfg.content)
-        f.close()
+        with open(os.path.expanduser(cfg.path), mode="w") as handler:
+            handler.write(cfg.content)
+
         os.chmod(os.path.expanduser(cfg.path), 0o600)
 
 

--- a/tests/integration/tier1/convert-offline-systems/run_conversion.py
+++ b/tests/integration/tier1/convert-offline-systems/run_conversion.py
@@ -1,5 +1,3 @@
-import os
-
 from envparse import env
 
 


### PR DESCRIPTION
This commit introduces a bunch of fixes for the warnings/notices that CodeQL was showing for Convert2RHEL under the the `Security` tab.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist
- [ ] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
