### PR TITLE
tests/hotfix/Remove parsing .env in conftest

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,8 +22,6 @@ try:
 except ImportError:
     from pathlib2 import Path
 
-env.read_envfile(str(Path(__file__).parents[2] / ".env"))
-
 logging.basicConfig(level="DEBUG" if env.str("DEBUG") else "INFO", stream=sys.stderr)
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
* we do not have any .env file in the repository, the line is redundant

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Tested on CentOS-8.4 with tier0 set:
http://artifacts.osci.redhat.com/testing-farm/8a854bf5-2487-494b-9dfd-0cfe2c53a8a0/