### PR TITLE
[RHELC-1040] Fix package back up during an offline conversion

### DIFF
--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -178,11 +178,6 @@ description+: |
 
 
     /convert_offline_systems:
-        adjust+:
-          # Disabled due to known issue: https://issues.redhat.com/browse/RHELC-1040
-          # Enable once this gets fixed
-          - enabled: false
-            when: distro == oraclelinux-7
         discover+:
             filter: tag:checks-after-conversion
         prepare+:


### PR DESCRIPTION
When the main transaction validation finds a package dependency problem, we try to remove the package that causes the problem. Before removing it we are backing it up so that we can install it back during a rollback.
This backup was failing on systems not connected to the internet.

Jira Issues: [RHELC-1040](https://issues.redhat.com/browse/RHELC-1040)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
