### PR TITLE
[RHELC-975] Output the pre-assessment as a json file.

### DIFF
--- a/convert2rhel/actions/report.py
+++ b/convert2rhel/actions/report.py
@@ -32,7 +32,7 @@ from convert2rhel.logger import colorize
 logger = logging.getLogger(__name__)
 
 #: The filename to store the results of running preassessment
-CONVERT2RHEL_JSON_RESULTS = "/etc/convert2rhel-assessment.json"
+CONVERT2RHEL_JSON_RESULTS = "/var/log/convert2rhel/convert2rhel-report.json"
 
 #: Map Status codes (from convert2rhel.actions.STATUS_CODE) to color name (from
 #: convert2rhel.logger.bcolor)

--- a/convert2rhel/actions/report.py
+++ b/convert2rhel/actions/report.py
@@ -15,7 +15,7 @@
 
 __metaclass__ = type
 
-
+import json
 import logging
 import textwrap
 
@@ -30,6 +30,9 @@ from convert2rhel.logger import colorize
 
 
 logger = logging.getLogger(__name__)
+
+#: The filename to store the results of running preassessment
+CONVERT2RHEL_JSON_RESULTS = "/etc/convert2rhel-assessment.json"
 
 #: Map Status codes (from convert2rhel.actions.STATUS_CODE) to color name (from
 #: convert2rhel.logger.bcolor)
@@ -46,6 +49,12 @@ _STATUS_TO_COLOR = {
     # ERROR
     202: "FAIL",
 }
+
+
+def summary_as_json(results, json_file=CONVERT2RHEL_JSON_RESULTS):
+    """Output the results as a json_file."""
+    with open(json_file, "w") as f:
+        json.dump(results, f)
 
 
 def summary(results, include_all_reports=False, with_colors=True):

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -75,6 +75,8 @@ def main():
 
     # handle command line arguments
     toolopts.CLI()
+
+    pre_conversion_results = None
     try:
         process_phase = ConversionPhase.POST_CLI
         perform_boilerplate()
@@ -86,7 +88,6 @@ def main():
         # we don't fail in case rollback is triggered during
         # actions.run_actions() (either from a bug or from the user hitting
         # Ctrl-C)
-        pre_conversion_results = None
         process_phase = ConversionPhase.PRE_PONR_CHANGES
         pre_conversion_results = actions.run_actions()
 
@@ -176,6 +177,11 @@ def main():
             )
             subscription.update_rhsm_custom_facts()
         return 1
+    finally:
+        # Write the assessment to a file as json data so that other tools can
+        # parse and act upon it.
+        if pre_conversion_results:
+            actions.report.summary_as_json(pre_conversion_results)
 
     return 0
 

--- a/convert2rhel/unit_tests/actions/report_test.py
+++ b/convert2rhel/unit_tests/actions/report_test.py
@@ -15,6 +15,8 @@
 
 __metaclass__ = type
 
+import json
+import os.path
 import re
 
 import pytest
@@ -25,6 +27,33 @@ from convert2rhel.logger import bcolors
 
 #: _LONG_MESSAGE since we do line wrapping
 _LONG_MESSAGE = "Will Robinson!  Will Robinson!  Danger Will Robinson...!  Please report directly to your parents in the spaceship immediately.  Danger!  Danger!  Danger!"
+
+
+@pytest.mark.parametrize(
+    ("results",),
+    (
+        (
+            {
+                "CONVERT2RHEL_LATEST_VERSION": {
+                    "result": dict(level=STATUS_CODE["SUCCESS"]),
+                    "messages": [
+                        dict(level=STATUS_CODE["WARNING"], id="WARNING_ONE", message="A warning message"),
+                    ],
+                },
+            },
+        ),
+    ),
+)
+def test_summary_as_json(results, tmpdir):
+    """Test that the results that we're given are what is written to the json log file."""
+    json_report_file = os.path.join(str(tmpdir), "c2r-assessment.json")
+
+    report.summary_as_json(results, json_report_file)
+
+    with open(json_report_file, "r") as f:
+        file_contents = json.load(f)
+
+    assert file_contents == results
 
 
 @pytest.mark.parametrize(

--- a/convert2rhel/unit_tests/actions/report_test.py
+++ b/convert2rhel/unit_tests/actions/report_test.py
@@ -30,7 +30,7 @@ _LONG_MESSAGE = "Will Robinson!  Will Robinson!  Danger Will Robinson...!  Pleas
 
 
 @pytest.mark.parametrize(
-    ("results",),
+    ("results", "expected"),
     (
         (
             {
@@ -41,10 +41,21 @@ _LONG_MESSAGE = "Will Robinson!  Will Robinson!  Danger Will Robinson...!  Pleas
                     ],
                 },
             },
+            {
+                "format_version": "1.0",
+                "actions": {
+                    "CONVERT2RHEL_LATEST_VERSION": {
+                        "result": dict(level="SUCCESS"),
+                        "messages": [
+                            dict(level="WARNING", id="WARNING_ONE", message="A warning message"),
+                        ],
+                    },
+                },
+            },
         ),
     ),
 )
-def test_summary_as_json(results, tmpdir):
+def test_summary_as_json(results, expected, tmpdir):
     """Test that the results that we're given are what is written to the json log file."""
     json_report_file = os.path.join(str(tmpdir), "c2r-assessment.json")
 
@@ -53,7 +64,7 @@ def test_summary_as_json(results, tmpdir):
     with open(json_report_file, "r") as f:
         file_contents = json.load(f)
 
-    assert file_contents == results
+    assert file_contents == expected
 
 
 @pytest.mark.parametrize(

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -228,6 +228,7 @@ def test_main(monkeypatch):
     finish_collection_mock = mock.Mock()
     check_kernel_boot_files_mock = mock.Mock()
     update_rhsm_custom_facts_mock = mock.Mock()
+    summary_as_json_mock = mock.Mock()
 
     monkeypatch.setattr(utils, "require_root", require_root_mock)
     monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
@@ -251,6 +252,7 @@ def test_main(monkeypatch):
     monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
     monkeypatch.setattr(checks, "check_kernel_boot_files", check_kernel_boot_files_mock)
     monkeypatch.setattr(subscription, "update_rhsm_custom_facts", update_rhsm_custom_facts_mock)
+    monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
 
     assert main.main() == 0
     assert require_root_mock.call_count == 1
@@ -273,6 +275,7 @@ def test_main(monkeypatch):
     assert finish_collection_mock.call_count == 1
     assert check_kernel_boot_files_mock.call_count == 1
     assert update_rhsm_custom_facts_mock.call_count == 1
+    assert summary_as_json_mock.call_count == 1
 
 
 def test_main_rollback_post_cli_phase(monkeypatch, caplog):
@@ -317,6 +320,7 @@ def test_main_rollback_pre_ponr_changes_phase(monkeypatch, caplog):
     # Mock the rollback calls
     finish_collection_mock = mock.Mock()
     rollback_changes_mock = mock.Mock()
+    summary_as_json_mock = mock.Mock()
 
     monkeypatch.setattr(utils, "require_root", require_root_mock)
     monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
@@ -333,6 +337,7 @@ def test_main_rollback_pre_ponr_changes_phase(monkeypatch, caplog):
     monkeypatch.setattr(actions, "find_actions_of_severity", find_actions_of_severity_mock)
     monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
     monkeypatch.setattr(main, "rollback_changes", rollback_changes_mock)
+    monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
 
     assert main.main() == 1
     assert require_root_mock.call_count == 1
@@ -349,6 +354,7 @@ def test_main_rollback_pre_ponr_changes_phase(monkeypatch, caplog):
     assert clear_versionlock_mock.call_count == 1
     assert finish_collection_mock.call_count == 1
     assert rollback_changes_mock.call_count == 1
+    assert summary_as_json_mock.call_count == 1
     assert caplog.records[-2].message == "Conversion failed."
     assert caplog.records[-2].levelname == "CRITICAL"
 
@@ -366,6 +372,7 @@ def test_main_rollback_analyze_exit_phase(global_tool_opts, monkeypatch):
     run_actions_mock = mock.Mock()
     report_summary_mock = mock.Mock()
     clear_versionlock_mock = mock.Mock()
+    summary_as_json_mock = mock.Mock()
 
     # Mock the rollback calls
     finish_collection_mock = mock.Mock()
@@ -386,6 +393,7 @@ def test_main_rollback_analyze_exit_phase(global_tool_opts, monkeypatch):
     monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
     monkeypatch.setattr(main, "rollback_changes", rollback_changes_mock)
     monkeypatch.setattr(os, "environ", {"CONVERT2RHEL_EXPERIMENTAL_ANALYSIS": 1})
+    monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
     global_tool_opts.activity = "analysis"
 
     assert main.main() == 0
@@ -402,6 +410,7 @@ def test_main_rollback_analyze_exit_phase(global_tool_opts, monkeypatch):
     assert clear_versionlock_mock.call_count == 1
     assert finish_collection_mock.call_count == 1
     assert rollback_changes_mock.call_count == 1
+    assert summary_as_json_mock.call_count == 1
 
 
 def test_main_rollback_post_ponr_changes_phase(monkeypatch, caplog):
@@ -420,6 +429,7 @@ def test_main_rollback_post_ponr_changes_phase(monkeypatch, caplog):
     clear_versionlock_mock = mock.Mock()
     ask_to_continue_mock = mock.Mock()
     post_ponr_conversion_mock = mock.Mock(side_effect=Exception)
+    summary_as_json_mock = mock.Mock()
 
     # Mock the rollback calls
     finish_collection_mock = mock.Mock()
@@ -442,6 +452,7 @@ def test_main_rollback_post_ponr_changes_phase(monkeypatch, caplog):
     monkeypatch.setattr(main, "post_ponr_conversion", post_ponr_conversion_mock)
     monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
     monkeypatch.setattr(subscription, "update_rhsm_custom_facts", update_rhsm_custom_facts_mock)
+    monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
 
     assert main.main() == 1
     assert require_root_mock.call_count == 1
@@ -459,5 +470,6 @@ def test_main_rollback_post_ponr_changes_phase(monkeypatch, caplog):
     assert ask_to_continue_mock.call_count == 1
     assert post_ponr_conversion_mock.call_count == 1
     assert finish_collection_mock.call_count == 1
+    assert summary_as_json_mock.call_count == 1
     assert "The system is left in an undetermined state that Convert2RHEL cannot fix." in caplog.records[-1].message
     assert update_rhsm_custom_facts_mock.call_count == 1


### PR DESCRIPTION
For integration with insights and other tools, we need to output the assessment report as a json file.

Jira Issues: [RHELC-975](https://issues.redhat.com/browse/RHELC-975)


### Open questions:
- [x] What file should it write?
  - Rodolfo thinks it makes more sense alongside the breadcrumbs output.  I've moved it to `/etc/convert2rhel-assessment.json` for now.
- [x] Is action.report the right place for the function to live? 
  - Rodolfo agrees that this location makes sense. 
- [x] Is writing the file after the results are returned the right place or should it be done nearer to where the breadcrumbs are written?  (maybe in a finally: in main.py))
  - Rodolfo thinks that `finally:` in main.py makes more sense so I will make this change. 

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
