### PR TITLE
[RHELC-873] tests/Remove workaround for three kernels installed

### DIFF
--- a/tests/integration/tier1/destructive/system-up-to-date/test_system_up_to_date.py
+++ b/tests/integration/tier1/destructive/system-up-to-date/test_system_up_to_date.py
@@ -68,15 +68,6 @@ def test_system_not_updated(shell, convert2rhel):
     centos_8_pkg_url = "https://vault.centos.org/8.1.1911/BaseOS/x86_64/os/Packages/wpa_supplicant-2.7-1.el8.x86_64.rpm"
 
     if "centos-8" in SYSTEM_RELEASE_ENV:
-        # The dnf transaction calculation fails if the maximum number of kernels that can be installed has been reached:
-        # "package kernel-4.18.0-348.23.1.el8_5.x86_64 requires kernel-core-uname-r = 4.18.0-348.23.1.el8_5.x86_64,
-        #     but none of the providers can be installed"
-        # To us now the only known solution is to remove the oldest kernel before proceeding.
-        oldest_kernel = shell(
-            "rpm -q --qf '%{BUILDTIME}\t%{EVR}.%{ARCH}\n' kernel | sort -n | head -1 | cut -f2"
-        ).output.strip()
-        assert shell("yum remove -y kernel*{0}".format(oldest_kernel)).returncode == 0
-
         # Try to downgrade two packages.
         # On CentOS-8 we cannot do the downgrade as the repos contain only the latest package version.
         # We need to install package from older repository as a workaround.


### PR DESCRIPTION
* the workaround removed the oldest kernel installed on the system to get around issues with yum/dnf transaction validation
* this issue was possibly fixed with the transaction validation tweaks in #833
* subsequently the removal allows verifying the issue 

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-873](https://issues.redhat.com/browse/RHELC-873)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
