### PR TITLE
Fix is_loaded_kernel_latest tests

### DIFF
--- a/convert2rhel/unit_tests/actions/is_loaded_kernel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/is_loaded_kernel_latest_test.py
@@ -158,8 +158,8 @@ class TestIsLoadedKernelLatest:
         ),
     )
     @centos8
-    @pytest.mark.skipif(pkgmanager.TYPE == "yum", reason="cannot test dnf backend if dnf is not present")
-    def test_is_loaded_kernel_latest_eus_system_invalid_kernel_package_dnf(
+    @pytest.mark.skipif(pkgmanager.TYPE != "dnf", reason="cannot test dnf backend if dnf is not present")
+    def test_is_loaded_kernel_latest_invalid_kernel_package_dnf(
         self,
         pretend_os,
         repoquery_version,
@@ -167,18 +167,9 @@ class TestIsLoadedKernelLatest:
         return_code,
         package_name,
         expected,
-        tmpdir,
         monkeypatch,
-        caplog,
         is_loaded_kernel_latest_action,
     ):
-        fake_reposdir_path = str(tmpdir)
-        monkeypatch.setattr(
-            actions.is_loaded_kernel_latest,
-            "get_hardcoded_repofiles_dir",
-            value=lambda: fake_reposdir_path,
-        )
-
         monkeypatch.setattr(actions.is_loaded_kernel_latest.system_info, "has_internet_access", True)
 
         run_subprocess_mocked = mock.Mock(
@@ -191,7 +182,6 @@ class TestIsLoadedKernelLatest:
                         "--quiet",
                         "--qf",
                         "C2R\\t%{BUILDTIME}\\t%{VERSION}-%{RELEASE}\\t%{REPOID}",
-                        "--setopt=reposdir=%s" % fake_reposdir_path,
                         package_name,
                     ),
                     (
@@ -224,21 +214,21 @@ class TestIsLoadedKernelLatest:
                 "C2R\t1634146676\t1-1.01-5.02\tbaseos",
                 "2-1.01-5.02",
                 0,
-                "kernel-core",
+                "kernel",
                 "The following field(s) are invalid - release : 1.01-5",
             ),
             (
                 "C2R\t1634146676\t1 .01-5.02\tbaseos",
                 "1 .01-5.03",
                 0,
-                "kernel-core",
+                "kernel",
                 "The following field(s) are invalid - version : 1 .01",
             ),
         ),
     )
     @centos7
-    @pytest.mark.skipif(pkgmanager.TYPE == "dnf", reason="cannot test yum backend if yum is not present")
-    def test_is_loaded_kernel_latest_eus_system_invalid_kernel_package_yum(
+    @pytest.mark.skipif(pkgmanager.TYPE != "yum", reason="cannot test yum backend if yum is not present")
+    def test_is_loaded_kernel_latest_invalid_kernel_package_yum(
         self,
         pretend_os,
         repoquery_version,
@@ -246,18 +236,9 @@ class TestIsLoadedKernelLatest:
         return_code,
         package_name,
         expected,
-        tmpdir,
         monkeypatch,
-        caplog,
         is_loaded_kernel_latest_action,
     ):
-        fake_reposdir_path = str(tmpdir)
-        monkeypatch.setattr(
-            actions.is_loaded_kernel_latest,
-            "get_hardcoded_repofiles_dir",
-            value=lambda: fake_reposdir_path,
-        )
-
         monkeypatch.setattr(actions.is_loaded_kernel_latest.system_info, "has_internet_access", True)
 
         run_subprocess_mocked = mock.Mock(
@@ -270,7 +251,6 @@ class TestIsLoadedKernelLatest:
                         "--quiet",
                         "--qf",
                         "C2R\\t%{BUILDTIME}\\t%{VERSION}-%{RELEASE}\\t%{REPOID}",
-                        "--setopt=reposdir=%s" % fake_reposdir_path,
                         package_name,
                     ),
                     (


### PR DESCRIPTION
The test separation between yum and dnf had a problem where for the yum part, it was not mocking correctly the run_subprocess command, as it was using `kernel-core` in it's parameter.

Also, the test doesn't need to be in EUS to be performed.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
