### PR TITLE
Fix for traceback in report when Ctrl-C is pressed.

### DIFF
--- a/convert2rhel/actions/report.py
+++ b/convert2rhel/actions/report.py
@@ -93,7 +93,7 @@ def summary(results, include_all_reports=False, with_colors=True):
         highest ones.
     :type include_all_reports: bool
     """
-    logger.task("Conversion analysis report")
+    logger.task("Pre-conversion analysis report")
 
     if include_all_reports:
         results = results.items()
@@ -101,7 +101,7 @@ def summary(results, include_all_reports=False, with_colors=True):
         results = find_actions_of_severity(results, "WARNING")
 
     terminal_size = utils.get_terminal_size()
-    word_wrapper = textwrap.TextWrapper(subsequent_indent="    ", width=terminal_size[0])
+    word_wrapper = textwrap.TextWrapper(subsequent_indent="    ", width=terminal_size[0], replace_whitespace=False)
     # Sort the results in reverse order, this way, the most important messages
     # will be on top.
     results = sorted(results, key=lambda item: item[1]["status"], reverse=True)

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -875,9 +875,12 @@ def get_terminal_size():
         return (80, 24)
 
     terminal_size_c_struct = struct.pack("HHHH", 0, 0, 0, 0)
-    size = fcntl.ioctl(sys.stdout.fileno(), termios.TIOCGWINSZ, terminal_size_c_struct)
+    terminal_info = fcntl.ioctl(sys.stdout.fileno(), termios.TIOCGWINSZ, terminal_size_c_struct)
 
-    return struct.unpack("HHHH", size)[:2]
+    size = struct.unpack("HHHH", terminal_info)[:2]
+    # The fcntl data has height, width but shutil.get_terminal_size, which
+    # we're emulating uses width, height.
+    return (size[1], size[0])
 
 
 def hide_secrets(


### PR DESCRIPTION
* If the user interrupts the conversion before the Actions finish running, then we don't have any results to display to the user.  This lead to a traceback when we attempted to print the report during rollback().  The code has ben modified to inform the user that no report can be printed in this circumstance.
* Fix compatibility code that detects the terminal size. The compat code was returning (height, width) while the pyhton-3.6+ code was returning (width, height).  Changed so both return width first.
* Preserve existing whitespace when printing messages in the report.  This leads to better formatting for tracebacks and longer messages which embed their own newlines.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
