### PR TITLE
[RHELC-934] Port check_rhel_compatible_kernel_is_used to Action framework

### DIFF
--- a/convert2rhel/actions/rhel_compatible_kernel.py
+++ b/convert2rhel/actions/rhel_compatible_kernel.py
@@ -41,6 +41,7 @@ class RhelCompatibleKernel(actions.Action):
         By requesting that, we can be confident that the RHEL kernel will provide the same capabilities as on the
         original system.
         """
+        super(RhelCompatibleKernel, self).run()
         logger.task("Prepare: Check kernel compatibility with RHEL")
         if any(
             (

--- a/convert2rhel/actions/rhel_compatible_kernel.py
+++ b/convert2rhel/actions/rhel_compatible_kernel.py
@@ -1,0 +1,141 @@
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import logging
+
+from convert2rhel import actions
+from convert2rhel.pkghandler import get_installed_pkg_objects, get_pkg_fingerprint
+from convert2rhel.systeminfo import system_info
+from convert2rhel.utils import run_subprocess
+
+
+logger = logging.getLogger(__name__)
+
+# The kernel version stays the same throughout a RHEL major version
+COMPATIBLE_KERNELS_VERS = {
+    7: "3.10.0",
+    8: "4.18.0",
+}
+BAD_KERNEL_RELEASE_SUBSTRINGS = ("uek", "rt", "linode")
+
+
+class RhelCompatibleKernel(actions.Action):
+    id = "RHEL_COMPATIBLE_KERNEL"
+
+    def run(self):
+        """Ensure the booted kernel is signed, is standard (not UEK, realtime, ...), and has the same version as in RHEL.
+        By requesting that, we can be confident that the RHEL kernel will provide the same capabilities as on the
+        original system.
+        """
+        logger.task("Prepare: Check kernel compatibility with RHEL")
+        if any(
+            (
+                _bad_kernel_version(system_info.booted_kernel),
+                _bad_kernel_package_signature(system_info.booted_kernel),
+                _bad_kernel_substring(system_info.booted_kernel),
+            )
+        ):
+            self.set_result(
+                status="ERROR",
+                error_id="BOOTED_KERNEL_INCOMPATIBLE",
+                message=(
+                    "The booted kernel version is incompatible with the standard RHEL kernel. "
+                    "To proceed with the conversion, boot into a kernel that is available in the {0} {1} base repository"
+                    " by executing the following steps:\n\n"
+                    "1. Ensure that the {0} {1} base repository is enabled\n"
+                    "2. Run: yum install kernel\n"
+                    "3. (optional) Run: grubby --set-default "
+                    '/boot/vmlinuz-`rpm -q --qf "%{{BUILDTIME}}\\t%{{EVR}}.%{{ARCH}}\\n" kernel | sort -nr | head -1 | cut -f2`\n'
+                    "4. Reboot the machine and if step 3 was not applied choose the kernel"
+                    " installed in step 2 manually".format(system_info.name, system_info.version.major)
+                ),
+            )
+            return
+        else:
+            logger.info("The booted kernel %s is compatible with RHEL." % system_info.booted_kernel)
+
+
+def _bad_kernel_version(kernel_release):
+    """Return True if the booted kernel version does not correspond to the kernel version available in RHEL."""
+    kernel_version = kernel_release.split("-")[0]
+    try:
+        incompatible_version = COMPATIBLE_KERNELS_VERS[system_info.version.major] != kernel_version
+        if incompatible_version:
+            logger.warning(
+                "Booted kernel version '%s' does not correspond to the version "
+                "'%s' available in RHEL %d"
+                % (
+                    kernel_version,
+                    COMPATIBLE_KERNELS_VERS[system_info.version.major],
+                    system_info.version.major,
+                )
+            )
+        else:
+            logger.debug(
+                "Booted kernel version '%s' corresponds to the version available in RHEL %d"
+                % (kernel_version, system_info.version.major)
+            )
+        return incompatible_version
+    except KeyError:
+        logger.debug("Unexpected OS major version. Expected: %r" % COMPATIBLE_KERNELS_VERS.keys())
+        return True
+
+
+def _bad_kernel_package_signature(kernel_release):
+    """Return True if the booted kernel is not signed by the original OS vendor, i.e. it's a custom kernel."""
+    vmlinuz_path = "/boot/vmlinuz-%s" % kernel_release
+
+    kernel_pkg, return_code = run_subprocess(
+        ["rpm", "-qf", "--qf", "%{VERSION}&%{RELEASE}&%{ARCH}&%{NAME}", vmlinuz_path], print_output=False
+    )
+
+    os_vendor = system_info.name.split()[0]
+    if return_code == 1:
+        logger.warning(
+            "The booted kernel %s is not owned by any installed package."
+            " It needs to be owned by a package signed by %s." % (vmlinuz_path, os_vendor)
+        )
+
+        return True
+
+    version, release, arch, name = tuple(kernel_pkg.split("&"))
+    logger.debug("Booted kernel package name: {0}".format(name))
+
+    kernel_pkg_obj = get_installed_pkg_objects(name, version, release, arch)[0]
+    kernel_pkg_gpg_fingerprint = get_pkg_fingerprint(kernel_pkg_obj)
+    bad_signature = system_info.cfg_content["gpg_fingerprints"] != kernel_pkg_gpg_fingerprint
+
+    # e.g. Oracle Linux Server -> Oracle or
+    #      Oracle Linux Server -> CentOS Linux
+    if bad_signature:
+        logger.warning("Custom kernel detected. The booted kernel needs to be signed by %s." % os_vendor)
+        return True
+
+    logger.debug("The booted kernel is signed by %s." % os_vendor)
+    return False
+
+
+def _bad_kernel_substring(kernel_release):
+    """Return True if the booted kernel release contains one of the strings that identify it as non-standard kernel."""
+    bad_substring = any(bad_substring in kernel_release for bad_substring in BAD_KERNEL_RELEASE_SUBSTRINGS)
+    if bad_substring:
+        logger.debug(
+            "The booted kernel '{0}' contains one of the disallowed "
+            "substrings: {1}".format(kernel_release, BAD_KERNEL_RELEASE_SUBSTRINGS)
+        )
+        return True
+    return False

--- a/convert2rhel/unit_tests/actions/rhel_compatible_kernel_test.py
+++ b/convert2rhel/unit_tests/actions/rhel_compatible_kernel_test.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+from collections import namedtuple
+
+import pytest
+import six
+
+from convert2rhel import actions, systeminfo
+from convert2rhel.actions import rhel_compatible_kernel
+from convert2rhel.unit_tests.conftest import centos8
+from convert2rhel.utils import run_subprocess
+
+
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
+
+
+@pytest.fixture
+def rhel_compatible_kernel_action():
+    return rhel_compatible_kernel.RhelCompatibleKernel()
+
+
+@pytest.mark.parametrize(
+    # i.e. _bad_kernel_version...
+    ("any_of_the_subchecks_is_true",),
+    (
+        (True,),
+        (False,),
+    ),
+)
+def test_check_rhel_compatible_kernel_is_used(
+    any_of_the_subchecks_is_true,
+    monkeypatch,
+    caplog,
+    rhel_compatible_kernel_action,
+):
+    monkeypatch.setattr(
+        rhel_compatible_kernel,
+        "_bad_kernel_version",
+        value=mock.Mock(return_value=any_of_the_subchecks_is_true),
+    )
+    monkeypatch.setattr(
+        rhel_compatible_kernel,
+        "_bad_kernel_substring",
+        value=mock.Mock(return_value=False),
+    )
+    monkeypatch.setattr(
+        rhel_compatible_kernel,
+        "_bad_kernel_package_signature",
+        value=mock.Mock(return_value=False),
+    )
+    Version = namedtuple("Version", ("major", "minor"))
+    monkeypatch.setattr(
+        actions.rhel_compatible_kernel.system_info,
+        "version",
+        value=Version(major=1, minor=0),
+    )
+    rhel_compatible_kernel_action.run()
+    if any_of_the_subchecks_is_true:
+        assert rhel_compatible_kernel_action.error_id == "BOOTED_KERNEL_INCOMPATIBLE"
+        assert rhel_compatible_kernel_action.status == actions.STATUS_CODE["ERROR"]
+        assert rhel_compatible_kernel_action.message == (
+            "The booted kernel version is incompatible with the standard RHEL kernel. "
+            "To proceed with the conversion, boot into a kernel that is available in the {0} {1} base repository"
+            " by executing the following steps:\n\n"
+            "1. Ensure that the {0} {1} base repository is enabled\n"
+            "2. Run: yum install kernel\n"
+            "3. (optional) Run: grubby --set-default "
+            '/boot/vmlinuz-`rpm -q --qf "%{{BUILDTIME}}\\t%{{EVR}}.%{{ARCH}}\\n" kernel | sort -nr | head -1 | cut -f2`\n'
+            "4. Reboot the machine and if step 3 was not applied choose the kernel"
+            " installed in step 2 manually".format(
+                actions.rhel_compatible_kernel.system_info.name,
+                actions.rhel_compatible_kernel.system_info.version.major,
+            )
+        )
+    else:
+        assert "is compatible with RHEL" in caplog.records[-1].message
+
+
+@pytest.mark.parametrize(
+    ("kernel_release", "major_ver", "exp_return"),
+    (
+        ("5.11.0-7614-generic", None, True),
+        ("3.10.0-1160.24.1.el7.x86_64", 7, False),
+        ("5.4.17-2102.200.13.el8uek.x86_64", 8, True),
+        ("4.18.0-240.22.1.el8_3.x86_64", 8, False),
+    ),
+)
+def test_bad_kernel_version(kernel_release, major_ver, exp_return, monkeypatch):
+    Version = namedtuple("Version", ("major", "minor"))
+    monkeypatch.setattr(
+        actions.rhel_compatible_kernel.system_info,
+        "version",
+        value=Version(major=major_ver, minor=0),
+    )
+    assert rhel_compatible_kernel._bad_kernel_version(kernel_release) == exp_return
+
+
+@pytest.mark.parametrize(
+    ("kernel_release", "exp_return"),
+    (
+        ("3.10.0-1160.24.1.el7.x86_64", False),
+        ("5.4.17-2102.200.13.el8uek.x86_64", True),
+        ("3.10.0-514.2.2.rt56.424.el7.x86_64", True),
+    ),
+)
+def test_bad_kernel_substring(kernel_release, exp_return, monkeypatch):
+    assert rhel_compatible_kernel._bad_kernel_substring(kernel_release) == exp_return
+
+
+@pytest.mark.parametrize(
+    ("kernel_release", "kernel_pkg", "kernel_pkg_fingerprint", "get_installed_pkg_objects", "exp_return"),
+    (
+        (
+            "4.18.0-240.22.1.el8_3.x86_64",
+            "4.18.0&240.22.1.el8_3&x86_64&kernel-core",
+            "05b555b38483c65d",
+            "yajl.x86_64",
+            False,
+        ),
+        (
+            "4.18.0-240.22.1.el8_3.x86_64",
+            "4.18.0&240.22.1.el8_3&x86_64&kernel-core",
+            "somebadsig",
+            "somepkgobj",
+            True,
+        ),
+    ),
+)
+@centos8
+def test_bad_kernel_package_signature(
+    kernel_release,
+    kernel_pkg,
+    kernel_pkg_fingerprint,
+    get_installed_pkg_objects,
+    exp_return,
+    monkeypatch,
+    pretend_os,
+):
+    run_subprocess_mocked = mock.Mock(spec=run_subprocess, return_value=(kernel_pkg, 0))
+    get_pkg_fingerprint_mocked = mock.Mock(
+        spec=rhel_compatible_kernel.get_pkg_fingerprint, return_value=kernel_pkg_fingerprint
+    )
+    monkeypatch.setattr(actions.rhel_compatible_kernel, "run_subprocess", run_subprocess_mocked)
+    get_installed_pkg_objects_mocked = mock.Mock(
+        spec=rhel_compatible_kernel.get_installed_pkg_objects, return_value=[kernel_pkg]
+    )
+    monkeypatch.setattr(
+        actions.rhel_compatible_kernel,
+        "get_installed_pkg_objects",
+        get_installed_pkg_objects_mocked,
+    )
+    monkeypatch.setattr(actions.rhel_compatible_kernel, "get_pkg_fingerprint", get_pkg_fingerprint_mocked)
+    assert rhel_compatible_kernel._bad_kernel_package_signature(kernel_release) == exp_return
+    run_subprocess_mocked.assert_called_with(
+        ["rpm", "-qf", "--qf", "%{VERSION}&%{RELEASE}&%{ARCH}&%{NAME}", "/boot/vmlinuz-%s" % kernel_release],
+        print_output=False,
+    )
+
+
+@centos8
+def test_kernel_not_installed(pretend_os, caplog, monkeypatch):
+    run_subprocess_mocked = mock.Mock(spec=run_subprocess, return_value=(" ", 1))
+    monkeypatch.setattr(actions.rhel_compatible_kernel, "run_subprocess", run_subprocess_mocked)
+    assert rhel_compatible_kernel._bad_kernel_package_signature("4.18.0-240.22.1.el8_3.x86_64")
+    log_message = (
+        "The booted kernel /boot/vmlinuz-4.18.0-240.22.1.el8_3.x86_64 is not owned by any installed package."
+        " It needs to be owned by a package signed by CentOS."
+    )
+    assert log_message in caplog.text


### PR DESCRIPTION
This PR ports the check_rhel_compatible_kernel_is_used and other associated functions to an action framework.


Jira Issues: [RHELC-934](https://issues.redhat.com/browse/RHELC-934)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
