### PR TITLE
[RHELC-970] Update CLI to introduce new subcommands for pre conversion analysis

### DIFF
--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -25,7 +25,7 @@ from collections import namedtuple
 from six.moves import configparser, urllib
 
 from convert2rhel import logger, utils
-from convert2rhel.toolopts import tool_opts
+from convert2rhel.toolopts import POST_RPM_VA_LOG_FILENAME, PRE_RPM_VA_LOG_FILENAME, tool_opts
 from convert2rhel.utils import run_subprocess
 
 
@@ -47,12 +47,6 @@ RELEASE_VER_MAPPING = {
     "8.4": "8.4",
     "7.9": "7Server",
 }
-
-# For a list of modified rpm files before the conversion starts
-PRE_RPM_VA_LOG_FILENAME = "rpm_va.log"
-
-# For a list of modified rpm files after the conversion finishes for comparison purposes
-POST_RPM_VA_LOG_FILENAME = "rpm_va_after_conversion.log"
 
 # List of EUS minor versions supported
 EUS_MINOR_VERSIONS = ["8.6"]

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -22,7 +22,6 @@ import os
 import re
 import sys
 
-from argparse import SUPPRESS
 
 from six.moves import configparser, urllib
 
@@ -130,7 +129,7 @@ class CLI(object):
             " [--enablerepo repoid] [--no-rpm-va] [--debug] [--restart] [-y]\n"
             "  convert2rhel [-k activation_key | -c conf_file_path] [-o organization] [--pool pool_id | -a] [--disablerepo repoid] [--enablerepo"
             " repoid] [--serverurl url] [--keep-rhsm] [--no-rpm-va] [--debug] [--restart] [-y]\n"
-            r"  convert2rhel {analyze}"
+            r" convert2rhel {analyze}"
             "\n\n"
             "*WARNING* The tool needs to be run under the root user\n"
         )
@@ -149,14 +148,12 @@ class CLI(object):
             " A rollback is initiated after the checks to put the system back"
             " in the original state.",
             parents=[self._shared_options_parser],
-            formatter_class=argparse.RawTextHelpFormatter,
             usage=self.usage,
         )
         self._convert_parser = subparsers.add_parser(
             "convert",
             help="Convert the system.",
             parents=[self._shared_options_parser],
-            formatter_class=argparse.RawTextHelpFormatter,
             usage=self.usage,
         )
 
@@ -364,8 +361,6 @@ class CLI(object):
         # algorithm function to properly organize all CLI args
         argv = _add_default_command(sys.argv[1:])
         parsed_opts = self._parser.parse_args(argv)
-        print(argv)
-        # sys.exit()
 
         if parsed_opts.debug:
             tool_opts.debug = True

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -374,7 +374,6 @@ class CLI(object):
             args.insert(0, "convert")
 
         args.extend(argv)
-        print(args)
 
         parsed_opts = self._parser.parse_args(args)
 

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -116,10 +116,10 @@ class CLI(object):
         self._register_options()
         self._process_cli_options()
 
-    @staticmethod
-    def _get_argparser():
+    @property
+    def usage(self):
         usage = (
-            "\n    "
+            "\n"
             "  convert2rhel\n"
             "  convert2rhel [-h]\n"
             "  convert2rhel [--version]\n"
@@ -134,9 +134,10 @@ class CLI(object):
             "\n\n"
             "*WARNING* The tool needs to be run under the root user\n"
         )
-        return argparse.ArgumentParser(
-            conflict_handler="resolve", usage=usage, formatter_class=argparse.RawTextHelpFormatter
-        )
+        return usage
+
+    def _get_argparser(self):
+        return argparse.ArgumentParser(conflict_handler="resolve", usage=self.usage)
 
     def _register_commands(self):
         """Configures parsers specific to the analyze and convert subcommands"""
@@ -149,14 +150,14 @@ class CLI(object):
             " in the original state.",
             parents=[self._shared_options_parser],
             formatter_class=argparse.RawTextHelpFormatter,
-            usage=SUPPRESS,
+            usage=self.usage,
         )
         self._convert_parser = subparsers.add_parser(
             "convert",
             help="Convert the system.",
             parents=[self._shared_options_parser],
             formatter_class=argparse.RawTextHelpFormatter,
-            usage=SUPPRESS,
+            usage=self.usage,
         )
 
     def _register_parent_options(self, parser):
@@ -360,24 +361,11 @@ class CLI(object):
 
         warn_on_unsupported_options()
 
-        args = []
-        argv = sys.argv[1:]
-
         # algorithm function to properly organize all CLI args
-        argv = _add_default_command(argv)
-
-        has_subcommand = False
-        for index, argument in enumerate(argv):
-            if argument in ("convert", "analyze") and argv[index - 1] not in ARGS_WITH_VALUES:
-                # subcommand is present in argv list
-                has_subcommand = True
-                break
-
-        if not has_subcommand:
-            args.insert(0, "convert")
-
-        args.extend(argv)
-        parsed_opts = self._parser.parse_args(args)
+        argv = _add_default_command(sys.argv[1:])
+        parsed_opts = self._parser.parse_args(argv)
+        print(argv)
+        # sys.exit()
 
         if parsed_opts.debug:
             tool_opts.debug = True

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -22,7 +22,6 @@ import os
 import re
 import sys
 
-
 from six.moves import configparser, urllib
 
 from convert2rhel import __version__, utils

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -679,15 +679,11 @@ def test_disable_and_enable_repos_with_different_repos(argv, expected, monkeypat
     ("argv", "expected"),
     (
         ([], ["convert"]),
-        (["convert", "--debug"], ["--debug", "convert"]),
-        (["analyze", "--debug"], ["--debug", "analyze"]),
-        (["--password=convert", "--debug", "convert"], ["--debug", "convert", "--password=convert"]),
-        (
-            ["--username", "convert", "-h", "--password", "xxxx", "--debug", "convert", "--pool", "xxxx"],
-            ["-h", "--debug", "convert", "--username", "convert", "--password", "xxxx", "--pool", "xxxx"],
-        ),
+        (["--debug"], ["convert", "--debug"]),
+        (["analyze", "--debug"], ["analyze", "--debug"]),
+        (["--password=convert", "--debug"], ["convert", "--password=convert", "--debug"]),
     ),
 )
-def test_organize_cli_options(argv, expected, monkeypatch):
+def test_add_default_command(argv, expected, monkeypatch):
     monkeypatch.setattr(sys, "argv", argv)
-    assert convert2rhel.toolopts._organize_cli_options(argv) == expected
+    assert convert2rhel.toolopts._add_default_command(argv) == expected

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -33,7 +33,10 @@ from six.moves import mock
 
 
 def mock_cli_arguments(args):
-    """Return a list of cli arguments where the first one is always the name of the executable, followed by 'args'."""
+    """
+    Return a list of cli arguments where the first one is always the name of
+    the executable, followed by 'args'.
+    """
     return sys.argv[0:1] + args
 
 
@@ -557,7 +560,7 @@ def test_validate_serverurl_parsing(url_parts, message):
         convert2rhel.toolopts._validate_serverurl_parsing(url_parts)
 
 
-def test__log_command_used(caplog, monkeypatch):
+def test_log_command_used(caplog, monkeypatch):
     obfuscation_string = "*" * 5
     input_command = mock_cli_arguments(
         ["--username", "uname", "--password", "123", "--activationkey", "456", "--org", "789"]
@@ -610,6 +613,23 @@ def test_org_activation_key_specified(argv, message, monkeypatch, caplog):
 @pytest.mark.parametrize(
     ("argv", "expected"),
     (
+        (mock_cli_arguments(["convert"]), "convert"),
+        (mock_cli_arguments(["analyze"]), "analyze"),
+        (mock_cli_arguments([]), "convert"),
+    ),
+)
+def test_pre_assessment_set(argv, expected, monkeypatch):
+    tool_opts.__init__()
+    monkeypatch.setattr(sys, "argv", argv)
+
+    convert2rhel.toolopts.CLI()
+
+    assert tool_opts.command == expected
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    (
         (
             mock_cli_arguments(["--disablerepo", "*", "--enablerepo", "*"]),
             "Duplicate repositories were found across disablerepo and enablerepo options",
@@ -653,3 +673,21 @@ def test_disable_and_enable_repos_with_different_repos(argv, expected, monkeypat
     convert2rhel.toolopts.CLI()
 
     assert expected not in caplog.records[-1].message
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    (
+        ([], ["convert"]),
+        (["convert", "--debug"], ["--debug", "convert"]),
+        (["analyze", "--debug"], ["--debug", "analyze"]),
+        (["--password=convert", "--debug", "convert"], ["--debug", "convert", "--password=convert"]),
+        (
+            ["--username", "convert", "-h", "--password", "xxxx", "--debug", "convert", "--pool", "xxxx"],
+            ["-h", "--debug", "convert", "--username", "convert", "--password", "xxxx", "--pool", "xxxx"],
+        ),
+    ),
+)
+def test_organize_cli_options(argv, expected, monkeypatch):
+    monkeypatch.setattr(sys, "argv", argv)
+    assert convert2rhel.toolopts._organize_cli_options(argv) == expected

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -613,9 +613,9 @@ def test_org_activation_key_specified(argv, message, monkeypatch, caplog):
 @pytest.mark.parametrize(
     ("argv", "expected"),
     (
-        (mock_cli_arguments(["convert"]), "convert"),
-        (mock_cli_arguments(["analyze"]), "analyze"),
-        (mock_cli_arguments([]), "convert"),
+        (mock_cli_arguments(["convert"]), "conversion"),
+        (mock_cli_arguments(["analyze"]), "analysis"),
+        (mock_cli_arguments([]), "conversion"),
     ),
 )
 def test_pre_assessment_set(argv, expected, monkeypatch):
@@ -624,7 +624,7 @@ def test_pre_assessment_set(argv, expected, monkeypatch):
 
     convert2rhel.toolopts.CLI()
 
-    assert tool_opts.command == expected
+    assert tool_opts.activity == expected
 
 
 @pytest.mark.parametrize(

--- a/man/__init__.py
+++ b/man/__init__.py
@@ -33,5 +33,4 @@ def get_parser():
         "Oracle Linux 6/7/8, Scientific Linux 7, Alma Linux 8, and Rocky Linux 8 "
         "to the respective major version of RHEL.".strip()
     )
-    parser.usage = None
     return parser

--- a/tests/integration/tier0/non-destructive/assessment-report/main.fmf
+++ b/tests/integration/tier0/non-destructive/assessment-report/main.fmf
@@ -9,9 +9,6 @@ tier: 0
 tag+:
     - pre-assessment-report
 
-environment+:
-    CONVERT2RHEL_EXPERIMENTAL_ANALYSIS: 1
-
 /failures_and_skips_in_report:
     summary+: |
         Verify that some actions failures and skips appeared in the report.
@@ -33,3 +30,17 @@ environment+:
         - success-report
     test: |
         pytest -svv -m test_successful_report
+
+/convert_successful_report:
+    summary+: |
+        Verify that the `convert` subcommand works.
+    description+: |
+        Validate that calling the `convert` subcommand works.
+        Verify the assessment report does not contain any header:
+        Success header, Error header, Skip header.
+        NOTE: Without the analyze subcommand the convert2rhel does not
+        pollute the output with Success header and checks.
+    tag+:
+        - convert-success-report
+    test: |
+        pytest -svv -m test_convert_successful_report

--- a/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
+++ b/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
@@ -1,6 +1,7 @@
 import pytest
 
 from envparse import env
+from pexpect import EOF
 
 
 @pytest.mark.test_failures_and_skips_in_report
@@ -11,7 +12,7 @@ def test_failures_and_skips_in_report(convert2rhel):
     Error header, skip header, success header.
     """
     with convert2rhel(
-        "--no-rpm-va --serverurl {} --username test --password test --pool a_pool --debug".format(
+        "analyze --no-rpm-va --serverurl {} --username test --password test --pool a_pool --debug".format(
             env.str("RHSM_SERVER_URL"),
         )
     ) as c2r:
@@ -44,10 +45,10 @@ def test_successful_report(convert2rhel):
     """
     Test if the assessment report contains the following header: Success header.
 
-    And does not contain: Error header, skip header, success header.
+    And does not contain: Error header, Skip header.
     """
     with convert2rhel(
-        "--no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug".format(
+        "analyze --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug".format(
             env.str("RHSM_SERVER_URL"),
             env.str("RHSM_USERNAME"),
             env.str("RHSM_PASSWORD"),
@@ -77,3 +78,50 @@ def test_successful_report(convert2rhel):
             assert AssertionError("Skip header in the analysis report.")
 
     assert c2r.exitstatus == 0
+
+
+@pytest.mark.test_convert_successful_report
+def test_convert_successful_report(convert2rhel):
+    """
+    Validate that calling the `convert` subcommand works.
+    Verify the assessment report does not contain any of the following headers:
+    Success header, Error header, Skip header.
+    """
+    with convert2rhel(
+        "convert --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug".format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        # We need to get past the data collection acknowledgement.
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("y")
+
+        # Refuse the full conversion at PONR
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("n")
+
+        # Assert that the utility starts the rollback first
+        assert c2r.expect("Rollback: RHSM-related actions") == 0
+
+        # Then, verify that the analysis report TASK header is printed
+        assert c2r.expect("Pre-conversion analysis report", timeout=600) == 0
+
+        # Verify that none of the headers is present, assert if it is present
+        c2r_report_header_index = c2r.expect(
+            [EOF, "No changes needed", "Must fix before conversion", "Could not be checked due to other failures"],
+            timeout=300,
+        )
+        if c2r_report_header_index == 0:
+            pass
+        elif c2r_report_header_index == 1:
+            assert AssertionError("Success header in the analysis report.")
+        elif c2r_report_header_index == 2:
+            assert AssertionError("Error header in the analysis report.")
+        elif c2r_report_header_index == 3:
+            assert AssertionError("Skip header in the analysis report.")
+
+    # Exitstatus is 1 due to user cancelling the conversion
+    assert c2r.exitstatus != 0

--- a/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
@@ -328,7 +328,7 @@ def test_analyze_incomplete_rollback(repositories, convert2rhel, analyze_incompl
        accepted and conversion continues
     # TODO(danmyway) switch to `convert2rhel analyze` when available.
     """
-    with convert2rhel("--debug --no-rpm-va") as c2r:
+    with convert2rhel("analyze --debug --no-rpm-va") as c2r:
         # We need to get past the data collection acknowledgement
         c2r.sendline("y")
         c2r.expect("REMOVE_REPOSITORY_FILES_PACKAGES::PACKAGE_REMOVAL_FAILED", timeout=300)

--- a/tests/integration/tier0/non-destructive/main.fmf
+++ b/tests/integration/tier0/non-destructive/main.fmf
@@ -8,3 +8,6 @@ description+: |
 
 tag+:
     - non-destructive
+
+environment+:
+    INT_TESTS_NONDESTRUCTIVE: 1

--- a/tests/integration/tier1/non-destructive/main.fmf
+++ b/tests/integration/tier1/non-destructive/main.fmf
@@ -8,3 +8,6 @@ description+: |
 
 tag+:
     - non-destructive
+
+environment+:
+    INT_TESTS_NONDESTRUCTIVE: 1


### PR DESCRIPTION
This PR updates the CLI to accept the new analyze subcommand. There is also a function called _organize_cli_options introduced to reorder the CLI arguments properly.

Jira Issues: [RHELC-970](https://issues.redhat.com/browse/RHELC-970)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
