### PR TITLE
[RHELC-1056] Fix lsmod not being found on OL7

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
+++ b/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
@@ -49,7 +49,7 @@ class EnsureKernelModulesCompatibility(actions.Action):
         kernel modules in case of different kernel release
         """
         logger.debug("Getting a list of loaded kernel modules.")
-        lsmod_output, _ = run_subprocess(["lsmod"], print_output=False)
+        lsmod_output, _ = run_subprocess(["/usr/sbin/lsmod"], print_output=False)
         modules = re.findall(r"^(\w+)\s.+$", lsmod_output, flags=re.MULTILINE)[1:]
         kernel_modules = [
             self._get_kmod_comparison_key(run_subprocess(["modinfo", "-F", "filename", module], print_output=False)[0])

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
@@ -287,7 +287,7 @@ def test_get_loaded_kmods(ensure_kernel_modules_compatibility_instance, monkeypa
         spec=run_subprocess,
         side_effect=run_subprocess_side_effect(
             (
-                ("lsmod",),
+                ("/usr/sbin/lsmod",),
                 (
                     "Module                  Size  Used by\n"
                     "a                 81920  4\n"

--- a/packaging/convert2rhel.spec
+++ b/packaging/convert2rhel.spec
@@ -37,6 +37,7 @@ BuildRequires:  rpm-python
 # We need to talk to subscription-manager over dbus
 Requires:       dbus
 Requires:       efibootmgr
+Requires:       kmod
 Requires:       rpm
 Requires:       python%{python_pkgversion}
 Requires:       python%{python_pkgversion}-setuptools


### PR DESCRIPTION
The lsmod binary may not always be available through PATH, better to call it using its full installation path.
Also the package that installs this binary was missing in the spec file as a dependency of convert2rhel.

Jira Issues: [RHELC-1056](https://issues.redhat.com/browse/RHELC-1056)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
