### PR TITLE
Format improvements to the report

### DIFF
--- a/convert2rhel/actions/__init__.py
+++ b/convert2rhel/actions/__init__.py
@@ -569,6 +569,7 @@ def format_report_section_heading(status_code):
     Format a section heading for a status in the report.
 
     :param status_code: The status code that will be used in the heading
+    :type status_code: int
     :return: The formatted heading that the caller can log.
     :rtype: str
     """

--- a/convert2rhel/actions/__init__.py
+++ b/convert2rhel/actions/__init__.py
@@ -91,6 +91,16 @@ STATUS_CODE = {
 #: messages and information for the user.
 _STATUS_NAME_FROM_CODE = dict((value, key) for key, value in STATUS_CODE.items())
 
+#: When we print a report for the user to view, we want some explanation of
+#: what the results mean
+_STATUS_HEADER = {
+    0: "Success (No changes needed)",
+    51: "Warning (Review and fix if needed)",
+    101: "Skip (Could not be checked due to other failures)",
+    152: "Overridable (Review and either fix or ignore the failure)",
+    202: "Error (Must fix before conversion)",
+}
+
 
 def _action_defaults_to_success(func):
     """
@@ -545,13 +555,28 @@ def find_actions_of_severity(results, severity):
 
     Example::
 
-        failed_actions = find_actions_of_severity(results, "SKIP")
-        # failed_actions will contain all actions which were skipped
+        matched_actions = find_actions_of_severity(results, "SKIP")
+        # matched_actions will contain all actions which were skipped
         # or failed while running.
     """
-    failed_actions = [a for a in results.items() if a[1]["status"] >= STATUS_CODE[severity]]
+    matched_actions = [action for action in results.items() if action[1]["status"] >= STATUS_CODE[severity]]
 
-    return failed_actions
+    return matched_actions
+
+
+def format_report_section_heading(status_code):
+    """
+    Format a section heading for a status in the report.
+
+    :param status_code: The status code that will be used in the heading
+    :return: The formatted heading that the caller can log.
+    :rtype: str
+    """
+    status_header = _STATUS_HEADER[status_code]
+    highlight = "=" * 10
+
+    heading = "{highlight} {status_header} {highlight}".format(highlight=highlight, status_header=status_header)
+    return heading
 
 
 def format_report_message(status_code, action_id, error_id, message):

--- a/convert2rhel/actions/report.py
+++ b/convert2rhel/actions/report.py
@@ -16,14 +16,33 @@
 __metaclass__ = type
 
 import logging
+import textwrap
 
-from convert2rhel.actions import find_actions_of_severity, format_report_message
+from convert2rhel import utils
+from convert2rhel.actions import find_actions_of_severity, format_report_message, format_report_section_heading
+from convert2rhel.logger import bcolors, colorize
 
 
 logger = logging.getLogger(__name__)
 
+#: Map Status codes (from convert2rhel.actions.STATUS_CODE) to color name (from
+#: convert2rhel.logger.bcolor)
 
-def summary(results, include_all_reports=False):
+_STATUS_TO_COLOR = {
+    # SUCCESS
+    0: "OKGREEN",
+    # WARNING
+    51: "WARNING",
+    # SKIP
+    101: "FAIL",
+    # OVERRIDABLE
+    152: "FAIL",
+    # ERROR
+    202: "FAIL",
+}
+
+
+def summary(results, include_all_reports=False, with_colors=True):
     """Output a summary regarding the actions execution.
 
     This summary is intended to be used to inform the user about the results
@@ -34,7 +53,7 @@ def summary(results, include_all_reports=False):
             "$Action_id": {
                 "status": int,
                 "error_id": "$error_id",
-                "message": "" or "$message"
+                "message": None or "$message"
             },
         }
 
@@ -43,7 +62,7 @@ def summary(results, include_all_reports=False):
             * If everything is a success, we just output a different message
                 for the user.
         * Some action_id have results that are not successes (warnings, errors...)
-            * For thoe cases, we only want to print whatever is higher than
+            * For those cases, we only want to print whatever is higher than
                 STATUS_CODE['WARNING']
             * If we print something, let's try to use the correct logger
                 instead of just relying on `info`
@@ -68,7 +87,9 @@ def summary(results, include_all_reports=False):
 
     :param results: Results dictionary as returned by :func:`run_actions`
     :type results: Mapping
-    :param include_all_reports: If all reports should be logged instead of the
+    :keyword with_colors: Whether to color the messages according to their status
+    :type with_colors: bool
+    :keyword include_all_reports: If all reports should be logged instead of the
         highest ones.
     :type include_all_reports: bool
     """
@@ -79,15 +100,29 @@ def summary(results, include_all_reports=False):
     else:
         results = find_actions_of_severity(results, "WARNING")
 
+    terminal_size = utils.get_terminal_size()
+    word_wrapper = textwrap.TextWrapper(subsequent_indent="    ", width=terminal_size[0])
     # Sort the results in reverse order, this way, the most important messages
     # will be on top.
     results = sorted(results, key=lambda item: item[1]["status"], reverse=True)
 
+    report = []
+    last_status = ""
     for action_id, result in results:
-        message = format_report_message(result["status"], action_id, result["error_id"], result["message"])
-        logger.info(message)
+        if last_status != result["status"]:
+            report.append("")
+            report.append(format_report_section_heading(result["status"]))
+            last_status = result["status"]
+
+        entry = format_report_message(result["status"], action_id, result["error_id"], result["message"])
+        entry = word_wrapper.fill(entry)
+        if with_colors:
+            entry = colorize(entry, _STATUS_TO_COLOR[result["status"]])
+        report.append(entry)
 
     # If there is no other message sent to the user, then we just give a
     # happy message to them.
     if not results:
-        logger.info("No problems detected during the analysis!")
+        report.append("No problems detected during the analysis!")
+
+    logger.info("\n".join(report))

--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -176,6 +176,10 @@ class bcolors:
     ENDC = "\033[0m"
 
 
+def colorize(message, color="OKGREEN"):
+    return "".join((getattr(bcolors, color), message, bcolors.ENDC))
+
+
 class CustomFormatter(logging.Formatter, object):
     """Custom formatter to handle different logging formats based on logging level
 
@@ -193,7 +197,7 @@ class CustomFormatter(logging.Formatter, object):
         if record.levelno == LogLevelTask.level:
             temp = "*" * (90 - len(record.msg) - 25)
             fmt_orig = "\n[%(asctime)s] %(levelname)s - [%(message)s] " + temp
-            new_fmt = fmt_orig if self.color_disabled else bcolors.OKGREEN + fmt_orig + bcolors.ENDC
+            new_fmt = fmt_orig if self.color_disabled else colorize(fmt_orig, "OKGREEN")
             self._fmt = new_fmt
             self.datefmt = "%m/%d/%Y %H:%M:%S"
         elif record.levelno in [logging.INFO]:
@@ -201,12 +205,12 @@ class CustomFormatter(logging.Formatter, object):
             self.datefmt = ""
         elif record.levelno in [logging.WARNING]:
             fmt_orig = "%(levelname)s - %(message)s"
-            new_fmt = fmt_orig if self.color_disabled else bcolors.WARNING + fmt_orig + bcolors.ENDC
+            new_fmt = fmt_orig if self.color_disabled else colorize(fmt_orig, "WARNING")
             self._fmt = new_fmt
             self.datefmt = ""
         elif record.levelno in [logging.CRITICAL, logging.ERROR]:
             fmt_orig = "%(levelname)s - %(message)s"
-            new_fmt = fmt_orig if self.color_disabled else bcolors.FAIL + fmt_orig + bcolors.ENDC
+            new_fmt = fmt_orig if self.color_disabled else colorize(fmt_orig, "FAIL")
             self._fmt = new_fmt
             self.datefmt = ""
         else:

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -100,7 +100,7 @@ def main():
         #
 
         # Print the assessment just before we ask the user whether to continue past the PONR
-        report.summary(pre_conversion_results, include_all_reports=experimental_analysis)
+        report.summary(pre_conversion_results, include_all_reports=experimental_analysis, with_colors=logger_module.should_disable_color_output())
 
         loggerinst.warning("********************************************************")
         loggerinst.warning("The tool allows rollback of any action until this point.")
@@ -122,7 +122,7 @@ def main():
         breadcrumbs.breadcrumbs.finish_collection(success=True)
 
         rollback_changes()
-        report.summary(pre_conversion_results, include_all_reports=experimental_analysis)
+        report.summary(pre_conversion_results, include_all_reports=experimental_analysis, with_colors=logger_module.should_disable_color_output())
         return 0
 
     except (Exception, SystemExit, KeyboardInterrupt) as err:
@@ -141,7 +141,7 @@ def main():
             loggerinst.info(no_changes_msg)
         elif process_phase == ConversionPhase.PRE_PONR_CHANGES:
             rollback_changes()
-            report.summary(pre_conversion_results, include_all_reports=experimental_analysis)
+            report.summary(pre_conversion_results, include_all_reports=experimental_analysis, with_colors=logger_module.should_disable_color_output())
         elif process_phase == ConversionPhase.POST_PONR_CHANGES:
             # After the process of subscription is done and the mass update of
             # packages is started convert2rhel will not be able to guarantee a

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -100,7 +100,11 @@ def main():
         #
 
         # Print the assessment just before we ask the user whether to continue past the PONR
-        report.summary(pre_conversion_results, include_all_reports=experimental_analysis, with_colors=logger_module.should_disable_color_output())
+        report.summary(
+            pre_conversion_results,
+            include_all_reports=experimental_analysis,
+            with_colors=logger_module.should_disable_color_output(),
+        )
 
         loggerinst.warning("********************************************************")
         loggerinst.warning("The tool allows rollback of any action until this point.")
@@ -122,7 +126,11 @@ def main():
         breadcrumbs.breadcrumbs.finish_collection(success=True)
 
         rollback_changes()
-        report.summary(pre_conversion_results, include_all_reports=experimental_analysis, with_colors=logger_module.should_disable_color_output())
+        report.summary(
+            pre_conversion_results,
+            include_all_reports=experimental_analysis,
+            with_colors=logger_module.should_disable_color_output(),
+        )
         return 0
 
     except (Exception, SystemExit, KeyboardInterrupt) as err:
@@ -141,7 +149,11 @@ def main():
             loggerinst.info(no_changes_msg)
         elif process_phase == ConversionPhase.PRE_PONR_CHANGES:
             rollback_changes()
-            report.summary(pre_conversion_results, include_all_reports=experimental_analysis, with_colors=logger_module.should_disable_color_output())
+            report.summary(
+                pre_conversion_results,
+                include_all_reports=experimental_analysis,
+                with_colors=logger_module.should_disable_color_output(),
+            )
         elif process_phase == ConversionPhase.POST_PONR_CHANGES:
             # After the process of subscription is done and the mass update of
             # packages is started convert2rhel will not be able to guarantee a

--- a/convert2rhel/unit_tests/actions/report_test.py
+++ b/convert2rhel/unit_tests/actions/report_test.py
@@ -15,9 +15,16 @@
 
 __metaclass__ = type
 
+import re
+
 import pytest
 
 from convert2rhel.actions import STATUS_CODE, report
+from convert2rhel.logger import bcolors
+
+
+#: _LONG_MESSAGE since we do line wrapping
+_LONG_MESSAGE = "Will Robinson!  Will Robinson!  Danger Will Robinson...!  Please report directly to your parents in the spaceship immediately.  Danger!  Danger!  Danger!"
 
 
 @pytest.mark.parametrize(
@@ -96,10 +103,16 @@ from convert2rhel.actions import STATUS_CODE, report
                     "message": "OVERRIDABLE MESSAGE",
                 },
                 "ErrorAction": {"status": STATUS_CODE["ERROR"], "error_id": "ERROR", "message": "ERROR MESSAGE"},
+                "TestAction": {
+                    "status": STATUS_CODE["ERROR"],
+                    "error_id": "SECONDERROR",
+                    "message": "Test that two of the same status works",
+                },
             },
             False,
             [
                 "(ERROR) ErrorAction.ERROR: ERROR MESSAGE",
+                "(ERROR) TestAction.SECONDERROR: Test that two of the same status works",
                 "(OVERRIDABLE) OverridableAction.OVERRIDABLE: OVERRIDABLE MESSAGE",
                 "(SKIP) SkipAction.SKIP: SKIP MESSAGE",
                 "(WARNING) WarningAction.WARNING: WARNING MESSAGE",
@@ -108,10 +121,29 @@ from convert2rhel.actions import STATUS_CODE, report
     ),
 )
 def test_summary(results, expected_results, include_all_reports, caplog):
-    report.summary(results, include_all_reports)
+    report.summary(results, include_all_reports, with_colors=False)
 
     for expected in expected_results:
-        assert any((expected in record.message) for record in caplog.records)
+        assert expected in caplog.records[-1].message.splitlines()
+
+
+def test_summary_with_long_message(caplog):
+    """Test a long message because we word wrap those."""
+    report.summary(
+        {
+            "ErrorAction": {
+                "status": STATUS_CODE["ERROR"],
+                "error_id": "ERROR",
+                "message": _LONG_MESSAGE,
+            }
+        },
+        with_colors=False,
+    )
+
+    # Word wrapping might break on any spaces so we need to substitute
+    # a pattern for those
+    pattern = _LONG_MESSAGE.replace(" ", "[ \t\n]+")
+    assert re.search(pattern, caplog.records[-1].message)
 
 
 @pytest.mark.parametrize(
@@ -129,8 +161,8 @@ def test_summary(results, expected_results, include_all_reports, caplog):
             },
             False,
             [
-                "(SKIP) PreSubscription2.SKIPPED: SKIP MESSAGE",
-                "(WARNING) PreSubscription1.SOME_WARNING: WARNING MESSAGE",
+                r"\(SKIP\) PreSubscription2.SKIPPED: SKIP MESSAGE",
+                r"\(WARNING\) PreSubscription1.SOME_WARNING: WARNING MESSAGE",
             ],
         ),
         (
@@ -150,10 +182,10 @@ def test_summary(results, expected_results, include_all_reports, caplog):
             },
             False,
             [
-                "(ERROR) ErrorAction.ERROR: ERROR MESSAGE",
-                "(OVERRIDABLE) OverridableAction.OVERRIDABLE: OVERRIDABLE MESSAGE",
-                "(SKIP) SkipAction.SKIP: SKIP MESSAGE",
-                "(WARNING) WarningAction.WARNING: WARNING MESSAGE",
+                r"\(ERROR\) ErrorAction.ERROR: ERROR MESSAGE",
+                r"\(OVERRIDABLE\) OverridableAction.OVERRIDABLE: OVERRIDABLE MESSAGE",
+                r"\(SKIP\) SkipAction.SKIP: SKIP MESSAGE",
+                r"\(WARNING\) WarningAction.WARNING: WARNING MESSAGE",
             ],
         ),
         # Message order with `include_all_reports` set to True.
@@ -175,18 +207,63 @@ def test_summary(results, expected_results, include_all_reports, caplog):
             },
             True,
             [
-                "(ERROR) ErrorAction.ERROR: ERROR MESSAGE",
-                "(OVERRIDABLE) OverridableAction.OVERRIDABLE: OVERRIDABLE MESSAGE",
-                "(SKIP) SkipAction.SKIP: SKIP MESSAGE",
-                "(WARNING) WarningAction.WARNING: WARNING MESSAGE",
-                "(SUCCESS) PreSubscription: All good!",
+                r"\(ERROR\) ErrorAction.ERROR: ERROR MESSAGE",
+                r"\(OVERRIDABLE\) OverridableAction.OVERRIDABLE: OVERRIDABLE MESSAGE",
+                r"\(SKIP\) SkipAction.SKIP: SKIP MESSAGE",
+                r"\(WARNING\) WarningAction.WARNING: WARNING MESSAGE",
+                r"\(SUCCESS\) PreSubscription: All good!",
             ],
         ),
     ),
 )
 def test_summary_ordering(results, include_all_reports, expected_results, caplog):
-    report.summary(results, include_all_reports)
 
-    log_ordering = [record.message for record in caplog.records[-len(expected_results) :]]
-    # Get the order and the message
-    assert expected_results == log_ordering
+    report.summary(results, include_all_reports, with_colors=False)
+
+    # Prove that all the messages occurred and in the right order.
+    message = caplog.records[-1].message
+
+    pattern = []
+    for entry in expected_results:
+        pattern.append(entry)
+    pattern = ".*".join(pattern)
+
+    assert re.search(pattern, message, re.DOTALL)
+
+
+@pytest.mark.parametrize(
+    ("results", "expected"),
+    (
+        (
+            {"ErrorAction": dict(status=STATUS_CODE["ERROR"], error_id="ERROR", message="ERROR MESSAGE")},
+            "%s(ERROR) ErrorAction.ERROR: ERROR MESSAGE%s" % (bcolors.FAIL, bcolors.ENDC),
+        ),
+        (
+            {
+                "OverridableAction": dict(
+                    status=STATUS_CODE["OVERRIDABLE"], error_id="OVERRIDABLE", message="OVERRIDABLE MESSAGE"
+                )
+            },
+            "%s(OVERRIDABLE) OverridableAction.OVERRIDABLE: OVERRIDABLE MESSAGE%s" % (bcolors.FAIL, bcolors.ENDC),
+        ),
+        (
+            {"SkipAction": dict(status=STATUS_CODE["SKIP"], error_id="SKIP", message="SKIP MESSAGE")},
+            "%s(SKIP) SkipAction.SKIP: SKIP MESSAGE%s" % (bcolors.FAIL, bcolors.ENDC),
+        ),
+        (
+            {"WarningAction": dict(status=STATUS_CODE["WARNING"], error_id="WARNING", message="WARNING MESSAGE")},
+            "%s(WARNING) WarningAction.WARNING: WARNING MESSAGE%s" % (bcolors.WARNING, bcolors.ENDC),
+        ),
+        (
+            {
+                "SuccessfulAction": dict(
+                    status=STATUS_CODE["SUCCESS"], error_id="SUCCESSFUL", message="SUCCESSFUL MESSAGE"
+                )
+            },
+            "%s(SUCCESS) SuccessfulAction.SUCCESSFUL: SUCCESSFUL MESSAGE%s" % (bcolors.OKGREEN, bcolors.ENDC),
+        ),
+    ),
+)
+def test_summary_colors(results, expected, caplog):
+    report.summary(results, include_all_reports=True, with_colors=True)
+    assert expected in caplog.records[-1].message

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import logging
 import os
 import unittest
 

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import errno
+import fcntl
 import getpass
 import inspect
 import json
@@ -23,9 +24,11 @@ import logging
 import os
 import re
 import shutil
+import struct
 import subprocess
 import sys
 import tempfile
+import termios
 import traceback
 
 import pexpect
@@ -679,6 +682,26 @@ def remove_orphan_folders():
     for path in rh_release_paths:
         if os.path.exists(path) and is_dir_empty(path):
             os.rmdir(path)
+
+
+def get_terminal_size():
+    try:
+        # Python 3.2+
+        return shutil.get_terminal_size()
+    except AttributeError:
+        pass
+
+    # Retrieve the terminal size on Linux systems in Python2
+
+    # We can't query the terminal size if it isn't a tty (For instance, if
+    # output is piped.  Use a default value in that case)
+    if not sys.stdout.isatty():
+        return (80, 24)
+
+    terminal_size_c_struct = struct.pack("HHHH", 0, 0, 0, 0)
+    size = fcntl.ioctl(sys.stdout.fileno(), termios.TIOCGWINSZ, terminal_size_c_struct)
+
+    return struct.unpack("HHHH", size)[:2]
 
 
 def hide_secrets(


### PR DESCRIPTION
* Print a section heading for each status level in the report.
* Add indentation if a message spans multiple lines.

New output should look like:
```
===== Error (Must fix before conversion) =====

(ERROR) KERNEL_TOO_OLD:OUTDATED: The problem was that there
    was a kernel that was older than the RHEL one.  And how
    to solve it.
(ERROR) THIRDPARTY_KMODS:NON_RHEL_KMODS: Another problem.

===== Success (No changes needed) =====

(SUCCESS) CONVERT2RHEL_LATEST
(SUCCESS) RHEL_REPOS_AVAILABLE
```
* Colorize report output unless NO_COLOR environment variable is used.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
