### PR TITLE
[RHELC-1008] Update packit.yaml and pre-commit-config.yaml

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -36,6 +36,9 @@ jobs:
 
 - &tests
   job: tests
+  # Do not merge the PR into the target branch, in case the merge is broken
+  # Given we are rebasing the source branches regularly, we do not need this feature enabled
+  merge_pr_in_ci: false
   targets:
     epel-7-x86_64:
       distros: [centos-7, oraclelinux-7]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
             sed -i '/^[[:space:]]*tier: 0/d' plans/rerun.fmf
             sed -i 's/\s\+$//' plans/rerun.fmf
         language: system
-        stages: [ commit ]
+        stages: [ manual ]
   - repo: local
     hooks:
       - id: black


### PR DESCRIPTION
* do not merge PR in the CI
* currently we are facing issues with Packit/TF trying to merge the PR into the target branch, with the merge not being completed
* this results to checking out to the HEAD of target branch to read the test fmf metadata from, resulting to not having the metadata updated
* add `merge_pr_in_ci: false` to mitigate the issue

* set stage for regenerate-rerun-plan to manual

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1008](https://issues.redhat.com/browse/RHELC-1008)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
