### PR TITLE
RHSM: do not use the 'force' D-Bus registration option

### DIFF
--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -145,10 +145,13 @@ def register_system():
         )
 
         # Force the system to be unregistered
-        # The subscription-manager DBus API has a force parameter but there's
-        # a bug in susbcription-manager where that doesn't take effect.
-        # Explicitly unregister here to workaround that.
-        # Sub-man bug: https://bugzilla.redhat.com/show_bug.cgi?id=2118486
+        # The subscription-manager D-Bus API has a 'force' parameter, however
+        # it is not implemented (and thus it does not work)
+        # - in RHEL 7 and earlier
+        # - in RHEL 8 before 8.8: https://bugzilla.redhat.com/show_bug.cgi?id=2118486
+        # - in RHEL 9 before 9.2: https://bugzilla.redhat.com/show_bug.cgi?id=2121350
+        # Explicitly unregister here to workaround that in any version,
+        # to not have to do version checks, keeping things simpler.
         loggerinst.info("Unregistering the system to clear the server's state for our registration.")
         try:
             unregister_system()
@@ -374,7 +377,7 @@ class RegistrationCommand(object):
         """
         # Note: dbus doesn't understand empty python dicts. Use dbus.Dictionary({}, signature="ss")
         # if we need one in the future.
-        REGISTER_OPTS_DICT = dbus.Dictionary({"force": True}, signature="sv", variant_level=1)
+        REGISTER_OPTS_DICT = dbus.Dictionary({}, signature="sv", variant_level=1)
 
         loggerinst.debug("Getting a handle to the system dbus")
         system_bus = dbus.SystemBus()

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -800,7 +800,7 @@ class TestRegistrationCommand(object):
                 organization or "",
                 username,
                 password,
-                {"force": True},
+                {},
                 {},
                 "C",
             )
@@ -809,7 +809,7 @@ class TestRegistrationCommand(object):
             args = (
                 organization or "",
                 [activation_key],
-                {"force": True},
+                {},
                 {},
                 "C",
             )


### PR DESCRIPTION
The 'force' D-Bus registration option used to simply be not implemented, effectively being a no-op; because of that, the system is manually unregistered before the actual registration.

Newer versions of subscription-manager (in 8.8 and 9.2) actually do implement the 'force' option; OTOH, since the system was unregistered before the registration attempt, having the option there does not make any difference. Hence, simply drop the 'force' option altogether.

Improve the comment regarding the unregistration to mention the status of the 'force' option, and the general reason for unconditionally unregistering at that point.

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
