### PR TITLE
Move report to after rollback

### DIFF
--- a/convert2rhel/actions/report.py
+++ b/convert2rhel/actions/report.py
@@ -72,6 +72,8 @@ def summary(results, include_all_reports=False):
         highest ones.
     :type include_all_reports: bool
     """
+    logger.task("Conversion analysis report")
+
     if include_all_reports:
         results = results.items()
     else:

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -126,7 +126,6 @@ def main():
         # ANALYZE_EXIT is an expected way of exiting.  So we don't want to
         # log a stacktrace or any other handling that is error related.
         if process_phase == ConversionPhase.ANALYZE_EXIT:
-            loggerinst.task("Conversion analysis report")
             rollback_changes()
             report.summary(pre_conversion_results, include_all_reports=experimental_analysis)
             return 0

--- a/convert2rhel/unit_tests/actions/report_test.py
+++ b/convert2rhel/unit_tests/actions/report_test.py
@@ -129,8 +129,8 @@ def test_summary(results, expected_results, include_all_reports, caplog):
             },
             False,
             [
-                (0, "(SKIP) PreSubscription2.SKIPPED: SKIP MESSAGE"),
-                (1, "(WARNING) PreSubscription1.SOME_WARNING: WARNING MESSAGE"),
+                "(SKIP) PreSubscription2.SKIPPED: SKIP MESSAGE",
+                "(WARNING) PreSubscription1.SOME_WARNING: WARNING MESSAGE",
             ],
         ),
         (
@@ -150,10 +150,10 @@ def test_summary(results, expected_results, include_all_reports, caplog):
             },
             False,
             [
-                (0, "(ERROR) ErrorAction.ERROR: ERROR MESSAGE"),
-                (1, "(OVERRIDABLE) OverridableAction.OVERRIDABLE: OVERRIDABLE MESSAGE"),
-                (2, "(SKIP) SkipAction.SKIP: SKIP MESSAGE"),
-                (3, "(WARNING) WarningAction.WARNING: WARNING MESSAGE"),
+                "(ERROR) ErrorAction.ERROR: ERROR MESSAGE",
+                "(OVERRIDABLE) OverridableAction.OVERRIDABLE: OVERRIDABLE MESSAGE",
+                "(SKIP) SkipAction.SKIP: SKIP MESSAGE",
+                "(WARNING) WarningAction.WARNING: WARNING MESSAGE",
             ],
         ),
         # Message order with `include_all_reports` set to True.
@@ -175,11 +175,11 @@ def test_summary(results, expected_results, include_all_reports, caplog):
             },
             True,
             [
-                (0, "(ERROR) ErrorAction.ERROR: ERROR MESSAGE"),
-                (1, "(OVERRIDABLE) OverridableAction.OVERRIDABLE: OVERRIDABLE MESSAGE"),
-                (2, "(SKIP) SkipAction.SKIP: SKIP MESSAGE"),
-                (3, "(WARNING) WarningAction.WARNING: WARNING MESSAGE"),
-                (4, "(SUCCESS) PreSubscription: All good!"),
+                "(ERROR) ErrorAction.ERROR: ERROR MESSAGE",
+                "(OVERRIDABLE) OverridableAction.OVERRIDABLE: OVERRIDABLE MESSAGE",
+                "(SKIP) SkipAction.SKIP: SKIP MESSAGE",
+                "(WARNING) WarningAction.WARNING: WARNING MESSAGE",
+                "(SUCCESS) PreSubscription: All good!",
             ],
         ),
     ),
@@ -187,6 +187,6 @@ def test_summary(results, expected_results, include_all_reports, caplog):
 def test_summary_ordering(results, include_all_reports, expected_results, caplog):
     report.summary(results, include_all_reports)
 
+    log_ordering = [record.message for record in caplog.records[-len(expected_results):]]
     # Get the order and the message
-    log_ordering = ((index, record.message) for index, record in enumerate(caplog.records))
-    assert expected_results == list(log_ordering)
+    assert expected_results == log_ordering

--- a/convert2rhel/unit_tests/actions/report_test.py
+++ b/convert2rhel/unit_tests/actions/report_test.py
@@ -187,6 +187,6 @@ def test_summary(results, expected_results, include_all_reports, caplog):
 def test_summary_ordering(results, include_all_reports, expected_results, caplog):
     report.summary(results, include_all_reports)
 
-    log_ordering = [record.message for record in caplog.records[-len(expected_results):]]
+    log_ordering = [record.message for record in caplog.records[-len(expected_results) :]]
     # Get the order and the message
     assert expected_results == log_ordering


### PR DESCRIPTION
    Move when we print the report.
    
    There are three separate cases where we want to print the report:
    
    1) For the user to review before confirming that they want to continue
       past the PONR.  This is where in the code's workflow that the
       happening.
    2) For the user to fix things when a conversion failed prior to the PONR
    3) For the user to see whether the machine is ready to convert (analyze
       report).
    
    Each of these three cases wants to print the report at a different point
    in the process:
    
    (1) Just before confirmation that the user should go past the PONR
    (2) After rollback, just before failing with return code 1
    (3) After rollback, just before returning with return code 0

Output for a conversion that fails before this change:
* https://toshio.fedorapeople.org/convert2rhel/pre-check-2023-04-04.log

Output for a conversion that fails after this change:
* https://toshio.fedorapeople.org/convert2rhel/pre-check-moved-report-2023-04-04.log

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)


Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
