### PR TITLE
[RHELC-978] Fix integration tests for check-internet-connection

### DIFF
--- a/tests/integration/tier0/internet-connection-check/test_internet_connection_check.py
+++ b/tests/integration/tier0/internet-connection-check/test_internet_connection_check.py
@@ -61,8 +61,7 @@ def test_check_if_internet_connection_is_reachable(convert2rhel):
             "Checking internet connectivity using address 'https://static.redhat.com/test/rhel-networkmanager.txt'"
         )
         assert c2r.expect("internet connection seems to be available", timeout=300) == 0
-        c2r.expect("Continue with the system conversion?")
-        c2r.sendline("n")
+        c2r.sendcontrol("c")
 
     assert c2r.exitstatus == 1
 
@@ -80,7 +79,6 @@ def test_check_if_internet_connection_is_not_reachable(convert2rhel, shell, conf
             "Checking internet connectivity using address 'https://static.redhat.com/test/rhel-networkmanager.txt'"
         )
         assert c2r.expect("There was a problem while trying to connect to", timeout=300) == 0
-        c2r.expect("Continue with the system conversion?")
-        c2r.sendline("n")
+        c2r.sendcontrol("c")
 
     assert c2r.exitstatus == 1


### PR DESCRIPTION
This commit introduces the fixes for the check-internet-connection checks regarding the changes done in pre-check

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-978](https://issues.redhat.com/browse/RHELC-978)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant

# This PR is blocked by 
- https://github.com/oamg/convert2rhel/pull/804
