### PR TITLE
[RHELC-1037] Auto-generate manpages

### DIFF
--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -1,0 +1,27 @@
+name: Generate Manpages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  generate-manpages:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+
+      - name: Install dependencies
+        run: pip install argparse-manpages
+
+      - name: Generate Manpages
+        run: |
+          chmod +x scripts/manpage_generate.sh
+          bash scripts/manpage_generate.sh

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -23,5 +23,5 @@ jobs:
 
       - name: Generate Manpages
         run: |
-          chmod +x scripts/manpage_generate.sh
-          bash scripts/manpage_generate.sh
+          chmod +x scripts/manpage_generation.sh
+          bash scripts/manpage_generation.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Trigger Manpage Generation
+        uses: ./.github/workflows
+        with:
+          workflow: generate_manpage.yml
+
       - name: Build RPM package for EL7
         id: rpm_build_el7
         uses: bocekm/rpmbuild@el7

--- a/scripts/manpage_generation.sh
+++ b/scripts/manpage_generation.sh
@@ -9,4 +9,4 @@ VER=$(grep -oP '^Version:\s+\K\S+' packaging/convert2rhel.spec)
 python -c 'from convert2rhel import toolopts; print("[synopsis]\n."+toolopts.CLI.usage())' > man/synopsis
 
 # Generate the manpage using argparse-manpage
-PYTHONPATH=. argparse-manpage --pyfile man/__init__.py --function get_parser --manual-title="General Commands Manual" --description="Automates the conversion of Red Hat Enterprise Linux derivative distributions to Red Hat Enterprise Linux." --project-name "convert2rhle $Ver" --prog="convert2rhel" --include man/distribution --include man/synopsis > "$MANPAGE_DIR/convert2rhel.8"
+PYTHONPATH=. argparse-manpage --pyfile man/__init__.py --function get_parser --manual-title="General Commands Manual" --description="Automates the conversion of Red Hat Enterprise Linux derivative distributions to Red Hat Enterprise Linux." --project-name "convert2rhel $Ver" --prog="convert2rhel" --include man/distribution --include man/synopsis > "$MANPAGE_DIR/convert2rhel.8"

--- a/scripts/manpage_generation.sh
+++ b/scripts/manpage_generation.sh
@@ -9,4 +9,4 @@ VER=$(grep -oP '^Version:\s+\K\S+' packaging/convert2rhel.spec)
 python -c 'from convert2rhel import toolopts; print("[synopsis]\n."+toolopts.CLI.usage())' > man/synopsis
 
 # Generate the manpage using argparse-manpage
-PYTHONPATH=. argparse-manpage --pyfile man/__init__.py --function get_parser --manual-title="General Commands Manual" --description="Automates the conversion of Red Hat Enterprise Linux derivative distributions to Red Hat Enterprise Linux." --project-name "convert2rhel $Ver" --prog="convert2rhel" --include man/distribution --include man/synopsis > "$MANPAGE_DIR/convert2rhel.8"
+PYTHONPATH=. argparse-manpage --pyfile man/__init__.py --function get_parser --manual-title="General Commands Manual" --description="Automates the conversion of Red Hat Enterprise Linux derivative distributions to Red Hat Enterprise Linux." --project-name "convert2rhel $VER" --prog="convert2rhel" --include man/distribution --include man/synopsis > "$MANPAGE_DIR/convert2rhel.8"

--- a/scripts/manpage_generation.sh
+++ b/scripts/manpage_generation.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Directory to store the generated manpages
+MANPAGE_DIR="man"
+
+VER=$(grep -oP '^Version:\s+\K\S+' packaging/convert2rhel.spec)
+
+# Generate the manpage using argparse-manpage
+PYTHONPATH=. argparse-manpage --pyfile man/__init__.py --function get_parser --manual-title="General Commands Manual" --description="Automates the conversion of Red Hat Enterprise Linux derivative distributions to Red Hat Enterprise Linux." --project-name "convert2rhle $Ver" --prog="convert2rhel" --include man/distribution --include man/synopsis > "$MANPAGE_DIR/convert2rhel.8"

--- a/scripts/manpage_generation.sh
+++ b/scripts/manpage_generation.sh
@@ -5,5 +5,8 @@ MANPAGE_DIR="man"
 
 VER=$(grep -oP '^Version:\s+\K\S+' packaging/convert2rhel.spec)
 
+# Generate a file with convert2rhel synopsis for argparse-manpage
+python -c 'from convert2rhel import toolopts; print("[synopsis]\n."+toolopts.CLI.usage())' > man/synopsis
+
 # Generate the manpage using argparse-manpage
 PYTHONPATH=. argparse-manpage --pyfile man/__init__.py --function get_parser --manual-title="General Commands Manual" --description="Automates the conversion of Red Hat Enterprise Linux derivative distributions to Red Hat Enterprise Linux." --project-name "convert2rhle $Ver" --prog="convert2rhel" --include man/distribution --include man/synopsis > "$MANPAGE_DIR/convert2rhel.8"


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
Convert2RHEL has moved away from using optparse, and we have decided to use argparse to generate our manpages now; this PR will change this by adding in a bash script to generate the manpages using argparse, and then it will be automated using GitHub actions.
<!-- Link to relevant Jira issue, add multiple if necessary -->
Jira Issues: [RHELC-1037](https://issues.redhat.com/browse/RHELC-1037)


Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
