### PR TITLE
[RHELC-982] Improvements to the backup_system module

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -17,12 +17,11 @@ __metaclass__ = type
 
 import logging
 
-from convert2rhel import actions, backup, repo
-from convert2rhel.redhatrelease import get_system_release_filepath
+from convert2rhel import actions, repo
+from convert2rhel.redhatrelease import os_release_file, system_release_file
 
 
 loggerinst = logging.getLogger(__name__)
-OS_RELEASE_FILEPATH = "/etc/os-release"
 
 
 class BackupRedhatRelease(actions.Action):
@@ -35,8 +34,11 @@ class BackupRedhatRelease(actions.Action):
         super(BackupRedhatRelease, self).run()
 
         try:
-            backup.RestorableFile(get_system_release_filepath()).backup()
-            backup.RestorableFile(OS_RELEASE_FILEPATH).backup()
+            # TODO(r0x0d): We need to keep calling those global objects from
+            # redhatrelease.py because of the below code:
+            # https://github.com/oamg/convert2rhel/blob/v1.2/convert2rhel/subscription.py#L189-L200
+            system_release_file.backup()
+            os_release_file.backup()
         except SystemExit as e:
             # TODO(pr-watson): Places where we raise SystemExit and need to be
             # changed to something more specific.

--- a/convert2rhel/actions/pre_ponr_changes/handle_packages.py
+++ b/convert2rhel/actions/pre_ponr_changes/handle_packages.py
@@ -73,6 +73,7 @@ class RemoveExcludedPackages(actions.Action):
 
 class RemoveRepositoryFilesPackages(actions.Action):
     id = "REMOVE_REPOSITORY_FILES_PACKAGES"
+    dependencies = ("BACKUP_REDHAT_RELEASE",)
 
     def run(self):
         """

--- a/convert2rhel/actions/pre_ponr_changes/subscription.py
+++ b/convert2rhel/actions/pre_ponr_changes/subscription.py
@@ -80,6 +80,7 @@ class PreSubscription(actions.Action):
 class SubscribeSystem(actions.Action):
     id = "SUBSCRIBE_SYSTEM"
     dependencies = (
+        # Implicit dependency for `BACKUP_REDHAT_RELEASE`
         "REMOVE_REPOSITORY_FILES_PACKAGES",
         "PRE_SUBSCRIPTION",
     )

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -86,14 +86,6 @@ def main():
         pre_conversion_results = actions.run_actions()
 
         ### Port the code below into pre_ponr_changes(), rollback(), or post_ponr_changes().
-
-        # backup system release file before starting conversion process
-        loggerinst.task("Prepare: Backup System")
-        redhatrelease.system_release_file.backup()
-        redhatrelease.os_release_file.backup()
-        repo.backup_yum_repos()
-        repo.backup_varsdir()
-
         ### End calls that should be put into pre_ponr_changes(), rollback(), or post_ponr_changes()
 
         experimental_analysis = bool(os.getenv("CONVERT2RHEL_EXPERIMENTAL_ANALYSIS", None))

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
@@ -124,6 +124,12 @@ def test_remove_repository_files_packages(remove_repository_files_packages_insta
     assert remove_repository_files_packages_instance.status == actions.STATUS_CODE["SUCCESS"]
 
 
+def test_remove_repository_files_packages_dependency_order(remove_repository_files_packages_instance):
+    expected_dependencies = ("BACKUP_REDHAT_RELEASE",)
+
+    assert expected_dependencies == remove_repository_files_packages_instance.dependencies
+
+
 def test_remove_repository_files_packages_error(remove_repository_files_packages_instance, monkeypatch):
     monkeypatch.setattr(system_info, "repofile_pkgs", [])
     monkeypatch.setattr(

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -131,16 +131,6 @@ class TestMain(unittest.TestCase):
         "restore_pkgs",
         unit_tests.CountableMockObject(),
     )
-    @unit_tests.mock(
-        redhatrelease.system_release_file,
-        "restore",
-        unit_tests.CountableMockObject(),
-    )
-    @unit_tests.mock(
-        redhatrelease.os_release_file,
-        "restore",
-        unit_tests.CountableMockObject(),
-    )
     @unit_tests.mock(repo, "restore_yum_repos", unit_tests.CountableMockObject())
     @unit_tests.mock(subscription, "rollback", unit_tests.CountableMockObject())
     @unit_tests.mock(
@@ -156,8 +146,6 @@ class TestMain(unittest.TestCase):
         main.rollback_changes()
         self.assertEqual(backup.changed_pkgs_control.restore_pkgs.called, 1)
         self.assertEqual(repo.restore_yum_repos.called, 1)
-        self.assertEqual(redhatrelease.system_release_file.restore.called, 1)
-        self.assertEqual(redhatrelease.os_release_file.restore.called, 1)
         self.assertEqual(subscription.rollback.called, 1)
         self.assertEqual(pkghandler.versionlock_file.restore.called, 1)
         self.assertEqual(cert.SystemCert.remove.called, 1)
@@ -228,10 +216,6 @@ def test_main(monkeypatch):
     print_system_information_mock = mock.Mock()
     collect_early_data_mock = mock.Mock()
     clean_yum_metadata_mock = mock.Mock()
-    system_release_file_mock = mock.Mock()
-    os_release_file_mock = mock.Mock()
-    backup_varsdir_mock = mock.Mock()
-    backup_yum_repos_mock = mock.Mock()
     run_actions_mock = mock.Mock()
     find_actions_of_severity_mock = mock.Mock(return_value=[])
     clear_versionlock_mock = mock.Mock()
@@ -256,10 +240,6 @@ def test_main(monkeypatch):
     monkeypatch.setattr(breadcrumbs, "collect_early_data", collect_early_data_mock)
     monkeypatch.setattr(pkghandler, "clear_versionlock", clear_versionlock_mock)
     monkeypatch.setattr(pkgmanager, "clean_yum_metadata", clean_yum_metadata_mock)
-    monkeypatch.setattr(redhatrelease.system_release_file, "backup", system_release_file_mock)
-    monkeypatch.setattr(redhatrelease.os_release_file, "backup", os_release_file_mock)
-    monkeypatch.setattr(repo, "backup_yum_repos", backup_yum_repos_mock)
-    monkeypatch.setattr(repo, "backup_varsdir", backup_varsdir_mock)
     monkeypatch.setattr(actions, "run_actions", run_actions_mock)
     monkeypatch.setattr(actions, "find_actions_of_severity", find_actions_of_severity_mock)
     monkeypatch.setattr(report, "summary", report_summary_mock)
@@ -282,10 +262,6 @@ def test_main(monkeypatch):
     assert resolve_system_info_mock.call_count == 1
     assert collect_early_data_mock.call_count == 1
     assert clean_yum_metadata_mock.call_count == 1
-    assert system_release_file_mock.call_count == 1
-    assert os_release_file_mock.call_count == 1
-    assert backup_yum_repos_mock.call_count == 1
-    assert backup_varsdir_mock.call_count == 1
     assert find_actions_of_severity_mock.call_count == 1
     assert run_actions_mock.call_count == 1
     assert clear_versionlock_mock.call_count == 1
@@ -336,10 +312,6 @@ def test_main_rollback_pre_ponr_changes_phase(monkeypatch, caplog):
     clean_yum_metadata_mock = mock.Mock()
     run_actions_mock = mock.Mock()
     report_summary_mock = mock.Mock()
-    system_release_file_mock = mock.Mock()
-    os_release_file_mock = mock.Mock()
-    backup_yum_repos_mock = mock.Mock()
-    backup_varsdir_mock = mock.Mock()
     clear_versionlock_mock = mock.Mock()
     find_actions_of_severity_mock = mock.Mock()
 
@@ -359,10 +331,6 @@ def test_main_rollback_pre_ponr_changes_phase(monkeypatch, caplog):
     monkeypatch.setattr(pkgmanager, "clean_yum_metadata", clean_yum_metadata_mock)
     monkeypatch.setattr(actions, "run_actions", run_actions_mock)
     monkeypatch.setattr(report, "summary", report_summary_mock)
-    monkeypatch.setattr(redhatrelease.system_release_file, "backup", system_release_file_mock)
-    monkeypatch.setattr(redhatrelease.os_release_file, "backup", os_release_file_mock)
-    monkeypatch.setattr(repo, "backup_yum_repos", backup_yum_repos_mock)
-    monkeypatch.setattr(repo, "backup_varsdir", backup_varsdir_mock)
     monkeypatch.setattr(actions, "find_actions_of_severity", find_actions_of_severity_mock)
     monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
     monkeypatch.setattr(main, "rollback_changes", rollback_changes_mock)
@@ -379,10 +347,6 @@ def test_main_rollback_pre_ponr_changes_phase(monkeypatch, caplog):
     assert run_actions_mock.call_count == 1
     assert report_summary_mock.call_count == 1
     assert find_actions_of_severity_mock.call_count == 1
-    assert system_release_file_mock.call_count == 1
-    assert os_release_file_mock.call_count == 1
-    assert backup_yum_repos_mock.call_count == 1
-    assert backup_varsdir_mock.call_count == 1
     assert clear_versionlock_mock.call_count == 1
     assert finish_collection_mock.call_count == 1
     assert rollback_changes_mock.call_count == 1
@@ -401,10 +365,6 @@ def test_main_rollback_analyze_exit_phase(monkeypatch):
     collect_early_data_mock = mock.Mock()
     clean_yum_metadata_mock = mock.Mock()
     run_actions_mock = mock.Mock()
-    system_release_file_mock = mock.Mock()
-    os_release_file_mock = mock.Mock()
-    backup_yum_repos_mock = mock.Mock()
-    backup_varsdir_mock = mock.Mock()
     report_summary_mock = mock.Mock()
     clear_versionlock_mock = mock.Mock()
 
@@ -423,10 +383,6 @@ def test_main_rollback_analyze_exit_phase(monkeypatch):
     monkeypatch.setattr(pkghandler, "clear_versionlock", clear_versionlock_mock)
     monkeypatch.setattr(pkgmanager, "clean_yum_metadata", clean_yum_metadata_mock)
     monkeypatch.setattr(actions, "run_actions", run_actions_mock)
-    monkeypatch.setattr(redhatrelease.system_release_file, "backup", system_release_file_mock)
-    monkeypatch.setattr(redhatrelease.os_release_file, "backup", os_release_file_mock)
-    monkeypatch.setattr(repo, "backup_yum_repos", backup_yum_repos_mock)
-    monkeypatch.setattr(repo, "backup_varsdir", backup_varsdir_mock)
     monkeypatch.setattr(report, "summary", report_summary_mock)
     monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
     monkeypatch.setattr(main, "rollback_changes", rollback_changes_mock)
@@ -443,10 +399,6 @@ def test_main_rollback_analyze_exit_phase(monkeypatch):
     assert collect_early_data_mock.call_count == 1
     assert clean_yum_metadata_mock.call_count == 1
     assert run_actions_mock.call_count == 1
-    assert system_release_file_mock.call_count == 1
-    assert os_release_file_mock.call_count == 1
-    assert backup_yum_repos_mock.call_count == 1
-    assert backup_varsdir_mock.call_count == 1
     assert report_summary_mock.call_count == 1
     assert clear_versionlock_mock.call_count == 1
     assert finish_collection_mock.call_count == 1
@@ -464,10 +416,6 @@ def test_main_rollback_post_ponr_changes_phase(monkeypatch, caplog):
     collect_early_data_mock = mock.Mock()
     clean_yum_metadata_mock = mock.Mock()
     run_actions_mock = mock.Mock()
-    system_release_file_mock = mock.Mock()
-    os_release_file_mock = mock.Mock()
-    backup_yum_repos_mock = mock.Mock()
-    backup_varsdir_mock = mock.Mock()
     find_actions_of_severity_mock = mock.Mock(return_value=[])
     report_summary_mock = mock.Mock()
     clear_versionlock_mock = mock.Mock()
@@ -489,10 +437,6 @@ def test_main_rollback_post_ponr_changes_phase(monkeypatch, caplog):
     monkeypatch.setattr(pkghandler, "clear_versionlock", clear_versionlock_mock)
     monkeypatch.setattr(pkgmanager, "clean_yum_metadata", clean_yum_metadata_mock)
     monkeypatch.setattr(actions, "run_actions", run_actions_mock)
-    monkeypatch.setattr(redhatrelease.system_release_file, "backup", system_release_file_mock)
-    monkeypatch.setattr(redhatrelease.os_release_file, "backup", os_release_file_mock)
-    monkeypatch.setattr(repo, "backup_yum_repos", backup_yum_repos_mock)
-    monkeypatch.setattr(repo, "backup_varsdir", backup_varsdir_mock)
     monkeypatch.setattr(actions, "find_actions_of_severity", find_actions_of_severity_mock)
     monkeypatch.setattr(report, "summary", report_summary_mock)
     monkeypatch.setattr(utils, "ask_to_continue", ask_to_continue_mock)
@@ -510,10 +454,6 @@ def test_main_rollback_post_ponr_changes_phase(monkeypatch, caplog):
     assert collect_early_data_mock.call_count == 1
     assert clean_yum_metadata_mock.call_count == 1
     assert run_actions_mock.call_count == 1
-    assert system_release_file_mock.call_count == 1
-    assert os_release_file_mock.call_count == 1
-    assert backup_yum_repos_mock.call_count == 1
-    assert backup_varsdir_mock.call_count == 1
     assert find_actions_of_severity_mock.call_count == 1
     assert clear_versionlock_mock.call_count == 1
     assert report_summary_mock.call_count == 1


### PR DESCRIPTION
This PR do a couple of different things rather than just adding a new dependency to the remove repo files action

- It adds the explicit dependency to the mentioned action
- Remove old code left from the backup system port
- Fixes the unit tests and the BackupRedhatRelease action to use old code fom redhatrelease.py

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>
<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-982](https://issues.redhat.com/browse/RHELC-982)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
