### PR TITLE
[RHELC-935] Port check_package_updates to Action framework

### DIFF
--- a/convert2rhel/actions/package_updates.py
+++ b/convert2rhel/actions/package_updates.py
@@ -32,6 +32,7 @@ class PackageUpdates(actions.Action):
 
     def run(self):
         """Ensure that the system packages installed are up-to-date."""
+        super(PackageUpdates, self).run()
         logger.task("Prepare: Check if the installed packages are up-to-date")
 
         if system_info.id == "oracle" and system_info.corresponds_to_rhel_eus_release():

--- a/convert2rhel/actions/package_updates.py
+++ b/convert2rhel/actions/package_updates.py
@@ -1,0 +1,81 @@
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import logging
+
+from convert2rhel import actions, pkgmanager
+from convert2rhel.pkghandler import get_total_packages_to_update
+from convert2rhel.repo import get_hardcoded_repofiles_dir
+from convert2rhel.systeminfo import system_info
+from convert2rhel.utils import ask_to_continue
+
+
+logger = logging.getLogger(__name__)
+
+
+class PackageUpdates(actions.Action):
+    id = "PACKAGE_UPDATES"
+
+    def run(self):
+        """Ensure that the system packages installed are up-to-date."""
+        logger.task("Prepare: Check if the installed packages are up-to-date")
+
+        if system_info.id == "oracle" and system_info.corresponds_to_rhel_eus_release():
+            logger.info(
+                "Skipping the check because there are no publicly available %s %d.%d repositories available."
+                % (system_info.name, system_info.version.major, system_info.version.minor)
+            )
+            return
+
+        reposdir = get_hardcoded_repofiles_dir()
+
+        if reposdir and not system_info.has_internet_access:
+            logger.warning("Skipping the check as no internet connection has been detected.")
+            return
+
+        try:
+            packages_to_update = get_total_packages_to_update(reposdir=reposdir)
+        except pkgmanager.RepoError as e:
+            # As both yum and dnf have the same error class (RepoError), to identify any problems when interacting with the
+            # repositories, we use this to catch exceptions when verifying if there is any packages to update on the system.
+            # Beware that the `RepoError` exception is based on the `pkgmanager` module and the message sent to the output
+            # can differ depending if the code is running in RHEL7 (yum) or RHEL8 (dnf).
+            logger.warning(
+                "There was an error while checking whether the installed packages are up-to-date. Having updated system is "
+                "an important prerequisite for a successful conversion. Consider stopping the conversion to "
+                "verify that manually."
+            )
+            logger.warning(str(e))
+            ask_to_continue()
+            return
+
+        if len(packages_to_update) > 0:
+            repos_message = (
+                "on the enabled system repositories"
+                if not reposdir
+                else "on repositories defined in the %s folder" % reposdir
+            )
+            logger.warning(
+                "The system has %s package(s) not updated based %s.\n"
+                "List of packages to update: %s.\n\n"
+                "Not updating the packages may cause the conversion to fail.\n"
+                "Consider stopping the conversion and update the packages before re-running convert2rhel."
+                % (len(packages_to_update), repos_message, " ".join(packages_to_update))
+            )
+            ask_to_continue()
+        else:
+            logger.info("System is up-to-date.")

--- a/convert2rhel/unit_tests/actions/package_updates_test.py
+++ b/convert2rhel/unit_tests/actions/package_updates_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright(C) 2018 Red Hat, Inc.
+# Copyright(C) 2023 Red Hat, Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/convert2rhel/unit_tests/actions/package_updates_test.py
+++ b/convert2rhel/unit_tests/actions/package_updates_test.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+from collections import namedtuple
+
+import pytest
+import six
+
+from convert2rhel import actions, pkgmanager, unit_tests
+from convert2rhel.actions import package_updates
+from convert2rhel.systeminfo import system_info
+from convert2rhel.unit_tests.conftest import centos8, oracle8
+
+
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
+
+
+@pytest.fixture
+def package_updates_action():
+    return package_updates.PackageUpdates()
+
+
+@oracle8
+def test_check_package_updates_skip_on_not_latest_ol(pretend_os, caplog, package_updates_action):
+    message = (
+        "Skipping the check because there are no publicly available Oracle Linux Server 8.4 repositories available."
+    )
+
+    package_updates_action.run()
+
+    assert message in caplog.records[-1].message
+
+
+@pytest.mark.parametrize(
+    ("packages", "exception", "expected"),
+    (
+        (["package-1", "package-2"], True, "The system has {0} package(s) not updated"),
+        ([], False, "System is up-to-date."),
+    ),
+)
+@centos8
+def test_check_package_updates(pretend_os, packages, exception, expected, monkeypatch, caplog, package_updates_action):
+    monkeypatch.setattr(actions.package_updates, "get_total_packages_to_update", value=lambda reposdir: packages)
+    monkeypatch.setattr(actions.package_updates, "ask_to_continue", value=lambda: mock.Mock())
+
+    package_updates_action.run()
+    if exception:
+        expected = expected.format(len(packages))
+
+    assert expected in caplog.records[-1].message
+
+
+def test_check_package_updates_with_repoerror(monkeypatch, caplog, package_updates_action):
+    get_total_packages_to_update_mock = mock.Mock(side_effect=pkgmanager.RepoError)
+    monkeypatch.setattr(
+        actions.package_updates, "get_total_packages_to_update", value=get_total_packages_to_update_mock
+    )
+    monkeypatch.setattr(actions.package_updates, "ask_to_continue", value=lambda: mock.Mock())
+
+    package_updates_action.run()
+    # This is -2 because the last message is the error from the RepoError class.
+    assert (
+        "There was an error while checking whether the installed packages are up-to-date." in caplog.records[-2].message
+    )
+
+
+@centos8
+def test_check_package_updates_without_internet(pretend_os, tmpdir, monkeypatch, caplog, package_updates_action):
+    monkeypatch.setattr(actions.package_updates, "get_hardcoded_repofiles_dir", value=lambda: str(tmpdir))
+    system_info.has_internet_access = False
+    package_updates_action.run()
+
+    assert "Skipping the check as no internet connection has been detected." in caplog.records[-1].message


### PR DESCRIPTION
This PR ports the check_package_updates function from checks.py to an Action framework.

Jira Issues: [RHELC-935](https://issues.redhat.com/browse/RHELC-935)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
