### PR TITLE
Fix repoquery in kernel modules action output

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
+++ b/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
@@ -71,7 +71,8 @@ class EnsureKernelModulesCompatibility(actions.Action):
             basecmd.extend(("--repoid", repoid))
 
         cmd = basecmd[:]
-        cmd.extend(("-f", "/lib/modules/*.ko"))
+        cmd.append("-f")
+        cmd.append("/lib/modules/*.ko*")
 
         # Without the release package installed, dnf can't determine the
         # modularity platform ID. get output of a command to get all


### PR DESCRIPTION
The EnsureKernelModulesCompatibility was failing and reporting that various kernel modules were not available in RHEL repositories, as it was using an wrong kernel version to determinate that.

This commit fixes the code and allow it to execute correctly.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
