### PR TITLE
[RHELC-937] Port check_dbus_is_running to Action framework

### DIFF
--- a/convert2rhel/actions/__init__.py
+++ b/convert2rhel/actions/__init__.py
@@ -315,7 +315,6 @@ def perform_system_checks():
     check_custom_repos_are_valid()
     check_tainted_kmods()
     is_loaded_kernel_latest()
-    check_dbus_is_running()
 
 
 def perform_pre_ponr_checks():
@@ -764,21 +763,3 @@ def is_loaded_kernel_latest():
         )
 
     logger.info("The currently loaded kernel is at the latest version.")
-
-
-def check_dbus_is_running():
-    """Error out if we need to register with rhsm and the dbus daemon is not running."""
-    logger.task("Prepare: Check that DBus Daemon is running")
-
-    if tool_opts.no_rhsm:
-        logger.info("Skipping the check because we have been asked not to subscribe this system to RHSM.")
-        return
-
-    if system_info.dbus_running:
-        logger.info("DBus Daemon is running")
-        return
-
-    logger.critical(
-        "Could not find a running DBus Daemon which is needed to register with subscription manager.\n"
-        "Please start dbus using `systemctl start dbus`"
-    )

--- a/convert2rhel/actions/dbus.py
+++ b/convert2rhel/actions/dbus.py
@@ -1,0 +1,51 @@
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import logging
+
+from convert2rhel import actions
+from convert2rhel.systeminfo import system_info
+from convert2rhel.toolopts import tool_opts
+
+
+logger = logging.getLogger(__name__)
+
+
+class DbusIsRunning(actions.Action):
+    id = "DBUS_IS_RUNNING"
+
+    def run(self):
+        """Error out if we need to register with rhsm and the dbus daemon is not running."""
+        super(DbusIsRunning, self).run()
+        logger.task("Prepare: Check that DBus Daemon is running")
+
+        if tool_opts.no_rhsm:
+            logger.info("Skipping the check because we have been asked not to subscribe this system to RHSM.")
+            return
+
+        if system_info.dbus_running:
+            logger.info("DBus Daemon is running")
+            return
+
+        self.set_result(
+            status="ERROR",
+            error_id="DBUS_DAEMON_NOT_RUNNING",
+            message=(
+                "Could not find a running DBus Daemon which is needed to register with subscription manager.\n"
+                "Please start dbus using `systemctl start dbus`"
+            ),
+        )

--- a/convert2rhel/unit_tests/actions/dbus_test.py
+++ b/convert2rhel/unit_tests/actions/dbus_test.py
@@ -1,0 +1,71 @@
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import pytest
+import six
+
+from convert2rhel import actions, unit_tests
+from convert2rhel.actions import dbus
+from convert2rhel.systeminfo import system_info
+
+
+@pytest.fixture
+def dbus_is_running_action():
+    return dbus.DbusIsRunning()
+
+
+@pytest.mark.parametrize(
+    ("no_rhsm", "dbus_running", "log_msg"),
+    (
+        (True, True, "Skipping the check because we have been asked not to subscribe this system to RHSM."),
+        (True, False, "Skipping the check because we have been asked not to subscribe this system to RHSM."),
+        (False, True, "DBus Daemon is running"),
+    ),
+)
+def test_check_dbus_is_running(
+    caplog, monkeypatch, global_tool_opts, global_system_info, no_rhsm, dbus_running, log_msg, dbus_is_running_action
+):
+    monkeypatch.setattr(actions.dbus, "tool_opts", global_tool_opts)
+    global_tool_opts.no_rhsm = no_rhsm
+    monkeypatch.setattr(actions.dbus, "system_info", global_system_info)
+    global_system_info.dbus_running = dbus_running
+
+    dbus_is_running_action.run()
+    unit_tests.assert_actions_result(dbus_is_running_action, status="SUCCESS")
+    assert caplog.records[-1].message == log_msg
+
+
+def test_check_dbus_is_running_not_running(
+    caplog, monkeypatch, global_tool_opts, global_system_info, dbus_is_running_action
+):
+    monkeypatch.setattr(actions.dbus, "tool_opts", global_tool_opts)
+    global_tool_opts.no_rhsm = False
+    monkeypatch.setattr(actions.dbus, "system_info", global_system_info)
+    global_system_info.dbus_running = False
+
+    dbus_is_running_action.run()
+
+    unit_tests.assert_actions_result(
+        dbus_is_running_action,
+        status="ERROR",
+        error_id="DBUS_DAEMON_NOT_RUNNING",
+        message=(
+            "Could not find a running DBus Daemon which is needed to"
+            " register with subscription manager.\nPlease start dbus using `systemctl"
+            " start dbus`"
+        ),
+    )


### PR DESCRIPTION
This PR ports the check_dbus_is_running function from checks.py to an Action framework

Jira Issues: [RHELC-937](https://issues.redhat.com/browse/RHELC-937)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
