### PR TITLE
[RHELC-752] Fix "missing boot files" test

### DIFF
--- a/tests/integration/tier1/kernel-boot-files/test_handle_missing_boot_files.py
+++ b/tests/integration/tier1/kernel-boot-files/test_handle_missing_boot_files.py
@@ -10,9 +10,6 @@ from envparse import env
 INITRAMFS_FILE = "/boot/initramfs-%s.img"
 VMLINUZ_FILE = "/boot/vmlinuz-%s"
 
-BACKUP_INITRAMFS_FILE = "/boot/initramfs-%s.backup.img"
-BACKUP_VMLINUZ_FILE = "/boot/vmlinuz-%s.backup"
-
 
 def get_latest_installed_kernel_version(kernel_name):
     """Utility function to get the latest installed kernel."""
@@ -23,47 +20,19 @@ def get_latest_installed_kernel_version(kernel_name):
     return latest_installed_kernel.strip()
 
 
-def restore_original_kernel_boot_files(shell, kernel_version):
-    """
-    Utility function to restore the required kernel boot files after the
-    conversion.
-    """
+def remove_kernel_boot_files(shell, kernel_version):
+    """Utility function to remove the RHEL kernel boot files."""
+
     initramfs_file = INITRAMFS_FILE % kernel_version
     vmlinuz_file = VMLINUZ_FILE % kernel_version
 
-    # Assert that the original files still doesn't exists
-    assert not os.path.exists(initramfs_file)
-    assert not os.path.exists(vmlinuz_file)
-
-    initramfs_backup = BACKUP_INITRAMFS_FILE % kernel_version
-    vmlinuz_backup = BACKUP_VMLINUZ_FILE % kernel_version
-
-    # Move the "backup" files back with the correct name
-    assert shell("mv %s %s" % (initramfs_backup, initramfs_file)).returncode == 0
-    assert shell("mv %s %s" % (vmlinuz_backup, vmlinuz_file)).returncode == 0
-
-    # Assert that both files exists now
+    # Assert that we have the files in the /boot/ folder
     assert os.path.exists(initramfs_file)
     assert os.path.exists(vmlinuz_file)
 
-
-def backup_kernel_boot_files(shell, kernel_version):
-    """
-    Utility function to backup the required kernel boot files.
-    """
-    initramfs_file = INITRAMFS_FILE % kernel_version
-    vmlinuz_file = VMLINUZ_FILE % kernel_version
-
-    # Assert that we have the files in the folder
-    assert os.path.exists(initramfs_file)
-    assert os.path.exists(vmlinuz_file)
-
-    initramfs_backup = BACKUP_INITRAMFS_FILE % kernel_version
-    vmlinuz_backup = BACKUP_VMLINUZ_FILE % kernel_version
-
-    # Move the original files to be a "backup", simulating that we deleted them
-    assert shell("mv %s %s" % (initramfs_file, initramfs_backup)).returncode == 0
-    assert shell("mv %s %s" % (vmlinuz_file, vmlinuz_backup)).returncode == 0
+    # Remove the installed RHEL kernel boot files, simulating that they failed to be generated during the conversion
+    assert shell("rm -f %s" % initramfs_file).returncode == 0
+    assert shell("rm -f %s" % vmlinuz_file).returncode == 0
 
 
 @pytest.mark.missing_kernel_boot_files
@@ -77,8 +46,8 @@ def test_missing_kernel_boot_files(convert2rhel, shell):
     the scriptlet can fail, the transaction will still continue and the
     workflow will continue to be executed. The problem is that, with a
     scriptlet failure when replacing/installing a kernel, the initramfs and
-    vmlinuz could not be available in the /boot partition, especially if there
-    is no sufficient disk space available in there. This test has the intention
+    vmlinuz may not be available in the /boot partition, especially if there
+    isn't sufficient disk space available in there. This test has the intention
     to verify that the warning with the correct steps are provided to the
     user in order to overcome this case and fix it for them.
     """
@@ -100,17 +69,19 @@ def test_missing_kernel_boot_files(convert2rhel, shell):
         kernel_version = get_latest_installed_kernel_version(kernel_name)
 
         # We want to simulate with this test that when we don't detect the
-        # initramfs and vmlinuz files, we will produce an warning and tell the
+        # initramfs and vmlinuz files, we will produce a warning and tell the
         # user what to do in order to fix the problem. To not cause any more
         # mess other than what we want, let's just remove the two file from the
         # system, and see if Convert2RHEL will detect that the right way.
-        backup_kernel_boot_files(shell, kernel_version)
+        remove_kernel_boot_files(shell, kernel_version)
 
         assert c2r.expect("Couldn't verify the kernel boot files in the boot partition.") == 0
 
-        # We have to restore the original initramfs file in order to use the
-        # checks-after-conversion tests to assert that most of the conversion
-        # is done properly.
-        restore_original_kernel_boot_files(shell, kernel_version)
+        # We have to restore the boot files in order to use the checks-after-conversion tests to
+        # assert that the rest of the conversion has succeeded.
+        # We'll do that the same way we're telling the user in a warning message how to fix the problem.
+        # That is by reinstalling the RHEL kernel and re-running grub2-mkconfig.
+        assert shell("yum reinstall kernel-{} -y".format(kernel_version)).returncode == 0
+        assert shell("grub2-mkconfig -o /boot/grub2/grub.cfg").returncode == 0
 
     assert c2r.exitstatus == 0


### PR DESCRIPTION
On CentOS and Oracle Linux 7 the test was failing because we were renaming the vmlinuz, thinking that it's enough to simulate that they are not present. But leaving them renamed in the /boot/ folder caused that the grub2-mkconfig picked them up and generated a new grub configuration using these renamed boot files:
```
09:39:43             out: [02/22/2023 09:39:43] TASK - [Final: Update GRUB2 configuration] ********************************
...
09:39:44             out: [02/22/2023 09:39:44] DEBUG - Output of the grub2-mkconfig call:
09:39:44             out: Found linux image: /boot/vmlinuz-3.10.0-1160.83.1.el7.x86_64.backup
09:39:44             out: Found initrd image: /boot/initramfs-3.10.0-1160.83.1.el7.x86_64.backup.img
```
Full test failure log: http://artifacts.osci.redhat.com/testing-farm/686cea0f-2101-49a5-9a57-0424d12e2d53/work-kernel_boot_files_missing_initramfs_and_vmlinuzqarmzy43/log.txt.

This test fix stops renaming the boot files and instead it simply removes them, simulating better the core test scenario of this integration test (the kernel rpm scriptlet failure to copy/generate the boot files). After verifying that convert2rhel detected this situation of missing boot files correctly, the test goes on to do what the user is instructed to do in such a case - that is reinstalling the kernel and re-runing grub2-mkconfig.

Fixes https://github.com/oamg/convert2rhel/pull/721.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issue: [RHELC-752](https://issues.redhat.com/browse/RHELC-752)

Checklist
- [x] PR meets acceptance criteria specified in the Jira issue
- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending`
