### PR TITLE
Fix failing system_up_to_date test

### DIFF
--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -378,9 +378,10 @@
           playbook: tests/ansible_collections/roles/reboot/main.yml
 
 /detect_correct_boot_partition:
+    enabled: false
     adjust+:
-        - enabled: false
-          when: trigger == commit
+        - enabled: true
+          when: initiator == human
           because: There are no UEFI images available on the Testing Farm yet.
     discover+:
         filter: tag:checks-after-conversion

--- a/tests/integration/tier1/system-up-to-date/test_system_up_to_date.py
+++ b/tests/integration/tier1/system-up-to-date/test_system_up_to_date.py
@@ -15,7 +15,7 @@ def test_skip_kernel_check(shell, convert2rhel):
     assert shell("mkdir /tmp/s_backup").returncode == 0
     assert shell("mv /etc/yum.repos.d/* /tmp/s_backup/").returncode == 0
 
-    # EUS version use hardoced repos from c2r as well
+    # EUS version use hardcoded repos from c2r as well
     if "centos-8" in SYSTEM_RELEASE_ENV:
         assert shell("mkdir /tmp/s_backup_eus").returncode == 0
         assert shell("mv /usr/share/convert2rhel/repos/* /tmp/s_backup_eus/").returncode == 0
@@ -62,8 +62,8 @@ def test_system_not_updated(shell, convert2rhel):
     """
     System contains at least one package that is not updated to
     the latest version. The c2r has to display a warning message
-    about that. Also not updated package it's version
-    is locked. Display a warning about used version lock.
+    about that. Also, not updated package has its version locked.
+    Display a warning about used version lock.
     """
     centos_8_pkg_url = "https://vault.centos.org/8.1.1911/BaseOS/x86_64/os/Packages/wpa_supplicant-2.7-1.el8.x86_64.rpm"
 


### PR DESCRIPTION
* sometimes the test for non-latest kernel inhibition fails, due to `kvm` kernel module getting tainted in the process of downgrading the kernel package on Oracle Linux 8.7
* for the sake of the test, detect if `kvm` module is marked tainted and remove it (and `kvm_intel` as dependent module)

