### PR TITLE
[RHELC-895] Fix error message when repoquery fails to retrieve information on kmod packages

### DIFF
--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -735,7 +735,7 @@ class TestRestorablePackageSet:
             package_set.enable()
 
         assert (
-            "Failed to install subscription-manager packages. See the above yum output for details."
+            "Failed to install subscription-manager packages. Check the yum output below for details"
             in caplog.records[-1].message
         )
 


### PR DESCRIPTION
When repoquery fails to run (for instance, when repoquery decides that there isn't enough disk space to download metadata from the repository), we were printing an error message that there were no kmod containing packages.  With this change, we will print an error message that says repoquery failed.

Fixes https://issues.redhat.com/browse/RHELC-895
Fixes #610

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-895](https://issues.redhat.com/browse/RHELC-895)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
