### PR TITLE
Replaced --disable-submgr with --no-rhsm.

### DIFF
--- a/tests/integration/tier0/destructive/method/custom_repos.py
+++ b/tests/integration/tier0/destructive/method/custom_repos.py
@@ -43,7 +43,7 @@ def test_run_conversion_using_custom_repos(shell, convert2rhel):
                     "--enablerepo rhel-8-for-x86_64-baseos-rpms --enablerepo rhel-8-for-x86_64-appstream-rpms"
                 )
 
-    with convert2rhel("-y --no-rpm-va --disable-submgr {} --debug".format(enable_repo_opt)) as c2r:
+    with convert2rhel("-y --no-rpm-va --no-rhsm {} --debug".format(enable_repo_opt)) as c2r:
         c2r.expect("Conversion successful!")
     assert c2r.exitstatus == 0
 

--- a/tests/integration/tier0/non-destructive/custom-repository/test_custom_repository.py
+++ b/tests/integration/tier0/non-destructive/custom-repository/test_custom_repository.py
@@ -88,7 +88,7 @@ def test_good_conversion_without_rhsm(shell, convert2rhel):
     prepare_custom_repository(shell)
 
     with convert2rhel(
-        "-y --no-rpm-va --disable-submgr {} --debug".format(AssignRepositoryVariables.enable_repo_opt), unregister=True
+        "-y --no-rpm-va --no-rhsm {} --debug".format(AssignRepositoryVariables.enable_repo_opt), unregister=True
     ) as c2r:
         c2r.expect("The repositories passed through the --enablerepo option are all accessible.")
         c2r.sendcontrol("c")
@@ -107,7 +107,7 @@ def test_bad_conversion_without_rhsm(shell, convert2rhel):
     prepare_custom_repository(shell)
 
     with convert2rhel(
-        "-y --no-rpm-va --disable-submgr --enablerepo fake-rhel-8-for-x86_64-baseos-rpms --debug", unregister=True
+        "-y --no-rpm-va --no-rhsm --enablerepo fake-rhel-8-for-x86_64-baseos-rpms --debug", unregister=True
     ) as c2r:
         c2r.expect(
             "CUSTOM_REPOSITORIES_ARE_VALID.UNABLE_TO_ACCESS_REPOSITORIES: Unable to access the repositories passed through the --enablerepo option. "

--- a/tests/integration/tier1/destructive/one-kernel-scenario/run_conversion.py
+++ b/tests/integration/tier1/destructive/one-kernel-scenario/run_conversion.py
@@ -38,7 +38,7 @@ def test_run_conversion_using_custom_repos(shell, convert2rhel):
     # not being updated. Mitigate the issues by exporting CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS.
     os.environ["CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS"] = "1"
 
-    with convert2rhel("-y --no-rpm-va --disable-submgr {} --debug".format(enable_repo_opt)) as c2r:
+    with convert2rhel("-y --no-rpm-va --no-rhsm {} --debug".format(enable_repo_opt)) as c2r:
         c2r.expect("Conversion successful!")
 
     assert c2r.exitstatus == 0


### PR DESCRIPTION
We decided that --no-rhsm was a better name for this option but kept --disable-submgr for backwards compatibility.  Test --no-rhsm in integration tests since it is the preferred name.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
