### PR TITLE
Tag cloud resources to sst_conversions

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -44,10 +44,17 @@ jobs:
         # Even though the distro context is 8.6 we are setting the SYSTEM_RELEASE_ENV to 8.7
         # to tag the updated system correctly
       distros: [centos-8.4, centos-8-latest, oraclelinux-8.6]
-  use_internal_tf: True
   trigger: pull_request
   identifier: "tier0"
   tmt_plan: "tier0"
+  # Run on Red Testing Farm Hat Ranch, tag resources to sst_conversions
+  use_internal_tf: True
+  tf_extra_params:
+    environments:
+      - settings:
+          provisioning:
+            tags:
+              BusinessUnit: sst_conversions
 
 - &tier1
   <<: *tests


### PR DESCRIPTION
We now have cloud costs reporting in Testing Farm.

This is required to tag the cloud resources to this project's sst team.

Will be soon documented here:

https://github.com/packit/packit.dev/pull/632