### PR TITLE
[RHELC-1016] Expect release of Oracle Linux 8.8

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -21,9 +21,9 @@ adjust+:
       when: distro == centos-8-latest
     - environment+:
         #TODO bump distro context to 8.7 when the image is available on the testing farm
-        # Even though the distro context is 8.6 we are setting the SYSTEM_RELEASE_ENV to 8.7
+        # Even though the distro context is 8.6 we are setting the SYSTEM_RELEASE_ENV to '8-latest'
         # to tag the updated system correctly
-        SYSTEM_RELEASE_ENV: oracle-8.7
+        SYSTEM_RELEASE_ENV: oracle-8-latest
       when: distro == oraclelinux-8.6
 
 prepare:

--- a/tests/ansible_collections/roles/add-custom-repos/main.yml
+++ b/tests/ansible_collections/roles/add-custom-repos/main.yml
@@ -7,6 +7,6 @@
   # When Oracle Linux 8.7 is released, the "8.6" needs to change to "8.7" and the
   # "8.6" is to be moved to the condition below related to enabling RHEL 8 EUS repos
 - import_playbook: rhel8-repos.yml
-  when: ansible_facts['distribution_version'] == "8.5" or ansible_facts['distribution_version'] == "8.7"
+  when: ansible_facts['distribution_version'] == "8.5" or ansible_facts['distribution_version'] == "8.8"
 - import_playbook: rhel8-eus-repos.yml
   when: ansible_facts['distribution_version'] == "8.4"

--- a/tests/integration/tier0/custom-kernel/test_custom_kernel.py
+++ b/tests/integration/tier0/custom-kernel/test_custom_kernel.py
@@ -30,7 +30,7 @@ DISTRO_KERNEL_MAPPING = {
         "grub_substring": "Oracle Linux Server 7.9, with Linux 3.10.0-1160.el7.x86_64",
     },
     # Install CentOS 8.5 kernel
-    "oracle-8.7": {
+    "oracle-8-latest": {
         "original_kernel": f"{ORIGINAL_KERNEL}",
         "custom_kernel": "https://vault.centos.org/centos/8.5.2111/BaseOS/x86_64/os/Packages/kernel-core-4.18.0-348.7.1.el8_5.x86_64.rpm",
         "grub_substring": "CentOS Linux (4.18.0-348.7.1.el8_5.x86_64) 8",

--- a/tests/integration/tier1/checks-after-conversion/test_release_version.py
+++ b/tests/integration/tier1/checks-after-conversion/test_release_version.py
@@ -19,6 +19,7 @@ DISTRO_CONVERSION_MAPPING = {
     "Red Hat Enterprise Linux release 8.4 (Ootpa)": ({"id": "null", "name": "CentOS Linux", "version": "8.4"},),
     "Red Hat Enterprise Linux release 8.5 (Ootpa)": ({"id": "null", "name": "CentOS Linux", "version": "8.5"},),
     "Red Hat Enterprise Linux release 8.7 (Ootpa)": ({"id": "null", "name": "Oracle Linux Server", "version": "8.7"},),
+    "Red Hat Enterprise Linux release 8.8 (Ootpa)": ({"id": "null", "name": "Oracle Linux Server", "version": "8.8"},),
 }
 
 

--- a/tests/integration/tier1/kernel-boot-files/test_handle_missing_boot_files.py
+++ b/tests/integration/tier1/kernel-boot-files/test_handle_missing_boot_files.py
@@ -54,7 +54,7 @@ def test_missing_kernel_boot_files(convert2rhel, shell):
     """
 
     kernel_name = "kernel"
-    if re.match(r"^(centos|oracle|alma|rocky)-8\.\d$", SYSTEM_RELEASE_ENV):
+    if re.match(r"^(centos|oracle|alma|rocky)-8(\.\d|-latest)$", SYSTEM_RELEASE_ENV):
         kernel_name = "kernel-core"
 
     with convert2rhel(


### PR DESCRIPTION
* change respective values to expect the new minor
* switch SYSTEM_RELEASE_ENV to oracle-8-latest to lower the overhead needed for changing test values

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1016](https://issues.redhat.com/browse/RHELC-1016)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
