### PR TITLE
[RHELC-824] Add remaining distros for the offline conversion test

### DIFF
--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -178,11 +178,11 @@ description+: |
 
 
     /convert_offline_systems:
-        # At the moment we have only CentOS7 repos available on Satellite server
         adjust+:
-            - enabled: false
-              when: >
-                distro != centos-7
+          # Disabled due to known issue: https://issues.redhat.com/browse/RHELC-1040
+          # Enable once this gets fixed
+          - enabled: false
+            when: distro == oraclelinux-7
         discover+:
             filter: tag:checks-after-conversion
         prepare+:

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -185,7 +185,7 @@ description+: |
         discover+:
             filter: tag:checks-after-conversion
         prepare+:
-            - name: modify /etc/default/grub with valid changes
+            - name: modify grub config file with valid changes
               how: shell
               script: pytest -svv tests/integration/*/destructive/changed-grub-file/test_valid_changed_grub.py
             - name: reboot after conversion
@@ -196,7 +196,7 @@ description+: |
         discover+:
             filter: tag:checks-after-conversion
         prepare+:
-            - name: modify /etc/default/grub with invalid changes
+            - name: modify grub config with invalid changes
               how: shell
               script: pytest -svv tests/integration/*/destructive/changed-grub-file/test_invalid_changed_grub.py
             - name: reboot after conversion

--- a/tests/integration/tier0/destructive/convert-offline-systems/prepare_system.py
+++ b/tests/integration/tier0/destructive/convert-offline-systems/prepare_system.py
@@ -1,7 +1,7 @@
 import re
 import socket
 
-from conftest import SATELLITE_PKG_DST, SATELLITE_PKG_URL, SATELLITE_URL
+from conftest import SATELLITE_PKG_DST, SATELLITE_PKG_URL, SATELLITE_URL, SYSTEM_RELEASE_ENV
 from envparse import env
 
 
@@ -51,10 +51,18 @@ def test_prepare_system(shell):
     shell("rm -rf /etc/yum.repos.d/*")
 
     # Subscribe system
+    if "centos-7" in SYSTEM_RELEASE_ENV:
+        satellite_key = env.str("SATELLITE_OFFLINE_KEY_CENTOS7")
+    elif "centos-8" in SYSTEM_RELEASE_ENV:
+        satellite_key = env.str("SATELLITE_OFFLINE_KEY_CENTOS8")
+    elif "oracle-7" in SYSTEM_RELEASE_ENV:
+        satellite_key = env.str("SATELLITE_OFFLINE_KEY_ORACLE7")
+    elif "oracle-8" in SYSTEM_RELEASE_ENV:
+        satellite_key = env.str("SATELLITE_OFFLINE_KEY_ORACLE8")
     assert (
         shell(
             ("subscription-manager register --org={} --activationkey={}").format(
-                env.str("SATELLITE_ORG"), env.str("SATELLITE_KEY_CENTOS7")
+                env.str("SATELLITE_ORG"), satellite_key
             )
         ).returncode
         == 0


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
Previously we added an offline conversion test. However, it was run only for the centos-7. 
The required repositories are present on the satellite instance also for the remaining distributions.


This PR enables running tests of other distros for the offline conversion test. 

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-824](https://issues.redhat.com/browse/RHELC-824)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
