### PR TITLE
[RHELC-1003] Allow to skip kernel check even if packages are available

### DIFF
--- a/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
+++ b/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
@@ -104,9 +104,9 @@ class IsLoadedKernelLatest(actions.Action):
                 # of the line.
                 logger.debug("Got a line without the C2R identifier: %s" % line)
 
-        # If we don't have any packages, then something went wrong, we need to
-        # decide whether to bail out or output a warning (only if the user used the
-        # special environment variable for it.
+        unsupported_skip = os.environ.get("CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK", None)
+
+        # If we don't have any packages, then something went wrong, bail out by default
         if not packages:
             unsupported_skip = os.environ.get("CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK", None)
             if not unsupported_skip:
@@ -122,6 +122,9 @@ class IsLoadedKernelLatest(actions.Action):
                 )
                 return
 
+        # Skip kernel package check and output a warning (only if the user used the
+        # special environment variable for it.
+        if unsupported_skip:
             logger.warning(
                 "Detected 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip "
                 "the %s comparison.\n"

--- a/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
+++ b/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
@@ -78,7 +78,7 @@ class IsLoadedKernelLatest(actions.Action):
             logger.warning(
                 "Detected 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip "
                 "the %s comparison.\n"
-                "Beware, this could leave your system in a broken state. " % package_to_check
+                "Beware, this could leave your system in a broken state." % package_to_check
             )
             return
 

--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -15,7 +15,6 @@
 
 import logging
 import os
-import os.path
 
 from convert2rhel import grub
 from convert2rhel.systeminfo import system_info

--- a/plans/rerun.fmf
+++ b/plans/rerun.fmf
@@ -199,48 +199,6 @@
             filter: tag:yum-excld-kernel
 
 
-/single_yum_transaction_validation:
-    summary: |
-        Single yum transaction validation
-
-    description: |
-        Verify that we are doing a proper rollback during the validation phase in
-        our transactions.
-        If any errors occurs during the transaction resolution, either by
-        downloading a package, dependency resolver and etc., the rollback should
-        start and revert the changes to the system.
-        We simulate the error by removing the entitlement certs found at /etc/pki/entitlement
-        at a specific times during the transaction validation.
-
-    link: https://issues.redhat.com/browse/RHELC-576
-
-
-    discover+:
-        filter: tag:transaction
-
-
-    /transaction_validation_error:
-        summary+: |
-            Error during processing the transaction
-        description+: |
-            This test case removes the certs during the transaction processing
-            to throw the following yum error: pkgmanager.Errors.YumDownloadError
-        adjust+:
-            - enabled: false
-              when: distro == centos-8 or distro == oraclelinux-8
-        discover+:
-            filter: tag:transaction-validation-error
-
-
-    /package_download_error:
-        summary+: |
-            Error during the package download
-        description+: |
-            This test case removes the certs during the package download phase for both yum and dnf transactions.
-        discover+:
-            filter: tag:package-download-error
-
-
 /config_file:
     summary: |
         Config file
@@ -627,6 +585,48 @@
             Verify that c2r goes successfully through the rollback.
         discover+:
             filter: tag:terminate-on-subscription
+
+
+/single_yum_transaction_validation:
+    summary: |
+        Single yum transaction validation
+
+    description: |
+        Verify that we are doing a proper rollback during the validation phase in
+        our transactions.
+        If any errors occurs during the transaction resolution, either by
+        downloading a package, dependency resolver and etc., the rollback should
+        start and revert the changes to the system.
+        We simulate the error by removing the entitlement certs found at /etc/pki/entitlement
+        at a specific times during the transaction validation.
+
+    link: https://issues.redhat.com/browse/RHELC-576
+
+
+    discover+:
+        filter: tag:transaction
+
+
+    /transaction_validation_error:
+        summary+: |
+            Error during processing the transaction
+        description+: |
+            This test case removes the certs during the transaction processing
+            to throw the following yum error: pkgmanager.Errors.YumDownloadError
+        adjust+:
+            - enabled: false
+              when: distro == centos-8 or distro == oraclelinux-8
+        discover+:
+            filter: tag:transaction-validation-error
+
+
+    /package_download_error:
+        summary+: |
+            Error during the package download
+        description+: |
+            This test case removes the certs during the package download phase for both yum and dnf transactions.
+        discover+:
+            filter: tag:package-download-error
 
 
 /system_release_backup:

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -435,3 +435,34 @@
         - name: reboot after conversion
           how: ansible
           playbook: tests/ansible_collections/roles/reboot/main.yml
+
+/latest_kernel_check_skip:
+    #TODO(danmyway) merge under system_not_updated in #757
+    enabled: false
+    adjust+:
+        - enabled: true
+          when: distro == centos-7, oraclelinux-7
+    environment+:
+        CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK: 1
+        # Since we are removing all the repositories other than rhel-7-server-rpms
+        # we need pass CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK due to the inability
+        # to download and backup packages
+        CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK: 1
+        # Unavailable kmods may be present on the system due to the kernel package
+        # not being updated. Mitigate the issues by exporting CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS.
+        CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS: 1
+    discover+:
+        filter: tag:checks-after-conversion
+    prepare+:
+        - name: prepare non latest kernel
+          how: shell
+          script: pytest -svv tests/integration/tier1/system-up-to-date/install_non_latest_kernel.py
+        - name: add custom repos
+          how: ansible
+          playbook: tests/ansible_collections/roles/add-custom-repos/main.yml
+        - name: reboot machine
+          how: ansible
+          playbook: tests/ansible_collections/roles/reboot/main.yml
+        - name: main conversion
+          how: shell
+          script: pytest -svv tests/integration/tier1/kernel-check-skip/test_latest_kernel_check_skip.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -55,5 +55,6 @@ markers =
     test_force_loaded_kmod
     test_tainted_kernel
     test_unsupported_kmod_with_envar
+    test_latest_kernel_check_skip
     test_failures_and_skips_in_report
     test_successful_report

--- a/tests/integration/tier1/checks-after-conversion/test_rhel_kernel.py
+++ b/tests/integration/tier1/checks-after-conversion/test_rhel_kernel.py
@@ -3,7 +3,12 @@ import pytest
 
 @pytest.mark.rhel_kernel
 def test_rhel_kernel(shell):
-    # Check if kernel is RHEL one
-    kernel = shell("rpm -q --qf '%{NAME} %{VERSION}-%{RELEASE} %{VENDOR}\n' kernel").output
-    assert "Red Hat" in kernel
-    # TODO This may return more than 1 kernel -> maybe it's better to check that every kernel is RHEL one (eg. do some for each..)
+    """
+    After conversion check.
+    Verify that every installed kernel is Red Hat kernel.
+    """
+    installed_kernels = shell("rpm -q --qf '%{NAME} %{VERSION}-%{RELEASE} %{VENDOR}\\n' kernel").output.split("\n")
+    # Iterate over the list of installed_kernels and verify that every kernel is Red Hat one
+    # We end up with an empty last item in the list due to a trailing whitespace,
+    # therefore we only verify non-empty items in the list comprehension (`if kernel`)
+    assert all("Red Hat" in kernel for kernel in installed_kernels if kernel)

--- a/tests/integration/tier1/kernel-check-skip/main.fmf
+++ b/tests/integration/tier1/kernel-check-skip/main.fmf
@@ -1,0 +1,16 @@
+summary+: |
+    Skip latest kernel check with older kernel
+
+description+: |
+    Verify that it's possible to run the full conversion with older kernel,
+    than available in the RHEL repositories.
+        1/ Install older kernel on the system
+        2/ Make sure the `CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK` is in place
+            * doing that we also verify, the deprecated envar is still allowed
+        3/ Enable *just* the rhel-7-server-rpms repository
+        4/ Run conversion verifying the conversion is not inhibited and completes successfully
+
+tag+:
+    - kernel
+
+test: pytest -svv -m test_latest_kernel_check_skip

--- a/tests/integration/tier1/kernel-check-skip/test_latest_kernel_check_skip.py
+++ b/tests/integration/tier1/kernel-check-skip/test_latest_kernel_check_skip.py
@@ -1,0 +1,61 @@
+import os
+
+import pytest
+
+from conftest import SYSTEM_RELEASE_ENV
+from envparse import env
+
+
+@pytest.mark.test_latest_kernel_check_skip
+def test_skip_kernel_check(shell, convert2rhel):
+    """
+    Verify that it's possible to run the full conversion with older kernel,
+    than available in the RHEL repositories.
+        1/ Install older kernel on the system
+        2/ Make sure the `CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK` is in place
+            * doing that we also verify, the deprecated envar is still allowed
+        3/ Enable *just* the rhel-7-server-rpms repository prior to conversion
+        4/ Run conversion verifying the conversion is not inhibited and completes successfully
+    """
+    backup_dir = "/tmp/repobckp"
+    shell(f"mkdir {backup_dir}")
+    # Move all the repos away except the rhel7.repo
+    shell("find /etc/yum.repos.d/ -type f -name '*.repo' ! -name 'rhel7.repo' -exec mv {} /tmp/repobckp \\;")
+
+    # Verify the environment variable to bypass the check is in place
+    # Intentionally use the deprecated variable to verify its compatibility
+    assert os.environ["CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK"] == "1"
+
+    # Resolve the $releasever for CentOS 7 latest manually as it gets resolved to `7` instead of required `7Server`
+    if "centos-7" in SYSTEM_RELEASE_ENV:
+        shell("sed -i 's/\$releasever/7Server/g' /etc/yum.repos.d/rhel7.repo")
+
+    # Disable all repositories
+    shell("yum-config-manager --disable *")
+    # Enable just the rhel-7-server-rpms repo
+    shell("yum-config-manager --enable rhel-7-server-rpms --releasever 7Server")
+
+    with convert2rhel(
+        "-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug".format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        # Verify that using the deprecated environment variable is still allowed and continues the conversion
+        # TODO(danmyway) uncomment in #684
+        # assert c2r.expect("You are using the deprecated 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK'") == 0
+        # Make sure the kernel comparison is skipped
+        c2r_expect_index = c2r.expect(
+            [
+                "we will skip the kernel comparison.",
+                "Could not find any kernel packages in repositories to compare against the loaded kernel.",
+            ]
+        )
+        if c2r_expect_index == 0:
+            pass
+        elif c2r_expect_index == 1:
+            assert AssertionError
+        assert c2r.expect("Conversion successful") == 0
+    assert c2r.exitstatus == 0

--- a/tests/integration/tier1/one-kernel-scenario/run_conversion.py
+++ b/tests/integration/tier1/one-kernel-scenario/run_conversion.py
@@ -34,6 +34,9 @@ def test_run_conversion_using_custom_repos(shell, convert2rhel):
 
     os.environ["CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK"] = "1"
     os.environ["CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK"] = "1"
+    # Unavailable kmods may be present on the system due to the kernel package
+    # not being updated. Mitigate the issues by exporting CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS.
+    os.environ["CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS"] = "1"
 
     with convert2rhel("-y --no-rpm-va --disable-submgr {} --debug".format(enable_repo_opt)) as c2r:
         c2r.expect("Conversion successful!")


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
The environment variable `CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK` doesn't work as expected in my opinion. The kernel package check will only be skipped if no kernel packages are found in the repo. If packages are available, the env var will be ignored and the conversion fails.

In a rare edge case, were a new minor kernel release in RHEL 7 is already available but not in CentOS 7, forcing the check to be skipped is the easiest way to move forward without jumping through further hoops. Observed with `kernel-3.10.0-1160.90.1.el7` as latest in RHEL 7 and `kernel-3.10.0-1160.88.1.el7` as latest in CentOS 7.

Even with set env var, the kernel check will not be skipped in `convert2rhel-1.2-2.el7.noarch`:
```
[05/02/2023 19:17:18] TASK - [Prepare: Check if the loaded kernel version is the most recent] ***
CRITICAL - The version of the loaded kernel is different from the latest version in the enabled system repositories.
 Latest kernel version available in rhel-7-server-rhui-rpms: 3.10.0-1160.90.1.el7
 Loaded kernel version: 3.10.0-1160.88.1.el7

To proceed with the conversion, update the kernel version by executing the following step:

1. yum install kernel-3.10.0-1160.90.1.el7 -y
2. reboot
Writing breadcrumbs to '/etc/migration-results'.
Writing RHSM custom facts to '/etc/rhsm/facts/convert2rhel.facts'.
No changes were made to the system.

[root@ip-10-0-138-67 etc]# printenv |grep -i convert2rhel
CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK=true
```

As follow up issue from skipping the kernel check, the kernel module check also fails:
```
CRITICAL - The following loaded kernel modules are not available in RHEL:
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/arch/x86/crypto/ghash-clmulni-intel.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/net/ipv4/netfilter/ip_tables.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/drivers/acpi/nfit/nfit.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/arch/x86/crypto/crct10dif-pclmul.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/crypto/lrw.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/arch/x86/crypto/crc32-pclmul.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/net/sunrpc/sunrpc.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/arch/x86/crypto/glue_helper.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/lib/libcrc32c.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/drivers/parport/parport_pc.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/drivers/input/misc/pcspkr.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/crypto/cryptd.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/drivers/input/serio/serio_raw.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/drivers/i2c/busses/i2c-piix4.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/arch/x86/platform/intel/iosf_mbi.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/drivers/parport/parport.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/crypto/gf128mul.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/arch/x86/crypto/aesni-intel.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/drivers/nvme/host/nvme-core.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/drivers/nvdimm/libnvdimm.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/fs/xfs/xfs.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/drivers/net/ethernet/amazon/ena/ena.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/drivers/char/ppdev.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/arch/x86/crypto/ablk_helper.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/drivers/nvme/host/nvme.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/crypto/crct10dif_common.ko.xz
/lib/modules/3.10.0-1160.88.1.el7.x86_64/kernel/arch/x86/crypto/crc32c-intel.ko.xz
Ensure you have updated the kernel to the latest available version and rebooted the system.
If this message persists, you can prevent the modules from loading by following https://access.redhat.com/solutions/41278 and rerun convert2rhel.
Keeping them loaded could cause the system to malfunction after the conversion as they might not work properly with the RHEL kernel.
To circumvent this check and accept the risk you can set environment variable 'CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS=1'.
Writing breadcrumbs to '/etc/migration-results'.
Writing RHSM custom facts to '/etc/rhsm/facts/convert2rhel.facts'.
WARNING - Abnormal exit! Performing rollback ...
```

But this check could then be skipped with `CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS=1` as expected.

I'm aware that skipping checks can cause massive issues, but there might be cases were someone really want it and needs an easy way to do that.

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1003](https://issues.redhat.com/browse/RHELC-1003)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
