### PR TITLE
hotfix/tests/Enable tier1 tests for commit to main

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -64,7 +64,14 @@ jobs:
   identifier: "tier1"
   tmt_plan: "tier1"
 
-- &main
+- &main-tier0
   <<: *tests
   trigger: commit
   branch: main
+
+- &main-tier1
+  <<: *tests
+  trigger: commit
+  branch: main
+  identifier: "tier1"
+  tmt_plan: "tier1"


### PR DESCRIPTION
* with the tier0 and tier1 pipeline split the tier1 did not get enabled correctly
* enable to not lose regression tracking for tier1

