### PR TITLE
Fix running pylint in a container

### DIFF
--- a/Containerfiles/centos8.Containerfile
+++ b/Containerfiles/centos8.Containerfile
@@ -28,7 +28,7 @@ RUN $PIP install -r $APP_DEV_DEPS
 
 FROM install_dev_deps as install_application
 RUN groupadd --gid=1000 -r app && \
-    useradd -r --uid=1000 --gid=1000 app
+    useradd --uid=1000 --gid=1000 app
 RUN chown -R app:app .
 COPY --chown=app:app . .
 USER app:app

--- a/requirements/centos8.requirements.txt
+++ b/requirements/centos8.requirements.txt
@@ -2,3 +2,4 @@ astroid==2.11.7
 pytest==7.0.1
 pytest-cov==3.0.0
 coverage[toml]
+pylint


### PR DESCRIPTION
Running `make lint` was failing due to not having pylint available in the CentOS Linux 8 container (we run the linting in just this one container). The original error:

```
$ make lint
Building images
bash: pylint: command not found
```

After adding the dependency, pylint started to complain about not being able to create a certain directory to the home folder of the user running the pylint. So this change also allows creating the user home folder by removing `-r` from the useradd command. The original error:

```
$ make lint
Building images

------------------------------------
Your code has been rated at 10.00/10

Unable to create directory /home/app/.cache/pylint
Unable to create file /home/app/.cache/pylint/convert2rhel1.stats: [Errno 2] No such file or directory: '/home/app/.cache/pylint/convert2rhel1.stats'
```

Now after this change there are no more pylint related errors:
```
$ make lint
Building images

------------------------------------
Your code has been rated at 10.00/10
```

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
