### PR TITLE
[RHELC-974] Adapt main.py for rollback.

### DIFF
--- a/convert2rhel/actions/__init__.py
+++ b/convert2rhel/actions/__init__.py
@@ -544,12 +544,12 @@ def run_actions():
 
 def find_actions_of_severity(results, severity):
     """
-    Filter results from :func:`run_actions` to include only results of ``severity`` or worse.
+    Filter results from :func:`run_actions` to include only results of ``severity`` or higher.
 
     :param results: Results dictionary as returned by :func:`run_actions`
     :type results: Mapping
     :param severity: The name of a ``STATUS_CODE`` for the severity to filter to.
-    :returns: List of actions which are at ``severity`` or worse result. Empty list
+    :returns: List of actions which are at ``severity`` or higher result. Empty list
         if there were no failures.
     :rtype: Sequence
 

--- a/convert2rhel/actions/__init__.py
+++ b/convert2rhel/actions/__init__.py
@@ -544,7 +544,7 @@ def run_actions():
 
 def find_actions_of_severity(results, severity):
     """
-    Filter results from run_actions() to include only results of ``severity`` or worse.
+    Filter results from :func:`run_actions` to include only results of ``severity`` or worse.
 
     :param results: Results dictionary as returned by :func:`run_actions`
     :type results: Mapping

--- a/convert2rhel/actions/__init__.py
+++ b/convert2rhel/actions/__init__.py
@@ -542,17 +542,24 @@ def run_actions():
     return formatted_results
 
 
-def find_failed_actions(results):
+def find_actions_of_severity(results, severity):
     """
-    Process results of run_actions for Actions which abort conversion.
+    Filter results from run_actions() to include only results of ``severity`` or worse.
 
     :param results: Results dictionary as returned by :func:`run_actions`
     :type results: Mapping
-    :returns: List of actions which cause the conversion to stop. Empty list
+    :param severity: The name of a ``STATUS_CODE`` for the severity to filter to.
+    :returns: List of actions which are at ``severity`` or worse result. Empty list
         if there were no failures.
     :rtype: Sequence
+
+    Example::
+
+        failed_actions = find_actions_of_severity(results, "SKIP")
+        # failed_actions will contain all actions which were skipped
+        # or failed while running.
     """
-    failed_actions = [a[0] for a in results.items() if a[1]["status"] > STATUS_CODE["WARNING"]]
+    failed_actions = [a for a in results.items() if a[1]["status"] >= STATUS_CODE[severity]]
 
     return failed_actions
 


### PR DESCRIPTION
* Exit from Analyze by setting the ConversionPhase to a new code, ANALYZE_EXIT and then raising an Exception.  This triggers recording of the breadcrumbs and rollback.
* Also rework find_actions_of_severity() so the code can be used in both main.py::main() and actions/report.py::summary().

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-974](https://issues.redhat.com/browse/RHELC-974)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
