### PR TITLE
[RHELC-1089] Add result OVERRIDABLE where ask_to_continue() was removed

### DIFF
--- a/convert2rhel/actions/__init__.py
+++ b/convert2rhel/actions/__init__.py
@@ -48,6 +48,7 @@ logger = logging.getLogger(__name__)
 #:      and start to use it with console.redhat.com
 #:
 #: :SUCCESS: no problem.
+#: :INFO: informational message to the user, no problem.
 #: :WARNING: the problem is just a warning displayed to the user. (unused,
 #:      warnings are currently emitted directly from the Action).
 #: :SKIP: the action could not be run because a dependent Action failed.
@@ -67,6 +68,7 @@ logger = logging.getLogger(__name__)
 #:        runs the Actions will set this.
 STATUS_CODE = {
     "SUCCESS": 0,
+    "INFO": 25,
     "WARNING": 51,
     "SKIP": 101,
     "OVERRIDABLE": 152,
@@ -109,10 +111,6 @@ def _action_defaults_to_success(func):
         return return_value
 
     return wrapper
-
-
-#: Used as a sentinel value for Action.set_result() method.
-_NO_USER_VALUE = object()
 
 
 class ActionError(Exception):
@@ -277,6 +275,22 @@ class ActionMessageBase:
         self.id = id
         self.level = STATUS_CODE[level]
         self.message = message
+
+    def __eq__(self, other):
+        if self.level == other.level and self.id == other.id and self.message == other.message:
+            return True
+        return False
+
+    def __hash__(self):
+        return hash((self.level, self.id, self.message))
+
+    def __repr__(self):
+        return "%s(level=%s, id=%s, message=%s)" % (
+            self.__class__.__name__,
+            _STATUS_NAME_FROM_CODE[self.level],
+            self.id,
+            self.message,
+        )
 
     def to_dict(self):
         """

--- a/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
+++ b/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
@@ -215,6 +215,15 @@ class EnsureKernelModulesCompatibility(actions.Action):
                     " We will continue the conversion with the following kernel modules unavailable in RHEL:\n"
                     "{kmods}\n".format(kmods="\n".join(unsupported_kmods))
                 )
+                self.add_message(
+                    level="WARNING",
+                    id="ALLOW_UNAVAILABLE_KERNEL_MODULES",
+                    message=(
+                        "Detected 'CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS' environment variable."
+                        " We will continue the conversion with the following kernel modules unavailable in RHEL:\n"
+                        "{kmods}\n".format(kmods="\n".join(unsupported_kmods))
+                    ),
+                )
                 return
 
             # If there is any unsupported kmods found, set the result to error

--- a/convert2rhel/actions/pre_ponr_changes/subscription.py
+++ b/convert2rhel/actions/pre_ponr_changes/subscription.py
@@ -108,17 +108,6 @@ class SubscribeSystem(actions.Action):
             logger.task("Convert: Get RHEL repository IDs")
             rhel_repoids = repo.get_rhel_repoids()
 
-            logger.task("Convert: Subscription Manager - Check required repositories")
-            non_available_repos = subscription.check_needed_repos_availability(rhel_repoids)
-            if non_available_repos:
-
-                self.add_message(
-                    level="WARNING",
-                    id="NON_AVAILABLE_REPOSITORIES_DETECTED",
-                    message="%s repositories are not available - some packages"
-                    " may not be replaced and thus not supported." % ", ".join(non_available_repos),
-                )
-
             logger.task("Convert: Subscription Manager - Disable all repositories")
             subscription.disable_repos()
 

--- a/convert2rhel/actions/pre_ponr_changes/subscription.py
+++ b/convert2rhel/actions/pre_ponr_changes/subscription.py
@@ -32,6 +32,11 @@ class PreSubscription(actions.Action):
 
         if toolopts.tool_opts.no_rhsm:
             logger.warning("Detected --no-rhsm option. Skipping.")
+            self.add_message(
+                level="WARNING",
+                id="PRE_SUBSCRIPTION_CHECK_SKIP",
+                message="Detected --no-rhsm option. Skipping.",
+            )
             return
 
         try:
@@ -89,6 +94,11 @@ class SubscribeSystem(actions.Action):
 
         if toolopts.tool_opts.no_rhsm:
             logger.warning("Detected --no-rhsm option. Skipping.")
+            self.add_message(
+                level="WARNING",
+                id="PRE_SUBSCRIPTION_CHECK_SKIP",
+                message="Detected --no-rhsm option. Skipping.",
+            )
             return
 
         try:
@@ -99,7 +109,15 @@ class SubscribeSystem(actions.Action):
             rhel_repoids = repo.get_rhel_repoids()
 
             logger.task("Convert: Subscription Manager - Check required repositories")
-            subscription.check_needed_repos_availability(rhel_repoids)
+            non_available_repos = subscription.check_needed_repos_availability(rhel_repoids)
+            if non_available_repos:
+
+                self.add_message(
+                    level="WARNING",
+                    id="NON_AVAILABLE_REPOSITORIES_DETECTED",
+                    message="%s repositories are not available - some packages"
+                    " may not be replaced and thus not supported." % ", ".join(non_available_repos),
+                )
 
             logger.task("Convert: Subscription Manager - Disable all repositories")
             subscription.disable_repos()

--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -60,6 +60,11 @@ class Convert2rhelLatest(actions.Action):
 
         if not system_info.has_internet_access:
             logger.warning("Skipping the check because no internet connection has been detected.")
+            self.add_message(
+                level="WARNING",
+                id="CONVERT2RHEL_LATEST_CHECK_SKIP_NO_INTERNET",
+                message="Skipping the check because no internet connection has been detected.",
+            )
             return
 
         repo_dir = tempfile.mkdtemp(prefix="convert2rhel_repo.", dir=utils.TMP_DIR)
@@ -90,6 +95,14 @@ class Convert2rhelLatest(actions.Action):
             logger.warning(
                 "Couldn't check if the current installed Convert2RHEL is the latest version.\n"
                 "repoquery failed with the following output:\n%s" % (raw_output_convert2rhel_versions)
+            )
+            self.add_message(
+                level="WARNING",
+                id="CONVERT2RHEL_LATEST_CHECK_SKIP",
+                message=(
+                    "Couldn't check if the current installed Convert2RHEL is the latest version.\n"
+                    "repoquery failed with the following output:\n%s" % (raw_output_convert2rhel_versions)
+                ),
             )
             return
 
@@ -164,11 +177,28 @@ class Convert2rhelLatest(actions.Action):
                         " environment variable.  Please switch to 'CONVERT2RHEL_ALLOW_OLDER_VERSION'"
                         " instead."
                     )
-
+                    self.add_message(
+                        level="WARNING",
+                        id="DEPRECATED_ENVIRONMENT_VARIABLE",
+                        message=(
+                            "You are using the deprecated 'CONVERT2RHEL_UNSUPPORTED_VERSION'"
+                            " environment variable.  Please switch to 'CONVERT2RHEL_ALLOW_OLDER_VERSION'"
+                            " instead."
+                        ),
+                    )
                 logger.warning(
                     "You are currently running %s and the latest version of Convert2RHEL is %s.\n"
                     "'CONVERT2RHEL_ALLOW_OLDER_VERSION' environment variable detected, continuing conversion"
                     % (installed_convert2rhel_version, latest_available_version[1])
+                )
+                self.add_message(
+                    level="WARNING",
+                    id="ALLOW_OLDER_VERSION_ENVIRONMENT_VARIABLE",
+                    message=(
+                        "You are currently running %s and the latest version of Convert2RHEL is %s.\n"
+                        "'CONVERT2RHEL_ALLOW_OLDER_VERSION' environment variable detected, continuing conversion"
+                        % (installed_convert2rhel_version, latest_available_version[1])
+                    ),
                 )
 
             else:
@@ -177,6 +207,15 @@ class Convert2rhelLatest(actions.Action):
                         "You are currently running %s and the latest version of Convert2RHEL is %s.\n"
                         "We encourage you to update to the latest version."
                         % (installed_convert2rhel_version, latest_available_version[1])
+                    )
+                    self.add_message(
+                        level="WARNING",
+                        id="OUTDATED_CONVERT2RHEL_VERSION",
+                        message=(
+                            "You are currently running %s and the latest version of Convert2RHEL is %s.\n"
+                            "We encourage you to update to the latest version."
+                            % (installed_convert2rhel_version, latest_available_version[1])
+                        ),
                     )
 
                 else:

--- a/convert2rhel/actions/system_checks/custom_repos_are_valid.py
+++ b/convert2rhel/actions/system_checks/custom_repos_are_valid.py
@@ -39,6 +39,12 @@ class CustomReposAreValid(actions.Action):
 
         if not tool_opts.no_rhsm:
             logger.info("Skipping the check of repositories due to the use of RHSM for the conversion.")
+
+            self.add_message(
+                level="INFO",
+                id="CUSTOM_REPOSITORIES_ARE_VALID_CHECK_SKIP",
+                message="Skipping the check of repositories due to the use of RHSM for the conversion.",
+            )
             return
 
         output, ret_code = call_yum_cmd(

--- a/convert2rhel/actions/system_checks/dbus.py
+++ b/convert2rhel/actions/system_checks/dbus.py
@@ -35,6 +35,11 @@ class DbusIsRunning(actions.Action):
 
         if tool_opts.no_rhsm:
             logger.info("Skipping the check because we have been asked not to subscribe this system to RHSM.")
+            self.add_message(
+                level="WARNING",
+                id="DBUS_IS_RUNNING_CHECK_SKIP",
+                message="Skipping the check because we have been asked not to subscribe this system to RHSM.",
+            )
             return
 
         if system_info.dbus_running:

--- a/convert2rhel/actions/system_checks/efi.py
+++ b/convert2rhel/actions/system_checks/efi.py
@@ -63,7 +63,7 @@ class Efi(actions.Action):
             )
             return
 
-        # Get information about the bootloader. Currently the data is not used, but it's
+        # Get information about the bootloader. Currently, the data is not used, but it's
         # good to check that we can obtain all the required data before the PONR.
         try:
             efiboot_info = grub.EFIBootInfo()
@@ -77,6 +77,14 @@ class Efi(actions.Action):
             logger.warning(
                 "The current UEFI bootloader '%s' is not referring to any binary UEFI"
                 " file located on local EFI System Partition (ESP)." % efiboot_info.current_bootnum
+            )
+            self.add_message(
+                level="WARNING",
+                id="UEFI_BOOTLOADER_MISMATCH",
+                message=(
+                    "The current UEFI bootloader '%s' is not referring to any binary UEFI"
+                    " file located on local EFI System Partition (ESP)." % efiboot_info.current_bootnum
+                ),
             )
         # TODO(pstodulk): print warning when multiple orig. UEFI entries point
         # to the original system (e.g. into the centos/ directory..). The point is

--- a/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
+++ b/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
@@ -55,6 +55,11 @@ class IsLoadedKernelLatest(actions.Action):
         reposdir = get_hardcoded_repofiles_dir()
         if reposdir and not system_info.has_internet_access:
             logger.warning("Skipping the check as no internet connection has been detected.")
+            self.add_message(
+                level="WARNING",
+                id="IS_LOADED_KERNEL_LATEST_CHECK_SKIP",
+                message=("Skipping the check as no internet connection has been detected."),
+            )
             return
 
         # If the reposdir variable is not empty, meaning that it detected the
@@ -80,6 +85,15 @@ class IsLoadedKernelLatest(actions.Action):
                 "the %s comparison.\n"
                 "Beware, this could leave your system in a broken state." % package_to_check
             )
+            self.add_message(
+                level="WARNING",
+                id="UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK_DETECTED",
+                message=(
+                    "Detected 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip "
+                    "the %s comparison.\n"
+                    "Beware, this could leave your system in a broken state." % package_to_check
+                ),
+            )
             return
 
         # Look up for available kernel (or kernel-core) packages versions available
@@ -95,6 +109,14 @@ class IsLoadedKernelLatest(actions.Action):
             logger.warning(
                 "Couldn't fetch the list of the most recent kernels available in "
                 "the repositories. Skipping the loaded kernel check."
+            )
+            self.add_message(
+                level="WARNING",
+                id="UNABLE_TO_FETCH_RECENT_KERNELS",
+                message=(
+                    "Couldn't fetch the list of the most recent kernels available in "
+                    "the repositories. Skipping the loaded kernel check."
+                ),
             )
             return
 

--- a/convert2rhel/actions/system_checks/package_updates.py
+++ b/convert2rhel/actions/system_checks/package_updates.py
@@ -39,12 +39,25 @@ class PackageUpdates(actions.Action):
                 "Skipping the check because there are no publicly available %s %d.%d repositories available."
                 % (system_info.name, system_info.version.major, system_info.version.minor)
             )
+            self.add_message(
+                level="INFO",
+                id="PACKAGE_UPDATES_CHECK_SKIP_NO_PUBLIC_REPOSITORIES",
+                message=(
+                    "Skipping the check because there are no publicly available %s %d.%d repositories available."
+                    % (system_info.name, system_info.version.major, system_info.version.minor)
+                ),
+            )
             return
 
         reposdir = get_hardcoded_repofiles_dir()
 
         if reposdir and not system_info.has_internet_access:
             logger.warning("Skipping the check as no internet connection has been detected.")
+            self.add_message(
+                level="WARNING",
+                id="PACKAGE_UPDATES_CHECK_SKIP_NO_INTERNET",
+                message="Skipping the check as no internet connection has been detected.",
+            )
             return
 
         try:
@@ -60,6 +73,15 @@ class PackageUpdates(actions.Action):
                 " before proceeding with the conversion."
             )
             logger.warning(str(e))
+            self.add_message(
+                level="WARNING",
+                id="PACKAGE_UP_TO_DATE_CHECK_FAIL",
+                message=(
+                    "There was an error while checking whether the installed packages are up-to-date. Having an updated system is"
+                    " an important prerequisite for a successful conversion. Consider verifyng the system is up to date manually"
+                    " before proceeding with the conversion. %s" % str(e)
+                ),
+            )
             return
 
         if len(packages_to_update) > 0:
@@ -74,6 +96,17 @@ class PackageUpdates(actions.Action):
                 "Not updating the packages may cause the conversion to fail.\n"
                 "Consider updating the packages before proceeding with the conversion."
                 % (len(packages_to_update), repos_message, " ".join(packages_to_update))
+            )
+            self.add_message(
+                level="WARNING",
+                id="OUT_OF_DATE_PACKAGES",
+                message=(
+                    "The system has %s package(s) not updated based %s.\n"
+                    "List of packages to update: %s.\n\n"
+                    "Not updating the packages may cause the conversion to fail.\n"
+                    "Consider updating the packages before proceeding with the conversion."
+                    % (len(packages_to_update), repos_message, " ".join(packages_to_update))
+                ),
             )
         else:
             logger.info("System is up-to-date.")

--- a/convert2rhel/actions/system_checks/rhel_compatible_kernel.py
+++ b/convert2rhel/actions/system_checks/rhel_compatible_kernel.py
@@ -44,7 +44,7 @@ class KernelIncompatibleError(Exception):
         self.variables = variables
 
     def __str__(self):
-        # substitute this for the jinga template format
+        # substitute this for the jinja template format
         return self.template.format(**self.variables)
 
 
@@ -63,8 +63,6 @@ class RhelCompatibleKernel(actions.Action):
                 check_function(system_info.booted_kernel)
             except KernelIncompatibleError as e:
                 bad_kernel_message = str(e)
-                logger.warning(bad_kernel_message)
-
                 self.set_result(
                     level="ERROR",
                     id=e.error_id,
@@ -92,8 +90,6 @@ def _bad_kernel_version(kernel_release):
     kernel_version = kernel_release.split("-")[0]
     try:
         incompatible_version = COMPATIBLE_KERNELS_VERS[system_info.version.major] != kernel_version
-        print(kernel_version)
-        print(COMPATIBLE_KERNELS_VERS[system_info.version.major])
     except KeyError:
         raise KernelIncompatibleError(
             "UNEXPECTED_VERSION",
@@ -105,11 +101,12 @@ def _bad_kernel_version(kernel_release):
         raise KernelIncompatibleError(
             "INCOMPATIBLE_VERSION",
             "Booted kernel version '{kernel_version}' does not correspond to the version "
-            "'{compatible_version}' available in RHEL {rhel_major_version}",
+            "'{compatible_version}' available in RHEL {rhel_major_version}.{rhel_minor_version}",
             dict(
                 kernel_version=kernel_version,
                 compatible_version=COMPATIBLE_KERNELS_VERS[system_info.version.major],
                 rhel_major_version=system_info.version.major,
+                rhel_minor_version=system_info.version.minor,
             ),
         )
 

--- a/convert2rhel/actions/system_checks/rhel_compatible_kernel.py
+++ b/convert2rhel/actions/system_checks/rhel_compatible_kernel.py
@@ -33,6 +33,21 @@ COMPATIBLE_KERNELS_VERS = {
 BAD_KERNEL_RELEASE_SUBSTRINGS = ("uek", "rt", "linode")
 
 
+class KernelIncompatibleError(Exception):
+    """
+    Exception raised when errors are found when rhel incompatible kernels are discovered
+    """
+
+    def __init__(self, error_id, template, variables):
+        self.error_id = error_id
+        self.template = template
+        self.variables = variables
+
+    def __str__(self):
+        # substitute this for the jinga template format
+        return self.template.format(**self.variables)
+
+
 class RhelCompatibleKernel(actions.Action):
     id = "RHEL_COMPATIBLE_KERNEL"
 
@@ -43,57 +58,66 @@ class RhelCompatibleKernel(actions.Action):
         """
         super(RhelCompatibleKernel, self).run()
         logger.task("Prepare: Check kernel compatibility with RHEL")
-        if any(
-            (
-                _bad_kernel_version(system_info.booted_kernel),
-                _bad_kernel_package_signature(system_info.booted_kernel),
-                _bad_kernel_substring(system_info.booted_kernel),
-            )
-        ):
-            self.set_result(
-                level="ERROR",
-                id="BOOTED_KERNEL_INCOMPATIBLE",
-                message=(
-                    "The booted kernel version is incompatible with the standard RHEL kernel. "
-                    "To proceed with the conversion, boot into a kernel that is available in the {0} {1} base repository"
-                    " by executing the following steps:\n\n"
-                    "1. Ensure that the {0} {1} base repository is enabled\n"
-                    "2. Run: yum install kernel\n"
-                    "3. (optional) Run: grubby --set-default "
-                    '/boot/vmlinuz-`rpm -q --qf "%{{BUILDTIME}}\\t%{{EVR}}.%{{ARCH}}\\n" kernel | sort -nr | head -1 | cut -f2`\n'
-                    "4. Reboot the machine and if step 3 was not applied choose the kernel"
-                    " installed in step 2 manually".format(system_info.name, system_info.version.major)
-                ),
-            )
-            return
-        else:
-            logger.info("The booted kernel %s is compatible with RHEL." % system_info.booted_kernel)
+        for check_function in (_bad_kernel_version, _bad_kernel_package_signature, _bad_kernel_substring):
+            try:
+                check_function(system_info.booted_kernel)
+            except KernelIncompatibleError as e:
+                bad_kernel_message = str(e)
+                logger.warning(bad_kernel_message)
+
+                self.set_result(
+                    level="ERROR",
+                    id=e.error_id,
+                    message=(
+                        "The booted kernel version is incompatible with the standard RHEL kernel. "
+                        "Diagnosis message: {0}"
+                        "To proceed with the conversion, boot into a kernel that is available in the {1} {2} base repository"
+                        " by executing the following steps:\n\n"
+                        "1. Ensure that the {1} {2} base repository is enabled\n"
+                        "2. Run: yum install kernel\n"
+                        "3. (optional) Run: grubby --set-default "
+                        '/boot/vmlinuz-`rpm -q --qf "%{{BUILDTIME}}\\t%{{EVR}}.%{{ARCH}}\\n" kernel | sort -nr | head -1 | cut -f2`\n'
+                        "4. Reboot the machine and if step 3 was not applied choose the kernel"
+                        " installed in step 2 manually".format(
+                            bad_kernel_message, system_info.name, system_info.version.major
+                        )
+                    ),
+                )
+                return
+        logger.info("The booted kernel %s is compatible with RHEL." % system_info.booted_kernel)
 
 
 def _bad_kernel_version(kernel_release):
-    """Return True if the booted kernel version does not correspond to the kernel version available in RHEL."""
+    """Raises exception if the booted kernel version does not correspond to the kernel version available in RHEL."""
     kernel_version = kernel_release.split("-")[0]
     try:
         incompatible_version = COMPATIBLE_KERNELS_VERS[system_info.version.major] != kernel_version
-        if incompatible_version:
-            logger.warning(
-                "Booted kernel version '%s' does not correspond to the version "
-                "'%s' available in RHEL %d"
-                % (
-                    kernel_version,
-                    COMPATIBLE_KERNELS_VERS[system_info.version.major],
-                    system_info.version.major,
-                )
-            )
-        else:
-            logger.debug(
-                "Booted kernel version '%s' corresponds to the version available in RHEL %d"
-                % (kernel_version, system_info.version.major)
-            )
-        return incompatible_version
+        print(kernel_version)
+        print(COMPATIBLE_KERNELS_VERS[system_info.version.major])
     except KeyError:
-        logger.debug("Unexpected OS major version. Expected: %r" % COMPATIBLE_KERNELS_VERS.keys())
-        return True
+        raise KernelIncompatibleError(
+            "UNEXPECTED_VERSION",
+            "Unexpected OS major version. Expected: {compatible_version}",
+            dict(compatible_version=COMPATIBLE_KERNELS_VERS.keys()),
+        )
+
+    if incompatible_version:
+        raise KernelIncompatibleError(
+            "INCOMPATIBLE_VERSION",
+            "Booted kernel version '{kernel_version}' does not correspond to the version "
+            "'{compatible_version}' available in RHEL {rhel_major_version}",
+            dict(
+                kernel_version=kernel_version,
+                compatible_version=COMPATIBLE_KERNELS_VERS[system_info.version.major],
+                rhel_major_version=system_info.version.major,
+            ),
+        )
+
+    logger.debug(
+        "Booted kernel version '%s' corresponds to the version available in RHEL %d"
+        % (kernel_version, system_info.version.major)
+    )
+    return False
 
 
 def _bad_kernel_package_signature(kernel_release):
@@ -106,12 +130,12 @@ def _bad_kernel_package_signature(kernel_release):
 
     os_vendor = system_info.name.split()[0]
     if return_code == 1:
-        logger.warning(
-            "The booted kernel %s is not owned by any installed package."
-            " It needs to be owned by a package signed by %s." % (vmlinuz_path, os_vendor)
+        raise KernelIncompatibleError(
+            "UNSIGNED_PACKAGE",
+            "The booted kernel {vmlinuz_path} is not owned by any installed package."
+            " It needs to be owned by a package signed by {os_vendor}.",
+            dict(vmlinuz_path=vmlinuz_path, os_vendor=os_vendor),
         )
-
-        return True
 
     version, release, arch, name = tuple(kernel_pkg.split("&"))
     logger.debug("Booted kernel package name: {0}".format(name))
@@ -123,8 +147,11 @@ def _bad_kernel_package_signature(kernel_release):
     # e.g. Oracle Linux Server -> Oracle or
     #      Oracle Linux Server -> CentOS Linux
     if bad_signature:
-        logger.warning("Custom kernel detected. The booted kernel needs to be signed by %s." % os_vendor)
-        return True
+        raise KernelIncompatibleError(
+            "INVALID_KERNEL_PACKAGE_SIGNATURE",
+            "Custom kernel detected. The booted kernel needs to be signed by {os_vendor}.",
+            dict(os_vendor=os_vendor),
+        )
 
     logger.debug("The booted kernel is signed by %s." % os_vendor)
     return False
@@ -134,9 +161,10 @@ def _bad_kernel_substring(kernel_release):
     """Return True if the booted kernel release contains one of the strings that identify it as non-standard kernel."""
     bad_substring = any(bad_substring in kernel_release for bad_substring in BAD_KERNEL_RELEASE_SUBSTRINGS)
     if bad_substring:
-        logger.debug(
-            "The booted kernel '{0}' contains one of the disallowed "
-            "substrings: {1}".format(kernel_release, BAD_KERNEL_RELEASE_SUBSTRINGS)
+        raise KernelIncompatibleError(
+            "INVALID_PACKAGE_SUBSTRING",
+            "The booted kernel '{kernel_release}' contains one of the disallowed "
+            "substrings: {bad_kernel_release_substrings}",
+            dict(kernel_release=kernel_release, bad_kernel_release_substrings=BAD_KERNEL_RELEASE_SUBSTRINGS),
         )
-        return True
     return False

--- a/convert2rhel/backup.py
+++ b/convert2rhel/backup.py
@@ -426,6 +426,9 @@ def remove_pkgs(
                 custom_releasever=custom_releasever,
                 varsdir=varsdir,
             )
+
+    pkgs_failed_to_remove = []
+    pkgs_removed = []
     for nevra in pkgs_to_remove:
         # It's necessary to remove an epoch from the NEVRA string returned by yum because the rpm command does not
         # handle the epoch well and considers the package we want to remove as not installed. On the other hand, the
@@ -434,10 +437,17 @@ def remove_pkgs(
         loggerinst.info("Removing package: %s" % nvra)
         _, ret_code = run_subprocess(["rpm", "-e", "--nodeps", nvra])
         if ret_code != 0:
-            if critical:
-                loggerinst.critical("Error: Couldn't remove %s." % nvra)
-            else:
-                loggerinst.warning("Couldn't remove %s." % nvra)
+            pkgs_failed_to_remove.append(nevra)
+        else:
+            pkgs_removed.append(nevra)
+
+    if pkgs_failed_to_remove:
+        if critical:
+            loggerinst.critical("Error: Couldn't remove %s." % ", ".join(pkgs_failed_to_remove))
+        else:
+            loggerinst.warning("Couldn't remove %s." % ", ".join(pkgs_failed_to_remove))
+
+    return pkgs_removed
 
 
 def remove_epoch_from_yum_nevra_notation(package_nevra):

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -361,10 +361,10 @@ def get_installed_pkgs_w_different_fingerprint(fingerprints, name="*"):
 
 
 @utils.run_as_child_process
-def print_pkg_info(pkgs):
-    """Print package information.
+def format_pkg_info(pkgs):
+    """Format package information.
 
-    :param pkgs: List of packages to be printed
+    :param pkgs: List of packages to be formatted
     :type pkgs: list[PackageInformation] | list[RPMInstalledPackage]
     """
     package_info = {}
@@ -425,8 +425,19 @@ def print_pkg_info(pkgs):
         )
 
     pkg_table = header + header_underline + pkg_list
-    loggerinst.info(pkg_table)
+
     return pkg_table
+
+
+def print_pkg_info(pkgs):
+    """
+    Print the results of format_pkg_info
+
+    :param pkgs: List of packages to be printed
+    :type pkgs: list[PackageInformation] | list[RPMInstalledPackage]
+    """
+
+    loggerinst.info(format_pkg_info(pkgs))
 
 
 def _get_package_repositories(pkgs):
@@ -578,7 +589,7 @@ def list_non_red_hat_pkgs_left():
     loggerinst.info("Listing packages not signed by Red Hat")
     non_red_hat_pkgs = get_installed_pkgs_w_different_fingerprint(system_info.fingerprints_rhel)
     if non_red_hat_pkgs:
-        loggerinst.info("The following packages were left unchanged.")
+        loggerinst.info("The following packages were left unchanged.\n")
         print_pkg_info(non_red_hat_pkgs)
     else:
         loggerinst.info("All packages are now signed by Red Hat.")
@@ -596,11 +607,13 @@ def remove_pkgs_unless_from_redhat(pkgs_to_remove, backup=True):
         loggerinst.info("\nNothing to do.")
         return
 
-    loggerinst.warning("Removing the following %s packages:" % str(len(pkgs_to_remove)))
+    loggerinst.warning("Removing the following %s packages:\n" % str(len(pkgs_to_remove)))
     print_pkg_info(pkgs_to_remove)
     loggerinst.info("\n")
-    remove_pkgs([get_pkg_nvra(pkg) for pkg in pkgs_to_remove], backup=backup)
+    pkgs_removed = remove_pkgs([get_pkg_nvra(pkg) for pkg in pkgs_to_remove], backup=backup)
     loggerinst.debug("Successfully removed %s packages" % str(len(pkgs_to_remove)))
+
+    return pkgs_removed
 
 
 @utils.run_as_child_process
@@ -815,7 +828,7 @@ def remove_non_rhel_kernels():
     loggerinst.info("Searching for non-RHEL kernels ...")
     non_rhel_kernels = get_installed_pkgs_w_different_fingerprint(system_info.fingerprints_rhel, "kernel*")
     if non_rhel_kernels:
-        loggerinst.info("Removing non-RHEL kernels")
+        loggerinst.info("Removing non-RHEL kernels\n")
         print_pkg_info(non_rhel_kernels)
         remove_pkgs(
             pkgs_to_remove=[get_pkg_nvra(pkg) for pkg in non_rhel_kernels],

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -728,14 +728,6 @@ def print_avail_subs(subs):
         loggerinst.info("\n======= Subscription number %d =======\n\n%s" % (index, sub.sub_raw))
 
 
-def get_avail_repos():
-    """Get list of all the repositories (their IDs) currently available for
-    the registered system through subscription-manager.
-    """
-    repos_raw, _ = utils.run_subprocess(["subscription-manager", "repos"], print_output=False)
-    return list(get_repo(repos_raw))
-
-
 def get_repo(repos_raw):
     """Generator that parses the raw string of available repositores and
     provides the repository IDs, one at a time.
@@ -857,33 +849,6 @@ def rollback():
         loggerinst.warning(str(e))
     except OSError:
         loggerinst.warning("subscription-manager not installed, skipping")
-
-
-def check_needed_repos_availability(repo_ids_needed):
-    """Check whether all the RHEL repositories needed for the system
-    conversion are available through subscription-manager.
-    """
-    loggerinst.info("Verifying needed RHEL repositories are available ... ")
-    avail_repos = get_avail_repos()
-    loggerinst.info("Repositories available through RHSM:\n%s" % "\n".join(avail_repos) + "\n")
-    non_avail_repos = []
-    all_repos_avail = True
-
-    for repo_id in repo_ids_needed:
-        if repo_id not in avail_repos:
-            # TODO: List the packages that would be left untouched
-            loggerinst.warning(
-                "Some repositories are not available: %s."
-                " Some packages may not be replaced with their corresponding"
-                " RHEL packages when converting. The converted system will end up"
-                " with a mixture of packages from RHEL and your current distribution." % repo_id
-            )
-            non_avail_repos.append(repo_id)
-            all_repos_avail = False
-
-    if all_repos_avail:
-        loggerinst.info("Needed RHEL repositories are available.")
-    return non_avail_repos
 
 
 def download_rhsm_pkgs():

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -561,7 +561,6 @@ def remove_original_subscription_manager():
         return
 
     loggerinst.info("We will now uninstall the following subscription-manager/katello-ca-consumer packages:\n")
-
     pkghandler.print_pkg_info(submgr_pkgs)
     submgr_pkg_names = [pkg.name for pkg in submgr_pkgs]
 
@@ -867,8 +866,9 @@ def check_needed_repos_availability(repo_ids_needed):
     loggerinst.info("Verifying needed RHEL repositories are available ... ")
     avail_repos = get_avail_repos()
     loggerinst.info("Repositories available through RHSM:\n%s" % "\n".join(avail_repos) + "\n")
-
+    non_avail_repos = []
     all_repos_avail = True
+
     for repo_id in repo_ids_needed:
         if repo_id not in avail_repos:
             # TODO: List the packages that would be left untouched
@@ -878,9 +878,12 @@ def check_needed_repos_availability(repo_ids_needed):
                 " RHEL packages when converting. The converted system will end up"
                 " with a mixture of packages from RHEL and your current distribution." % repo_id
             )
+            non_avail_repos.append(repo_id)
             all_repos_avail = False
+
     if all_repos_avail:
         loggerinst.info("Needed RHEL repositories are available.")
+    return non_avail_repos
 
 
 def download_rhsm_pkgs():

--- a/convert2rhel/unit_tests/__init__.py
+++ b/convert2rhel/unit_tests/__init__.py
@@ -448,12 +448,17 @@ def assert_actions_result(instance, level=_NO_USER_VALUE, id=_NO_USER_VALUE, mes
     """Helper function to assert result set by Actions Framework."""
 
     if level != _NO_USER_VALUE:
+        print(instance.result.level)
+        print(STATUS_CODE[level])
         assert instance.result.level == STATUS_CODE[level]
 
     if id != _NO_USER_VALUE:
         assert instance.result.id == id
 
     if message != _NO_USER_VALUE:
+        print(instance.result.message)
+        print("\n")
+        print(message)
         assert message in instance.result.message
 
 

--- a/convert2rhel/unit_tests/actions/actions_test.py
+++ b/convert2rhel/unit_tests/actions/actions_test.py
@@ -127,12 +127,16 @@ class TestAction:
         action = _ActionForTesting(id="TestAction")
         action.add_message(level="WARNING", id="WARNING_ID", message="warning message 1")
         action.add_message(level="WARNING", id="WARNING_ID", message="warning message 2")
+        action.add_message(level="INFO", id="INFO_ID", message="info message 1")
+        action.add_message(level="INFO", id="INFO_ID", message="info message 2")
         actual_messages = []
         for msg in action.messages:
             actual_messages.append(msg.to_dict())
         assert actual_messages == [
             {"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "warning message 1"},
             {"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "warning message 2"},
+            {"level": STATUS_CODE["INFO"], "id": "INFO_ID", "message": "info message 1"},
+            {"level": STATUS_CODE["INFO"], "id": "INFO_ID", "message": "info message 2"},
         ]
 
 
@@ -1036,6 +1040,12 @@ class TestActionClasses:
                 "WARNING",
                 "Warning message",
                 dict(id="WARNING_ID", level=STATUS_CODE["WARNING"], message="Warning message"),
+            ),
+            (
+                "INFO_ID",
+                "INFO",
+                "Info message",
+                dict(id="INFO_ID", level=STATUS_CODE["INFO"], message="Info message"),
             ),
         ),
     )

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
@@ -28,13 +28,13 @@ from six.moves import mock
 
 
 class PrintPkgInfoMocked(unit_tests.MockFunction):
-    def __init__(self):
+    def __init__(self, pkgs):
         self.called = 0
-        self.pkgs = []
+        self.pkgs = pkgs
 
     def __call__(self, pkgs):
         self.called += 1
-        self.pkgs = pkgs
+        return self.pkgs
 
 
 @pytest.fixture
@@ -53,25 +53,39 @@ def test_list_third_party_packages_no_packages(list_third_party_packages_instanc
 
 def test_list_third_party_packages(list_third_party_packages_instance, monkeypatch, caplog):
     monkeypatch.setattr(pkghandler, "get_third_party_pkgs", unit_tests.GetInstalledPkgsWFingerprintsMocked())
-    monkeypatch.setattr(pkghandler, "print_pkg_info", PrintPkgInfoMocked())
-
+    monkeypatch.setattr(pkghandler, "format_pkg_info", PrintPkgInfoMocked(["shim", "ruby", "pytest"]))
+    monkeypatch.setattr(system_info, "name", "Centos7")
+    expected = set(
+        (
+            actions.ActionMessage(
+                level="WARNING",
+                id="THIRD_PARTY_PACKAGE_DETECTED",
+                message=(
+                    "Only packages signed by Centos7 are to be replaced. Red Hat support won't be provided"
+                    " for the following third party packages:\nshim, ruby, pytest"
+                ),
+            ),
+        )
+    )
     list_third_party_packages_instance.run()
-
-    assert len(pkghandler.print_pkg_info.pkgs) == 3
+    assert expected.issuperset(list_third_party_packages_instance.messages)
+    assert expected.issubset(list_third_party_packages_instance.messages)
     assert "Only packages signed by" in caplog.records[-1].message
+    assert len(pkghandler.format_pkg_info.pkgs) == 3
 
     assert list_third_party_packages_instance.result.level == actions.STATUS_CODE["SUCCESS"]
 
 
 class CommandCallableObject(unit_tests.MockFunction):
-    def __init__(self):
+    def __init__(self, mock_data):
         self.called = 0
+        self.mock_data = mock_data
         self.command = None
 
     def __call__(self, command):
         self.called += 1
         self.command = command
-        return
+        return self.mock_data
 
 
 @pytest.fixture
@@ -79,13 +93,51 @@ def remove_excluded_packages_instance():
     return handle_packages.RemoveExcludedPackages()
 
 
-def test_remove_excluded_packages(remove_excluded_packages_instance, monkeypatch):
+def test_remove_excluded_packages_all_removed(remove_excluded_packages_instance, monkeypatch):
+    pkgs_to_remove = ["shim", "ruby", "kernel-core"]
+    pkgs_removed = ["shim", "ruby", "kernel-core"]
+    expected = set(
+        (
+            actions.ActionMessage(
+                level="INFO",
+                id="EXCLUDED_PACKAGES_REMOVED",
+                message="The following packages were removed: kernel-core, ruby, shim",
+            ),
+        )
+    )
     monkeypatch.setattr(system_info, "excluded_pkgs", ["installed_pkg", "not_installed_pkg"])
-    monkeypatch.setattr(pkghandler, "_get_packages_to_remove", CommandCallableObject())
-    monkeypatch.setattr(pkghandler, "remove_pkgs_unless_from_redhat", CommandCallableObject())
+    monkeypatch.setattr(pkghandler, "_get_packages_to_remove", CommandCallableObject(pkgs_removed))
+    monkeypatch.setattr(pkghandler, "remove_pkgs_unless_from_redhat", CommandCallableObject(pkgs_to_remove))
+
+    remove_excluded_packages_instance.run()
+    assert expected.issuperset(remove_excluded_packages_instance.messages)
+    assert expected.issubset(remove_excluded_packages_instance.messages)
+    assert pkghandler._get_packages_to_remove.called == 1
+    assert pkghandler.remove_pkgs_unless_from_redhat.called == 1
+    assert pkghandler._get_packages_to_remove.command == system_info.excluded_pkgs
+    assert remove_excluded_packages_instance.result.level == actions.STATUS_CODE["SUCCESS"]
+
+
+def test_remove_excluded_packages_not_removed(remove_excluded_packages_instance, monkeypatch):
+    pkgs_to_remove = ["shim", "ruby", "kernel-core"]
+    pkgs_removed = ["kernel-core"]
+    expected = set(
+        (
+            actions.ActionMessage(
+                level="WARNING",
+                id="EXCLUDED_PACKAGES_NOT_REMOVED",
+                message="The following packages were not removed: ruby, shim",
+            ),
+        )
+    )
+    monkeypatch.setattr(system_info, "excluded_pkgs", ["installed_pkg", "not_installed_pkg"])
+    monkeypatch.setattr(pkghandler, "_get_packages_to_remove", CommandCallableObject(pkgs_to_remove))
+    monkeypatch.setattr(pkghandler, "remove_pkgs_unless_from_redhat", CommandCallableObject(pkgs_removed))
 
     remove_excluded_packages_instance.run()
 
+    assert expected.issuperset(remove_excluded_packages_instance.messages)
+    assert expected.issubset(remove_excluded_packages_instance.messages)
     assert pkghandler._get_packages_to_remove.called == 1
     assert pkghandler.remove_pkgs_unless_from_redhat.called == 1
     assert pkghandler._get_packages_to_remove.command == system_info.excluded_pkgs
@@ -93,8 +145,9 @@ def test_remove_excluded_packages(remove_excluded_packages_instance, monkeypatch
 
 
 def test_remove_excluded_packages_error(remove_excluded_packages_instance, monkeypatch):
+    pkgs_removed = ["shim", "ruby", "kernel-core"]
     monkeypatch.setattr(system_info, "excluded_pkgs", [])
-    monkeypatch.setattr(pkghandler, "_get_packages_to_remove", CommandCallableObject())
+    monkeypatch.setattr(pkghandler, "_get_packages_to_remove", CommandCallableObject(pkgs_removed))
     monkeypatch.setattr(
         pkghandler, "remove_pkgs_unless_from_redhat", mock.Mock(side_effect=SystemExit("Raising SystemExit"))
     )
@@ -104,7 +157,7 @@ def test_remove_excluded_packages_error(remove_excluded_packages_instance, monke
     unit_tests.assert_actions_result(
         remove_excluded_packages_instance,
         level="ERROR",
-        id="PACKAGE_REMOVAL_FAILED",
+        id="EXCLUDED_PACKAGE_REMOVAL_FAILED",
         message="Raising SystemExit",
     )
 
@@ -114,13 +167,52 @@ def remove_repository_files_packages_instance():
     return handle_packages.RemoveRepositoryFilesPackages()
 
 
-def test_remove_repository_files_packages(remove_repository_files_packages_instance, monkeypatch):
+def test_remove_repository_files_packages_all_removed(remove_repository_files_packages_instance, monkeypatch):
+    pkgs_to_remove = ["shim", "ruby", "kernel-core"]
+    pkgs_removed = ["shim", "ruby", "kernel-core"]
+    expected = set(
+        (
+            actions.ActionMessage(
+                level="INFO",
+                id="REPOSITORY_FILE_PACKAGES_REMOVED",
+                message="The following packages were removed: kernel-core, ruby, shim",
+            ),
+        )
+    )
     monkeypatch.setattr(system_info, "repofile_pkgs", ["installed_pkg", "not_installed_pkg"])
-    monkeypatch.setattr(pkghandler, "_get_packages_to_remove", CommandCallableObject())
-    monkeypatch.setattr(pkghandler, "remove_pkgs_unless_from_redhat", CommandCallableObject())
+    monkeypatch.setattr(pkghandler, "_get_packages_to_remove", CommandCallableObject(pkgs_to_remove))
+    monkeypatch.setattr(pkghandler, "remove_pkgs_unless_from_redhat", CommandCallableObject(pkgs_removed))
 
     remove_repository_files_packages_instance.run()
 
+    assert expected.issuperset(remove_repository_files_packages_instance.messages)
+    assert expected.issubset(remove_repository_files_packages_instance.messages)
+    assert pkghandler._get_packages_to_remove.called == 1
+    assert pkghandler.remove_pkgs_unless_from_redhat.called == 1
+    assert pkghandler._get_packages_to_remove.command == system_info.repofile_pkgs
+    assert remove_repository_files_packages_instance.result.level == actions.STATUS_CODE["SUCCESS"]
+
+
+def test_remove_repository_files_packages_not_removed(remove_repository_files_packages_instance, monkeypatch):
+    pkgs_to_remove = ["shim", "ruby", "kernel-core"]
+    pkgs_removed = ["kernel-core"]
+    expected = set(
+        (
+            actions.ActionMessage(
+                level="WARNING",
+                id="REPOSITORY_FILE_PACKAGES_NOT_REMOVED",
+                message="The following packages were not removed: ruby, shim",
+            ),
+        )
+    )
+    monkeypatch.setattr(system_info, "repofile_pkgs", ["installed_pkg", "not_installed_pkg"])
+    monkeypatch.setattr(pkghandler, "_get_packages_to_remove", CommandCallableObject(pkgs_to_remove))
+    monkeypatch.setattr(pkghandler, "remove_pkgs_unless_from_redhat", CommandCallableObject(pkgs_removed))
+
+    remove_repository_files_packages_instance.run()
+
+    assert expected.issuperset(remove_repository_files_packages_instance.messages)
+    assert expected.issubset(remove_repository_files_packages_instance.messages)
     assert pkghandler._get_packages_to_remove.called == 1
     assert pkghandler.remove_pkgs_unless_from_redhat.called == 1
     assert pkghandler._get_packages_to_remove.command == system_info.repofile_pkgs
@@ -144,6 +236,6 @@ def test_remove_repository_files_packages_error(remove_repository_files_packages
     unit_tests.assert_actions_result(
         remove_repository_files_packages_instance,
         level="ERROR",
-        id="PACKAGE_REMOVAL_FAILED",
+        id="REPOSITORY_FILE_PACKAGE_REMOVAL_FAILED",
         message="Raising SystemExit",
     )

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
@@ -21,7 +21,7 @@ import re
 import pytest
 import six
 
-from convert2rhel import actions
+from convert2rhel.actions import STATUS_CODE
 from convert2rhel.actions.pre_ponr_changes import kernel_modules
 from convert2rhel.systeminfo import system_info
 from convert2rhel.unit_tests import assert_actions_result, run_subprocess_side_effect
@@ -183,11 +183,10 @@ def test_ensure_compatibility_of_kmods_check_env_and_message(
     )
     assert re.match(pattern=should_be_in_logs, string=caplog.records[-1].message, flags=re.MULTILINE | re.DOTALL)
     # cannot assert exact action message contents as the kmods arrangement in the message is not static
-    assert "level=WARNING" in str(ensure_kernel_modules_compatibility_instance.messages)
-    assert "id=ALLOW_UNAVAILABLE_KERNEL_MODULES" in str(ensure_kernel_modules_compatibility_instance.messages)
-    assert "Detected 'CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS' environment variable." in str(
-        ensure_kernel_modules_compatibility_instance.messages
-    )
+    message = ensure_kernel_modules_compatibility_instance.messages[0]
+    assert STATUS_CODE["WARNING"] == message.level
+    assert "ALLOW_UNAVAILABLE_KERNEL_MODULES" == message.id
+    assert "Detected 'CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS' environment variable." in message.message
 
 
 @pytest.mark.parametrize(

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
@@ -21,6 +21,7 @@ import re
 import pytest
 import six
 
+from convert2rhel import actions
 from convert2rhel.actions.pre_ponr_changes import kernel_modules
 from convert2rhel.systeminfo import system_info
 from convert2rhel.unit_tests import assert_actions_result, run_subprocess_side_effect
@@ -151,7 +152,7 @@ def test_ensure_compatibility_of_kmods(
 
 
 @centos8
-def test_ensure_compatibility_of_kmods_check_env(
+def test_ensure_compatibility_of_kmods_check_env_and_message(
     ensure_kernel_modules_compatibility_instance,
     monkeypatch,
     pretend_os,
@@ -181,6 +182,12 @@ def test_ensure_compatibility_of_kmods_check_env(
         " We will continue the conversion with the following kernel modules unavailable in RHEL:.*"
     )
     assert re.match(pattern=should_be_in_logs, string=caplog.records[-1].message, flags=re.MULTILINE | re.DOTALL)
+    # cannot assert exact action message contents as the kmods arrangement in the message is not static
+    assert "level=WARNING" in str(ensure_kernel_modules_compatibility_instance.messages)
+    assert "id=ALLOW_UNAVAILABLE_KERNEL_MODULES" in str(ensure_kernel_modules_compatibility_instance.messages)
+    assert "Detected 'CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS' environment variable." in str(
+        ensure_kernel_modules_compatibility_instance.messages
+    )
 
 
 @pytest.mark.parametrize(

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/subscription_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/subscription_test.py
@@ -117,10 +117,8 @@ def test_subscribe_system_no_rhsm_option_detected(subscribe_system_instance, mon
 
 
 def test_subscribe_system_run(subscribe_system_instance, monkeypatch):
-    non_available_repos = ["subscription_repo", "rhel_repo"]
     monkeypatch.setattr(subscription, "subscribe_system", mock.Mock())
     monkeypatch.setattr(repo, "get_rhel_repoids", mock.Mock())
-    monkeypatch.setattr(subscription, "check_needed_repos_availability", mock.Mock(return_value=non_available_repos))
     monkeypatch.setattr(subscription, "disable_repos", mock.Mock())
     monkeypatch.setattr(subscription, "enable_repos", mock.Mock())
 
@@ -129,7 +127,6 @@ def test_subscribe_system_run(subscribe_system_instance, monkeypatch):
     assert subscribe_system_instance.result.level == STATUS_CODE["SUCCESS"]
     assert subscription.subscribe_system.call_count == 1
     assert repo.get_rhel_repoids.call_count == 1
-    assert subscription.check_needed_repos_availability.call_count == 1
     assert subscription.disable_repos.call_count == 1
     assert subscription.enable_repos.call_count == 1
 

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/subscription_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/subscription_test.py
@@ -117,9 +117,10 @@ def test_subscribe_system_no_rhsm_option_detected(subscribe_system_instance, mon
 
 
 def test_subscribe_system_run(subscribe_system_instance, monkeypatch):
+    non_available_repos = ["subscription_repo", "rhel_repo"]
     monkeypatch.setattr(subscription, "subscribe_system", mock.Mock())
     monkeypatch.setattr(repo, "get_rhel_repoids", mock.Mock())
-    monkeypatch.setattr(subscription, "check_needed_repos_availability", mock.Mock())
+    monkeypatch.setattr(subscription, "check_needed_repos_availability", mock.Mock(return_value=non_available_repos))
     monkeypatch.setattr(subscription, "disable_repos", mock.Mock())
     monkeypatch.setattr(subscription, "enable_repos", mock.Mock())
 

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -52,6 +52,11 @@ def convert2rhel_latest_version_test(monkeypatch, tmpdir, request, global_system
     return marker["local_version"], marker["package_version"]
 
 
+@pytest.fixture
+def current_version(request):
+    return request.param
+
+
 class TestCheckConvert2rhelLatest:
     @pytest.mark.parametrize(
         ("convert2rhel_latest_version_test",),
@@ -67,10 +72,21 @@ class TestCheckConvert2rhelLatest:
     ):
         global_system_info.has_internet_access = False
         convert2rhel_latest_action.run()
+        expected = set(
+            (
+                actions.ActionMessage(
+                    level="WARNING",
+                    id="CONVERT2RHEL_LATEST_CHECK_SKIP_NO_INTERNET",
+                    message="Skipping the check because no internet connection has been detected.",
+                ),
+            )
+        )
 
         log_msg = "Skipping the check because no internet connection has been detected."
         assert log_msg in caplog.text
         assert convert2rhel_latest_action.result.level == actions.STATUS_CODE["SUCCESS"]
+        assert expected.issuperset(convert2rhel_latest_action.messages)
+        assert expected.issubset(convert2rhel_latest_action.messages)
 
     @pytest.mark.parametrize(
         ("convert2rhel_latest_version_test",),
@@ -103,6 +119,45 @@ class TestCheckConvert2rhelLatest:
             % (local_version, package_version)
         )
         assert convert2rhel_latest_action.result.message == msg
+
+    @pytest.mark.parametrize(
+        ("convert2rhel_latest_version_test",),
+        (
+            [{"local_version": "0.21", "package_version": "C2R convert2rhel-0:0.22-1.el7.noarch", "pmajor": "6"}],
+            [{"local_version": "0.21", "package_version": "C2R convert2rhel-0:1.10-1.el7.noarch", "pmajor": "6"}],
+            [{"local_version": "1.21.0", "package_version": "C2R convert2rhel-0:1.21.1-1.el7.noarch", "pmajor": "6"}],
+            [{"local_version": "1.21", "package_version": "C2R convert2rhel-0:1.21.1-1.el7.noarch", "pmajor": "6"}],
+            [{"local_version": "1.21.1", "package_version": "C2R convert2rhel-0:1.22-1.el7.noarch", "pmajor": "6"}],
+        ),
+        indirect=True,
+    )
+    def test_convert2rhel_latest_action_outdated_version(
+        self, convert2rhel_latest_action, convert2rhel_latest_version_test
+    ):
+
+        convert2rhel_latest_action.run()
+
+        local_version, package_version = convert2rhel_latest_version_test
+        if len(package_version) > 36:
+
+            package_version = package_version[19:25]
+        else:
+            package_version = package_version[19:23]
+
+        expected = set(
+            (
+                actions.ActionMessage(
+                    level="WARNING",
+                    id="OUTDATED_CONVERT2RHEL_VERSION",
+                    message=(
+                        "You are currently running %s and the latest version of Convert2RHEL is %s.\n"
+                        "We encourage you to update to the latest version." % (local_version, package_version)
+                    ),
+                ),
+            )
+        )
+        assert expected.issuperset(convert2rhel_latest_action.messages)
+        assert expected.issubset(convert2rhel_latest_action.messages)
 
     @pytest.mark.parametrize(
         ("convert2rhel_latest_version_test",),
@@ -204,7 +259,18 @@ class TestCheckConvert2rhelLatest:
         self, caplog, monkeypatch, convert2rhel_latest_action, convert2rhel_latest_version_test
     ):
         monkeypatch.setattr(utils, "run_subprocess", mock.Mock(return_value=("Repoquery did not run", 1)))
-
+        expected = set(
+            (
+                actions.ActionMessage(
+                    level="WARNING",
+                    id="CONVERT2RHEL_LATEST_CHECK_SKIP",
+                    message=(
+                        "Couldn't check if the current installed Convert2RHEL is the latest version.\n"
+                        "repoquery failed with the following output:\nRepoquery did not run"
+                    ),
+                ),
+            )
+        )
         convert2rhel_latest_action.run()
 
         log_msg = (
@@ -212,6 +278,8 @@ class TestCheckConvert2rhelLatest:
             "repoquery failed with the following output:\nRepoquery did not run"
         )
         assert log_msg in caplog.text
+        assert expected.issuperset(convert2rhel_latest_action.messages)
+        assert expected.issubset(convert2rhel_latest_action.messages)
 
     @pytest.mark.parametrize(
         ("convert2rhel_latest_version_test",),
@@ -263,20 +331,51 @@ class TestCheckConvert2rhelLatest:
         assert convert2rhel_latest_action.result.message == msg
 
     @pytest.mark.parametrize(
-        ("convert2rhel_latest_version_test",),
         (
-            [{"local_version": "0.17.0", "package_version": "C2R convert2rhel-0:0.18.0-1.el7.noarch", "pmajor": "8"}],
-            [{"local_version": "0.17", "package_version": "C2R convert2rhel-0:0.18.0-1.el7.noarch", "pmajor": "8"}],
-            [{"local_version": "0.17.0", "package_version": "C2R convert2rhel-0:0.18-1.el7.noarch", "pmajor": "8"}],
+            "convert2rhel_latest_version_test",
+            "current_version",
+        ),
+        (
+            [
+                {"local_version": "0.17.0", "package_version": "C2R convert2rhel-0:0.18.0-1.el7.noarch", "pmajor": "8"},
+                "0.18.0",
+            ],
+            [
+                {"local_version": "0.17", "package_version": "C2R convert2rhel-0:0.18.0-1.el7.noarch", "pmajor": "8"},
+                "0.18.0",
+            ],
+            [
+                {"local_version": "0.17.0", "package_version": "C2R convert2rhel-0:0.18-1.el7.noarch", "pmajor": "8"},
+                "0.18",
+            ],
         ),
         indirect=True,
     )
     def test_c2r_up_to_date_deprecated_env_var(
-        self, caplog, monkeypatch, convert2rhel_latest_action, convert2rhel_latest_version_test
+        self, caplog, monkeypatch, convert2rhel_latest_action, convert2rhel_latest_version_test, current_version
     ):
         env = {"CONVERT2RHEL_UNSUPPORTED_VERSION": 1}
         monkeypatch.setattr(os, "environ", env)
-
+        expected = set(
+            (
+                actions.ActionMessage(
+                    level="WARNING",
+                    id="DEPRECATED_ENVIRONMENT_VARIABLE",
+                    message=(
+                        "You are using the deprecated 'CONVERT2RHEL_UNSUPPORTED_VERSION'"
+                        " environment variable.  Please switch to 'CONVERT2RHEL_ALLOW_OLDER_VERSION'"
+                        " instead."
+                    ),
+                ),
+                actions.ActionMessage(
+                    level="WARNING",
+                    id="ALLOW_OLDER_VERSION_ENVIRONMENT_VARIABLE",
+                    message="You are currently running %s and the latest version of Convert2RHEL is %s.\n"
+                    "'CONVERT2RHEL_ALLOW_OLDER_VERSION' environment variable detected, continuing conversion"
+                    % (convert2rhel_latest_version_test[0], current_version),
+                ),
+            )
+        )
         convert2rhel_latest_action.run()
 
         log_msg = (
@@ -284,5 +383,6 @@ class TestCheckConvert2rhelLatest:
             " environment variable.  Please switch to 'CONVERT2RHEL_ALLOW_OLDER_VERSION'"
             " instead."
         )
-
+        assert expected.issuperset(convert2rhel_latest_action.messages)
+        assert expected.issubset(convert2rhel_latest_action.messages)
         assert log_msg in caplog.text

--- a/convert2rhel/unit_tests/actions/system_checks/custom_repos_are_valid_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/custom_repos_are_valid_test.py
@@ -78,3 +78,18 @@ class TestCustomReposAreValid(unittest.TestCase):
             "Unable to access the repositories passed through the --enablerepo option. ",
             self.custom_repos_are_valid_action.result.message,
         )
+
+    @unit_tests.mock(custom_repos_are_valid.tool_opts, "no_rhsm", False)
+    def test_custom_repos_are_valid_skip(self):
+        self.custom_repos_are_valid_action.run()
+        expected = set(
+            (
+                actions.ActionMessage(
+                    level="INFO",
+                    id="CUSTOM_REPOSITORIES_ARE_VALID_CHECK_SKIP",
+                    message="Skipping the check of repositories due to the use of RHSM for the conversion.",
+                ),
+            )
+        )
+        assert expected.issuperset(self.custom_repos_are_valid_action.messages)
+        assert expected.issubset(self.custom_repos_are_valid_action.messages)

--- a/convert2rhel/unit_tests/actions/system_checks/dbus_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/dbus_test.py
@@ -67,9 +67,7 @@ def test_check_dbus_is_running_not_running(monkeypatch, global_tool_opts, global
     )
 
 
-def test_check_dbus_is_running_warning_message(
-    monkeypatch, global_tool_opts, global_system_info, dbus_is_running_action
-):
+def test_check_dbus_is_running_warning_message(monkeypatch, global_tool_opts, dbus_is_running_action):
     monkeypatch.setattr(dbus, "tool_opts", global_tool_opts)
     global_tool_opts.no_rhsm = True
     dbus_is_running_action.run()

--- a/convert2rhel/unit_tests/actions/system_checks/dbus_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/dbus_test.py
@@ -17,7 +17,7 @@ __metaclass__ = type
 
 import pytest
 
-from convert2rhel import unit_tests
+from convert2rhel import actions, unit_tests
 from convert2rhel.actions.system_checks import dbus
 
 
@@ -65,3 +65,22 @@ def test_check_dbus_is_running_not_running(monkeypatch, global_tool_opts, global
             " start dbus`"
         ),
     )
+
+
+def test_check_dbus_is_running_warning_message(
+    monkeypatch, global_tool_opts, global_system_info, dbus_is_running_action
+):
+    monkeypatch.setattr(dbus, "tool_opts", global_tool_opts)
+    global_tool_opts.no_rhsm = True
+    dbus_is_running_action.run()
+    expected = set(
+        (
+            actions.ActionMessage(
+                level="WARNING",
+                id="DBUS_IS_RUNNING_CHECK_SKIP",
+                message="Skipping the check because we have been asked not to subscribe this system to RHSM.",
+            ),
+        )
+    )
+    assert expected.issuperset(dbus_is_running_action.messages)
+    assert expected.issubset(dbus_is_running_action.messages)

--- a/convert2rhel/unit_tests/actions/system_checks/efi_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/efi_test.py
@@ -129,6 +129,21 @@ class TestEFIChecks(unittest.TestCase):
         )
         self.assertIn(warn_msg, efi.logger.warning_msgs)
 
+        expected = set(
+            (
+                actions.ActionMessage(
+                    level="WARNING",
+                    id="UEFI_BOOTLOADER_MISMATCH",
+                    message=(
+                        "The current UEFI bootloader '0002' is not referring to any binary UEFI"
+                        " file located on local EFI System Partition (ESP)."
+                    ),
+                ),
+            )
+        )
+        assert expected.issuperset(self.efi_action.messages)
+        assert expected.issubset(self.efi_action.messages)
+
     @unit_tests.mock(grub, "is_efi", lambda: True)
     @unit_tests.mock(grub, "is_secure_boot", lambda: False)
     @unit_tests.mock(efi.system_info, "arch", "x86_64")

--- a/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
@@ -421,8 +421,7 @@ class TestIsLoadedKernelLatest:
         )
         expected_set = set((actions.ActionMessage(level=expected_level, id=expected_id, message=expected_message),))
         is_loaded_kernel_latest_action.run()
-        print(is_loaded_kernel_latest_action.messages)
-        print(expected_set)
+
         assert expected_message in caplog.records[-1].message
         assert expected_set.issuperset(is_loaded_kernel_latest_action.messages)
         assert expected_set.issubset(is_loaded_kernel_latest_action.messages)

--- a/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
@@ -21,7 +21,7 @@ __metaclass__ = type
 import pytest
 import six
 
-from convert2rhel import pkgmanager
+from convert2rhel import actions, pkgmanager
 from convert2rhel.actions.system_checks import package_updates
 from convert2rhel.systeminfo import system_info
 from convert2rhel.unit_tests.conftest import centos8, oracle8
@@ -41,10 +41,23 @@ def test_check_package_updates_skip_on_not_latest_ol(pretend_os, caplog, package
     message = (
         "Skipping the check because there are no publicly available Oracle Linux Server 8.6 repositories available."
     )
+    expected = set(
+        (
+            actions.ActionMessage(
+                level="INFO",
+                id="PACKAGE_UPDATES_CHECK_SKIP_NO_PUBLIC_REPOSITORIES",
+                message=(
+                    "Skipping the check because there are no publicly available Oracle Linux Server 8.6 repositories available."
+                ),
+            ),
+        )
+    )
 
     package_updates_action.run()
 
     assert message in caplog.records[-1].message
+    assert expected.issuperset(package_updates_action.messages)
+    assert expected.issubset(package_updates_action.messages)
 
 
 @pytest.mark.parametrize(
@@ -65,22 +78,71 @@ def test_check_package_updates(pretend_os, packages, exception, expected, monkey
     assert expected in caplog.records[-1].message
 
 
+@centos8
+def test_check_pacakge_updates_warning_message(pretend_os, monkeypatch, package_updates_action):
+    packages = ["package-1", "package-2"]
+    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=lambda reposdir: packages)
+    expected = set(
+        (
+            actions.ActionMessage(
+                level="WARNING",
+                id="OUT_OF_DATE_PACKAGES",
+                message=(
+                    "The system has 2 package(s) not updated based on the enabled system repositories.\n"
+                    "List of packages to update: package-1 package-2.\n\n"
+                    "Not updating the packages may cause the conversion to fail.\n"
+                    "Consider updating the packages before proceeding with the conversion."
+                ),
+            ),
+        )
+    )
+    package_updates_action.run()
+    assert expected.issuperset(package_updates_action.messages)
+    assert expected.issubset(package_updates_action.messages)
+
+
 def test_check_package_updates_with_repoerror(monkeypatch, caplog, package_updates_action):
-    get_total_packages_to_update_mock = mock.Mock(side_effect=pkgmanager.RepoError)
+    get_total_packages_to_update_mock = mock.Mock(side_effect=pkgmanager.RepoError("This is an error"))
     monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=get_total_packages_to_update_mock)
     monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=get_total_packages_to_update_mock)
+    expected = set(
+        (
+            actions.ActionMessage(
+                level="WARNING",
+                id="PACKAGE_UP_TO_DATE_CHECK_FAIL",
+                message=(
+                    "There was an error while checking whether the installed packages are up-to-date. Having an updated system is"
+                    " an important prerequisite for a successful conversion. Consider verifyng the system is up to date manually"
+                    " before proceeding with the conversion. This is an error"
+                ),
+            ),
+        )
+    )
 
     package_updates_action.run()
     # This is -2 because the last message is the error from the RepoError class.
     assert (
         "There was an error while checking whether the installed packages are up-to-date." in caplog.records[-2].message
     )
+    assert expected.issuperset(package_updates_action.messages)
+    assert expected.issubset(package_updates_action.messages)
 
 
 @centos8
 def test_check_package_updates_without_internet(pretend_os, tmpdir, monkeypatch, caplog, package_updates_action):
     monkeypatch.setattr(package_updates, "get_hardcoded_repofiles_dir", value=lambda: str(tmpdir))
     system_info.has_internet_access = False
+    expected = set(
+        (
+            actions.ActionMessage(
+                level="WARNING",
+                id="PACKAGE_UPDATES_CHECK_SKIP_NO_INTERNET",
+                message="Skipping the check as no internet connection has been detected.",
+            ),
+        )
+    )
     package_updates_action.run()
 
     assert "Skipping the check as no internet connection has been detected." in caplog.records[-1].message
+    assert expected.issuperset(package_updates_action.messages)
+    assert expected.issubset(package_updates_action.messages)

--- a/convert2rhel/unit_tests/actions/system_checks/readonly_mounts_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/readonly_mounts_test.py
@@ -49,7 +49,6 @@ class TestReadOnlyMountsChecks(unittest.TestCase):
     )
     def test_mounted_mnt_is_readwrite(self):
         self.readonly_mounts_action_mnt.run()
-        print(readonly_mounts.logger.debug_msgs)
         self.assertEqual(len(readonly_mounts.logger.debug_msgs), 1)
         self.assertIn("/mnt mount point is not read-only.", readonly_mounts.logger.debug_msgs)
 

--- a/convert2rhel/unit_tests/actions/system_checks/rhel_compatible_kernel_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/rhel_compatible_kernel_test.py
@@ -159,8 +159,13 @@ def test_bad_kernel_version_success(kernel_release, major_ver, exp_return, monke
             8,
             "INCOMPATIBLE_VERSION",
             "Booted kernel version '{kernel_version}' does not correspond to the version "
-            "'{compatible_version}' available in RHEL {rhel_major_version}",
-            dict(kernel_version="5.4.17", compatible_version=COMPATIBLE_KERNELS_VERS[8], rhel_major_version=8),
+            "'{compatible_version}' available in RHEL {rhel_major_version}.{rhel_minor_version}",
+            dict(
+                kernel_version="5.4.17",
+                compatible_version=COMPATIBLE_KERNELS_VERS[8],
+                rhel_major_version=8,
+                rhel_minor_version=0,
+            ),
         ),
     ),
 )

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -1684,7 +1684,7 @@ def test_get_installed_pkgs_by_fingerprint_incorrect_fingerprint(pretend_os, mon
     reason="No yum module detected on the system, skipping it.",
 )
 @centos7
-def test_print_pkg_info_yum(pretend_os, monkeypatch):
+def test_format_pkg_info_yum(pretend_os, monkeypatch):
     packages = [
         create_pkg_information(
             packager="Oracle",
@@ -1732,7 +1732,7 @@ C2R 0:gpg-pubkey-0.1-1.x86_64&test
         ),
     )
 
-    result = pkghandler.print_pkg_info(packages)
+    result = pkghandler.format_pkg_info(packages)
     assert re.search(
         r"^Package\s+Vendor/Packager\s+Repository$",
         result,
@@ -1756,7 +1756,7 @@ C2R 0:gpg-pubkey-0.1-1.x86_64&test
     reason="No dnf module detected on the system, skipping it.",
 )
 @centos8
-def test_print_pkg_info_dnf(pretend_os, monkeypatch):
+def test_format_pkg_info_dnf(pretend_os, monkeypatch):
     packages = [
         create_pkg_information(
             packager="Oracle",
@@ -1804,7 +1804,7 @@ C2R gpg-pubkey-0:0.1-1.x86_64&test
         ),
     )
 
-    result = pkghandler.print_pkg_info(packages)
+    result = pkghandler.format_pkg_info(packages)
 
     assert re.search(
         r"^pkg1-0:0\.1-1\.x86_64\s+Oracle\s+anaconda$",
@@ -1853,7 +1853,7 @@ def test_get_packages_to_remove(monkeypatch):
 
 def test_remove_pkgs_with_confirm(monkeypatch):
     monkeypatch.setattr(utils, "ask_to_continue", DumbCallableObject())
-    monkeypatch.setattr(pkghandler, "print_pkg_info", DumbCallable())
+    monkeypatch.setattr(pkghandler, "format_pkg_info", DumbCallable())
     monkeypatch.setattr(pkghandler, "remove_pkgs", RemovePkgsMocked())
 
     pkghandler.remove_pkgs_unless_from_redhat(
@@ -1951,23 +1951,23 @@ def test_get_pkg_nevra(pkgmanager_name, package, include_zero_epoch, expected, m
 )
 def test_get_third_party_pkgs(fingerprint_orig_os, expected_count, expected_pkgs, monkeypatch):
     monkeypatch.setattr(utils, "ask_to_continue", DumbCallableObject())
-    monkeypatch.setattr(pkghandler, "print_pkg_info", PrintPkgInfoMocked())
+    monkeypatch.setattr(pkghandler, "format_pkg_info", PrintPkgInfoMocked())
     monkeypatch.setattr(system_info, "fingerprints_orig_os", fingerprint_orig_os)
     monkeypatch.setattr(pkghandler, "get_installed_pkg_information", GetInstalledPkgsWFingerprintsMocked())
 
     pkgs = pkghandler.get_third_party_pkgs()
 
-    assert pkghandler.print_pkg_info.called == expected_count
+    assert pkghandler.format_pkg_info.called == expected_count
     assert len(pkgs) == expected_pkgs
 
 
 def test_list_non_red_hat_pkgs_left(monkeypatch):
-    monkeypatch.setattr(pkghandler, "print_pkg_info", PrintPkgInfoMocked())
+    monkeypatch.setattr(pkghandler, "format_pkg_info", PrintPkgInfoMocked())
     monkeypatch.setattr(pkghandler, "get_installed_pkg_information", GetInstalledPkgsWFingerprintsMocked())
     pkghandler.list_non_red_hat_pkgs_left()
 
-    assert len(pkghandler.print_pkg_info.pkgs) == 1
-    assert pkghandler.print_pkg_info.pkgs[0].nevra.name == "pkg2"
+    assert len(pkghandler.format_pkg_info.pkgs) == 1
+    assert pkghandler.format_pkg_info.pkgs[0].nevra.name == "pkg2"
 
 
 @centos7
@@ -2029,7 +2029,7 @@ def test_remove_non_rhel_kernels(monkeypatch):
     monkeypatch.setattr(
         pkghandler, "get_installed_pkgs_w_different_fingerprint", GetInstalledPkgsWDifferentFingerprintMocked()
     )
-    monkeypatch.setattr(pkghandler, "print_pkg_info", DumbCallableObject())
+    monkeypatch.setattr(pkghandler, "format_pkg_info", DumbCallableObject())
     monkeypatch.setattr(pkghandler, "remove_pkgs", RemovePkgsMocked())
 
     removed_pkgs = pkghandler.remove_non_rhel_kernels()
@@ -2049,7 +2049,7 @@ def test_install_additional_rhel_kernel_pkgs(monkeypatch):
     monkeypatch.setattr(
         pkghandler, "get_installed_pkgs_w_different_fingerprint", GetInstalledPkgsWDifferentFingerprintMocked()
     )
-    monkeypatch.setattr(pkghandler, "print_pkg_info", DumbCallableObject())
+    monkeypatch.setattr(pkghandler, "format_pkg_info", DumbCallableObject())
     monkeypatch.setattr(pkghandler, "remove_pkgs", RemovePkgsMocked())
     monkeypatch.setattr(pkghandler, "call_yum_cmd", CallYumCmdMocked())
 

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -207,7 +207,7 @@ class TestSubscription(unittest.TestCase):
             self.msg += "%s\n" % msg
 
     @unit_tests.mock(pkghandler, "get_installed_pkg_objects", lambda _: [namedtuple("Pkg", ["name"])("submgr")])
-    @unit_tests.mock(pkghandler, "print_pkg_info", lambda x: None)
+    @unit_tests.mock(pkghandler, "format_pkg_info", lambda x: None)
     @unit_tests.mock(utils, "ask_to_continue", PromptUserMocked())
     @unit_tests.mock(backup, "remove_pkgs", DumbCallable())
     def test_remove_original_subscription_manager(self):
@@ -222,7 +222,7 @@ class TestSubscription(unittest.TestCase):
     )
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(8, 5))
     @unit_tests.mock(system_info, "id", "centos")
-    @unit_tests.mock(pkghandler, "print_pkg_info", lambda x: None)
+    @unit_tests.mock(pkghandler, "format_pkg_info", lambda x: None)
     @unit_tests.mock(utils, "ask_to_continue", PromptUserMocked())
     @unit_tests.mock(backup, "remove_pkgs", DumbCallable())
     def test_remove_original_subscription_manager_missing_package_ol_85(self):

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -100,39 +100,6 @@ class PromptUserLoopMocked(unit_tests.MockFunction):
         return return_value
 
 
-class TestCheckNeededReposAvailability(object):
-    def test_check_needed_repos_availability(self, monkeypatch, caplog):
-        monkeypatch.setattr(subscription, "get_avail_repos", lambda: ["rhel_x", "rhel_y"])
-
-        avail_repos_message = "Needed RHEL repositories are available."
-        subscription.check_needed_repos_availability(["rhel_x"])
-
-        assert avail_repos_message in caplog.records[-1].message
-
-        no_avail_repos_message = (
-            "Some repositories are not available: rhel_z."
-            " Some packages may not be replaced with their corresponding"
-            " RHEL packages when converting. The converted system will end up"
-            " with a mixture of packages from RHEL and your current distribution."
-        )
-
-        subscription.check_needed_repos_availability(["rhel_z"])
-        assert no_avail_repos_message in caplog.records[-1].message
-
-    def test_check_needed_repos_availability_no_repo_available(self, monkeypatch, caplog):
-        monkeypatch.setattr(subscription, "get_avail_repos", lambda: [])
-
-        no_avail_repos_message = (
-            "Some repositories are not available: rhel."
-            " Some packages may not be replaced with their corresponding"
-            " RHEL packages when converting. The converted system will end up"
-            " with a mixture of packages from RHEL and your current distribution."
-        )
-        subscription.check_needed_repos_availability(["rhel"])
-
-        assert no_avail_repos_message in caplog.records[-1].message
-
-
 class TestSubscription(unittest.TestCase):
     class IsFileMocked(unit_tests.MockFunction):
         def __init__(self, is_file):


### PR DESCRIPTION
This PR adds the "OVERRIDABLE" result in areas where the ask_to_continue() function was previously removed. The change allows for users to skip these checks by setting an environment variable.

# Note 
This branch was checked out from another PR #857 in review, since it had some required changes. The changes to look for are in pre_ponr_changes/handle_packages pre_ponr_changes/subscription.py, system_checks/package_updates.py and convert2rhel/subscription.py and all subsequent unit test files.


Jira Issues: [RHELC-1089](https://issues.redhat.com/browse/RHELC-1089)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
