### PR TITLE
[RHELC-927] Add actions report to be displayed by the end of the analysis

### DIFF
--- a/convert2rhel/actions/__init__.py
+++ b/convert2rhel/actions/__init__.py
@@ -81,6 +81,7 @@ LINK_PREVENT_KMODS_FROM_LOADING = "https://access.redhat.com/solutions/41278"
 STATUS_CODE = {
     "SUCCESS": 0,
     "WARNING": 300,
+    "SKIP": 450,
     "OVERRIDABLE": 600,
     "ERROR": 900,
     "FATAL": 1200,

--- a/convert2rhel/actions/report.py
+++ b/convert2rhel/actions/report.py
@@ -23,7 +23,7 @@ from convert2rhel.actions import STATUS_CODE
 logger = logging.getLogger(__name__)
 
 
-_STATUS_NAME_FROM_CODE = dict((value, key) for key, value in actions.STATUS_CODE.items())
+_STATUS_NAME_FROM_CODE = dict((value, key) for key, value in STATUS_CODE.items())
 
 
 def _format_report_message(template, status_name, action_id, error_id, message):

--- a/convert2rhel/actions/report.py
+++ b/convert2rhel/actions/report.py
@@ -23,24 +23,7 @@ from convert2rhel.actions import STATUS_CODE
 logger = logging.getLogger(__name__)
 
 
-def _dictionary_value_lookup(dictionary=None, look_for=None):
-    """Return the key associated with the value.
-
-    .. important:: This function will not do a depth search for the dictionary,
-        it is meant to be used with dictionaries of one level.
-
-    :param dictionary: The dictionary to be used in the revese search.
-    :type dictionary: Mapping
-    :param look_for: The value to be used in the revese search.
-    :type look_for: Any
-
-    :return: The expected key inside the dictionary
-    :rtype: str | None
-    """
-    for key, value in dictionary.items():
-        if value == look_for:
-            return key
-
+_STATUS_NAME_FROM_CODE = dict((value, key) for key, value in actions.STATUS_CODE.items())
 
 def _format_report_message(template, status_name, action_id, error_id, message):
     """Helper function to format the report message.
@@ -139,7 +122,7 @@ def summary(results, include_all_reports=False):
     template = "({STATUS}) {ACTION_ID}"
 
     for action_id, result in results:
-        status_name = _dictionary_value_lookup(dictionary=STATUS_CODE, look_for=result["status"])
+        status_name = _STATUS_NAME_FROM_CODE[result["status"]]
         message = _format_report_message(template, status_name, action_id, result["error_id"], result["message"])
 
         if include_all_reports:
@@ -149,7 +132,7 @@ def summary(results, include_all_reports=False):
             has_report_message = True
             logger.info(message)
 
-    # If there is no warning or higher sent to the user, then we just give a
+    # If there is no other message sent to the user, then we just give a
     # happy message to them.
     if not has_report_message:
         logger.info("No problems detected during the analysis!")

--- a/convert2rhel/actions/report.py
+++ b/convert2rhel/actions/report.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 _STATUS_NAME_FROM_CODE = dict((value, key) for key, value in actions.STATUS_CODE.items())
 
+
 def _format_report_message(template, status_name, action_id, error_id, message):
     """Helper function to format the report message.
 

--- a/convert2rhel/actions/report.py
+++ b/convert2rhel/actions/report.py
@@ -1,0 +1,155 @@
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import logging
+
+from convert2rhel.actions import STATUS_CODE
+
+
+logger = logging.getLogger(__name__)
+
+
+def _dictionary_value_lookup(dictionary=None, look_for=None):
+    """Return the key associated with the value.
+
+    .. important:: This function will not do a depth search for the dictionary,
+        it is meant to be used with dictionaries of one level.
+
+    :param dictionary: The dictionary to be used in the revese search.
+    :type dictionary: Mapping
+    :param look_for: The value to be used in the revese search.
+    :type look_for: Any
+
+    :return: The expected key inside the dictionary
+    :rtype: str | None
+    """
+    for key, value in dictionary.items():
+        if value == look_for:
+            return key
+
+
+def _format_report_message(template, status_name, action_id, error_id, message):
+    """Helper function to format the report message.
+
+    :param template: The template to be formatted and returned to the caller.
+    :type template: str
+    :param status_name: The status name that will be used in the template.
+    :type status_name: str
+    :param action_id: Action id for the report
+    :type action_id: str
+    :param error_id: Error id associated with the action
+    :type error_id: str
+    :param message: The message that was produced in the action
+    :type message: str
+
+    :return: The formatted message that will be logged to the user.
+    :rtype: str
+    """
+    # `error_id` and `message` may not be present everytime, since it
+    # can be empty (either by mistake, or, intended), we only want to
+    # apply these fields if they are present, with a special mention to
+    # `message`.
+    if error_id:
+        template += ".{ERROR_ID}"
+
+    # Special case for `message` to not output empty message to the
+    # user without message.
+    if message:
+        template += ": {MESSAGE}"
+    else:
+        template += ": [No further information given]"
+
+    return template.format(
+        STATUS=status_name,
+        ACTION_ID=action_id,
+        ERROR_ID=error_id,
+        MESSAGE=message,
+    )
+
+
+def summary(results, include_all_reports=False):
+    """Output a summary regarding the actions execution.
+
+    This summary is intended to be used to inform the user about the results
+    reported by the actions.
+
+    .. note:: Expected results format is as following
+        {
+            "$Action_id": {
+                "status": int,
+                "error_id": "$error_id",
+                "message": "" or "$message"
+            },
+        }
+
+    .. important:: Cases where the summary will be used
+        * All action_id have results that are successes (best case possible)
+            * If everything is a success, we just output a different message
+                for the user.
+        * Some action_id have results that are not successes (warnings, errors...)
+            * For thoe cases, we only want to print whatever is higher than
+                STATUS_CODE['WARNING']
+            * If we print something, let's try to use the correct logger
+                instead of just relying on `info`
+            * If one of the status has no corresponding logger function, we
+                should use just `info`
+
+        The order of the message is from the highest priority (FATAL) to the
+        lowest priority (WARNING).
+
+        Message example's::
+            * (FATAL) SubscribeSystem.FATAL: Fatal error message
+            * (ERROR) SubscribeSystem.ERROR: Error message
+            * (SKIP) SubscribeSystem.SKIP: Skip message
+            * (WARNING) SubscribeSystem.WARNING: Warning message
+
+        In case of `message` being empty (as it is optional for some cases), a
+        default message will be used::
+            * (ERROR) SubscribeSystem.ERROR: [No further information given]
+
+        In case of all actions executed without warnings or errors, the
+        following message is used::
+            * No problems detected during the analysis!
+
+    :param results: Results dictionary as returned by :func:`run_actions`
+    :type results: Mapping
+    :param include_all_reports: If all reports should be logged instead of the
+        highest ones.
+    :type include_all_reports: bool
+    """
+    # Sort the results in reverse order, this way, the most important messages
+    # will be on top.
+    results = sorted(results.items(), key=lambda item: item[1]["status"], reverse=True)
+
+    has_report_message = False
+    template = "({STATUS}) {ACTION_ID}"
+
+    for action_id, result in results:
+        status_name = _dictionary_value_lookup(dictionary=STATUS_CODE, look_for=result["status"])
+        message = _format_report_message(template, status_name, action_id, result["error_id"], result["message"])
+
+        if include_all_reports:
+            has_report_message = True
+            logger.info(message)
+        elif result["status"] >= STATUS_CODE["WARNING"]:
+            has_report_message = True
+            logger.info(message)
+
+    # If there is no warning or higher sent to the user, then we just give a
+    # happy message to them.
+    if not has_report_message:
+        logger.info("No problems detected during the analysis!")

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -21,6 +21,7 @@ import os
 from convert2rhel import actions, backup, breadcrumbs, cert, checks, grub
 from convert2rhel import logger as logger_module
 from convert2rhel import pkghandler, pkgmanager, redhatrelease, repo, subscription, systeminfo, toolopts, utils
+from convert2rhel.actions import report
 
 
 loggerinst = logging.getLogger(__name__)
@@ -98,7 +99,11 @@ def main():
         process_phase = ConversionPhase.PRE_PONR_CHANGES
         # pre_ponr_conversion()
 
-        if os.getenv("CONVERT2RHEL_EXPERIMENTAL_ANALYSIS", None):
+        experimental_analysis = bool(os.getenv("CONVERT2RHEL_EXPERIMENTAL_ANALYSIS", None))
+        loggerinst.task("Conversion analysis report")
+        report.summary({}, include_all_reports=experimental_analysis)
+
+        if experimental_analysis:
             # TODO: Include report before rollback
             rollback()
 

--- a/convert2rhel/unit_tests/actions/report_test.py
+++ b/convert2rhel/unit_tests/actions/report_test.py
@@ -1,0 +1,165 @@
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import pytest
+
+from convert2rhel.actions import report
+
+
+@pytest.mark.parametrize(
+    ("dictionary", "look_for", "expected"), (({"zero": 0}, 0, "zero"), ({"zero": 0, "one": 1}, 0, "zero"))
+)
+def test_dictionary_value_lookup(dictionary, look_for, expected):
+    assert report._dictionary_value_lookup(dictionary, look_for) == expected
+
+
+@pytest.mark.parametrize(
+    ("results", "include_all_reports", "expected_results"),
+    (
+        # Test that all messages are being used with the `include_all_reports`
+        # parameter.
+        (
+            {"PreSubscription": {"status": 0, "error_id": None, "message": "All good!"}},
+            True,
+            ["(SUCCESS) PreSubscription: All good!"],
+        ),
+        (
+            {"PreSubscription": {"status": 0, "error_id": None, "message": None}},
+            True,
+            ["(SUCCESS) PreSubscription: [No further information given]"],
+        ),
+        (
+            {
+                "PreSubscription": {"status": 0, "error_id": None, "message": "All good!"},
+                "PreSubscription2": {"status": 300, "error_id": "SOME_WARNING", "message": "WARNING MESSAGE"},
+            },
+            True,
+            ["(SUCCESS) PreSubscription: All good!", "(WARNING) PreSubscription2.SOME_WARNING: WARNING MESSAGE"],
+        ),
+        # Test that messages that are bellow WARNING (300) will not appear in
+        # the logs.
+        (
+            {"PreSubscription": {"status": 0, "error_id": None, "message": None}},
+            False,
+            ["No problems detected during the analysis!"],
+        ),
+        (
+            {
+                "PreSubscription": {"status": 0, "error_id": None, "message": None},
+                "PreSubscription2": {"status": 300, "error_id": "SOME_WARNING", "message": "WARNING MESSAGE"},
+            },
+            False,
+            ["(WARNING) PreSubscription2.SOME_WARNING: WARNING MESSAGE"],
+        ),
+        # Test all messages are displayed, WARNING and higher
+        (
+            {
+                "PreSubscription1": {"status": 300, "error_id": "SOME_WARNING", "message": "WARNING MESSAGE"},
+                "PreSubscription2": {"status": 450, "error_id": "SKIPPED", "message": "SKIP MESSAGE"},
+            },
+            False,
+            [
+                "(SKIP) PreSubscription2.SKIPPED: SKIP MESSAGE",
+                "(WARNING) PreSubscription1.SOME_WARNING: WARNING MESSAGE",
+            ],
+        ),
+        (
+            {
+                "WarningAction": {"status": 300, "error_id": "WARNING", "message": "WARNING MESSAGE"},
+                "SkipAction": {"status": 450, "error_id": "SKIP", "message": "SKIP MESSAGE"},
+                "OverridableAction": {"status": 600, "error_id": "OVERRIDABLE", "message": "OVERRIDABLE MESSAGE"},
+                "ErrorAction": {"status": 900, "error_id": "ERROR", "message": "ERROR MESSAGE"},
+                "FatalAction": {"status": 1200, "error_id": "FATAL", "message": "FATAL MESSAGE"},
+            },
+            False,
+            [
+                "(FATAL) FatalAction.FATAL: FATAL MESSAGE",
+                "(ERROR) ErrorAction.ERROR: ERROR MESSAGE",
+                "(OVERRIDABLE) OverridableAction.OVERRIDABLE: OVERRIDABLE MESSAGE",
+                "(SKIP) SkipAction.SKIP: SKIP MESSAGE",
+                "(WARNING) WarningAction.WARNING: WARNING MESSAGE",
+            ],
+        ),
+    ),
+)
+def test_summary(results, expected_results, include_all_reports, caplog):
+    report.summary(results, include_all_reports)
+
+    for expected in expected_results:
+        assert any((expected in record.message) for record in caplog.records)
+
+
+@pytest.mark.parametrize(
+    ("results", "include_all_reports", "expected_results"),
+    (
+        # Test all messages are displayed, WARNING and higher
+        (
+            {
+                "PreSubscription1": {"status": 300, "error_id": "SOME_WARNING", "message": "WARNING MESSAGE"},
+                "PreSubscription2": {"status": 450, "error_id": "SKIPPED", "message": "SKIP MESSAGE"},
+            },
+            False,
+            [
+                (0, "(SKIP) PreSubscription2.SKIPPED: SKIP MESSAGE"),
+                (1, "(WARNING) PreSubscription1.SOME_WARNING: WARNING MESSAGE"),
+            ],
+        ),
+        (
+            {
+                "WarningAction": {"status": 300, "error_id": "WARNING", "message": "WARNING MESSAGE"},
+                "SkipAction": {"status": 450, "error_id": "SKIP", "message": "SKIP MESSAGE"},
+                "OverridableAction": {"status": 600, "error_id": "OVERRIDABLE", "message": "OVERRIDABLE MESSAGE"},
+                "ErrorAction": {"status": 900, "error_id": "ERROR", "message": "ERROR MESSAGE"},
+                "FatalAction": {"status": 1200, "error_id": "FATAL", "message": "FATAL MESSAGE"},
+            },
+            False,
+            [
+                (0, "(FATAL) FatalAction.FATAL: FATAL MESSAGE"),
+                (1, "(ERROR) ErrorAction.ERROR: ERROR MESSAGE"),
+                (2, "(OVERRIDABLE) OverridableAction.OVERRIDABLE: OVERRIDABLE MESSAGE"),
+                (3, "(SKIP) SkipAction.SKIP: SKIP MESSAGE"),
+                (4, "(WARNING) WarningAction.WARNING: WARNING MESSAGE"),
+            ],
+        ),
+        # Message order with `include_all_reports` set to True.
+        (
+            {
+                "PreSubscription": {"status": 0, "error_id": None, "message": "All good!"},
+                "WarningAction": {"status": 300, "error_id": "WARNING", "message": "WARNING MESSAGE"},
+                "SkipAction": {"status": 450, "error_id": "SKIP", "message": "SKIP MESSAGE"},
+                "OverridableAction": {"status": 600, "error_id": "OVERRIDABLE", "message": "OVERRIDABLE MESSAGE"},
+                "ErrorAction": {"status": 900, "error_id": "ERROR", "message": "ERROR MESSAGE"},
+                "FatalAction": {"status": 1200, "error_id": "FATAL", "message": "FATAL MESSAGE"},
+            },
+            True,
+            [
+                (0, "(FATAL) FatalAction.FATAL: FATAL MESSAGE"),
+                (1, "(ERROR) ErrorAction.ERROR: ERROR MESSAGE"),
+                (2, "(OVERRIDABLE) OverridableAction.OVERRIDABLE: OVERRIDABLE MESSAGE"),
+                (3, "(SKIP) SkipAction.SKIP: SKIP MESSAGE"),
+                (4, "(WARNING) WarningAction.WARNING: WARNING MESSAGE"),
+                (5, "(SUCCESS) PreSubscription: All good!"),
+            ],
+        ),
+    ),
+)
+def test_summary_ordering(results, include_all_reports, expected_results, caplog):
+    report.summary(results, include_all_reports)
+
+    # Get the order and the message
+    log_ordering = ((index, record.message) for index, record in enumerate(caplog.records))
+    assert expected_results == list(log_ordering)

--- a/convert2rhel/unit_tests/actions/report_test.py
+++ b/convert2rhel/unit_tests/actions/report_test.py
@@ -20,8 +20,6 @@ import pytest
 from convert2rhel.actions import report
 
 
-
-
 @pytest.mark.parametrize(
     ("results", "include_all_reports", "expected_results"),
     (

--- a/convert2rhel/unit_tests/actions/report_test.py
+++ b/convert2rhel/unit_tests/actions/report_test.py
@@ -20,11 +20,6 @@ import pytest
 from convert2rhel.actions import report
 
 
-@pytest.mark.parametrize(
-    ("dictionary", "look_for", "expected"), (({"zero": 0}, 0, "zero"), ({"zero": 0, "one": 1}, 0, "zero"))
-)
-def test_dictionary_value_lookup(dictionary, look_for, expected):
-    assert report._dictionary_value_lookup(dictionary, look_for) == expected
 
 
 @pytest.mark.parametrize(

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -28,12 +28,11 @@ import six
 six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
 from six.moves import mock
 
-from convert2rhel import actions, backup, cert, checks, grub
+from convert2rhel import backup, cert, checks, grub
 from convert2rhel import logger as logger_module
 from convert2rhel import main, pkghandler, pkgmanager, redhatrelease, repo, subscription, toolopts, unit_tests, utils
 from convert2rhel.breadcrumbs import breadcrumbs
 from convert2rhel.systeminfo import system_info
-from convert2rhel.toolopts import tool_opts
 
 
 def mock_calls(class_or_module, method_name, mock_obj):

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -763,7 +763,7 @@ def flatten(dictionary, parent_key=False, separator="."):
 
 
 def write_json_object_to_file(path, data, mode=0o600):
-    """Write a JSOn object to a file in the system.
+    """Write a Json object to a file in the system.
 
     :param path: The path of the file to be written.
     :type path: str


### PR DESCRIPTION
This commit introduces the report summary that will be displayed to the user by end of the analysis, regardless if they are using doing a normal conversion, or a pre conversion check.

The report is pretty simple as it consist mainly of logging the message to the user in a nice format, ordered by most important first.

The catch here is that if the user is doing a pre conversion analysis, they will get all messages generated by the action classes displayed for them, while, if they are doing a normal conversion, only `WARNINGS` and above will be displayed.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-927](https://issues.redhat.com/browse/RHELC-927)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
