### PR TITLE
[RHELC-1009] Fix the log message for invalid package detection

### DIFF
--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -1227,7 +1227,7 @@ def _validate_parsed_fields(package, name, epoch, version, release, arch):
     parsed_pkg_length = len("".join(pkg_fields)) + seperators
     if pkg_length != parsed_pkg_length:
         raise ValueError(
-            "Invalid package - %s, enter a package in one of the following formats: NEVRA, NEVR, NVRA, NVR, ENVRA, ENVR."
+            "Invalid package - %s, packages need to be in one of the following formats: NEVRA, NEVR, NVRA, NVR, ENVRA, ENVR."
             " Reason: The total length of the parsed package fields does not equal the package length," % package
         )
 
@@ -1316,8 +1316,8 @@ def _parse_pkg_with_dnf(pkg):
         # therefore the package entered is invalid and/or in the wrong format
         if no_arch_data is None:
             raise ValueError(
-                "Invalid package string - %s, enter a package in one of the formats: NEVRA, NEVR, NVRA, NVR, ENVRA, ENVR."
-                % pkg
+                "Invalid package - %s, packages need to be in one of the following"
+                " formats: NEVRA, NEVR, NVRA, NVR, ENVRA, ENVR." % pkg
             )
 
         name = no_arch_data.name

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -1155,13 +1155,13 @@ def test_validate_parsed_fields_invalid(package, name, epoch, version, release, 
         (
             "foo-15.x86_64",
             re.escape(
-                "Invalid package - foo-15.x86_64, enter a package in one of the following formats: NEVRA, NEVR, NVRA, NVR, ENVRA, ENVR. Reason: The total length of the parsed package fields does not equal the package length,"
+                "Invalid package - foo-15.x86_64, packages need to be in one of the following formats: NEVRA, NEVR, NVRA, NVR, ENVRA, ENVR. Reason: The total length of the parsed package fields does not equal the package length,"
             ),
         ),
         (
             "notavalidpackage",
             re.escape(
-                "Invalid package - notavalidpackage, enter a package in one of the following formats: NEVRA, NEVR, NVRA, NVR, ENVRA, ENVR. Reason: The total length of the parsed package fields does not equal the package length,"
+                "Invalid package - notavalidpackage, packages need to be in one of the following formats: NEVRA, NEVR, NVRA, NVR, ENVRA, ENVR. Reason: The total length of the parsed package fields does not equal the package length,"
             ),
         ),
     ),


### PR DESCRIPTION
This PR rewrites two log messages for when invalid packages are detected.



Jira Issues: [RHELC-1009](https://issues.redhat.com/browse/RHELC-1009)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
