### PR TITLE
[RHELC-781, RHELC-821] Don't require --pool or --auto-attach 

### DIFF
--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -79,9 +79,6 @@ REGISTRATION_TIMEOUT = 180
 
 _SUBMGR_PKG_REMOVED_IN_CL_85 = "subscription-manager-initial-setup-addon"
 
-# Path to the releasever variable file for dnf.
-DNF_RELEASEVER_FILE = "/etc/yum/vars/releasever"
-
 
 class UnregisterError(Exception):
     """Raised with problems unregistering a system."""
@@ -677,7 +674,7 @@ def attach_subscription():
 
     # check if SCA is enabled
     output, _ = utils.run_subprocess(["subscription-manager", "status"], print_output=False)
-    if output == "Content Access Mode is set to Simple Content Access":
+    if "Content Access Mode is set to Simple Content Access." in output:
         loggerinst.info("Simple Content Access is enabled, skipping subscription attachment")
         if tool_opts.pool:
             loggerinst.warning(
@@ -697,84 +694,22 @@ def attach_subscription():
         # option
         pool.extend(["--pool", tool_opts.pool])
         loggerinst.info("Attaching provided subscription pool ID to the system ...")
-
-    if not tool_opts.auto_attach and not tool_opts.pool:
-        loggerinst.critical(
-            "Stopping the conversion. When using --username and --password options without"
-            " having SCA enabled for the account, either the --pool or the --auto-attach"
-            " options are required to successfully convert the system."
-            " The activation key/organization options can be used as an alternative."
-        )
-    else:
-        subs_list = get_avail_subs()
-
-        if len(subs_list) == 0:
-            loggerinst.warning("No subscription available for the conversion.")
-            return False
-
-        elif len(subs_list) == 1:
-            sub_num = 0
-            loggerinst.info(
-                " %s is the only subscription available, it will automatically be selected for the conversion."
-                % subs_list[0].pool_id
-            )
-
-        pool.extend(["--pool", subs_list[sub_num].pool_id])
+    elif not tool_opts.auto_attach and not tool_opts.pool:
+        # defaulting to --auto similiar to the functioning of subscription-manager
+        pool.append("--auto")
+        loggerinst.info("Auto-attaching compatible subscriptions to the system ...")
 
     _, ret_code = utils.run_subprocess(pool)
 
     if ret_code != 0:
         # Unsuccessful attachment, e.g. the pool ID is incorrect or the
         # number of purchased attachments has been depleted.
-        loggerinst.critical("Unsuccessful attachment of a subscription.")
+        loggerinst.critical(
+            "Unsuccessful attachment of a subscription. Please refer to https://access.redhat.com/management/"
+            " where you can either enable the SCA, create an activation key, or find a Pool ID of the subscription"
+            " you wish to use and pass it to convert2rhel through the --pool CLI option."
+        )
     return True
-
-
-def get_avail_subs():
-    """Get list of all the subscriptions available to the user so they are
-    accessible by index once the user chooses one.
-
-    .. note::
-        Get multiline string holding all the subscriptions available to the
-        logged-in user
-    """
-    # With the current changes introduced in PR#627, we needed to remove the
-    # non-RHEL packages that contain repofiles before we do any call to
-    # subscription-manager, and since we are doing that, this function starts to
-    # fail because it doesn't have the package that sets the releasever anymore.
-    # For some reason, subscription-manager needs to call libdnf internally to
-    # read the repositories on the system, and since libdnf needs to do
-    # substitutions on those repofiles, mainly the releasever and any other file
-    # placed in /etc/dnf/vars, this command call fails as it cannot replace the
-    # releasever variable anymore.
-    releaver_created = False
-    if system_info.version.major >= 8:
-        if not os.path.exists(DNF_RELEASEVER_FILE):
-            with open(DNF_RELEASEVER_FILE, "w") as handler:
-                handler.write(system_info.original_releasever)
-
-            releaver_created = True
-
-    subs_raw, ret_code = utils.run_subprocess(["subscription-manager", "list", "--available"], print_output=False)
-
-    if releaver_created:
-        os.remove(DNF_RELEASEVER_FILE)
-
-    if ret_code != 0:
-        loggerinst.critical("Unable to get list of available subscriptions:\n%s" % subs_raw)
-    return list(get_sub(subs_raw))
-
-
-def get_sub(subs_raw):
-    """Generator that provides subscriptions available to a logged-in user."""
-    # Split all the available subscriptions per one subscription
-    for sub_raw in re.findall(
-        r"Subscription Name.*?Type:\s+\w+\n\n",
-        subs_raw,
-        re.DOTALL | re.MULTILINE,
-    ):
-        pool_id = get_pool_id(sub_raw)
-        yield namedtuple("Sub", ["pool_id", "sub_raw"])(pool_id, sub_raw)
 
 
 def get_pool_id(sub_raw_attrs):

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -674,11 +674,11 @@ def attach_subscription():
 
     # check if SCA is enabled
     output, _ = utils.run_subprocess(["subscription-manager", "status"], print_output=False)
-    if "Content Access Mode is set to Simple Content Access." in output:
+    if "content access mode is set to simple content access." in output.lower():
         loggerinst.info("Simple Content Access is enabled, skipping subscription attachment")
         if tool_opts.pool:
             loggerinst.warning(
-                "Because Simple Content Access is enabled the subscription specified by the pool ID will not be attached"
+                "Because Simple Content Access is enabled the subscription specified by the pool ID will not be attached."
             )
         return True
 

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -102,7 +102,6 @@ class SystemInfo(object):
         self.kmods_to_ignore = []
         # Booted kernel VRA (version, release, architecture), e.g. "4.18.0-240.22.1.el8_3.x86_64"
         self.booted_kernel = ""
-        self.original_releasever = ""
 
     def resolve_system_info(self):
         self.logger = logging.getLogger(__name__)
@@ -125,7 +124,6 @@ class SystemInfo(object):
         self.booted_kernel = self._get_booted_kernel()
         self.has_internet_access = self._check_internet_access()
         self.dbus_running = self._is_dbus_running()
-        self.original_releasever = _get_original_releasever()
 
     def print_system_information(self):
         """Print system related information."""
@@ -460,21 +458,6 @@ class SystemInfo(object):
         }
 
         return release_info
-
-
-def _get_original_releasever():
-    """Get the original value for releasever using either YUM or DNF."""
-    from convert2rhel import pkgmanager
-
-    original_releasever = ""
-    if pkgmanager.TYPE == "yum":
-        yb = pkgmanager.YumBase()
-        original_releasever = yb.conf.yumvar["releasever"]
-    else:
-        db = pkgmanager.Base()
-        original_releasever = db.conf.releasever
-
-    return str(original_releasever)
 
 
 def _is_systemd_managed_dbus_running():

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -269,7 +269,8 @@ class CLI(object):
             "--pool",
             help="Subscription pool ID. A list of the available"
             " subscriptions is possible to obtain by running"
-            " 'subscription-manager list --available'.",
+            " 'subscription-manager list --available'."
+            " If no pool ID is provided, the --auto option is used",
         )
         group.add_argument(
             "-v",

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -267,9 +267,7 @@ class CLI(object):
         )
         group.add_argument(
             "--pool",
-            help="Subscription pool ID. If not used,"
-            " the user is asked to choose from the available"
-            " subscriptions. A list of the available"
+            help="Subscription pool ID. A list of the available"
             " subscriptions is possible to obtain by running"
             " 'subscription-manager list --available'.",
         )

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -100,6 +100,39 @@ class PromptUserLoopMocked(unit_tests.MockFunction):
         return return_value
 
 
+class TestCheckNeededReposAvailability(object):
+    def test_check_needed_repos_availability(self, monkeypatch, caplog):
+        monkeypatch.setattr(subscription, "get_avail_repos", lambda: ["rhel_x", "rhel_y"])
+
+        avail_repos_message = "Needed RHEL repositories are available."
+        subscription.check_needed_repos_availability(["rhel_x"])
+
+        assert avail_repos_message in caplog.records[-1].message
+
+        no_avail_repos_message = (
+            "Some repositories are not available: rhel_z."
+            " Some packages may not be replaced with their corresponding"
+            " RHEL packages when converting. The converted system will end up"
+            " with a mixture of packages from RHEL and your current distribution."
+        )
+
+        subscription.check_needed_repos_availability(["rhel_z"])
+        assert no_avail_repos_message in caplog.records[-1].message
+
+    def test_check_needed_repos_availability_no_repo_available(self, monkeypatch, caplog):
+        monkeypatch.setattr(subscription, "get_avail_repos", lambda: [])
+
+        no_avail_repos_message = (
+            "Some repositories are not available: rhel."
+            " Some packages may not be replaced with their corresponding"
+            " RHEL packages when converting. The converted system will end up"
+            " with a mixture of packages from RHEL and your current distribution."
+        )
+        subscription.check_needed_repos_availability(["rhel"])
+
+        assert no_avail_repos_message in caplog.records[-1].message
+
+
 class TestSubscription(unittest.TestCase):
     class IsFileMocked(unit_tests.MockFunction):
         def __init__(self, is_file):
@@ -172,24 +205,6 @@ class TestSubscription(unittest.TestCase):
 
         def __call__(self, msg):
             self.msg += "%s\n" % msg
-
-    @unit_tests.mock(logging.Logger, "info", LogMocked())
-    @unit_tests.mock(logging.Logger, "warning", LogMocked())
-    @unit_tests.mock(utils, "ask_to_continue", PromptUserMocked())
-    @unit_tests.mock(subscription, "get_avail_repos", lambda: ["rhel_x", "rhel_y"])
-    def test_check_needed_repos_availability(self):
-        subscription.check_needed_repos_availability(["rhel_x"])
-        self.assertIn("Needed RHEL repositories are available.", logging.Logger.info.msg)
-
-        subscription.check_needed_repos_availability(["rhel_z"])
-        self.assertIn("rhel_z repository is not available", logging.Logger.warning.msg)
-
-    @unit_tests.mock(logging.Logger, "warning", LogMocked())
-    @unit_tests.mock(utils, "ask_to_continue", PromptUserMocked())
-    @unit_tests.mock(subscription, "get_avail_repos", lambda: [])
-    def test_check_needed_repos_availability_no_repo_available(self):
-        subscription.check_needed_repos_availability(["rhel"])
-        self.assertIn("rhel repository is not available", logging.Logger.warning.msg)
 
     @unit_tests.mock(pkghandler, "get_installed_pkg_objects", lambda _: [namedtuple("Pkg", ["name"])("submgr")])
     @unit_tests.mock(pkghandler, "print_pkg_info", lambda x: None)
@@ -746,7 +761,7 @@ class TestRegistrationCommand(object):
                 organization or "",
                 username,
                 password,
-                {"force": True},
+                {},
                 {},
                 "C",
             )
@@ -755,7 +770,7 @@ class TestRegistrationCommand(object):
             args = (
                 organization or "",
                 [activation_key],
-                {"force": True},
+                {},
                 {},
                 "C",
             )

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -30,7 +30,7 @@ from convert2rhel import logger, systeminfo, unit_tests, utils  # Imports unit_t
 from convert2rhel.systeminfo import RELEASE_VER_MAPPING, Version, system_info
 from convert2rhel.toolopts import tool_opts
 from convert2rhel.unit_tests import is_rpm_based_os
-from convert2rhel.unit_tests.conftest import all_systems, centos7, centos8
+from convert2rhel.unit_tests.conftest import all_systems, centos8
 
 
 six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -514,22 +514,6 @@ class PexpectSpawnWithDimensions(pexpect.spawn):
             self.setwinsize = real_setwinsize
 
 
-def let_user_choose_item(num_of_options, item_to_choose):
-    """Ask user to enter a number corresponding to the item they choose."""
-    while True:  # Loop until user enters a valid number
-        opt_num = prompt_user("Enter number of the chosen %s: " % item_to_choose)
-        try:
-            opt_num = int(opt_num)
-        except ValueError:
-            loggerinst.warning("Enter a valid number.")
-        # Ensure the entered number is in the proper range
-        if 0 < opt_num <= num_of_options:
-            break
-        else:
-            loggerinst.warning("The entered number is not in range 1 - %s." % num_of_options)
-    return opt_num - 1  # Get zero-based list index
-
-
 def mkdir_p(path):
     """Create all missing directories for the path and raise no exception
     if the path exists.

--- a/pytest.ini
+++ b/pytest.ini
@@ -24,17 +24,16 @@ markers =
     test_passing_password_to_submgr
     test_passing_activation_key_to_submgr
     test_empty_username_and_password
-    test_auto_attach_pool
     test_unsupported_kernel
     test_modified_config
     test_unknown_release
     test_rhsm_cleanup
     test_packages_untracked_graceful_rollback
     test_packages_untracked_forced_rollback
-    test_terminate_on_registration
+    test_terminate_on_registration_start
+    test_terminate_on_registration_success
     test_terminate_on_username
     test_terminate_on_password
-    test_terminate_on_subscription
     test_available_connection
     test_unavailable_connection
     test_custom_kernel

--- a/tests/integration/tier0/rollback-handling/main.fmf
+++ b/tests/integration/tier0/rollback-handling/main.fmf
@@ -51,12 +51,28 @@ tag+:
     summary+: |
         Rollback during registration
     description+: |
-        Send termination signal immediately after c2r tries the registration.
-        Verify that c2r goes successfully through the rollback.
-    tag+:
-        - terminate-on-registration
-    test: |
-        pytest -svv -m test_terminate_on_registration
+        Send termination signal during the registration phase.
+    /registration_start:
+        summary+: |
+            Terminate at the start of the registration
+        description+: |
+            Terminate immediately after c2r tries the registration.
+            Verify that c2r goes successfully through the rollback.
+        tag+:
+            - terminate-on-registration-start
+        test: |
+            pytest -svv -m test_terminate_on_registration_start
+    /registration_success:
+        summary+: |
+            Terminate after successful registration
+        description+: |
+            Terminate immediately after c2r successfully finishes the registration.
+            Verify, that the subscription is auto-attached.
+            Verify that c2r goes successfully through the rollback.
+        tag+:
+            - terminate-on-registration-success
+        test: |
+            pytest -svv -m test_terminate_on_registration_success
 
 /terminate_on_username:
     summary+: |
@@ -79,14 +95,3 @@ tag+:
         - terminate-on-password
     test: |
         pytest -svv -m test_terminate_on_password
-
-/terminate_on_subscription:
-    summary+: |
-        Rollback from subscription prompt
-    description+: |
-        Send termination signal on the user prompt for subscription number.
-        Verify that c2r goes successfully through the rollback.
-    tag+:
-        - terminate-on-subscription
-    test: |
-        pytest -svv -m test_terminate_on_subscription

--- a/tests/integration/tier0/user-prompt-response/main.fmf
+++ b/tests/integration/tier0/user-prompt-response/main.fmf
@@ -18,14 +18,3 @@ tag+:
         - empty-username-and-password
     test: |
       pytest -svv -m test_empty_username_and_password
-
-/auto_attach_pool:
-    summary: |
-        One subscription attached auto-selected
-    description+: |
-        Verify that passing username and password with just one subscription attached
-        automatically selects the subscription.
-    tag+:
-        - auto-attach-pool
-    test: |
-      pytest -svv -m test_auto_attach_pool

--- a/tests/integration/tier0/user-prompt-response/test_user_prompt_response.py
+++ b/tests/integration/tier0/user-prompt-response/test_user_prompt_response.py
@@ -39,31 +39,7 @@ def test_check_user_response_user_and_password(convert2rhel):
                     raise
                 continue
 
-        c2r.sendcontrol("c")
+        # Due to inconsistent behavior of Ctrl+c
+        # the Ctrl+d is used to terminate the process instead
+        c2r.sendcontrol("d")
     assert c2r.exitstatus != 0
-
-
-@pytest.mark.test_auto_attach_pool
-def test_auto_attach_pool_submgr(convert2rhel):
-    """
-    Provide Convert2RHEL with username and password with just one subscription available.
-    Verify that the subscription is automatically selected.
-    """
-    single_pool_id = env.str("RHSM_SINGLE_SUB_POOL")
-    with convert2rhel(
-        "-y --no-rpm-va --serverurl {} --username {} --password {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_SINGLE_SUB_USERNAME"),
-            env.str("RHSM_SINGLE_SUB_PASSWORD"),
-        ),
-        unregister=True,
-    ) as c2r:
-        if (
-            c2r.expect(
-                f"{single_pool_id} is the only subscription available, it will automatically be selected for the conversion."
-            )
-            == 0
-        ):
-            c2r.sendcontrol("c")
-
-        assert c2r.exitstatus != 0

--- a/tests/integration/tier0/user-prompt-response/test_user_prompt_response.py
+++ b/tests/integration/tier0/user-prompt-response/test_user_prompt_response.py
@@ -10,28 +10,28 @@ def test_check_user_response_user_and_password(convert2rhel):
     Verify that user has to pass non empty username/password string to continue, otherwise enforce the input prompt again.
     """
     with convert2rhel("-y --no-rpm-va --serverurl {}".format(env.str("RHSM_SERVER_URL")), unregister=True) as c2r:
-        c2r.expect_exact(" ... activation key not found, username and password required")
-        c2r.expect_exact("Username")
+        c2r.expect(" ... activation key not found, username and password required")
+        c2r.expect("Username")
         c2r.sendline()
         # Assert the prompt loops and returns "Username:"
         # when the input is empty, hence the '0' index.
         # In case the loop doesn't work, the prompt returns
         # "Password" and raises the assertion error.
-        assert c2r.expect_exact(["Username", "Password"], timeout=300) == 0
+        assert c2r.expect("Username", timeout=300) == 0
         # Provide username, expect password prompt
 
         retries = 0
         while True:
             c2r.sendline(env.str("RHSM_USERNAME"))
             print("Sending username:", env.str("RHSM_USERNAME"))
-            c2r.expect_exact("Password: ")
+            c2r.expect("Password: ")
             c2r.sendline()
             try:
-                assert c2r.expect_exact(["Password", "Enter number of the chosen subscription"], timeout=300) == 0
+                assert c2r.expect("Password", timeout=300) == 0
                 # Provide password, expect successful registration and subscription prompt
                 c2r.sendline(env.str("RHSM_PASSWORD"))
                 print("Sending password")
-                c2r.expect_exact("Enter number of the chosen subscription: ")
+                assert c2r.expect("System registration succeeded", timeout=180) == 0
                 break
             except Exception:
                 retries = retries + 1
@@ -39,7 +39,5 @@ def test_check_user_response_user_and_password(convert2rhel):
                     raise
                 continue
 
-        # Due to inconsistent behavior of Ctrl+c
-        # the Ctrl+d is used to terminate the process instead
-        c2r.sendcontrol("d")
+        c2r.sendcontrol("c")
     assert c2r.exitstatus != 0


### PR DESCRIPTION
This PR removes the need for --pool or --auto-attach options to be required. The listing of available subscriptions to the user has been removed as well as the code hacks introduced to make it possible - these removals are apart of a separate task [RHELC-821]. If SCA is enabled we don't attach any subscription as SCA handles the attachment. A warning has been added if SCA is enabled and the --pool option is added as a CLI argument. If SCA is not enabled and neither the --pool or --auto_attach options are not specified, the code defaults to auto attaching subscriptions similar to how subscription-manager functions. In the event the subscription attachment fails, an error message is printed to the user pointing them to https://access.redhat.com/management/ and mentioning that there they can either enable the SCA, or create an activation key, or find a Pool ID of the subscription they wish to use and pass it to convert2rhel through the --pool CLI option. 

Jira Issues: [RHELC-781](https://issues.redhat.com/browse/RHELC-781), [RHELC-821](https://issues.redhat.com/browse/RHELC-821)


Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
