### PR TITLE
Test fix: reinstall kernel package for epel8

### DIFF
--- a/tests/integration/tier0/log-command/test_log_command.py
+++ b/tests/integration/tier0/log-command/test_log_command.py
@@ -29,9 +29,10 @@ def test_verify_logfile_starts_with_command(shell):
 
     # Run command twice with both long and short options to verify, the secrets are obfuscated.
     for command in commands:
-        # There is no need to run the conversion past the first prompt
-        # pass the command with appending 'n'
-        assert shell(f"{command} <<< n").returncode != 0
+        # We need to get past the first prompt acknowledging the data collection,
+        # to make sure the convert2rhel.facts file is created.
+        # After that we can stop the execution at the following prompt.
+        assert shell(f"{command} <<< y n").returncode != 0
 
         with open(C2R_LOG, "r") as logfile:
             command_line = None

--- a/tests/integration/tier1/kernel-boot-files/test_handle_missing_boot_files.py
+++ b/tests/integration/tier1/kernel-boot-files/test_handle_missing_boot_files.py
@@ -81,7 +81,7 @@ def test_missing_kernel_boot_files(convert2rhel, shell):
         # assert that the rest of the conversion has succeeded.
         # We'll do that the same way we're telling the user in a warning message how to fix the problem.
         # That is by reinstalling the RHEL kernel and re-running grub2-mkconfig.
-        assert shell("yum reinstall kernel-{} -y".format(kernel_version)).returncode == 0
+        assert shell("yum reinstall {}-{} -y".format(kernel_name, kernel_version)).returncode == 0
         assert shell("grub2-mkconfig -o /boot/grub2/grub.cfg").returncode == 0
 
     assert c2r.exitstatus == 0


### PR DESCRIPTION
* the test failed to reboot on epel8 due to bad reinstall
* the kernel-core package should be reinstalled, not kernel
