### PR TITLE
[RHELC-1000] Change datetime to ISO with timezone to be standardized

### DIFF
--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -211,7 +211,7 @@ class CustomFormatter(logging.Formatter, object):
             fmt_orig = "\n[%(asctime)s] %(levelname)s - [%(message)s] " + temp
             new_fmt = fmt_orig if self.color_disabled else colorize(fmt_orig, "OKGREEN")
             self._fmt = new_fmt
-            self.datefmt = "%m/%d/%Y %H:%M:%S"
+            self.datefmt = "%Y-%m-%dT%H:%M:%S%z"
         elif record.levelno in [logging.INFO]:
             self._fmt = "%(message)s"
             self.datefmt = ""
@@ -227,7 +227,7 @@ class CustomFormatter(logging.Formatter, object):
             self.datefmt = ""
         else:
             self._fmt = "[%(asctime)s] %(levelname)s - %(message)s"
-            self.datefmt = "%m/%d/%Y %H:%M:%S"
+            self.datefmt = "%Y-%m-%dT%H:%M:%S%z"
 
         if hasattr(self, "_style"):
             # Python 3 has _style for formatter


### PR DESCRIPTION
The default for convert2rhel was using format that wasn't standardized.
This changes it from "mm/dd/yyyy HH:mm:ss" format to "yyyy-mm-ddTHH:mm:ssZ"

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1000](https://issues.redhat.com/browse/RHELC-1000)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
