### PR TITLE
[RHELC-993] Fix the output order for RemoveRepositoryFiles action

### DIFF
--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -688,10 +688,10 @@ def remove_pkgs_unless_from_redhat(pkgs_to_remove, backup=True):
         loggerinst.info("\nNothing to do.")
         return
 
+    loggerinst.warning("Removing the following %s packages:" % str(len(pkgs_to_remove)))
+    print_pkg_info(pkgs_to_remove)
     loggerinst.info("\n")
     remove_pkgs([get_pkg_nvra(pkg.nevra) for pkg in pkgs_to_remove], backup=backup)
-    loggerinst.warning("Successfully removed the following %s packages:" % str(len(pkgs_to_remove)))
-    print_pkg_info(pkgs_to_remove)
 
 
 @utils.run_as_child_process


### PR DESCRIPTION
The order of output of this action was a bit different from what we have in main right now, this commit changes it to a more sane order.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-993](https://issues.redhat.com/browse/RHELC-993)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
