### PR TITLE
[RHELC-899] Prevent packages marked for update to reinstall

### DIFF
--- a/convert2rhel/pkgmanager/__init__.py
+++ b/convert2rhel/pkgmanager/__init__.py
@@ -41,7 +41,6 @@ try:
 except ImportError as e:
 
     import hawkey
-    import libdnf
 
     from dnf import *  # pylint: disable=import-error
     from dnf.callback import Depsolve, DownloadProgress

--- a/convert2rhel/pkgmanager/__init__.py
+++ b/convert2rhel/pkgmanager/__init__.py
@@ -41,6 +41,7 @@ try:
 except ImportError as e:
 
     import hawkey
+    import libdnf
 
     from dnf import *  # pylint: disable=import-error
     from dnf.callback import Depsolve, DownloadProgress

--- a/convert2rhel/pkgmanager/handlers/dnf/__init__.py
+++ b/convert2rhel/pkgmanager/handlers/dnf/__init__.py
@@ -128,14 +128,14 @@ class DnfTransactionHandler(TransactionHandlerBase):
             # package. This is an inconsistency that could lead to packages
             # being outdated in the system after the conversion.
             if upgrade_pkg:
-                self._base.upgrade(pkg)
+                self._base.upgrade(pkg_spec=pkg)
                 continue
 
             try:
-                self._base.reinstall(pkg)
+                self._base.reinstall(pkg_spec=pkg)
             except pkgmanager.exceptions.PackagesNotAvailableError:
                 try:
-                    self._base.downgrade(pkg)
+                    self._base.downgrade(pkg_spec=pkg)
                 except pkgmanager.exceptions.PackagesNotInstalledError:
                     loggerinst.warning("Package %s not available in RHEL repositories.", pkg)
 

--- a/convert2rhel/pkgmanager/handlers/yum/__init__.py
+++ b/convert2rhel/pkgmanager/handlers/yum/__init__.py
@@ -173,7 +173,15 @@ class YumTransactionHandler(TransactionHandlerBase):
 
         try:
             for pkg in original_os_pkgs:
-                self._base.update(pattern=pkg)
+                can_update = self._base.update(pattern=pkg)
+
+                # If a package is marked for update, then we don't need to
+                # proceed with reinstall, and possibly, the downgrade of this
+                # package. This is an inconsistency that could lead to packages
+                # being outdated in the system after the conversion.
+                if can_update:
+                    continue
+
                 try:
                     self._base.reinstall(pattern=pkg)
                 except (pkgmanager.Errors.ReinstallInstallError, pkgmanager.Errors.ReinstallRemoveError):

--- a/convert2rhel/unit_tests/pkgmanager/handlers/dnf/dnf_test.py
+++ b/convert2rhel/unit_tests/pkgmanager/handlers/dnf/dnf_test.py
@@ -14,9 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-from typing import Any
-
 import pytest
 import six
 

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -399,6 +399,17 @@
           how: ansible
           playbook: tests/ansible_collections/roles/reboot/main.yml
 
+/single_yum_transaction_check_for_latest_packages:
+    discover+:
+        filter: tag:checks-after-conversion
+    prepare+:
+        - name: main conversion preparation
+          how: shell
+          script: pytest -svv tests/integration/tier1/single-yum-transaction/test_check_for_latest_packages.py
+        - name: reboot after conversion
+          how: ansible
+          playbook: tests/ansible_collections/roles/reboot/main.yml
+
 /detect_correct_boot_partition:
     adjust+:
         - enabled: false

--- a/pytest.ini
+++ b/pytest.ini
@@ -60,4 +60,3 @@ markers =
     test_failed_to_parse_package_info_empty_arch_not_present
     test_packages_upgraded_after_conversion
     test_analyze_incomplete_rollback
-    

--- a/pytest.ini
+++ b/pytest.ini
@@ -59,3 +59,4 @@ markers =
     test_failures_and_skips_in_report
     test_successful_report
     test_failed_to_parse_package_info_empty_arch_not_present
+    test_packages_upgraded_after_conversion

--- a/tests/integration/tier1/single-yum-transaction/main.fmf
+++ b/tests/integration/tier1/single-yum-transaction/main.fmf
@@ -5,7 +5,13 @@ description: |
     error. Previous iterations used a lot of different steps, whereas now it is
     one transaction that can be rolled back more easily.
 
-link: https://issues.redhat.com/browse/RHELC-576
+    Verify that packages got upgraded by the end of conversion instead of
+    reinstalled/downgraded.
+
+
+link:
+   - https://issues.redhat.com/browse/RHELC-576
+   - https://issues.redhat.com/browse/RHELC-899
 
 tier: 1
 

--- a/tests/integration/tier1/single-yum-transaction/test_check_for_latest_packages.py
+++ b/tests/integration/tier1/single-yum-transaction/test_check_for_latest_packages.py
@@ -1,0 +1,36 @@
+from conftest import SYSTEM_RELEASE_ENV
+from envparse import env
+
+
+PACKAGES_TO_VERIFY_RHEL_7 = [("shim-x64", "shim-x64-15.6-3.el7_9.x86_64")]
+# Match the latest version used for conversion, currently Oracle Linux 8.7
+PACKAGES_TO_VERIFY_RHEL_8_X = [("shim-x64", "shim-x64-15.6-1.el8.x86_64")]
+# Mainly for CentOS Linux 8.5
+PACKAGES_TO_VERIFY_RHEL_8_5 = [("shim-x64", "shim-x64-15.4-2.el8_1.x86_64")]
+
+
+def test_packages_upgraded_after_conversion(convert2rhel, shell):
+    """."""
+
+    # Run utility until the reboot
+    with convert2rhel(
+        "-y --no-rpm-va --serverurl {} --username {} --password {} --pool {} --debug".format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        c2r.expect("Conversion successful!")
+    assert c2r.exitstatus == 0
+
+    packages_to_verify = PACKAGES_TO_VERIFY_RHEL_7
+
+    if "centos-8" in SYSTEM_RELEASE_ENV:
+        packages_to_verify = PACKAGES_TO_VERIFY_RHEL_8_5
+    elif "oracle-8" in SYSTEM_RELEASE_ENV:
+        packages_to_verify = PACKAGES_TO_VERIFY_RHEL_8_X
+
+    cmd = "rpm -q %s"
+    for package, latest_version in packages_to_verify:
+        assert shell(cmd % package).output == latest_version

--- a/tests/integration/tier1/single-yum-transaction/test_check_for_latest_packages.py
+++ b/tests/integration/tier1/single-yum-transaction/test_check_for_latest_packages.py
@@ -51,10 +51,12 @@ def test_packages_upgraded_after_conversion(convert2rhel, shell):
     # We need to point the releasever to 8.5 with CentOS latest
     # otherwise the yum check-update looks at releasever 8
     # discovering package versions not available for 8.5
+    # Doing that, we also need to disable the epel-modular repo
+    # as it raises an 404 error
     if "centos-8.5" in SYSTEM_RELEASE_ENV:
-        cmd = "yum check-update --quiet --releasever=8.5 %s"
+        cmd = "yum check-update --quiet --releasever=8.5 --disablerepo epel-modular %s"
     for package in packages_to_verify:
         # If tha package lands on latest version after conversion
         # `yum check-update` will return 0
-        # If the package is possible to update the returncode yields 100
+        # If it is possible to update the package, the yum returncode yields 100
         assert shell(cmd % package).returncode == 0

--- a/tests/integration/tier1/system-up-to-date/main.fmf
+++ b/tests/integration/tier1/system-up-to-date/main.fmf
@@ -7,5 +7,4 @@ description: |
     Verify that the conversion emits a warning if the yum versionlock plugin is being used.
 
 tier: 1
-
 test: pytest -svv


### PR DESCRIPTION
During our transaction handler, some packages were trying to be reinstalled/downgraded on the system without necessity, as they were already marked for update.

This patch prevents those packages marked for update to be reinstalled or downgraded in further cases.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-899](https://issues.redhat.com/browse/RHELC-899)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
