### PR TITLE
[RHELC-929] Port check_custom_repos_are_valid to Action framework

### DIFF
--- a/convert2rhel/actions/__init__.py
+++ b/convert2rhel/actions/__init__.py
@@ -312,7 +312,6 @@ def run_actions():
 
 def perform_system_checks():
     """Early checks after system facts should be added here."""
-    check_custom_repos_are_valid()
     check_tainted_kmods()
     is_loaded_kernel_latest()
     check_dbus_is_running()
@@ -347,34 +346,6 @@ def check_tainted_kmods():
             )
         )
     logger.info("No tainted kernel module is loaded.")
-
-
-def check_custom_repos_are_valid():
-    """To prevent failures past the PONR, make sure that the enabled custom repositories are valid.
-
-    What is meant by valid:
-    - YUM/DNF is able to find the repoids (to rule out a typo)
-    - the repository "baseurl" is accessible and contains repository metadata
-    """
-    logger.task("Prepare: Check if --enablerepo repositories are accessible")
-
-    if not tool_opts.no_rhsm:
-        logger.info("Skipping the check of repositories due to the use of RHSM for the conversion.")
-        return
-
-    output, ret_code = call_yum_cmd(
-        command="makecache",
-        args=["-v", "--setopt=*.skip_if_unavailable=False"],
-        print_output=False,
-    )
-    if ret_code != 0:
-        logger.critical(
-            "Unable to access the repositories passed through the --enablerepo option. "
-            "For more details, see YUM/DNF output:\n{0}".format(output)
-        )
-
-    logger.debug("Output of the previous yum command:\n{0}".format(output))
-    logger.info("The repositories passed through the --enablerepo option are all accessible.")
 
 
 def ensure_compatibility_of_kmods():

--- a/convert2rhel/actions/custom_repos_are_valid.py
+++ b/convert2rhel/actions/custom_repos_are_valid.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 class CustomReposAreValid(actions.Action):
-    id = "CUSTOM_REPOS_ARE_VALID"
+    id = "CUSTOM_REPOSITORIES_ARE_VALID"
 
     def run(self):
         """To prevent failures past the PONR, make sure that the enabled custom repositories are valid.
@@ -50,7 +50,7 @@ class CustomReposAreValid(actions.Action):
         if ret_code != 0:
             self.set_result(
                 status="ERROR",
-                error_id="UNABLE_TO_ACCESS_REPOS",
+                error_id="UNABLE_TO_ACCESS_REPOSITORIES",
                 message=(
                     "Unable to access the repositories passed through the --enablerepo option. "
                     "For more details, see YUM/DNF output:\n{0}".format(output)

--- a/convert2rhel/actions/custom_repos_are_valid.py
+++ b/convert2rhel/actions/custom_repos_are_valid.py
@@ -1,0 +1,62 @@
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import logging
+
+from convert2rhel import actions
+from convert2rhel.pkghandler import call_yum_cmd
+from convert2rhel.systeminfo import system_info
+from convert2rhel.toolopts import tool_opts
+
+
+logger = logging.getLogger(__name__)
+
+
+class CustomReposAreValid(actions.Action):
+    id = "CUSTOM_REPOS_ARE_VALID"
+
+    def run(self):
+        """To prevent failures past the PONR, make sure that the enabled custom repositories are valid.
+        What is meant by valid:
+        - YUM/DNF is able to find the repoids (to rule out a typo)
+        - the repository "baseurl" is accessible and contains repository metadata
+        """
+        super(CustomReposAreValid, self).run()
+        logger.task("Prepare: Check if --enablerepo repositories are accessible")
+
+        if not tool_opts.no_rhsm:
+            logger.info("Skipping the check of repositories due to the use of RHSM for the conversion.")
+            return
+
+        output, ret_code = call_yum_cmd(
+            command="makecache",
+            args=["-v", "--setopt=*.skip_if_unavailable=False"],
+            print_output=False,
+        )
+        if ret_code != 0:
+            self.set_result(
+                status="ERROR",
+                error_id="UNABLE_TO_ACCESS_REPOS",
+                message=(
+                    "Unable to access the repositories passed through the --enablerepo option. "
+                    "For more details, see YUM/DNF output:\n{0}".format(output)
+                ),
+            )
+            return
+
+        logger.debug("Output of the previous yum command:\n{0}".format(output))
+        logger.info("The repositories passed through the --enablerepo option are all accessible.")

--- a/convert2rhel/unit_tests/actions/actions_test.py
+++ b/convert2rhel/unit_tests/actions/actions_test.py
@@ -155,7 +155,6 @@ class TestRunActions:
 
 def test_perform_pre_checks(monkeypatch):
     check_thirdparty_kmods_mock = mock.Mock()
-    check_custom_repos_are_valid_mock = mock.Mock()
     is_loaded_kernel_latest_mock = mock.Mock()
     check_dbus_is_running_mock = mock.Mock()
 
@@ -163,16 +162,6 @@ def test_perform_pre_checks(monkeypatch):
         actions,
         "check_tainted_kmods",
         value=check_thirdparty_kmods_mock,
-    )
-    monkeypatch.setattr(
-        actions,
-        "check_custom_repos_are_valid",
-        value=check_custom_repos_are_valid_mock,
-    )
-    monkeypatch.setattr(
-        actions,
-        "check_custom_repos_are_valid",
-        value=check_custom_repos_are_valid_mock,
     )
     monkeypatch.setattr(actions, "is_loaded_kernel_latest", value=is_loaded_kernel_latest_mock)
     monkeypatch.setattr(actions, "check_dbus_is_running", value=check_dbus_is_running_mock)
@@ -585,38 +574,6 @@ class CallYumCmdMocked(unit_tests.MockFunction):
         self.called += 1
         self.command = command
         return self.return_string, self.return_code
-
-
-class TestCustomReposAreValid(unittest.TestCase):
-    @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
-    @unit_tests.mock(
-        actions,
-        "call_yum_cmd",
-        CallYumCmdMocked(ret_code=0, ret_string="Abcdef"),
-    )
-    @unit_tests.mock(actions, "logger", GetLoggerMocked())
-    @unit_tests.mock(tool_opts, "no_rhsm", True)
-    def test_custom_repos_are_valid(self):
-        actions.check_custom_repos_are_valid()
-        self.assertEqual(len(actions.logger.info_msgs), 1)
-        self.assertEqual(len(actions.logger.debug_msgs), 1)
-        self.assertIn(
-            "The repositories passed through the --enablerepo option are all accessible.", actions.logger.info_msgs
-        )
-
-    @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0))
-    @unit_tests.mock(
-        actions,
-        "call_yum_cmd",
-        CallYumCmdMocked(ret_code=1, ret_string="Abcdef"),
-    )
-    @unit_tests.mock(actions, "logger", GetLoggerMocked())
-    @unit_tests.mock(tool_opts, "no_rhsm", True)
-    def test_custom_repos_are_invalid(self):
-        self.assertRaises(SystemExit, actions.check_custom_repos_are_valid)
-        self.assertEqual(len(actions.logger.critical_msgs), 1)
-        self.assertEqual(len(actions.logger.info_msgs), 0)
-        self.assertIn("Unable to access the repositories passed through ", actions.logger.critical_msgs[0])
 
 
 class TestIsLoadedKernelLatest:

--- a/convert2rhel/unit_tests/actions/custom_repos_are_valid_test.py
+++ b/convert2rhel/unit_tests/actions/custom_repos_are_valid_test.py
@@ -89,7 +89,7 @@ class TestCustomReposAreValid(unittest.TestCase):
         self.custom_repos_are_valid_action.run()
         self.assertEqual(len(actions.custom_repos_are_valid.logger.info_msgs), 0)
         self.assertEqual(self.custom_repos_are_valid_action.status, actions.STATUS_CODE["ERROR"])
-        self.assertEqual(self.custom_repos_are_valid_action.error_id, "UNABLE_TO_ACCESS_REPOS")
+        self.assertEqual(self.custom_repos_are_valid_action.error_id, "UNABLE_TO_ACCESS_REPOSITORIES")
         self.assertIn(
             "Unable to access the repositories passed through the --enablerepo option. ",
             self.custom_repos_are_valid_action.message,

--- a/convert2rhel/unit_tests/actions/custom_repos_are_valid_test.py
+++ b/convert2rhel/unit_tests/actions/custom_repos_are_valid_test.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import unittest
+
+from collections import namedtuple
+
+import pytest
+import six
+
+from convert2rhel import actions, unit_tests
+from convert2rhel.actions import custom_repos_are_valid
+from convert2rhel.systeminfo import system_info
+from convert2rhel.unit_tests import GetLoggerMocked
+
+
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
+
+
+class CallYumCmdMocked(unit_tests.MockFunction):
+    def __init__(self, ret_code, ret_string):
+        self.called = 0
+        self.return_code = ret_code
+        self.return_string = ret_string
+        self.fail_once = False
+        self.command = None
+
+    def __call__(self, command, *args, **kwargs):
+        if self.fail_once and self.called == 0:
+            self.return_code = 1
+        if self.fail_once and self.called > 0:
+            self.return_code = 0
+        self.called += 1
+        self.command = command
+        return self.return_string, self.return_code
+
+
+class TestCustomReposAreValid(unittest.TestCase):
+    def setUp(self):
+        self.custom_repos_are_valid_action = actions.custom_repos_are_valid.CustomReposAreValid()
+
+    @unit_tests.mock(
+        actions.custom_repos_are_valid.system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0)
+    )
+    @unit_tests.mock(
+        actions.custom_repos_are_valid,
+        "call_yum_cmd",
+        CallYumCmdMocked(ret_code=0, ret_string="Abcdef"),
+    )
+    @unit_tests.mock(actions.custom_repos_are_valid, "logger", GetLoggerMocked())
+    @unit_tests.mock(actions.custom_repos_are_valid.tool_opts, "no_rhsm", True)
+    def test_custom_repos_are_valid(self):
+        self.custom_repos_are_valid_action.run()
+        self.assertEqual(len(actions.custom_repos_are_valid.logger.info_msgs), 1)
+        self.assertEqual(len(actions.custom_repos_are_valid.logger.debug_msgs), 1)
+        self.assertIn(
+            "The repositories passed through the --enablerepo option are all accessible.",
+            actions.custom_repos_are_valid.logger.info_msgs,
+        )
+
+    @unit_tests.mock(
+        actions.custom_repos_are_valid.system_info, "version", namedtuple("Version", ["major", "minor"])(7, 0)
+    )
+    @unit_tests.mock(
+        actions.custom_repos_are_valid,
+        "call_yum_cmd",
+        CallYumCmdMocked(ret_code=1, ret_string="Abcdef"),
+    )
+    @unit_tests.mock(actions.custom_repos_are_valid, "logger", GetLoggerMocked())
+    @unit_tests.mock(actions.custom_repos_are_valid.tool_opts, "no_rhsm", True)
+    def test_custom_repos_are_invalid(self):
+        self.custom_repos_are_valid_action.run()
+        self.assertEqual(len(actions.custom_repos_are_valid.logger.info_msgs), 0)
+        self.assertEqual(self.custom_repos_are_valid_action.status, actions.STATUS_CODE["ERROR"])
+        self.assertEqual(self.custom_repos_are_valid_action.error_id, "UNABLE_TO_ACCESS_REPOS")
+        self.assertIn(
+            "Unable to access the repositories passed through the --enablerepo option. ",
+            self.custom_repos_are_valid_action.message,
+        )


### PR DESCRIPTION
This PR ports the check_custom_repos_are_valid function from checks.py to an Action framework.

Jira Issues: [RHELC-929](https://issues.redhat.com/browse/RHELC-929)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
