### PR TITLE
[RHELC-971] Port main::backup_system to Actions framework

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -1,0 +1,59 @@
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import logging
+
+from convert2rhel import actions, backup, redhatrelease, repo
+from convert2rhel.redhatrelease import get_system_release_filepath
+
+
+loggerinst = logging.getLogger(__name__)
+OS_RELEASE_FILEPATH = "/etc/os-release"
+
+
+class BackupRedhatRelease(actions.Action):
+    id = "BACKUP_REDHAT_RELEASE"
+
+    def run(self):
+        """Backup redhat release file before starting conversion process"""
+        loggerinst.task("Prepare: Backup Redhat Release Files")
+
+        super(BackupRedhatRelease, self).run()
+
+        try:
+            backup.RestorableFile(get_system_release_filepath()).backup()
+            backup.RestorableFile(OS_RELEASE_FILEPATH).backup()
+        except SystemExit as e:
+            # TODO(pr-watson): Places where we raise SystemExit and need to be
+            # changed to something more specific.
+            # Raised in module redhatrelease on lines 49 and 60
+            #   - If unable to find the /etc/system-release file,
+            #     SystemExit is raised
+            self.set_result(status="ERROR", error_id="UNKNOWN_ERROR", message=str(e))
+
+
+class BackupRepository(actions.Action):
+    id = "BACKUP_REPOSITORY"
+
+    def run(self):
+        """Backup repository files before starting conversion process"""
+        loggerinst.task("Prepare: Backup Repository Files")
+
+        super(BackupRepository, self).run()
+
+        repo.backup_yum_repos()
+        repo.backup_varsdir()

--- a/convert2rhel/unit_tests/actions/backup_system_test.py
+++ b/convert2rhel/unit_tests/actions/backup_system_test.py
@@ -1,0 +1,89 @@
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import os
+import unittest
+
+import pytest
+import six
+
+from convert2rhel import actions, backup, redhatrelease, repo, unit_tests
+from convert2rhel.actions.pre_ponr_changes import backup_system
+from convert2rhel.backup import RestorableFile
+from convert2rhel.redhatrelease import OS_RELEASE_FILEPATH
+
+
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
+
+
+@pytest.fixture
+def backup_redhat_release_action():
+    return backup_system.BackupRedhatRelease()
+
+
+@pytest.fixture
+def backup_repository_action():
+    return backup_system.BackupRepository()
+
+
+class RestorableFileMock(unit_tests.MockFunction):
+    def __init__(self):
+        self.called = 0
+
+    def __call__(self, filepath):
+        self.filepath = filepath
+        return self
+
+    def backup(self):
+        self.called += 1
+
+
+class TestBackupSystem:
+    def test_backup_redhat_release_calls(self, backup_redhat_release_action, monkeypatch):
+        monkeypatch.setattr(backup, "RestorableFile", RestorableFileMock())
+        backup_redhat_release_action.run()
+        assert backup_system.backup.RestorableFile.called == 2
+
+    def test_backup_repository_calls(self, backup_repository_action, monkeypatch):
+        backup_varsdir_mock = mock.Mock()
+        backup_yum_repos_mock = mock.Mock()
+
+        monkeypatch.setattr(repo, "backup_yum_repos", backup_yum_repos_mock)
+        monkeypatch.setattr(repo, "backup_varsdir", backup_varsdir_mock)
+
+        backup_repository_action.run()
+
+        backup_yum_repos_mock.assert_called_once()
+        backup_varsdir_mock.assert_called_once()
+
+    @pytest.mark.parametrize(
+        ("is_file", "exception"),
+        ((False, True),),
+    )
+    def test_backup_redhat_release_error(self, backup_redhat_release_action, is_file, exception, monkeypatch):
+        is_file_mock = mock.MagicMock(return_value=is_file)
+        monkeypatch.setattr(os.path, "isfile", value=is_file_mock)
+
+        if exception:
+            backup_redhat_release_action.run()
+            unit_tests.assert_actions_result(
+                backup_redhat_release_action,
+                status="ERROR",
+                error_id="UNKNOWN_ERROR",
+                message="Error: Unable to find the /etc/system-release file containing the OS name and version",
+            )


### PR DESCRIPTION
This PR ports the backup_system calls in main to an Action framework

Jira Issues: [RHELC-971](https://issues.redhat.com/browse/RHELC-971)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
