### PR TITLE
[RHELC-244] Rename unavailable kmod inhibitor envar

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -369,20 +369,21 @@ def ensure_compatibility_of_kmods():
     if not unsupported_kmods:
         logger.debug("All loaded kernel modules are available in RHEL.")
     else:
-        if "CONVERT2RHEL_ALLOW_UNCHECKED_KMODS" in os.environ:
+        if "CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS" in os.environ:
             logger.warning(
-                "Detected 'CONVERT2RHEL_ALLOW_UNCHECKED_KMODS' environment variable."
-                " We will continue the conversion, with the following kernel modules:\n{kmods}\n".format(
-                    kmods="\n".join(unsupported_kmods)
-                )
+                "Detected 'CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS' environment variable."
+                " We will continue the conversion with the following kernel modules unavailable in RHEL:\n"
+                "{kmods}\n".format(kmods="\n".join(unsupported_kmods))
             )
         else:
             logger.critical(
                 "The following loaded kernel modules are not available in RHEL:\n{0}\n"
-                "Kernel modules need to be up-to-date to minimize the risk for issues occurring related to first-party kernel modules.\n"
-                "Ensure you have updated the kernel to the latest available version and rebooted the system.\n"
-                "If this message persists, you can prevent the modules from loading by following {1} and rerun convert2rhel.\n"
-                "To circumvent this check and allow the risk you can set environment variable 'CONVERT2RHEL_ALLOW_UNCHECKED_KMODS=1'.".format(
+                "Ensure you have updated the kernel to the latest available version and rebooted the system.\nIf this "
+                "message persists, you can prevent the modules from loading by following {1} and rerun convert2rhel.\n"
+                "Keeping them loaded could cause the system to malfunction after the conversion as they might not work "
+                "properly with the RHEL kernel.\n"
+                "To circumvent this check and accept the risk you can set environment variable "
+                "'CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS=1'.".format(
                     "\n".join(unsupported_kmods), LINK_PREVENT_KMODS_FROM_LOADING
                 )
             )

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -446,7 +446,7 @@ def test_ensure_compatibility_of_kmods_check_env(
     caplog,
 ):
 
-    monkeypatch.setattr(os, "environ", {"CONVERT2RHEL_ALLOW_UNCHECKED_KMODS": "1"})
+    monkeypatch.setattr(os, "environ", {"CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS": "1"})
     monkeypatch.setattr(checks, "get_loaded_kmods", mock.Mock(return_value=HOST_MODULES_STUB_BAD))
     run_subprocess_mock = mock.Mock(
         side_effect=run_subprocess_side_effect(
@@ -463,8 +463,8 @@ def test_ensure_compatibility_of_kmods_check_env(
 
     checks.ensure_compatibility_of_kmods()
     should_be_in_logs = (
-        ".*Detected 'CONVERT2RHEL_ALLOW_UNCHECKED_KMODS' environment variable."
-        " We will continue the conversion, with the following kernel modules:.*"
+        ".*Detected 'CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS' environment variable."
+        " We will continue the conversion with the following kernel modules unavailable in RHEL:.*"
     )
     assert re.match(pattern=should_be_in_logs, string=caplog.records[-1].message, flags=re.MULTILINE | re.DOTALL)
 


### PR DESCRIPTION
Before we do an upstream release we can still change the CONVERT2RHEL_ALLOW_UNCHECKED_KMODS environment variable used for overriding the check that inhibits the conversion when kernel modules not available in RHEL are loaded. This variable was introduced recently under https://github.com/oamg/convert2rhel/pull/613.

It is not clear what we mean by UNCHECKED in the envar. CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS is more self-explanatory.

Also, this PR rewords the use of _"first-party kernel modules"_ as it's also quite unclear what we mean by that.

The https://github.com/oamg/convert2rhel/pull/735 that introduces an integration check for the new environment variable needs to be updated accordingly.

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-244](https://issues.redhat.com/browse/RHELC-244)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
