### PR TITLE
[RHELC-972] Remove user confirmation from actions

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/handle_packages.py
+++ b/convert2rhel/actions/pre_ponr_changes/handle_packages.py
@@ -44,7 +44,6 @@ class ListThirdPartyPackages(actions.Action):
                 " for the following third party packages:\n" % system_info.name
             )
             pkghandler.print_pkg_info(third_party_pkgs)
-            utils.ask_to_continue()
         else:
             logger.info("No third party packages installed.")
 
@@ -62,7 +61,7 @@ class RemoveExcludedPackages(actions.Action):
         logger.task("Convert: Remove excluded packages")
         logger.info("Searching for the following excluded packages:\n")
         try:
-            pkghandler.remove_pkgs_with_confirm(system_info.excluded_pkgs)
+            pkghandler.remove_pkgs_unless_from_redhat(system_info.excluded_pkgs)
             # TODO: Handling SystemExit here as way to speedup exception
             # handling and not refactor contents of the underlying function.
         except SystemExit as e:
@@ -95,7 +94,7 @@ class RemoveRepositoryFilesPackages(actions.Action):
         logger.task("Convert: Remove packages containing .repo files")
         logger.info("Searching for packages containing .repo files or affecting variables in the .repo files:\n")
         try:
-            pkghandler.remove_pkgs_with_confirm(system_info.repofile_pkgs)
+            pkghandler.remove_pkgs_unless_from_redhat(system_info.repofile_pkgs)
             # TODO: Handling SystemExit here as way to speedup exception
             # handling and not refactor contents of the underlying function.
         except SystemExit as e:

--- a/convert2rhel/actions/system_checks/package_updates.py
+++ b/convert2rhel/actions/system_checks/package_updates.py
@@ -61,7 +61,6 @@ class PackageUpdates(actions.Action):
                 "verify that manually."
             )
             logger.warning(str(e))
-            ask_to_continue()
             return
 
         if len(packages_to_update) > 0:
@@ -77,6 +76,5 @@ class PackageUpdates(actions.Action):
                 "Consider stopping the conversion and update the packages before re-running convert2rhel."
                 % (len(packages_to_update), repos_message, " ".join(packages_to_update))
             )
-            ask_to_continue()
         else:
             logger.info("System is up-to-date.")

--- a/convert2rhel/actions/system_checks/package_updates.py
+++ b/convert2rhel/actions/system_checks/package_updates.py
@@ -56,9 +56,9 @@ class PackageUpdates(actions.Action):
             # Beware that the `RepoError` exception is based on the `pkgmanager` module and the message sent to the output
             # can differ depending if the code is running in RHEL7 (yum) or RHEL8 (dnf).
             logger.warning(
-                "There was an error while checking whether the installed packages are up-to-date. Having updated system is "
-                "an important prerequisite for a successful conversion. Consider stopping the conversion to "
-                "verify that manually."
+                "There was an error while checking whether the installed packages are up-to-date. Having an updated system is"
+                " an important prerequisite for a successful conversion. Consider verifyng the system is up to date manually"
+                " before proceeding with the conversion."
             )
             logger.warning(str(e))
             return
@@ -73,7 +73,7 @@ class PackageUpdates(actions.Action):
                 "The system has %s package(s) not updated based %s.\n"
                 "List of packages to update: %s.\n\n"
                 "Not updating the packages may cause the conversion to fail.\n"
-                "Consider stopping the conversion and update the packages before re-running convert2rhel."
+                "Consider updating the packages before proceeding with the conversion."
                 % (len(packages_to_update), repos_message, " ".join(packages_to_update))
             )
         else:

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -575,11 +575,9 @@ def remove_pkgs_unless_from_redhat(pkgs, backup=True):
         loggerinst.info("\nNothing to do.")
         return
     loggerinst.info("\n")
-    loggerinst.warning("The following packages will be removed...")
-    print_pkg_info(pkgs_to_remove)
     remove_pkgs([get_pkg_nvra(pkg) for pkg in pkgs_to_remove], backup=backup)
-    loggerinst.debug("Successfully removed %s packages" % str(len(pkgs_to_remove)))
-
+    loggerinst.warning("Successfully removed the following %s packages:" % str(len(pkgs_to_remove)))
+    print_pkg_info(pkgs_to_remove)
 
 def get_system_packages_for_replacement():
     """Get a list of packages in the system to be replaced.

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -579,6 +579,7 @@ def remove_pkgs_unless_from_redhat(pkgs, backup=True):
     loggerinst.warning("Successfully removed the following %s packages:" % str(len(pkgs_to_remove)))
     print_pkg_info(pkgs_to_remove)
 
+
 def get_system_packages_for_replacement():
     """Get a list of packages in the system to be replaced.
     This function will return a list of packages installed on the system by

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -560,7 +560,7 @@ def list_non_red_hat_pkgs_left():
         loggerinst.info("All packages are now signed by Red Hat.")
 
 
-def remove_pkgs_with_confirm(pkgs, backup=True):
+def remove_pkgs_unless_from_redhat(pkgs, backup=True):
     """
     Remove selected packages with a breakdown and user confirmation prompt.
     """
@@ -577,7 +577,6 @@ def remove_pkgs_with_confirm(pkgs, backup=True):
     loggerinst.info("\n")
     loggerinst.warning("The following packages will be removed...")
     print_pkg_info(pkgs_to_remove)
-    utils.ask_to_continue()
     remove_pkgs([get_pkg_nvra(pkg) for pkg in pkgs_to_remove], backup=backup)
     loggerinst.debug("Successfully removed %s packages" % str(len(pkgs_to_remove)))
 

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -564,7 +564,6 @@ def remove_original_subscription_manager():
         "Upon continuing, we will uninstall the following subscription-manager/katello-ca-consumer packages:\n"
     )
     pkghandler.print_pkg_info(submgr_pkgs)
-    utils.ask_to_continue()
     submgr_pkg_names = [pkg.name for pkg in submgr_pkgs]
 
     if system_info.id == "centos" and system_info.version.major == 8 and system_info.version.minor == 5:
@@ -928,7 +927,6 @@ def check_needed_repos_availability(repo_ids_needed):
                 "%s repository is not available - some packages"
                 " may not be replaced and thus not supported." % repo_id
             )
-            utils.ask_to_continue()
             all_repos_avail = False
     if all_repos_avail:
         loggerinst.info("Needed RHEL repositories are available.")

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -561,7 +561,7 @@ def remove_original_subscription_manager():
         return
 
     loggerinst.info(
-        "Upon continuing, we will uninstall the following subscription-manager/katello-ca-consumer packages:\n"
+        "We will now uninstall the following subscription-manager/katello-ca-consumer packages:\n"
     )
     pkghandler.print_pkg_info(submgr_pkgs)
     submgr_pkg_names = [pkg.name for pkg in submgr_pkgs]

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -560,9 +560,7 @@ def remove_original_subscription_manager():
         loggerinst.info("No packages related to subscription-manager installed.")
         return
 
-    loggerinst.info(
-        "We will now uninstall the following subscription-manager/katello-ca-consumer packages:\n"
-    )
+    loggerinst.info("We will now uninstall the following subscription-manager/katello-ca-consumer packages:\n")
     pkghandler.print_pkg_info(submgr_pkgs)
     submgr_pkg_names = [pkg.name for pkg in submgr_pkgs]
 

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
@@ -19,7 +19,7 @@ import pytest
 import six
 
 from convert2rhel import actions, pkghandler, unit_tests
-from convert2rhel.actions import handle_packages
+from convert2rhel.actions.pre_ponr_changes import handle_packages
 from convert2rhel.systeminfo import system_info
 
 

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
@@ -18,8 +18,8 @@ __metaclass__ = type
 import pytest
 import six
 
-from convert2rhel import actions, pkghandler, unit_tests, utils
-from convert2rhel.actions.pre_ponr_changes import handle_packages
+from convert2rhel import actions, pkghandler, unit_tests
+from convert2rhel.actions import handle_packages
 from convert2rhel.systeminfo import system_info
 
 
@@ -54,7 +54,6 @@ def test_list_third_party_packages_no_packages(list_third_party_packages_instanc
 def test_list_third_party_packages(list_third_party_packages_instance, monkeypatch, caplog):
     monkeypatch.setattr(pkghandler, "get_third_party_pkgs", unit_tests.GetInstalledPkgsWFingerprintsMocked())
     monkeypatch.setattr(pkghandler, "print_pkg_info", PrintPkgInfoMocked())
-    monkeypatch.setattr(utils, "ask_to_continue", unit_tests.DumbCallableObject())
 
     list_third_party_packages_instance.run()
 
@@ -83,18 +82,20 @@ def remove_excluded_packages_instance():
 def test_remove_excluded_packages(remove_excluded_packages_instance, monkeypatch):
     excluded_pkgs = ["installed_pkg", "not_installed_pkg"]
     monkeypatch.setattr(system_info, "excluded_pkgs", excluded_pkgs)
-    monkeypatch.setattr(pkghandler, "remove_pkgs_with_confirm", CommandCallableObject())
+    monkeypatch.setattr(pkghandler, "remove_pkgs_unless_from_redhat", CommandCallableObject())
 
     remove_excluded_packages_instance.run()
 
-    assert pkghandler.remove_pkgs_with_confirm.called == 1
-    assert pkghandler.remove_pkgs_with_confirm.command == excluded_pkgs
+    assert pkghandler.remove_pkgs_unless_from_redhat.called == 1
+    assert pkghandler.remove_pkgs_unless_from_redhat.command == excluded_pkgs
     assert remove_excluded_packages_instance.status == actions.STATUS_CODE["SUCCESS"]
 
 
 def test_remove_excluded_packages_error(remove_excluded_packages_instance, monkeypatch):
     monkeypatch.setattr(system_info, "excluded_pkgs", [])
-    monkeypatch.setattr(pkghandler, "remove_pkgs_with_confirm", mock.Mock(side_effect=SystemExit("Raising SystemExit")))
+    monkeypatch.setattr(
+        pkghandler, "remove_pkgs_unless_from_redhat", mock.Mock(side_effect=SystemExit("Raising SystemExit"))
+    )
 
     remove_excluded_packages_instance.run()
 
@@ -114,18 +115,20 @@ def remove_repository_files_packages_instance():
 def test_remove_repository_files_packages(remove_repository_files_packages_instance, monkeypatch):
     repofile_pkgs = ["installed_pkg", "not_installed_pkg"]
     monkeypatch.setattr(system_info, "repofile_pkgs", repofile_pkgs)
-    monkeypatch.setattr(pkghandler, "remove_pkgs_with_confirm", CommandCallableObject())
+    monkeypatch.setattr(pkghandler, "remove_pkgs_unless_from_redhat", CommandCallableObject())
 
     remove_repository_files_packages_instance.run()
 
-    assert pkghandler.remove_pkgs_with_confirm.called == 1
-    assert pkghandler.remove_pkgs_with_confirm.command == repofile_pkgs
+    assert pkghandler.remove_pkgs_unless_from_redhat.called == 1
+    assert pkghandler.remove_pkgs_unless_from_redhat.command == repofile_pkgs
     assert remove_repository_files_packages_instance.status == actions.STATUS_CODE["SUCCESS"]
 
 
 def test_remove_repository_files_packages_error(remove_repository_files_packages_instance, monkeypatch):
     monkeypatch.setattr(system_info, "repofile_pkgs", [])
-    monkeypatch.setattr(pkghandler, "remove_pkgs_with_confirm", mock.Mock(side_effect=SystemExit("Raising SystemExit")))
+    monkeypatch.setattr(
+        pkghandler, "remove_pkgs_unless_from_redhat", mock.Mock(side_effect=SystemExit("Raising SystemExit"))
+    )
 
     remove_repository_files_packages_instance.run()
 

--- a/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
@@ -56,7 +56,7 @@ def test_check_package_updates_skip_on_not_latest_ol(pretend_os, caplog, package
 )
 @centos8
 def test_check_package_updates(pretend_os, packages, exception, expected, monkeypatch, caplog, package_updates_action):
-    monkeypatch.setattr(actions.package_updates, "get_total_packages_to_update", value=lambda reposdir: packages)
+    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=lambda reposdir: packages)
 
     package_updates_action.run()
     if exception:
@@ -69,9 +69,7 @@ def test_check_package_updates_with_repoerror(monkeypatch, caplog, package_updat
     get_total_packages_to_update_mock = mock.Mock(side_effect=pkgmanager.RepoError)
     monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=get_total_packages_to_update_mock)
     monkeypatch.setattr(package_updates, "ask_to_continue", value=lambda: mock.Mock())
-    monkeypatch.setattr(
-        actions.package_updates, "get_total_packages_to_update", value=get_total_packages_to_update_mock
-    )
+    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=get_total_packages_to_update_mock)
 
     package_updates_action.run()
     # This is -2 because the last message is the error from the RepoError class.

--- a/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
@@ -56,8 +56,7 @@ def test_check_package_updates_skip_on_not_latest_ol(pretend_os, caplog, package
 )
 @centos8
 def test_check_package_updates(pretend_os, packages, exception, expected, monkeypatch, caplog, package_updates_action):
-    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=lambda reposdir: packages)
-    monkeypatch.setattr(package_updates, "ask_to_continue", value=lambda: mock.Mock())
+    monkeypatch.setattr(actions.package_updates, "get_total_packages_to_update", value=lambda reposdir: packages)
 
     package_updates_action.run()
     if exception:
@@ -70,6 +69,9 @@ def test_check_package_updates_with_repoerror(monkeypatch, caplog, package_updat
     get_total_packages_to_update_mock = mock.Mock(side_effect=pkgmanager.RepoError)
     monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=get_total_packages_to_update_mock)
     monkeypatch.setattr(package_updates, "ask_to_continue", value=lambda: mock.Mock())
+    monkeypatch.setattr(
+        actions.package_updates, "get_total_packages_to_update", value=get_total_packages_to_update_mock
+    )
 
     package_updates_action.run()
     # This is -2 because the last message is the error from the RepoError class.

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -746,7 +746,6 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
                 )
             return [pkg_obj]
 
-    @unit_tests.mock(utils, "ask_to_continue", DumbCallableObject())
     @unit_tests.mock(pkghandler, "print_pkg_info", DumbCallableObject())
     @unit_tests.mock(system_info, "fingerprints_rhel", ["rhel_fingerprint"])
     @unit_tests.mock(pkghandler, "remove_pkgs", RemovePkgsMocked())
@@ -755,8 +754,8 @@ class TestPkgHandler(unit_tests.ExtendedTestCase):
         "get_installed_pkgs_w_different_fingerprint",
         GetInstalledPkgObjectsWDiffFingerprintMocked(),
     )
-    def test_remove_pkgs_with_confirm(self):
-        pkghandler.remove_pkgs_with_confirm(["installed_pkg", "not_installed_pkg"])
+    def test_remove_pkgs_unless_from_redhat(self):
+        pkghandler.remove_pkgs_unless_from_redhat(["installed_pkg", "not_installed_pkg"])
 
         self.assertEqual(len(pkghandler.remove_pkgs.pkgs), 1)
         self.assertEqual(pkghandler.remove_pkgs.pkgs[0], "installed_pkg-0.1-1.x86_64")

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -219,7 +219,6 @@ class TestSubscription(unittest.TestCase):
 
     @unit_tests.mock(logging.Logger, "info", LogMocked())
     @unit_tests.mock(logging.Logger, "warning", LogMocked())
-    @unit_tests.mock(utils, "ask_to_continue", PromptUserMocked())
     @unit_tests.mock(subscription, "get_avail_repos", lambda: ["rhel_x", "rhel_y"])
     def test_check_needed_repos_availability(self):
         subscription.check_needed_repos_availability(["rhel_x"])
@@ -229,7 +228,6 @@ class TestSubscription(unittest.TestCase):
         self.assertIn("rhel_z repository is not available", logging.Logger.warning.msg)
 
     @unit_tests.mock(logging.Logger, "warning", LogMocked())
-    @unit_tests.mock(utils, "ask_to_continue", PromptUserMocked())
     @unit_tests.mock(subscription, "get_avail_repos", lambda: [])
     def test_check_needed_repos_availability_no_repo_available(self):
         subscription.check_needed_repos_availability(["rhel"])
@@ -237,7 +235,6 @@ class TestSubscription(unittest.TestCase):
 
     @unit_tests.mock(pkghandler, "get_installed_pkg_objects", lambda _: [namedtuple("Pkg", ["name"])("submgr")])
     @unit_tests.mock(pkghandler, "print_pkg_info", lambda x: None)
-    @unit_tests.mock(utils, "ask_to_continue", PromptUserMocked())
     @unit_tests.mock(backup, "remove_pkgs", DumbCallable())
     def test_remove_original_subscription_manager(self):
         subscription.remove_original_subscription_manager()
@@ -252,7 +249,6 @@ class TestSubscription(unittest.TestCase):
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(8, 5))
     @unit_tests.mock(system_info, "id", "centos")
     @unit_tests.mock(pkghandler, "print_pkg_info", lambda x: None)
-    @unit_tests.mock(utils, "ask_to_continue", PromptUserMocked())
     @unit_tests.mock(backup, "remove_pkgs", DumbCallable())
     def test_remove_original_subscription_manager_missing_package_ol_85(self):
         subscription.remove_original_subscription_manager()


### PR DESCRIPTION
This PR removes instances of the ask_to_continue() function from utils.py being used in actions

Jira Issues: [RHELC-972](https://issues.redhat.com/browse/RHELC-972)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
