### PR TITLE
Try custom action for test dispatch

### DIFF
--- a/.github/workflows/label-comment-tests.yml
+++ b/.github/workflows/label-comment-tests.yml
@@ -1,0 +1,22 @@
+name: Run tests on run-tests Label
+
+on:
+  pull_request_target:
+    types: [
+      # Default types from `pull_request_target` event
+      opened, synchronize, reopened,
+      # Trigger on labels
+      labeled
+    ]
+    branches: [ main ]
+
+jobs:
+  add-comment:
+    if: contains(github.event.pull_request.labels.*.name, 'run-integration-tests')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: '/packit test'

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -6,33 +6,33 @@ upstream_project_url: https://github.com/oamg/convert2rhel
 srpm_build_deps: []
 
 jobs:
-- job: copr_build
-  trigger: pull_request
-  owner: "@oamg"
-  project: convert2rhel
-  targets:
-  - epel-7-x86_64
-  - epel-8-x86_64
-  actions:
-    # do not get the version from a tag (git describe) but from the spec file
-    get-current-version:
-    - grep -oP '^Version:\s+\K\S+' packaging/convert2rhel.spec
-- job: copr_build
-  trigger: commit
-  branch: main
-  owner: "@oamg"
-  project: convert2rhel
-  targets:
-  - epel-7-x86_64
-  - epel-8-x86_64
-  actions:
-    # bump spec so we get release starting with 2 and hence all the default branch builds will
-    # have higher NVR than all the PR builds
-    post-upstream-clone:
-    - rpmdev-bumpspec --comment='latest upstream build' ./packaging/convert2rhel.spec
-    # do not get the version from a tag (git describe) but from the spec file
-    get-current-version:
-    - grep -oP '^Version:\s+\K\S+' packaging/convert2rhel.spec
+#- job: copr_build
+#  trigger: pull_request
+#  owner: "@oamg"
+#  project: convert2rhel
+#  targets:
+#  - epel-7-x86_64
+#  - epel-8-x86_64
+#  actions:
+#    # do not get the version from a tag (git describe) but from the spec file
+#    get-current-version:
+#    - grep -oP '^Version:\s+\K\S+' packaging/convert2rhel.spec
+#- job: copr_build
+#  trigger: commit
+#  branch: main
+#  owner: "@oamg"
+#  project: convert2rhel
+#  targets:
+#  - epel-7-x86_64
+#  - epel-8-x86_64
+#  actions:
+#    # bump spec so we get release starting with 2 and hence all the default branch builds will
+#    # have higher NVR than all the PR builds
+#    post-upstream-clone:
+#    - rpmdev-bumpspec --comment='latest upstream build' ./packaging/convert2rhel.spec
+#    # do not get the version from a tag (git describe) but from the spec file
+#    get-current-version:
+#    - grep -oP '^Version:\s+\K\S+' packaging/convert2rhel.spec
 
 - &tests
   job: tests
@@ -47,7 +47,8 @@ jobs:
         # Even though the distro context is 8.6 we are setting the SYSTEM_RELEASE_ENV to 8.7
         # to tag the updated system correctly
       distros: [centos-8.4, centos-8-latest, oraclelinux-8.6]
-  trigger: pull_request
+  trigger: commit
+  branch: main
   identifier: "tier0"
   tmt_plan: "tier0"
   # Run on Red Testing Farm Hat Ranch, tag resources to sst_conversions
@@ -63,8 +64,3 @@ jobs:
   <<: *tests
   identifier: "tier1"
   tmt_plan: "tier1"
-
-- &main
-  <<: *tests
-  trigger: commit
-  branch: main


### PR DESCRIPTION
* sometimes the PR is not ready to have the whole test suite run when opened
* lower the infrastructure load with custom action
* when PR is labeled with `run-integration-tests` a comment `/packit test` is issued to run the verification tests

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
