### PR TITLE
[RHELC-901] Allow username and organization in the config file

### DIFF
--- a/config/convert2rhel.ini
+++ b/config/convert2rhel.ini
@@ -7,5 +7,7 @@
 # 3) /etc/convert2rhel.ini; the lowest priority
 
 [subscription_manager]
-# password = <insert_password>
+# username       = <insert_username>
+# password       = <insert_password>
 # activation_key = <insert_activation_key>
+# org            = <insert_org>

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -447,6 +447,13 @@ class CLI(object):
                 " We're going to use the password from file."
             )
 
+        # Config files matches
+        if (config_opts.username or config_opts.org) and (parsed_opts.username or parsed_opts.org):
+            loggerinst.warning(
+                "You have passed either the RHSM username or org through both the command line and the"
+                " configuration file. We're going to use the command line values."
+            )
+
         if (config_opts.activation_key or config_opts.password) and (parsed_opts.activationkey or parsed_opts.password):
             loggerinst.warning(
                 "You have passed either the RHSM password or activation key through both the command line and the"
@@ -503,16 +510,17 @@ def options_from_config_files(cfg_path=None):
     :type cfg_path: str
 
     :return: Dict with the supported options alongside their values.
-    :rtype: dict[str | None, str | None]
+    :rtype: dict[str, str | None]
     """
     headers = ["subscription_manager"]  # supported sections in config file
-    config_file = configparser.ConfigParser()
-    paths = [os.path.expanduser(path) for path in CONFIG_PATHS]
     # Create dict with all supported options, all of them set to None
     # needed for avoiding problems with files priority
     # The name of supported option MUST correspond with the name in ToolOpts()
     # Otherwise it won't be used
-    supported_opts = {"password": None, "activation_key": None}
+    supported_opts = {"username": None, "password": None, "activation_key": None, "org": None}
+
+    config_file = configparser.ConfigParser()
+    paths = [os.path.expanduser(path) for path in CONFIG_PATHS]
 
     if cfg_path:
         cfg_path = os.path.expanduser(cfg_path)

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -448,9 +448,15 @@ class CLI(object):
             )
 
         # Config files matches
-        if (config_opts.username or config_opts.org) and (parsed_opts.username or parsed_opts.org):
+        if config_opts.username or config_opts.org:
             loggerinst.warning(
-                "You have passed either the RHSM username or org through both the command line and the"
+                "You have passed the RHSM username through both the command line and the"
+                " configuration file. We're going to use the command line values."
+            )
+
+        if parsed_opts.username or parsed_opts.org:
+            loggerinst.warning(
+                "You have passed the RHSM org through both the command line and the"
                 " configuration file. We're going to use the command line values."
             )
 

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -358,19 +358,30 @@ def test_multiple_auth_src_cli(argv, message, output, caplog, monkeypatch):
     ("content", "output"),
     (
         (
+            "[subscription_manager]\nusername = correct_username",
+            {"username": "correct_username", "password": None, "activation_key": None, "org": None},
+        ),
+        (
             "[subscription_manager]\npassword = correct_password",
-            {"password": "correct_password", "activation_key": None},
+            {"username": None, "password": "correct_password", "activation_key": None, "org": None},
         ),
         (
             "[subscription_manager]\nactivation_key = correct_key\nPassword = correct_password",
-            {"password": "correct_password", "activation_key": "correct_key"},
+            {"username": None, "password": "correct_password", "activation_key": "correct_key", "org": None},
+        ),
+        (
+            "[subscription_manager]\norg = correct_org",
+            {"username": None, "password": None, "activation_key": None, "org": "correct_org"},
         ),
         (
             "[subscription_manager]\nincorrect_option = incorrect_content",
-            {"password": None, "activation_key": None},
+            {"username": None, "password": None, "activation_key": None, "org": None},
         ),
-        ("[INVALID_HEADER]\nactivation_key = correct_key", {"password": None, "activation_key": None}),
-        (None, {"password": None, "activation_key": None}),
+        (
+            "[INVALID_HEADER]\nusername = correct_username\npassword = correct_password\nactivation_key = correct_key\norg = correct_org",
+            {"username": None, "password": None, "activation_key": None, "org": None},
+        ),
+        (None, {"username": None, "password": None, "activation_key": None, "org": None}),
     ),
 )
 def test_options_from_config_files_default(content, output, monkeypatch, tmpdir, caplog):
@@ -385,8 +396,11 @@ def test_options_from_config_files_default(content, output, monkeypatch, tmpdir,
     monkeypatch.setattr(convert2rhel.toolopts, "CONFIG_PATHS", value=paths)
     opts = convert2rhel.toolopts.options_from_config_files()
 
+    assert opts["username"] == output["username"]
     assert opts["password"] == output["password"]
     assert opts["activation_key"] == output["activation_key"]
+    assert opts["org"] == output["org"]
+
     if content:
         if "INVALID_HEADER" in content:
             assert "Unsupported header" in caplog.text
@@ -398,18 +412,28 @@ def test_options_from_config_files_default(content, output, monkeypatch, tmpdir,
     ("content", "output", "content_lower_priority"),
     (
         (
+            "[subscription_manager]\nusername = correct_username\nactivation_key = correct_key",
+            {"username": "correct_username", "password": None, "activation_key": "correct_key", "org": None},
+            "[subscription_manager]\nusername = low_prior_username",
+        ),
+        (
+            "[subscription_manager]\nactivation_key = correct_key\norg = correct_org",
+            {"username": None, "password": None, "activation_key": "correct_key", "org": "correct_org"},
+            "[subscription_manager]\norg = low_prior_org",
+        ),
+        (
             "[subscription_manager]\nactivation_key = correct_key\nPassword = correct_password",
-            {"password": "correct_password", "activation_key": "correct_key"},
+            {"username": None, "password": "correct_password", "activation_key": "correct_key", "org": None},
             "[subscription_manager]\npassword = low_prior_pass",
         ),
         (
             "[subscription_manager]\nactivation_key = correct_key\nPassword = correct_password",
-            {"password": "correct_password", "activation_key": "correct_key"},
-            "[INVALID_HEADER]\nincorrect_option = incorrect_option",
+            {"username": None, "password": "correct_password", "activation_key": "correct_key", "org": None},
+            "[INVALID_HEADER]\npassword = low_prior_pass",
         ),
         (
             "[subscription_manager]\nactivation_key = correct_key\nPassword = correct_password",
-            {"password": "correct_password", "activation_key": "correct_key"},
+            {"username": None, "password": "correct_password", "activation_key": "correct_key", "org": None},
             "[subscription_manager]\nincorrect_option = incorrect_option",
         ),
     ),
@@ -422,7 +446,6 @@ def test_options_from_config_files_specified(content, output, content_lower_prio
     os.chmod(path, 0o600)
 
     path_lower_priority = os.path.join(str(tmpdir), "convert2rhel_lower.ini")
-    content_lower_priority = "[subscription_manager]\npassword = low_prior_pass"
     with open(path_lower_priority, "w") as file:
         file.write(content_lower_priority)
     os.chmod(path_lower_priority, 0o600)
@@ -432,8 +455,11 @@ def test_options_from_config_files_specified(content, output, content_lower_prio
     # user specified path
     opts = convert2rhel.toolopts.options_from_config_files(path)
 
+    assert opts["username"] == output["username"]
     assert opts["password"] == output["password"]
     assert opts["activation_key"] == output["activation_key"]
+    assert opts["org"] == output["org"]
+
     if "INVALID_HEADER" in content or "INVALID_HEADER" in content_lower_priority:
         assert "Unsupported header" in caplog.text
     if "incorrect_option" in content or "incorrect_option" in content_lower_priority:
@@ -443,16 +469,29 @@ def test_options_from_config_files_specified(content, output, content_lower_prio
 @pytest.mark.parametrize(
     "supported_opts",
     (
-        {"password": "correct_password", "activation_key": "correct_key"},
-        {"password": "correct_password", "activation_key": "correct_key", "invalid_key": "invalid_key"},
+        {
+            "username": "correct_username",
+            "password": "correct_password",
+            "activation_key": "correct_key",
+            "org": "correct_org",
+        },
+        {
+            "username": "correct_username",
+            "password": "correct_password",
+            "activation_key": "correct_key",
+            "org": "correct_org",
+            "invalid_key": "invalid_key",
+        },
     ),
 )
 def test_set_opts(supported_opts):
     tool_opts.__init__()
     convert2rhel.toolopts.ToolOpts.set_opts(tool_opts, supported_opts)
 
+    assert tool_opts.username == supported_opts["username"]
     assert tool_opts.password == supported_opts["password"]
     assert tool_opts.activation_key == supported_opts["activation_key"]
+    assert tool_opts.org == supported_opts["org"]
     assert not hasattr(tool_opts, "invalid_key")
 
 

--- a/tests/integration/tier0/config-file/test_config_file.py
+++ b/tests/integration/tier0/config-file/test_config_file.py
@@ -49,14 +49,28 @@ def test_user_path_std_filename(convert2rhel):
 
 @pytest.mark.test_config_cli_priority
 def test_user_path_cli_priority(convert2rhel):
-    config = [Config("~/.convert2rhel.ini", "[subscription_manager]\npassword = config_password")]
+    config = [
+        Config(
+            "~/.convert2rhel.ini",
+            "[subscription_manager]\nusername = config_username\npassword = config_password\nacitvation_key = config_key\norg = config_org",
+        )
+    ]
     create_files(config)
 
     with convert2rhel("--no-rpm-va --password password --debug") as c2r:
+        # Found options in config file
+        c2r.expect("DEBUG - Found username in /root/.convert2rhel.ini")
         c2r.expect("DEBUG - Found password in /root/.convert2rhel.ini")
+        c2r.expect("DEBUG - Found activation_key in /root/.convert2rhel.ini")
+        c2r.expect("DEBUG - Found org in /root/.convert2rhel.ini")
+
+        c2r.expect(
+            "WARNING - You have passed either the RHSM password or activation key through both the command line and"
+            " the configuration file. We're going to use the command line values."
+        )
         if (
             c2r.expect(
-                "WARNING - You have passed either the RHSM password or activation key through both the command line and"
+                "WARNING - You have passed either the RHSM username or org through both the command line and"
                 " the configuration file. We're going to use the command line values."
             )
             == 0

--- a/tests/integration/tier0/config-file/test_config_file.py
+++ b/tests/integration/tier0/config-file/test_config_file.py
@@ -68,9 +68,13 @@ def test_user_path_cli_priority(convert2rhel):
             "WARNING - You have passed either the RHSM password or activation key through both the command line and"
             " the configuration file. We're going to use the command line values."
         )
+        c2r.expect(
+            "WARNING - You have passed the RHSM username through both the command line and"
+            " the configuration file. We're going to use the command line values."
+        )
         if (
             c2r.expect(
-                "WARNING - You have passed either the RHSM username or org through both the command line and"
+                "WARNING - You have passed the RHSM org through both the command line and"
                 " the configuration file. We're going to use the command line values."
             )
             == 0

--- a/tests/integration/tier0/config-file/test_config_file.py
+++ b/tests/integration/tier0/config-file/test_config_file.py
@@ -52,7 +52,7 @@ def test_user_path_cli_priority(convert2rhel):
     config = [
         Config(
             "~/.convert2rhel.ini",
-            "[subscription_manager]\nusername = config_username\npassword = config_password\nacitvation_key = config_key\norg = config_org",
+            "[subscription_manager]\nusername = config_username\npassword = config_password\nactivation_key = config_key\norg = config_org",
         )
     ]
     create_files(config)
@@ -65,21 +65,18 @@ def test_user_path_cli_priority(convert2rhel):
         c2r.expect("DEBUG - Found org in /root/.convert2rhel.ini")
 
         c2r.expect(
-            "WARNING - You have passed either the RHSM password or activation key through both the command line and"
-            " the configuration file. We're going to use the command line values."
-        )
-        c2r.expect(
             "WARNING - You have passed the RHSM username through both the command line and"
             " the configuration file. We're going to use the command line values."
         )
         if (
             c2r.expect(
-                "WARNING - You have passed the RHSM org through both the command line and"
+                "WARNING - You have passed either the RHSM password or activation key through both the command line and"
                 " the configuration file. We're going to use the command line values."
             )
             == 0
         ):
             c2r.sendcontrol("c")
+
     assert c2r.exitstatus != 0
 
     remove_files(config)

--- a/tests/integration/tier1/config-file/test_config_file.py
+++ b/tests/integration/tier1/config-file/test_config_file.py
@@ -22,16 +22,15 @@ def remove_files(config):
 
 
 def test_conversion(convert2rhel):
-    activation_key = "[subscription_manager]\nactivation_key = {}".format(env.str("RHSM_KEY"))
+    activation_key = "[subscription_manager]\nactivation_key = {}\norg = {}".format(
+        env.str("RHSM_KEY"), env.str("RHSM_ORG")
+    )
     config = [Config("~/.convert2rhel.ini", activation_key)]
     create_files(config)
 
-    with convert2rhel(
-        "-y --no-rpm-va --serverurl {} -o {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_ORG"),
-        )
-    ) as c2r:
+    with convert2rhel("-y --no-rpm-va --serverurl {} --debug".format(env.str("RHSM_SERVER_URL"))) as c2r:
         c2r.expect("DEBUG - Found activation_key in /root/.convert2rhel.ini")
+        c2r.expect("DEBUG - Found org in /root/.convert2rhel.ini")
         c2r.expect("Conversion successful!")
+
     assert c2r.exitstatus == 0


### PR DESCRIPTION
Allow the username and organization to be used in the config file as a secure way of using the RHSM credentials duirng the conversion.

Previously, only the password and activation key were used and parsed in the config file.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-901](https://issues.redhat.com/browse/RHELC-901)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
