### PR TITLE
[RHELC-775] Compare the release part of the c2r rpm NEVRA

### DIFF
--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -162,7 +162,7 @@ class Convert2rhelLatest(actions.Action):
 
         running_convert2rhel_NEVRA = _extract_convert2rhel_versions(running_convert2rhel_NEVRA)
 
-        # If we couldn't get a NEVRA above, then print a warning that we could not determine the rpm release and use convert2rhel.__version__ to compare with the latest packaged version
+        # If any of those steps fail, we print a warning that we could not determine the rpm release and use convert2rhel.{}version{} to compare with the latest packaged version
         if return_code != 0 or len(running_convert2rhel_NEVRA) != 1:
             logger.warning(
                 "Couldn't determine the rpm release; We will check that the version of convert2rhel (%s) is the latest but ignore the rpm release."

--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -162,7 +162,7 @@ class Convert2rhelLatest(actions.Action):
 
         running_convert2rhel_NEVRA = _extract_convert2rhel_versions(running_convert2rhel_NEVRA)
 
-        # If any of those steps fail, we print a warning that we could not determine the rpm release and use convert2rhel.{}version{} to compare with the latest packaged version
+        # If we couldn't get a NEVRA above, then print a warning that we could not determine the rpm release and use convert2rhel.__version__ to compare with the latest packaged version
         if return_code != 0 or len(running_convert2rhel_NEVRA) != 1:
             logger.warning(
                 "Couldn't determine the rpm release; We will check that the version of convert2rhel (%s) is the latest but ignore the rpm release."

--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -274,7 +274,7 @@ class Convert2rhelLatest(actions.Action):
 
 
 def _format_EVR(epoch, version, release):
-    return "%s" % (version)
+    return "%s:%s-%s" % (epoch, version, release)
 
 
 def _extract_convert2rhel_versions(raw_versions):

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -989,7 +989,7 @@ class Test_ExtractConvert2rhelVersions:
             ),
         ),
     )
-    def test_extract_convert2rhel_version(self, precise_raw_version, expected_versions):
-        list_of_versions = convert2rhel_latest._extract_convert2rhel_versions(precise_raw_version)
+    def test_extract_convert2rhel_version(self, raw_versions, expected_versions):
+        list_of_versions = convert2rhel_latest._extract_convert2rhel_versions(raw_versions)
 
         assert list_of_versions == expected_versions

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -987,9 +987,9 @@ class Test_ExtractConvert2rhelVersions:
                 "Output\nfrom repoquery where\nno strings were for\npackages",
                 [],
             ),
-        ),
+        )
     )
-    def test_extract_convert2rhel_version(self, raw_versions, expected_versions):
-        list_of_versions = convert2rhel_latest._extract_convert2rhel_versions(raw_versions)
+    def test_extract_convert2rhel_version(self, precise_raw_version, expected_versions):
+        list_of_versions = convert2rhel_latest._extract_convert2rhel_versions(precise_raw_version)
 
         assert list_of_versions == expected_versions

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -19,8 +19,6 @@ __metaclass__ = type
 
 import os
 
-from unittest import mock
-
 import pytest
 import six
 

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -987,7 +987,7 @@ class Test_ExtractConvert2rhelVersions:
                 "Output\nfrom repoquery where\nno strings were for\npackages",
                 [],
             ),
-        )
+        ),
     )
     def test_extract_convert2rhel_version(self, precise_raw_version, expected_versions):
         list_of_versions = convert2rhel_latest._extract_convert2rhel_versions(precise_raw_version)

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -857,71 +857,6 @@ class TestCheckConvert2rhelLatest:
         )
 
         assert log_msg in caplog.text
-        
-    @pytest.mark.parametrize(
-    ("convert2rhel_latest_version_test",),
-    (
-        [
-            {
-                "local_version": "0.19.0",
-                "package_version_repoquery": "C2R convert2rhel-0:0.18.0-1.el7.noarch\nNot a NEVRA that we was not filtered due to a bug\nC2R convert2rhel-0:0.20.0-1.el7.noarch",
-                "package_version_qf": "C2R convert2rhel-0:0.19.0-1.el7.noarch",
-                "package_version_V": 0,
-                "pmajor": "8",
-                "running_version": "0:0.19.0-1.el7",
-                "latest_version": "0:0.20-1.el7",
-            }
-        ],
-    ),
-    indirect=True,
-    )
-    def test_bad_NEVRA_to_parse_pkg_string(
-        self,
-        convert2rhel_latest_action,
-        convert2rhel_latest_version_test,
-        monkeypatch,
-    ):
-        generator = extract_convert2rhel_versions_generator()
-
-        monkeypatch.setattr(
-            convert2rhel_latest,
-            "_extract_convert2rhel_versions",
-            mock.Mock(spec=convert2rhel_latest._extract_convert2rhel_versions, return_value=next(generator)),
-        )
-
-        convert2rhel_latest_action.run()
-
-        running_version, latest_version = convert2rhel_latest_version_test
-
-        unit_tests.assert_actions_result(
-            convert2rhel_latest_action,
-            level="ERROR",
-            id="OUT_OF_DATE",
-            title="Outdated convert2rhel version detected",
-            description="An outdated convert2rhel version has been detected",
-            diagnosis=(
-                "You are currently running %s and the latest version of convert2rhel is %s.\n"
-                "Only the latest version is supported for conversion." % (running_version, latest_version)
-            ),
-            remediation="If you want to ignore this check, then set the environment variable 'CONVERT2RHEL_ALLOW_OLDER_VERSION=1' to continue.",
-        )
-
-
-def extract_convert2rhel_versions_generator():
-    # Yield bad output
-    yield [
-        "convert2rhel-0:0.18.0-1.el7.noarch",
-        "Not a NEVRA that we was not filtered due to a bug",
-        "convert2rhel-0:0.20.0-1.el7.noarch",
-    ]
-
-    # Yield good output
-    yield [
-        "convert2rhel-0:0.18.0-1.el7.noarch",
-        "convert2rhel-0:0.19.0-1.el7.noarch",
-        "convert2rhel-0:0.20.0-1.el7.noarch",
-    ]
-
 
     @pytest.mark.parametrize(
         ("convert2rhel_latest_version_test",),
@@ -1058,5 +993,3 @@ class Test_ExtractConvert2rhelVersions:
         list_of_versions = convert2rhel_latest._extract_convert2rhel_versions(precise_raw_version)
 
         assert list_of_versions == expected_versions
-
-    

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -408,8 +408,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.17.0-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "6",
-                    "running_version": "0:0.17.1-1.el7",
-                    "latest_version": "0:0.17.0-1.el7",
+                    "running_version": "0.17.1",
+                    "latest_version": "0.17.0",
                 }
             ],
             [

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -144,8 +144,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.21-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "7",
-                    "running_version": "0.21",
-                    "latest_version": "0.22",
+                    "running_version": "0:0.21-1.el7",
+                    "latest_version": "0:0.22-1.el7",
                 }
             ],
             [
@@ -156,8 +156,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.21-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "7",
-                    "running_version": "0.21",
-                    "latest_version": "1.10",
+                    "running_version": "0:0.21-1.el7",
+                    "latest_version": "0:1.10-1.el7",
                 }
             ],
             [
@@ -168,8 +168,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:1.21.0-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "7",
-                    "running_version": "1.21.0",
-                    "latest_version": "1.21.1",
+                    "running_version": "0:1.21.0-1.el7",
+                    "latest_version": "0:1.21.1-1.el7",
                 }
             ],
             [
@@ -180,8 +180,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:1.21-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "7",
-                    "running_version": "1.21",
-                    "latest_version": "1.21.1",
+                    "running_version": "0:1.21-1.el7",
+                    "latest_version": "0:1.21.1-1.el7",
                 }
             ],
             [
@@ -192,8 +192,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:1.21.1-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "7",
-                    "running_version": "1.21.1",
-                    "latest_version": "1.22",
+                    "running_version": "0:1.21.1-1.el7",
+                    "latest_version": "0:1.22-1.el7",
                 }
             ],
         ),
@@ -228,8 +228,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.21-1.el7.noarch",
                     "package_version_V": " ",
                     "pmajor": "6",
-                    "running_version": "0.21",
-                    "latest_version": "0.22",
+                    "running_version": "0:0.21-1.el7",
+                    "latest_version": "0:0.22-1.el7",
                 }
             ],
             [
@@ -240,8 +240,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.21-1.el7.noarch",
                     "package_version_V": " ",
                     "pmajor": "6",
-                    "running_version": "0.21",
-                    "latest_version": "1.10",
+                    "running_version": "0:0.21-1.el7",
+                    "latest_version": "0:1.10-1.el7",
                 }
             ],
             [
@@ -252,8 +252,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:1.21.0-1.el7.noarch",
                     "package_version_V": " ",
                     "pmajor": "6",
-                    "running_version": "1.21.0",
-                    "latest_version": "1.21.1",
+                    "running_version": "0:1.21.0-1.el7",
+                    "latest_version": "0:1.21.1-1.el7",
                 }
             ],
             [
@@ -264,8 +264,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:1.21-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "6",
-                    "running_version": "1.21",
-                    "latest_version": "1.21.1",
+                    "running_version": "0:1.21-1.el7",
+                    "latest_version": "0:1.21.1-1.el7",
                 }
             ],
             [
@@ -276,8 +276,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:1.21.1-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "6",
-                    "running_version": "1.21.1",
-                    "latest_version": "1.22",
+                    "running_version": "0:1.21.1-1.el7",
+                    "latest_version": "0:1.22-1.el7",
                 }
             ],
         ),
@@ -320,8 +320,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_V": 0,
                     "pmajor": "6",
                     "enset": "1",
-                    "running_version": "0.18.0",
-                    "latest_version": "0.22.0",
+                    "running_version": "0:0.18.0-1.el7",
+                    "latest_version": "0:0.22.0-1.el7",
                 }
             ],
             [
@@ -333,8 +333,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_V": 0,
                     "pmajor": "7",
                     "enset": "1",
-                    "running_version": "0.18.1",
-                    "latest_version": "0.22.0",
+                    "running_version": "0:0.18.1-1.el7",
+                    "latest_version": "0:0.22.0-1.el7",
                 }
             ],
             [
@@ -346,8 +346,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_V": 0,
                     "pmajor": "8",
                     "enset": "1",
-                    "running_version": "0.18.3",
-                    "latest_version": "0.22.1",
+                    "running_version": "0:0.18.3-1.el7",
+                    "latest_version": "0:0.22.1-1.el7",
                 }
             ],
             [
@@ -359,8 +359,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_V": 0,
                     "pmajor": "8",
                     "enset": "1",
-                    "running_version": "0.18",
-                    "latest_version": "1.10.2",
+                    "running_version": "0:0.18-1.el7",
+                    "latest_version": "0:1.10.2-1.el7",
                 }
             ],
             [
@@ -372,8 +372,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_V": 0,
                     "pmajor": "8",
                     "enset": "1",
-                    "running_version": "0.18.0",
-                    "latest_version": "1.10",
+                    "running_version": "0:0.18.0-1.el7",
+                    "latest_version": "0:1.10-1.el7",
                 }
             ],
         ),
@@ -408,8 +408,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.17.0-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "6",
-                    "running_version": "0.17.1",
-                    "latest_version": "0.17.0",
+                    "running_version": "0:0.17.1-1.el7",
+                    "latest_version": "0:0.17.0-1.el7",
                 }
             ],
             [
@@ -589,8 +589,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.19.0-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "8",
-                    "running_version": "0.19.0",
-                    "latest_version": "0.20.0",
+                    "running_version": "0:0.19.0-1.el7",
+                    "latest_version": "0:0.20.0-1.el7",
                 }
             ],
             [
@@ -601,8 +601,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.19-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "8",
-                    "running_version": "0.19",
-                    "latest_version": "0.20.0",
+                    "running_version": "0:0.19-1.el7",
+                    "latest_version": "0:0.20.0-1.el7",
                 }
             ],
             [
@@ -613,8 +613,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.19.0-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "8",
-                    "running_version": "0.19.0",
-                    "latest_version": "0.20",
+                    "running_version": "0:0.19.0-1.el7",
+                    "latest_version": "0:0.20-1.el7",
                 }
             ],
         ),
@@ -649,8 +649,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.17.0-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "8",
-                    "running_version": "0.17.0",
-                    "latest_version": "0.18.0",
+                    "running_version": "0:0.17.0-1.el7",
+                    "latest_version": "0:0.18.0-1.el7",
                 }
             ],
             [
@@ -661,8 +661,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.17-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "8",
-                    "running_version": "0.17",
-                    "latest_version": "0.18.0",
+                    "running_version": "0:0.17-1.el7",
+                    "latest_version": "0:0.18.0-1.el7",
                 }
             ],
             [
@@ -673,8 +673,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.17.0-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "8",
-                    "running_version": "0.17.0",
-                    "latest_version": "0.18",
+                    "running_version": "0:0.17.0-1.el7",
+                    "latest_version": "0:0.18-1.el7",
                 }
             ],
         ),
@@ -868,8 +868,8 @@ class TestCheckConvert2rhelLatest:
                     "package_version_qf": "C2R convert2rhel-0:0.19.0-1.el7.noarch",
                     "package_version_V": 0,
                     "pmajor": "8",
-                    "running_version": "0.19.0",
-                    "latest_version": "0.20.0",
+                    "running_version": "0:0.19.0-1.el7",
+                    "latest_version": "0:0.20.0-1.el7",
                 }
             ],
         ),

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -19,6 +19,8 @@ __metaclass__ = type
 
 import os
 
+from unittest import mock
+
 import pytest
 import six
 

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -857,6 +857,71 @@ class TestCheckConvert2rhelLatest:
         )
 
         assert log_msg in caplog.text
+        
+    @pytest.mark.parametrize(
+    ("convert2rhel_latest_version_test",),
+    (
+        [
+            {
+                "local_version": "0.19.0",
+                "package_version_repoquery": "C2R convert2rhel-0:0.18.0-1.el7.noarch\nNot a NEVRA that we was not filtered due to a bug\nC2R convert2rhel-0:0.20.0-1.el7.noarch",
+                "package_version_qf": "C2R convert2rhel-0:0.19.0-1.el7.noarch",
+                "package_version_V": 0,
+                "pmajor": "8",
+                "running_version": "0:0.19.0-1.el7",
+                "latest_version": "0:0.20-1.el7",
+            }
+        ],
+    ),
+    indirect=True,
+    )
+    def test_bad_NEVRA_to_parse_pkg_string(
+        self,
+        convert2rhel_latest_action,
+        convert2rhel_latest_version_test,
+        monkeypatch,
+    ):
+        generator = extract_convert2rhel_versions_generator()
+
+        monkeypatch.setattr(
+            convert2rhel_latest,
+            "_extract_convert2rhel_versions",
+            mock.Mock(spec=convert2rhel_latest._extract_convert2rhel_versions, return_value=next(generator)),
+        )
+
+        convert2rhel_latest_action.run()
+
+        running_version, latest_version = convert2rhel_latest_version_test
+
+        unit_tests.assert_actions_result(
+            convert2rhel_latest_action,
+            level="ERROR",
+            id="OUT_OF_DATE",
+            title="Outdated convert2rhel version detected",
+            description="An outdated convert2rhel version has been detected",
+            diagnosis=(
+                "You are currently running %s and the latest version of convert2rhel is %s.\n"
+                "Only the latest version is supported for conversion." % (running_version, latest_version)
+            ),
+            remediation="If you want to ignore this check, then set the environment variable 'CONVERT2RHEL_ALLOW_OLDER_VERSION=1' to continue.",
+        )
+
+
+def extract_convert2rhel_versions_generator():
+    # Yield bad output
+    yield [
+        "convert2rhel-0:0.18.0-1.el7.noarch",
+        "Not a NEVRA that we was not filtered due to a bug",
+        "convert2rhel-0:0.20.0-1.el7.noarch",
+    ]
+
+    # Yield good output
+    yield [
+        "convert2rhel-0:0.18.0-1.el7.noarch",
+        "convert2rhel-0:0.19.0-1.el7.noarch",
+        "convert2rhel-0:0.20.0-1.el7.noarch",
+    ]
+
 
     @pytest.mark.parametrize(
         ("convert2rhel_latest_version_test",),
@@ -993,3 +1058,5 @@ class Test_ExtractConvert2rhelVersions:
         list_of_versions = convert2rhel_latest._extract_convert2rhel_versions(precise_raw_version)
 
         assert list_of_versions == expected_versions
+
+    


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
In Convert2RHEL, we compare the version to make sure that it is correct, but we should also check the release to confirm further that we have the correct version of Convert2RHEL. We should have this second check to ensure we catch the downstream release.
<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-775](https://issues.redhat.com/browse/RHELC-775)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
