### PR TITLE
[RHELC-1094] Split report messages into four fields

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -40,7 +40,7 @@ jobs:
 
 # TEST JOBS
 ## Tests on pull request stage
-- &tests-tier0
+- &tests-tier0-destructive-manual
   job: tests
   # Run tests on-demand
   manual_trigger: true
@@ -56,8 +56,8 @@ jobs:
         # to tag the updated system correctly
       distros: [centos-8-latest, oraclelinux-8.6]
   trigger: pull_request
-  identifier: "tier0"
-  tmt_plan: "tier0"
+  identifier: "tier0-destructive"
+  tmt_plan: "tier0/destructive"
   # Run on Red Testing Farm Hat Ranch, tag resources to sst_conversions
   use_internal_tf: True
   tf_extra_params:
@@ -68,33 +68,39 @@ jobs:
               BusinessUnit: sst_conversions
   labels:
     - tier0
+    - tier0-destructive
+    - destructive
 
 - &tests-tier0-non-destructive-manual
-  <<: *tests-tier0
+  <<: *tests-tier0-destructive-manual
   identifier: "tier0-non-destructive"
   tmt_plan: "tier0/non-destructive"
   labels:
+    - tier0
     - tier0-non-destructive
     - non-destructive
 
-- &tests-tier1-manual
-  <<: *tests-tier0
-  identifier: "tier1"
-  tmt_plan: "tier1"
+- &tests-tier1-destructive-manual
+  <<: *tests-tier0-destructive-manual
+  identifier: "tier1-destructive"
+  tmt_plan: "tier1/destructive"
   labels:
     - tier1
+    - tier1-destructive
+    - destructive
 
-- &tests-tier1-non-destructive-manual
-  <<: *tests-tier0
-  identifier: "tier1-non-destructive"
-  tmt_plan: "tier1/non-destructive"
-  labels:
-    - tier1-non-destructive
-    - non-destructive
+# Disabled for now
+#- &tests-tier1-non-destructive-manual
+#  <<: *tests-tier0-destructive-manual
+#  identifier: "tier1-non-destructive"
+#  tmt_plan: "tier1/non-destructive"
+#  labels:
+#    - tier1-non-destructive
+#    - non-destructive
 
 # Tests on merge to main stage
 - &tests-tier1
-  <<: *tests-tier0
+  <<: *tests-tier0-destructive-manual
   # Run test automatically with merge commit to main branch
   manual_trigger: false
   identifier: "tier1"

--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -45,7 +45,9 @@ class BackupRedhatRelease(actions.Action):
             # Raised in module redhatrelease on lines 49 and 60
             #   - If unable to find the /etc/system-release file,
             #     SystemExit is raised
-            self.set_result(level="ERROR", id="UNKNOWN_ERROR", message=str(e))
+            self.set_result(
+                level="ERROR", id="UNKNOWN_ERROR", title="An unknown error has occurred", description=str(e)
+            )
 
 
 class BackupRepository(actions.Action):

--- a/convert2rhel/actions/pre_ponr_changes/handle_packages.py
+++ b/convert2rhel/actions/pre_ponr_changes/handle_packages.py
@@ -24,6 +24,10 @@ from convert2rhel.systeminfo import system_info
 logger = logging.getLogger(__name__)
 
 
+def _get_pkg_names(packages):
+    return [pkghandler.get_pkg_nevra(pkg_obj, include_zero_epoch=True) for pkg_obj in packages]
+
+
 class ListThirdPartyPackages(actions.Action):
     id = "LIST_THIRD_PARTY_PACKAGES"
 
@@ -37,14 +41,34 @@ class ListThirdPartyPackages(actions.Action):
         logger.task("Convert: List third-party packages")
         third_party_pkgs = pkghandler.get_third_party_pkgs()
         if third_party_pkgs:
-            logger.warning(
+            pkg_list = pkghandler.format_pkg_info(sorted(third_party_pkgs, key=self.extract_packages))
+            warning_message = (
                 "Only packages signed by %s are to be"
                 " replaced. Red Hat support won't be provided"
                 " for the following third party packages:\n" % system_info.name
             )
-            pkghandler.print_pkg_info(third_party_pkgs)
+
+            logger.warning(warning_message)
+            logger.info(pkg_list)
+            self.set_result(
+                level="SUCCESS",
+                id="THIRD_PARTY_PACKAGE_DETECTED",
+                title="Third party packages detected",
+            )
+            self.add_message(
+                level="WARNING",
+                id="THIRD_PARTY_PACKAGE_DETECTED_MESSAGE",
+                title="Third party packages detected",
+                description="Third party packages will not be replaced during the conversion.",
+                diagnosis=warning_message + ", ".join(_get_pkg_names(third_party_pkgs)),
+            )
+            return
         else:
             logger.info("No third party packages installed.")
+
+    def extract_packages(self, pkg):
+        """Key function to extract the package name from third_party_pkgs"""
+        return pkg.nevra.name
 
 
 class RemoveExcludedPackages(actions.Action):
@@ -60,8 +84,9 @@ class RemoveExcludedPackages(actions.Action):
         logger.task("Convert: Remove excluded packages")
         logger.info("Searching for the following excluded packages:\n")
         try:
-            pkgs_to_remove = pkghandler._get_packages_to_remove(system_info.excluded_pkgs)
-            pkghandler.remove_pkgs_unless_from_redhat(pkgs_to_remove)
+            pkgs_to_remove = sorted(pkghandler.get_packages_to_remove(system_info.excluded_pkgs))
+            # this call can return None, which is not ideal to use with sorted.
+            pkgs_removed = sorted(pkghandler.remove_pkgs_unless_from_redhat(pkgs_to_remove) or [])
 
             # TODO: Handling SystemExit here as way to speedup exception
             # handling and not refactor contents of the underlying function.
@@ -69,7 +94,38 @@ class RemoveExcludedPackages(actions.Action):
             # TODO(r0x0d): Places where we raise SystemExit and need to be
             # changed to something more specific.
             #   - When we can't remove a package.
-            self.set_result(level="ERROR", id="PACKAGE_REMOVAL_FAILED", message=str(e))
+            self.set_result(
+                level="ERROR",
+                id="EXCLUDED_PACKAGE_REMOVAL_FAILED",
+                title="Failed to remove excluded package",
+                description="The cause of this error is unknown, please look at the diagnosis for more information.",
+                diagnosis=str(e),
+            )
+            return
+
+        # shows which packages were not removed, if false, all packages were removed
+        pkgs_not_removed = sorted(frozenset(pkgs_to_remove).difference(pkgs_removed))
+        if pkgs_not_removed:
+            pkg_names = _get_pkg_names(pkgs_not_removed)
+            message = "The following packages were not removed: %s" % ", ".join(pkg_names)
+            logger.warning(message)
+            self.add_message(
+                level="WARNING",
+                id="EXCLUDED_PACKAGES_NOT_REMOVED",
+                title="Excluded packages not removed",
+                description="Excluded packages which could not be removed",
+                diagnosis=message,
+            )
+        else:
+            message = "The following packages were removed: %s" % ", ".join(pkgs_removed)
+            logger.info(message)
+            self.add_message(
+                level="INFO",
+                id="EXCLUDED_PACKAGES_REMOVED",
+                title="Excluded packages removed",
+                description="Excluded packages that have been removed",
+                diagnosis=message,
+            )
 
 
 class RemoveRepositoryFilesPackages(actions.Action):
@@ -96,8 +152,9 @@ class RemoveRepositoryFilesPackages(actions.Action):
         logger.task("Convert: Remove packages containing .repo files")
         logger.info("Searching for packages containing .repo files or affecting variables in the .repo files:\n")
         try:
-            pkgs_to_remove = pkghandler._get_packages_to_remove(system_info.repofile_pkgs)
-            pkghandler.remove_pkgs_unless_from_redhat(pkgs_to_remove)
+            pkgs_to_remove = sorted(pkghandler.get_packages_to_remove(system_info.repofile_pkgs))
+            # this call can return None, which is not ideal to use with sorted.
+            pkgs_removed = sorted(pkghandler.remove_pkgs_unless_from_redhat(pkgs_to_remove) or [])
 
             # TODO: Handling SystemExit here as way to speedup exception
             # handling and not refactor contents of the underlying function.
@@ -105,4 +162,35 @@ class RemoveRepositoryFilesPackages(actions.Action):
             # TODO(r0x0d): Places where we raise SystemExit and need to be
             # changed to something more specific.
             #   - When we can't remove a package.
-            self.set_result(level="ERROR", id="PACKAGE_REMOVAL_FAILED", message=str(e))
+            self.set_result(
+                level="ERROR",
+                id="REPOSITORY_FILE_PACKAGE_REMOVAL_FAILED",
+                title="Repository file package removal failure",
+                description="The cause of this error is unknown, please look at the diagnosis for more information.",
+                diagnosis=str(e),
+            )
+            return
+
+        # shows which packages were not removed, if false, all packages were removed
+        pkgs_not_removed = sorted(frozenset(pkgs_to_remove).difference(pkgs_removed))
+        if pkgs_not_removed:
+            pkg_names = _get_pkg_names(pkgs_not_removed)
+            message = "The following packages were not removed: %s" % ", ".join(pkg_names)
+            logger.warning(message)
+            self.add_message(
+                level="WARNING",
+                id="REPOSITORY_FILE_PACKAGES_NOT_REMOVED",
+                title="Repository file packages not removed",
+                description="Repository file packages which could not be removed",
+                diagnosis=message,
+            )
+        else:
+            message = "The following packages were removed: %s" % ", ".join(pkgs_removed)
+            logger.info(message)
+            self.add_message(
+                level="INFO",
+                id="REPOSITORY_FILE_PACKAGES_REMOVED",
+                title="Repository file packages removed",
+                description="Repository file packages that were removed",
+                diagnosis=message,
+            )

--- a/convert2rhel/actions/pre_ponr_changes/special_cases.py
+++ b/convert2rhel/actions/pre_ponr_changes/special_cases.py
@@ -63,6 +63,13 @@ class RemoveIwlax2xxFirmware(actions.Action):
                 _, exit_code = run_subprocess(["rpm", "-e", "--nodeps", "iwlax2xx-firmware"])
                 if exit_code != 0:
                     logger.error("Unable to remove the package iwlax2xx-firmware.")
+                    self.add_message(
+                        level="WARNING",
+                        id="IWLAX2XX_FIRMWARE_REMOVAL_FAILED",
+                        title="Package removal failed",
+                        description="Unable to remove the package iwlax2xx-firmware.",
+                    )
+
             else:
                 logger.info(
                     "The iwl7260-firmware and iwlax2xx-firmware packages are not both installed. Nothing to do."

--- a/convert2rhel/actions/pre_ponr_changes/transaction.py
+++ b/convert2rhel/actions/pre_ponr_changes/transaction.py
@@ -65,4 +65,10 @@ class ValidatePackageManagerTransaction(actions.Action):
             #       - If we fail to resolve dependencies in the transaction
             #       - If we fail to download the transaction packages
             #       - If we fail to validate the transaction
-            self.set_result(level="ERROR", id="UNKNOWN_ERROR", message=str(e))
+            self.set_result(
+                level="ERROR",
+                id="UNKNOWN_ERROR",
+                title="Unknown",
+                description="The cause of this error is unknown, please look at the diagnosis for more information.",
+                diagnosis=str(e),
+            )

--- a/convert2rhel/actions/system_checks/custom_repos_are_valid.py
+++ b/convert2rhel/actions/system_checks/custom_repos_are_valid.py
@@ -38,7 +38,14 @@ class CustomReposAreValid(actions.Action):
         logger.task("Prepare: Check if --enablerepo repositories are accessible")
 
         if not tool_opts.no_rhsm:
-            logger.info("Skipping the check of repositories due to the use of RHSM for the conversion.")
+            description = "Skipping the check of repositories due to the use of RHSM for the conversion."
+            logger.info(description)
+            self.add_message(
+                level="INFO",
+                id="CUSTOM_REPOSITORIES_ARE_VALID_CHECK_SKIP",
+                title="Skipping the custom repos are valid check",
+                description=description,
+            )
             return
 
         output, ret_code = call_yum_cmd(
@@ -50,10 +57,10 @@ class CustomReposAreValid(actions.Action):
             self.set_result(
                 level="ERROR",
                 id="UNABLE_TO_ACCESS_REPOSITORIES",
-                message=(
-                    "Unable to access the repositories passed through the --enablerepo option. "
-                    "For more details, see YUM/DNF output:\n{0}".format(output)
-                ),
+                title="Unable to access repositories",
+                description="Access could not be made to the custom repositories.",
+                diagnosis="Unable to access the repositories passed through the --enablerepo option.",
+                remediation="For more details, see YUM/DNF output:\n{0}".format(output),
             )
             return
 

--- a/convert2rhel/actions/system_checks/dbus.py
+++ b/convert2rhel/actions/system_checks/dbus.py
@@ -35,6 +35,12 @@ class DbusIsRunning(actions.Action):
 
         if tool_opts.no_rhsm:
             logger.info("Skipping the check because we have been asked not to subscribe this system to RHSM.")
+            self.add_message(
+                level="WARNING",
+                id="DBUS_IS_RUNNING_CHECK_SKIP",
+                title="Skipping the dbus is running check",
+                description="Skipping the check because we have been asked not to subscribe this system to RHSM.",
+            )
             return
 
         if system_info.dbus_running:
@@ -44,8 +50,8 @@ class DbusIsRunning(actions.Action):
         self.set_result(
             level="ERROR",
             id="DBUS_DAEMON_NOT_RUNNING",
-            message=(
-                "Could not find a running DBus Daemon which is needed to register with subscription manager.\n"
-                "Please start dbus using `systemctl start dbus`"
-            ),
+            title="Dbus daemon not running",
+            description="The Dbus daemon is not running",
+            diagnosis="Could not find a running DBus Daemon which is needed to register with subscription manager.",
+            remediation="Please start dbus using `systemctl start dbus`",
         )

--- a/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
+++ b/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
@@ -55,6 +55,12 @@ class IsLoadedKernelLatest(actions.Action):
         reposdir = get_hardcoded_repofiles_dir()
         if reposdir and not system_info.has_internet_access:
             logger.warning("Skipping the check as no internet connection has been detected.")
+            self.add_message(
+                level="WARNING",
+                id="IS_LOADED_KERNEL_LATEST_CHECK_SKIP",
+                title="Skipping the is loaded kernel latest check",
+                description="Skipping the check as no internet connection has been detected.",
+            )
             return
 
         # If the reposdir variable is not empty, meaning that it detected the
@@ -80,6 +86,16 @@ class IsLoadedKernelLatest(actions.Action):
                 "the %s comparison.\n"
                 "Beware, this could leave your system in a broken state." % package_to_check
             )
+            self.add_message(
+                level="WARNING",
+                id="UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK_DETECTED",
+                title="Skipping the kernel currency check",
+                description=(
+                    "Detected 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip "
+                    "the %s comparison.\n"
+                    "Beware, this could leave your system in a broken state." % package_to_check
+                ),
+            )
             return
 
         # Look up for available kernel (or kernel-core) packages versions available
@@ -95,6 +111,15 @@ class IsLoadedKernelLatest(actions.Action):
             logger.warning(
                 "Couldn't fetch the list of the most recent kernels available in "
                 "the repositories. Skipping the loaded kernel check."
+            )
+            self.add_message(
+                level="WARNING",
+                id="UNABLE_TO_FETCH_RECENT_KERNELS",
+                title="Unable to fetch recent kernels",
+                description=(
+                    "Couldn't fetch the list of the most recent kernels available in "
+                    "the repositories. Skipping the loaded kernel check."
+                ),
             )
             return
 
@@ -120,11 +145,15 @@ class IsLoadedKernelLatest(actions.Action):
             self.set_result(
                 level="ERROR",
                 id="KERNEL_CURRENCY_CHECK_FAIL",
-                message=(
-                    "Could not find any %s from repositories to compare against the loaded kernel.\n"
+                title="Kernel currency check failed",
+                description="Please refer to the diagnosis for further information",
+                diagnosis=(
+                    "Could not find any %s from repositories to compare against the loaded kernel." % package_to_check
+                ),
+                remediation=(
                     "Please, check if you have any vendor repositories enabled to proceed with the conversion.\n"
                     "If you wish to ignore this message, set the environment variable "
-                    "'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK' to 1." % package_to_check
+                    "'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK' to 1."
                 ),
             )
             return
@@ -144,7 +173,9 @@ class IsLoadedKernelLatest(actions.Action):
             self.set_result(
                 level="ERROR",
                 id="INVALID_KERNEL_PACKAGE",
-                message=str(exc),
+                title="Invalid kernel package found",
+                description="Please refer to the diagnosis for further information",
+                diagnosis=str(exc),
             )
             return
 
@@ -157,13 +188,17 @@ class IsLoadedKernelLatest(actions.Action):
             self.set_result(
                 level="ERROR",
                 id="INVALID_KERNEL_VERSION",
-                message=(
+                title="Invalid kernel version detected",
+                description="The loaded kernel version mismatch the latest one available %s" % repos_message,
+                diagnosis=(
                     "The version of the loaded kernel is different from the latest version %s.\n"
                     " Latest kernel version available in %s: %s\n"
-                    " Loaded kernel version: %s\n\n"
+                    " Loaded kernel version: %s" % (repos_message, repoid, latest_kernel, loaded_kernel)
+                ),
+                remediation=(
                     "To proceed with the conversion, update the kernel version by executing the following step:\n\n"
                     "1. yum install %s-%s -y\n"
-                    "2. reboot" % (repos_message, repoid, latest_kernel, loaded_kernel, package_to_check, latest_kernel)
+                    "2. reboot" % (package_to_check, latest_kernel)
                 ),
             )
             return

--- a/convert2rhel/actions/system_checks/readonly_mounts.py
+++ b/convert2rhel/actions/system_checks/readonly_mounts.py
@@ -54,7 +54,8 @@ class ReadonlyMountMnt(actions.Action):
             self.set_result(
                 level="ERROR",
                 id="MNT_DIR_READONLY_MOUNT",
-                message=(
+                title="Read-only mount in /mnt directory",
+                description=(
                     "Stopping conversion due to read-only mount to /mnt directory.\n"
                     "Mount at a subdirectory of /mnt to have /mnt writeable."
                 ),
@@ -72,7 +73,8 @@ class ReadonlyMountSys(actions.Action):
             self.set_result(
                 level="ERROR",
                 id="SYS_DIR_READONLY_MOUNT",
-                message=(
+                title="Read-only mount in /sys directory",
+                description=(
                     "Stopping conversion due to read-only mount to /sys directory.\n"
                     "Ensure mount point is writable before executing convert2rhel."
                 ),

--- a/convert2rhel/actions/system_checks/rhel_compatible_kernel.py
+++ b/convert2rhel/actions/system_checks/rhel_compatible_kernel.py
@@ -33,6 +33,21 @@ COMPATIBLE_KERNELS_VERS = {
 BAD_KERNEL_RELEASE_SUBSTRINGS = ("uek", "rt", "linode")
 
 
+class KernelIncompatibleError(Exception):
+    """
+    Exception raised when errors are found when rhel incompatible kernels are discovered
+    """
+
+    def __init__(self, error_id, template, variables):
+        self.error_id = error_id
+        self.template = template
+        self.variables = variables
+
+    def __str__(self):
+        # substitute this for the jinga template format
+        return self.template.format(**self.variables)
+
+
 class RhelCompatibleKernel(actions.Action):
     id = "RHEL_COMPATIBLE_KERNEL"
 
@@ -43,57 +58,66 @@ class RhelCompatibleKernel(actions.Action):
         """
         super(RhelCompatibleKernel, self).run()
         logger.task("Prepare: Check kernel compatibility with RHEL")
-        if any(
-            (
-                _bad_kernel_version(system_info.booted_kernel),
-                _bad_kernel_package_signature(system_info.booted_kernel),
-                _bad_kernel_substring(system_info.booted_kernel),
-            )
-        ):
-            self.set_result(
-                level="ERROR",
-                id="BOOTED_KERNEL_INCOMPATIBLE",
-                message=(
-                    "The booted kernel version is incompatible with the standard RHEL kernel. "
-                    "To proceed with the conversion, boot into a kernel that is available in the {0} {1} base repository"
-                    " by executing the following steps:\n\n"
-                    "1. Ensure that the {0} {1} base repository is enabled\n"
-                    "2. Run: yum install kernel\n"
-                    "3. (optional) Run: grubby --set-default "
-                    '/boot/vmlinuz-`rpm -q --qf "%{{BUILDTIME}}\\t%{{EVR}}.%{{ARCH}}\\n" kernel | sort -nr | head -1 | cut -f2`\n'
-                    "4. Reboot the machine and if step 3 was not applied choose the kernel"
-                    " installed in step 2 manually".format(system_info.name, system_info.version.major)
-                ),
-            )
-            return
-        else:
-            logger.info("The booted kernel %s is compatible with RHEL." % system_info.booted_kernel)
+        for check_function in (_bad_kernel_version, _bad_kernel_package_signature, _bad_kernel_substring):
+            try:
+                check_function(system_info.booted_kernel)
+            except KernelIncompatibleError as e:
+                bad_kernel_message = str(e)
+                logger.warning(bad_kernel_message)
+
+                self.set_result(
+                    level="ERROR",
+                    id=e.error_id,
+                    title="Incompatible booted kernel version",
+                    description="Please refer to the diagnosis for further information",
+                    diagnosis=(
+                        "The booted kernel version is incompatible with the standard RHEL kernel. %s"
+                        % bad_kernel_message
+                    ),
+                    remediation=(
+                        "To proceed with the conversion, boot into a kernel that is available in the {0} {1} base repository"
+                        " by executing the following steps:\n\n"
+                        "1. Ensure that the {0} {1} base repository is enabled\n"
+                        "2. Run: yum install kernel\n"
+                        "3. (optional) Run: grubby --set-default "
+                        '/boot/vmlinuz-`rpm -q --qf "%{{BUILDTIME}}\\t%{{EVR}}.%{{ARCH}}\\n" kernel | sort -nr | head -1 | cut -f2`\n'
+                        "4. Reboot the machine and if step 3 was not applied choose the kernel"
+                        " installed in step 2 manually".format(system_info.name, system_info.version.major)
+                    ),
+                )
+                return
+        logger.info("The booted kernel %s is compatible with RHEL." % system_info.booted_kernel)
 
 
 def _bad_kernel_version(kernel_release):
-    """Return True if the booted kernel version does not correspond to the kernel version available in RHEL."""
+    """Raises exception if the booted kernel version does not correspond to the kernel version available in RHEL."""
     kernel_version = kernel_release.split("-")[0]
     try:
         incompatible_version = COMPATIBLE_KERNELS_VERS[system_info.version.major] != kernel_version
-        if incompatible_version:
-            logger.warning(
-                "Booted kernel version '%s' does not correspond to the version "
-                "'%s' available in RHEL %d"
-                % (
-                    kernel_version,
-                    COMPATIBLE_KERNELS_VERS[system_info.version.major],
-                    system_info.version.major,
-                )
-            )
-        else:
-            logger.debug(
-                "Booted kernel version '%s' corresponds to the version available in RHEL %d"
-                % (kernel_version, system_info.version.major)
-            )
-        return incompatible_version
     except KeyError:
-        logger.debug("Unexpected OS major version. Expected: %r" % COMPATIBLE_KERNELS_VERS.keys())
-        return True
+        raise KernelIncompatibleError(
+            "UNEXPECTED_VERSION",
+            "Unexpected OS major version. Expected: {compatible_version}",
+            dict(compatible_version=COMPATIBLE_KERNELS_VERS.keys()),
+        )
+
+    if incompatible_version:
+        raise KernelIncompatibleError(
+            "INCOMPATIBLE_VERSION",
+            "Booted kernel version '{kernel_version}' does not correspond to the version "
+            "'{compatible_version}' available in RHEL {rhel_major_version}",
+            dict(
+                kernel_version=kernel_version,
+                compatible_version=COMPATIBLE_KERNELS_VERS[system_info.version.major],
+                rhel_major_version=system_info.version.major,
+            ),
+        )
+
+    logger.debug(
+        "Booted kernel version '%s' corresponds to the version available in RHEL %d"
+        % (kernel_version, system_info.version.major)
+    )
+    return False
 
 
 def _bad_kernel_package_signature(kernel_release):
@@ -106,12 +130,12 @@ def _bad_kernel_package_signature(kernel_release):
 
     os_vendor = system_info.name.split()[0]
     if return_code == 1:
-        logger.warning(
-            "The booted kernel %s is not owned by any installed package."
-            " It needs to be owned by a package signed by %s." % (vmlinuz_path, os_vendor)
+        raise KernelIncompatibleError(
+            "UNSIGNED_PACKAGE",
+            "The booted kernel {vmlinuz_path} is not owned by any installed package."
+            " It needs to be owned by a package signed by {os_vendor}.",
+            dict(vmlinuz_path=vmlinuz_path, os_vendor=os_vendor),
         )
-
-        return True
 
     version, release, arch, name = tuple(kernel_pkg.split("&"))
     logger.debug("Booted kernel package name: {0}".format(name))
@@ -123,8 +147,11 @@ def _bad_kernel_package_signature(kernel_release):
     # e.g. Oracle Linux Server -> Oracle or
     #      Oracle Linux Server -> CentOS Linux
     if bad_signature:
-        logger.warning("Custom kernel detected. The booted kernel needs to be signed by %s." % os_vendor)
-        return True
+        raise KernelIncompatibleError(
+            "INVALID_KERNEL_PACKAGE_SIGNATURE",
+            "Custom kernel detected. The booted kernel needs to be signed by {os_vendor}.",
+            dict(os_vendor=os_vendor),
+        )
 
     logger.debug("The booted kernel is signed by %s." % os_vendor)
     return False
@@ -134,9 +161,10 @@ def _bad_kernel_substring(kernel_release):
     """Return True if the booted kernel release contains one of the strings that identify it as non-standard kernel."""
     bad_substring = any(bad_substring in kernel_release for bad_substring in BAD_KERNEL_RELEASE_SUBSTRINGS)
     if bad_substring:
-        logger.debug(
-            "The booted kernel '{0}' contains one of the disallowed "
-            "substrings: {1}".format(kernel_release, BAD_KERNEL_RELEASE_SUBSTRINGS)
+        raise KernelIncompatibleError(
+            "INVALID_PACKAGE_SUBSTRING",
+            "The booted kernel '{kernel_release}' contains one of the disallowed "
+            "substrings: {bad_kernel_release_substrings}",
+            dict(kernel_release=kernel_release, bad_kernel_release_substrings=BAD_KERNEL_RELEASE_SUBSTRINGS),
         )
-        return True
     return False

--- a/convert2rhel/actions/system_checks/tainted_kmods.py
+++ b/convert2rhel/actions/system_checks/tainted_kmods.py
@@ -47,13 +47,17 @@ class TaintedKmods(actions.Action):
             self.set_result(
                 level="ERROR",
                 id="TAINTED_KMODS_DETECTED",
-                message=(
+                description="Please refer to the diagnosis for further information",
+                title="Tainted kernel modules detected",
+                diagnosis=(
                     "Tainted kernel modules detected:\n  {0}\n"
                     "Third-party components are not supported per our "
-                    "software support policy:\n {1}\n"
-                    "Prevent the modules from loading by following {2}"
+                    "software support policy:\n {1}\n".format(module_names, LINK_KMODS_RH_POLICY)
+                ),
+                remediation=(
+                    "Prevent the modules from loading by following {0}"
                     " and run convert2rhel again to continue with the conversion.".format(
-                        module_names, LINK_KMODS_RH_POLICY, LINK_PREVENT_KMODS_FROM_LOADING
+                        LINK_PREVENT_KMODS_FROM_LOADING
                     )
                 ),
             )

--- a/convert2rhel/backup.py
+++ b/convert2rhel/backup.py
@@ -426,6 +426,9 @@ def remove_pkgs(
                 custom_releasever=custom_releasever,
                 varsdir=varsdir,
             )
+
+    pkgs_failed_to_remove = []
+    pkgs_removed = []
     for nevra in pkgs_to_remove:
         # It's necessary to remove an epoch from the NEVRA string returned by yum because the rpm command does not
         # handle the epoch well and considers the package we want to remove as not installed. On the other hand, the
@@ -434,10 +437,17 @@ def remove_pkgs(
         loggerinst.info("Removing package: %s" % nvra)
         _, ret_code = run_subprocess(["rpm", "-e", "--nodeps", nvra])
         if ret_code != 0:
-            if critical:
-                loggerinst.critical("Error: Couldn't remove %s." % nvra)
-            else:
-                loggerinst.warning("Couldn't remove %s." % nvra)
+            pkgs_failed_to_remove.append(nevra)
+        else:
+            pkgs_removed.append(nevra)
+
+    if pkgs_failed_to_remove:
+        if critical:
+            loggerinst.critical("Error: Couldn't remove %s." % ", ".join(pkgs_failed_to_remove))
+        else:
+            loggerinst.warning("Couldn't remove %s." % ", ".join(pkgs_failed_to_remove))
+
+    return pkgs_removed
 
 
 def remove_epoch_from_yum_nevra_notation(package_nevra):

--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -171,6 +171,7 @@ def _debug(self, msg, *args, **kwargs):
 
 class bcolors:
     OKGREEN = "\033[92m"
+    INFO = "\033[94m"
     WARNING = "\033[93m"
     FAIL = "\033[91m"
     ENDC = "\033[0m"

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -561,7 +561,6 @@ def remove_original_subscription_manager():
         return
 
     loggerinst.info("We will now uninstall the following subscription-manager/katello-ca-consumer packages:\n")
-
     pkghandler.print_pkg_info(submgr_pkgs)
     submgr_pkg_names = [pkg.name for pkg in submgr_pkgs]
 
@@ -729,14 +728,6 @@ def print_avail_subs(subs):
         loggerinst.info("\n======= Subscription number %d =======\n\n%s" % (index, sub.sub_raw))
 
 
-def get_avail_repos():
-    """Get list of all the repositories (their IDs) currently available for
-    the registered system through subscription-manager.
-    """
-    repos_raw, _ = utils.run_subprocess(["subscription-manager", "repos"], print_output=False)
-    return list(get_repo(repos_raw))
-
-
 def get_repo(repos_raw):
     """Generator that parses the raw string of available repositores and
     provides the repository IDs, one at a time.
@@ -858,29 +849,6 @@ def rollback():
         loggerinst.warning(str(e))
     except OSError:
         loggerinst.warning("subscription-manager not installed, skipping")
-
-
-def check_needed_repos_availability(repo_ids_needed):
-    """Check whether all the RHEL repositories needed for the system
-    conversion are available through subscription-manager.
-    """
-    loggerinst.info("Verifying needed RHEL repositories are available ... ")
-    avail_repos = get_avail_repos()
-    loggerinst.info("Repositories available through RHSM:\n%s" % "\n".join(avail_repos) + "\n")
-
-    all_repos_avail = True
-    for repo_id in repo_ids_needed:
-        if repo_id not in avail_repos:
-            # TODO: List the packages that would be left untouched
-            loggerinst.warning(
-                "Some repositories are not available: %s."
-                " Some packages may not be replaced with their corresponding"
-                " RHEL packages when converting. The converted system will end up"
-                " with a mixture of packages from RHEL and your current distribution." % repo_id
-            )
-            all_repos_avail = False
-    if all_repos_avail:
-        loggerinst.info("Needed RHEL repositories are available.")
 
 
 def download_rhsm_pkgs():

--- a/convert2rhel/unit_tests/__init__.py
+++ b/convert2rhel/unit_tests/__init__.py
@@ -419,24 +419,17 @@ def mock_decorator(func):
 
 
 class GetInstalledPkgsWFingerprintsMocked(MockFunction):
-    def prepare_test_pkg_tuples_w_fingerprints(self):
-        class PkgData:
-            def __init__(self, pkg_obj, fingerprint):
-                self.pkg_obj = pkg_obj
-                self.fingerprint = fingerprint
-
-        obj1 = create_pkg_obj("pkg1")
-        obj2 = create_pkg_obj("pkg2")
-        obj3 = create_pkg_obj("gpg-pubkey")
-        pkgs = [
-            PkgData(obj1, "199e2f91fd431d51"),  # RHEL
-            PkgData(obj2, "72f97b74ec551f03"),  # OL
-            PkgData(obj3, "199e2f91fd431d51"),
-        ]  # RHEL
-        return pkgs
+    obj1 = create_pkg_information(name="pkg1", fingerprint="199e2f91fd431d51")  # RHEL
+    obj2 = create_pkg_information(name="pkg2", fingerprint="72f97b74ec551f03")  # OL
+    obj3 = create_pkg_information(
+        name="gpg-pubkey", version="1.0.0", release="1", arch="x86_64", fingerprint="199e2f91fd431d51"  # RHEL
+    )
 
     def __call__(self, *args, **kwargs):
-        return self.prepare_test_pkg_tuples_w_fingerprints()
+        return self.get_packages()
+
+    def get_packages(self):
+        return [self.obj1, self.obj2, self.obj3]
 
 
 #: Used as a sentinel value for assert_action_result() so we only check
@@ -444,17 +437,34 @@ class GetInstalledPkgsWFingerprintsMocked(MockFunction):
 _NO_USER_VALUE = object()
 
 
-def assert_actions_result(instance, level=_NO_USER_VALUE, id=_NO_USER_VALUE, message=_NO_USER_VALUE):
+def assert_actions_result(
+    instance,
+    level=_NO_USER_VALUE,
+    id=_NO_USER_VALUE,
+    title=_NO_USER_VALUE,
+    description=_NO_USER_VALUE,
+    diagnosis=_NO_USER_VALUE,
+    remediation=_NO_USER_VALUE,
+):
     """Helper function to assert result set by Actions Framework."""
 
-    if level != _NO_USER_VALUE:
+    if level and level != _NO_USER_VALUE:
         assert instance.result.level == STATUS_CODE[level]
 
-    if id != _NO_USER_VALUE:
+    if id and id != _NO_USER_VALUE:
         assert instance.result.id == id
 
-    if message != _NO_USER_VALUE:
-        assert message in instance.result.message
+    if title and title != _NO_USER_VALUE:
+        assert title in instance.result.title
+
+    if description and description != _NO_USER_VALUE:
+        assert description in instance.result.description
+
+    if diagnosis and diagnosis != _NO_USER_VALUE:
+        assert diagnosis in instance.result.diagnosis
+
+    if remediation and remediation != _NO_USER_VALUE:
+        assert remediation in instance.result.remediation
 
 
 class EFIBootInfoMocked:

--- a/convert2rhel/unit_tests/actions/actions_test.py
+++ b/convert2rhel/unit_tests/actions/actions_test.py
@@ -58,21 +58,27 @@ class TestAction:
         (
             # Set one result field
             (
-                dict(level="SUCCESS"),
-                dict(level="SUCCESS", id=None, message=None),
-            ),
-            (
-                dict(level="SUCCESS", message="Check was skipped because CONVERT2RHEL_SKIP_CHECK was set"),
-                dict(
-                    level="SUCCESS",
-                    id=None,
-                    message="Check was skipped because CONVERT2RHEL_SKIP_CHECK was set",
-                ),
+                dict(level="SUCCESS", id="SUCCESS"),
+                dict(level="SUCCESS", id="SUCCESS", title=None, description=None, diagnosis=None, remediation=None),
             ),
             # Set all result fields
             (
-                dict(level="ERROR", id="ERRORCASE", message="Problem detected"),
-                dict(level="ERROR", id="ERRORCASE", message="Problem detected"),
+                dict(
+                    level="ERROR",
+                    id="ERRORCASE",
+                    title="Problem detected",
+                    description="problem",
+                    diagnosis="detected",
+                    remediation="move on",
+                ),
+                dict(
+                    level="ERROR",
+                    id="ERRORCASE",
+                    title="Problem detected",
+                    description="problem",
+                    diagnosis="detected",
+                    remediation="move on",
+                ),
             ),
         ),
     )
@@ -83,21 +89,25 @@ class TestAction:
         action.run()
 
         assert action.result.level == STATUS_CODE[expected["level"]]
+
         assert action.result.id == expected["id"]
-        assert action.result.message == expected["message"]
+        assert action.result.title == expected["title"]
+        assert action.result.description == expected["description"]
+        assert action.result.diagnosis == expected["diagnosis"]
+        assert action.result.remediation == expected["remediation"]
 
     @pytest.mark.parametrize(
-        ("level",),
+        ("level", "id"),
         (
-            ("FOOBAR",),
-            (actions.STATUS_CODE["ERROR"],),
+            ("FOOBAR", "FOOBAR"),
+            (actions.STATUS_CODE["ERROR"], "ERROR_ID"),
         ),
     )
-    def test_set_results_bad_level(self, level):
+    def test_set_results_bad_level(self, level, id):
         action = _ActionForTesting(id="TestAction")
 
         with pytest.raises(KeyError):
-            action.set_result(level=level)
+            action.set_result(level=level, id=id)
 
     def test_no_duplicate_ids(self):
         """Test that each Action has its own unique id."""
@@ -122,17 +132,77 @@ class TestAction:
         with pytest.raises(actions.ActionError, match="Action TestAction has already run"):
             action.run()
 
-    def test_add_message(self, monkeypatch):
+    def test_add_message(self):
         """Test that add_message formats messages correctly"""
         action = _ActionForTesting(id="TestAction")
-        action.add_message(level="WARNING", id="WARNING_ID", message="warning message 1")
-        action.add_message(level="WARNING", id="WARNING_ID", message="warning message 2")
+        action.add_message(
+            level="WARNING",
+            id="WARNING_ID",
+            title="warning message 1",
+            description="action warning",
+            diagnosis="user warning",
+            remediation="move on",
+        )
+        action.add_message(
+            level="WARNING",
+            id="WARNING_ID",
+            title="warning message 2",
+            description="action warning",
+            diagnosis="user warning",
+            remediation="move on",
+        )
+        action.add_message(
+            level="INFO",
+            id="INFO_ID",
+            title="info message 1",
+            description="action info",
+            diagnosis="user info",
+            remediation="move on",
+        )
+        action.add_message(
+            level="INFO",
+            id="INFO_ID",
+            title="info message 2",
+            description="action info",
+            diagnosis="user info",
+            remediation="move on",
+        )
         actual_messages = []
         for msg in action.messages:
             actual_messages.append(msg.to_dict())
         assert actual_messages == [
-            {"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "warning message 1"},
-            {"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "warning message 2"},
+            {
+                "level": STATUS_CODE["WARNING"],
+                "id": "WARNING_ID",
+                "title": "warning message 1",
+                "description": "action warning",
+                "diagnosis": "user warning",
+                "remediation": "move on",
+            },
+            {
+                "level": STATUS_CODE["WARNING"],
+                "id": "WARNING_ID",
+                "title": "warning message 2",
+                "description": "action warning",
+                "diagnosis": "user warning",
+                "remediation": "move on",
+            },
+            {
+                "level": STATUS_CODE["INFO"],
+                "id": "INFO_ID",
+                "title": "info message 1",
+                "description": "action info",
+                "diagnosis": "user info",
+                "remediation": "move on",
+            },
+            {
+                "level": STATUS_CODE["INFO"],
+                "id": "INFO_ID",
+                "title": "info message 2",
+                "description": "action info",
+                "diagnosis": "user info",
+                "remediation": "move on",
+            },
         ]
 
 
@@ -658,23 +728,38 @@ class TestRunActions:
             (
                 actions.FinishedActions(
                     [
-                        _ActionForTesting(id="One", messages=[], result=ActionResult(level="SUCCESS")),
+                        _ActionForTesting(id="One", messages=[], result=ActionResult(level="SUCCESS", id="SUCCESS")),
                     ],
                     [],
                     [],
                 ),
-                {"One": dict(messages=[], result=dict(level=STATUS_CODE["SUCCESS"], id=None, message=""))},
+                {
+                    "One": dict(
+                        messages=[],
+                        result=dict(
+                            level=STATUS_CODE["SUCCESS"],
+                            id="SUCCESS",
+                            title="",
+                            description="",
+                            diagnosis="",
+                            remediation="",
+                        ),
+                    )
+                },
             ),
             (
                 actions.FinishedActions(
                     [
                         _ActionForTesting(
-                            id="One", messages=[], result=ActionResult(level="SUCCESS"), dependencies=("One",)
+                            id="One",
+                            messages=[],
+                            result=ActionResult(level="SUCCESS", id="SUCCESS"),
+                            dependencies=("One",),
                         ),
                         _ActionForTesting(
                             id="Two",
                             messages=[],
-                            result=ActionResult(level="SUCCESS"),
+                            result=ActionResult(level="SUCCESS", id="SUCCESS"),
                             dependencies=(
                                 "One",
                                 "Two",
@@ -685,8 +770,28 @@ class TestRunActions:
                     [],
                 ),
                 {
-                    "One": dict(messages=[], result=dict(level=STATUS_CODE["SUCCESS"], id=None, message="")),
-                    "Two": dict(messages=[], result=dict(level=STATUS_CODE["SUCCESS"], id=None, message="")),
+                    "One": dict(
+                        messages=[],
+                        result=dict(
+                            level=STATUS_CODE["SUCCESS"],
+                            id="SUCCESS",
+                            title="",
+                            description="",
+                            diagnosis="",
+                            remediation="",
+                        ),
+                    ),
+                    "Two": dict(
+                        messages=[],
+                        result=dict(
+                            level=STATUS_CODE["SUCCESS"],
+                            id="SUCCESS",
+                            title="",
+                            description="",
+                            diagnosis="",
+                            remediation="",
+                        ),
+                    ),
                 },
             ),
             # Single Failures
@@ -697,14 +802,29 @@ class TestRunActions:
                         _ActionForTesting(
                             id="One",
                             messages=[],
-                            result=ActionResult(level="ERROR", id="SOME_ERROR", message="message"),
+                            result=ActionResult(
+                                level="ERROR",
+                                id="SOME_ERROR",
+                                title="Error",
+                                description="Action error",
+                                diagnosis="User error",
+                                remediation="move on",
+                            ),
                         ),
                     ],
                     [],
                 ),
                 {
                     "One": dict(
-                        messages=[], result=dict(level=STATUS_CODE["ERROR"], id="SOME_ERROR", message="message")
+                        messages=[],
+                        result=dict(
+                            level=STATUS_CODE["ERROR"],
+                            id="SOME_ERROR",
+                            title="Error",
+                            description="Action error",
+                            diagnosis="User error",
+                            remediation="move on",
+                        ),
                     ),
                 },
             ),
@@ -715,14 +835,29 @@ class TestRunActions:
                         _ActionForTesting(
                             id="One",
                             messages=[],
-                            result=ActionResult(level="OVERRIDABLE", id="SOME_ERROR", message="message"),
+                            result=ActionResult(
+                                level="OVERRIDABLE",
+                                id="SOME_ERROR",
+                                title="Overridable",
+                                description="Action overridable",
+                                diagnosis="User overridable",
+                                remediation="move on",
+                            ),
                         ),
                     ],
                     [],
                 ),
                 {
                     "One": dict(
-                        messages=[], result=dict(level=STATUS_CODE["OVERRIDABLE"], id="SOME_ERROR", message="message")
+                        messages=[],
+                        result=dict(
+                            level=STATUS_CODE["OVERRIDABLE"],
+                            id="SOME_ERROR",
+                            title="Overridable",
+                            description="Action overridable",
+                            diagnosis="User overridable",
+                            remediation="move on",
+                        ),
                     ),
                 },
             ),
@@ -732,13 +867,30 @@ class TestRunActions:
                     [],
                     [
                         _ActionForTesting(
-                            id="One", messages=[], result=ActionResult(level="SKIP", id="SOME_ERROR", message="message")
+                            id="One",
+                            messages=[],
+                            result=ActionResult(
+                                level="SKIP",
+                                id="SOME_ERROR",
+                                title="Skip",
+                                description="Action skip",
+                                diagnosis="User skip",
+                                remediation="move on",
+                            ),
                         ),
                     ],
                 ),
                 {
                     "One": dict(
-                        messages=[], result=dict(level=STATUS_CODE["SKIP"], id="SOME_ERROR", message="message")
+                        messages=[],
+                        result=dict(
+                            level=STATUS_CODE["SKIP"],
+                            id="SOME_ERROR",
+                            title="Skip",
+                            description="Action skip",
+                            diagnosis="User skip",
+                            remediation="move on",
+                        ),
                     ),
                 },
             ),
@@ -746,23 +898,71 @@ class TestRunActions:
             (
                 actions.FinishedActions(
                     [
-                        _ActionForTesting(id="Three", messages=[], result=ActionResult(level="SUCCESS")),
+                        _ActionForTesting(id="Three", messages=[], result=ActionResult(level="SUCCESS", id="SUCCESS")),
                     ],
                     [
                         _ActionForTesting(
-                            id="One", messages=[], result=ActionResult(level="ERROR", id="ERROR_ID", message="message")
+                            id="One",
+                            messages=[],
+                            result=ActionResult(
+                                level="ERROR",
+                                id="ERROR_ID",
+                                title="Error",
+                                description="Action error",
+                                diagnosis="User error",
+                                remediation="move on",
+                            ),
                         ),
                     ],
                     [
                         _ActionForTesting(
-                            id="Two", messages=[], result=ActionResult(level="SKIP", id="SKIP_ID", message="message")
+                            id="Two",
+                            messages=[],
+                            result=ActionResult(
+                                level="SKIP",
+                                id="SKIP_ID",
+                                title="Skip",
+                                description="Action skip",
+                                diagnosis="User skip",
+                                remediation="move on",
+                            ),
                         ),
                     ],
                 ),
                 {
-                    "One": dict(messages=[], result=dict(level=STATUS_CODE["ERROR"], id="ERROR_ID", message="message")),
-                    "Two": dict(messages=[], result=dict(level=STATUS_CODE["SKIP"], id="SKIP_ID", message="message")),
-                    "Three": dict(messages=[], result=dict(level=STATUS_CODE["SUCCESS"], id=None, message="")),
+                    "One": dict(
+                        messages=[],
+                        result=dict(
+                            level=STATUS_CODE["ERROR"],
+                            id="ERROR_ID",
+                            title="Error",
+                            description="Action error",
+                            diagnosis="User error",
+                            remediation="move on",
+                        ),
+                    ),
+                    "Two": dict(
+                        messages=[],
+                        result=dict(
+                            level=STATUS_CODE["SKIP"],
+                            id="SKIP_ID",
+                            title="Skip",
+                            description="Action skip",
+                            diagnosis="User skip",
+                            remediation="move on",
+                        ),
+                    ),
+                    "Three": dict(
+                        messages=[],
+                        result=dict(
+                            level=STATUS_CODE["SUCCESS"],
+                            id="SUCCESS",
+                            title="",
+                            description="",
+                            diagnosis="",
+                            remediation="",
+                        ),
+                    ),
                 },
             ),
         ),
@@ -785,8 +985,17 @@ class TestRunActions:
                     [
                         _ActionForTesting(
                             id="One",
-                            messages=[ActionMessage(level="WARNING", id="WARNING_ID", message="WARNING MESSAGE")],
-                            result=ActionResult(level="SUCCESS"),
+                            messages=[
+                                ActionMessage(
+                                    level="WARNING",
+                                    id="WARNING_ID",
+                                    title="Warning",
+                                    description="Action warning",
+                                    diagnosis="User warning",
+                                    remediation="move on",
+                                )
+                            ],
+                            result=ActionResult(level="SUCCESS", id="SUCCESS"),
                         ),
                     ],
                     [],
@@ -794,8 +1003,24 @@ class TestRunActions:
                 ),
                 {
                     "One": dict(
-                        messages=[dict(level=STATUS_CODE["WARNING"], id="WARNING_ID", message="WARNING MESSAGE")],
-                        result=dict(level=STATUS_CODE["SUCCESS"], id=None, message=""),
+                        messages=[
+                            dict(
+                                level=STATUS_CODE["WARNING"],
+                                id="WARNING_ID",
+                                title="Warning",
+                                description="Action warning",
+                                diagnosis="User warning",
+                                remediation="move on",
+                            )
+                        ],
+                        result=dict(
+                            level=STATUS_CODE["SUCCESS"],
+                            id="SUCCESS",
+                            title="",
+                            description="",
+                            diagnosis="",
+                            remediation="",
+                        ),
                     )
                 },
             ),
@@ -804,14 +1029,32 @@ class TestRunActions:
                     [
                         _ActionForTesting(
                             id="One",
-                            messages=[ActionMessage(level="WARNING", id="WARNING_ID", message="WARNING MESSAGE")],
-                            result=ActionResult(level="SUCCESS"),
+                            messages=[
+                                ActionMessage(
+                                    level="WARNING",
+                                    id="WARNING_ID",
+                                    title="Warning",
+                                    description="Action warning",
+                                    diagnosis="User warning",
+                                    remediation="move on",
+                                )
+                            ],
+                            result=ActionResult(level="SUCCESS", id="SUCCESS"),
                             dependencies=("One",),
                         ),
                         _ActionForTesting(
                             id="Two",
-                            messages=[ActionMessage(level="WARNING", id="WARNING_ID", message="WARNING MESSAGE")],
-                            result=ActionResult(level="SUCCESS"),
+                            messages=[
+                                ActionMessage(
+                                    level="WARNING",
+                                    id="WARNING_ID",
+                                    title="Warning",
+                                    description="Action warning",
+                                    diagnosis="User warning",
+                                    remediation="move on",
+                                )
+                            ],
+                            result=ActionResult(level="SUCCESS", id="SUCCESS"),
                             dependencies=(
                                 "One",
                                 "Two",
@@ -823,12 +1066,44 @@ class TestRunActions:
                 ),
                 {
                     "One": dict(
-                        messages=[dict(level=STATUS_CODE["WARNING"], id="WARNING_ID", message="WARNING MESSAGE")],
-                        result=dict(level=STATUS_CODE["SUCCESS"], id=None, message=""),
+                        messages=[
+                            dict(
+                                level=STATUS_CODE["WARNING"],
+                                id="WARNING_ID",
+                                title="Warning",
+                                description="Action warning",
+                                diagnosis="User warning",
+                                remediation="move on",
+                            )
+                        ],
+                        result=dict(
+                            level=STATUS_CODE["SUCCESS"],
+                            id="SUCCESS",
+                            title="",
+                            description="",
+                            diagnosis="",
+                            remediation="",
+                        ),
                     ),
                     "Two": dict(
-                        messages=[dict(level=STATUS_CODE["WARNING"], id="WARNING_ID", message="WARNING MESSAGE")],
-                        result=dict(level=STATUS_CODE["SUCCESS"], id=None, message=""),
+                        messages=[
+                            dict(
+                                level=STATUS_CODE["WARNING"],
+                                id="WARNING_ID",
+                                title="Warning",
+                                description="Action warning",
+                                diagnosis="User warning",
+                                remediation="move on",
+                            )
+                        ],
+                        result=dict(
+                            level=STATUS_CODE["SUCCESS"],
+                            id="SUCCESS",
+                            title="",
+                            description="",
+                            diagnosis="",
+                            remediation="",
+                        ),
                     ),
                 },
             ),
@@ -839,16 +1114,48 @@ class TestRunActions:
                     [
                         _ActionForTesting(
                             id="One",
-                            messages=[ActionMessage(level="WARNING", id="WARNING_ID", message="WARNING MESSAGE")],
-                            result=ActionResult(level="ERROR", id="SOME_ERROR", message="message"),
+                            messages=[
+                                ActionMessage(
+                                    level="WARNING",
+                                    id="WARNING_ID",
+                                    title="Warning",
+                                    description="Action warning",
+                                    diagnosis="User warning",
+                                    remediation="move on",
+                                )
+                            ],
+                            result=ActionResult(
+                                level="ERROR",
+                                id="SOME_ERROR",
+                                title="Error",
+                                description="Action error",
+                                diagnosis="User error",
+                                remediation="move on",
+                            ),
                         ),
                     ],
                     [],
                 ),
                 {
                     "One": dict(
-                        messages=[dict(level=STATUS_CODE["WARNING"], id="WARNING_ID", message="WARNING MESSAGE")],
-                        result=dict(level=STATUS_CODE["ERROR"], id="SOME_ERROR", message="message"),
+                        messages=[
+                            dict(
+                                level=STATUS_CODE["WARNING"],
+                                id="WARNING_ID",
+                                title="Warning",
+                                description="Action warning",
+                                diagnosis="User warning",
+                                remediation="move on",
+                            )
+                        ],
+                        result=dict(
+                            level=STATUS_CODE["ERROR"],
+                            id="SOME_ERROR",
+                            title="Error",
+                            description="Action error",
+                            diagnosis="User error",
+                            remediation="move on",
+                        ),
                     ),
                 },
             ),
@@ -858,16 +1165,48 @@ class TestRunActions:
                     [
                         _ActionForTesting(
                             id="One",
-                            messages=[ActionMessage(level="WARNING", id="WARNING_ID", message="WARNING MESSAGE")],
-                            result=ActionResult(level="OVERRIDABLE", id="SOME_ERROR", message="message"),
+                            messages=[
+                                ActionMessage(
+                                    level="WARNING",
+                                    id="WARNING_ID",
+                                    title="Warning",
+                                    description="Action warning",
+                                    diagnosis="User warning",
+                                    remediation="move on",
+                                )
+                            ],
+                            result=ActionResult(
+                                level="OVERRIDABLE",
+                                id="SOME_ERROR",
+                                title="Overridable",
+                                description="Action overridable",
+                                diagnosis="User overridable",
+                                remediation="move on",
+                            ),
                         ),
                     ],
                     [],
                 ),
                 {
                     "One": dict(
-                        messages=[dict(level=STATUS_CODE["WARNING"], id="WARNING_ID", message="WARNING MESSAGE")],
-                        result=dict(level=STATUS_CODE["OVERRIDABLE"], id="SOME_ERROR", message="message"),
+                        messages=[
+                            dict(
+                                level=STATUS_CODE["WARNING"],
+                                id="WARNING_ID",
+                                title="Warning",
+                                description="Action warning",
+                                diagnosis="User warning",
+                                remediation="move on",
+                            )
+                        ],
+                        result=dict(
+                            level=STATUS_CODE["OVERRIDABLE"],
+                            id="SOME_ERROR",
+                            title="Overridable",
+                            description="Action overridable",
+                            diagnosis="User overridable",
+                            remediation="move on",
+                        ),
                     ),
                 },
             ),
@@ -878,15 +1217,47 @@ class TestRunActions:
                     [
                         _ActionForTesting(
                             id="One",
-                            messages=[ActionMessage(level="WARNING", id="WARNING_ID", message="WARNING MESSAGE")],
-                            result=ActionResult(level="SKIP", id="SOME_ERROR", message="message"),
+                            messages=[
+                                ActionMessage(
+                                    level="WARNING",
+                                    id="WARNING_ID",
+                                    title="Warning",
+                                    description="Action warning",
+                                    diagnosis="User warning",
+                                    remediation="move on",
+                                )
+                            ],
+                            result=ActionResult(
+                                level="SKIP",
+                                id="SOME_ERROR",
+                                title="Skip",
+                                description="Action skip",
+                                diagnosis="User skip",
+                                remediation="move on",
+                            ),
                         ),
                     ],
                 ),
                 {
                     "One": dict(
-                        messages=[dict(level=STATUS_CODE["WARNING"], id="WARNING_ID", message="WARNING MESSAGE")],
-                        result=dict(level=STATUS_CODE["SKIP"], id="SOME_ERROR", message="message"),
+                        messages=[
+                            dict(
+                                level=STATUS_CODE["WARNING"],
+                                id="WARNING_ID",
+                                title="Warning",
+                                description="Action warning",
+                                diagnosis="User warning",
+                                remediation="move on",
+                            )
+                        ],
+                        result=dict(
+                            level=STATUS_CODE["SKIP"],
+                            id="SOME_ERROR",
+                            title="Skip",
+                            description="Action skip",
+                            diagnosis="User skip",
+                            remediation="move on",
+                        ),
                     ),
                 },
             ),
@@ -896,37 +1267,126 @@ class TestRunActions:
                     [
                         _ActionForTesting(
                             id="Three",
-                            messages=[ActionMessage(level="WARNING", id="WARNING_ID", message="WARNING MESSAGE 3")],
-                            result=ActionResult(level="SUCCESS"),
+                            messages=[
+                                ActionMessage(
+                                    level="WARNING",
+                                    id="WARNING_ID",
+                                    title="Warning",
+                                    description="Action warning",
+                                    diagnosis="User warning",
+                                    remediation="move on",
+                                )
+                            ],
+                            result=ActionResult(level="SUCCESS", id="SUCCESS"),
                         ),
                     ],
                     [
                         _ActionForTesting(
                             id="One",
-                            messages=[ActionMessage(level="WARNING", id="WARNING_ID", message="WARNING MESSAGE 1")],
-                            result=ActionResult(level="ERROR", id="ERROR_ID", message="message"),
+                            messages=[
+                                ActionMessage(
+                                    level="WARNING",
+                                    id="WARNING_ID",
+                                    title="Warning",
+                                    description="Action warning",
+                                    diagnosis="User warning",
+                                    remediation="move on",
+                                )
+                            ],
+                            result=ActionResult(
+                                level="ERROR",
+                                id="ERROR_ID",
+                                title="Error",
+                                description="Action error",
+                                diagnosis="User error",
+                                remediation="move on",
+                            ),
                         ),
                     ],
                     [
                         _ActionForTesting(
                             id="Two",
-                            messages=[ActionMessage(level="WARNING", id="WARNING_ID", message="WARNING MESSAGE 2")],
-                            result=ActionResult(level="SKIP", id="SKIP_ID", message="message"),
+                            messages=[
+                                ActionMessage(
+                                    level="WARNING",
+                                    id="WARNING_ID",
+                                    title="Warning",
+                                    description="Action warning",
+                                    diagnosis="User warning",
+                                    remediation="move on",
+                                )
+                            ],
+                            result=ActionResult(
+                                level="SKIP",
+                                id="SKIP_ID",
+                                title="Skip",
+                                description="Action skip",
+                                diagnosis="User skip",
+                                remediation="move on",
+                            ),
                         ),
                     ],
                 ),
                 {
                     "One": dict(
-                        messages=[dict(level=STATUS_CODE["WARNING"], id="WARNING_ID", message="WARNING MESSAGE 1")],
-                        result=dict(level=STATUS_CODE["ERROR"], id="ERROR_ID", message="message"),
+                        messages=[
+                            dict(
+                                level=STATUS_CODE["WARNING"],
+                                id="WARNING_ID",
+                                title="Warning",
+                                description="Action warning",
+                                diagnosis="User warning",
+                                remediation="move on",
+                            )
+                        ],
+                        result=dict(
+                            level=STATUS_CODE["ERROR"],
+                            id="ERROR_ID",
+                            title="Error",
+                            description="Action error",
+                            diagnosis="User error",
+                            remediation="move on",
+                        ),
                     ),
                     "Two": dict(
-                        messages=[dict(level=STATUS_CODE["WARNING"], id="WARNING_ID", message="WARNING MESSAGE 2")],
-                        result=dict(level=STATUS_CODE["SKIP"], id="SKIP_ID", message="message"),
+                        messages=[
+                            dict(
+                                level=STATUS_CODE["WARNING"],
+                                id="WARNING_ID",
+                                title="Warning",
+                                description="Action warning",
+                                diagnosis="User warning",
+                                remediation="move on",
+                            )
+                        ],
+                        result=dict(
+                            level=STATUS_CODE["SKIP"],
+                            id="SKIP_ID",
+                            title="Skip",
+                            description="Action skip",
+                            diagnosis="User skip",
+                            remediation="move on",
+                        ),
                     ),
                     "Three": dict(
-                        messages=[dict(level=STATUS_CODE["WARNING"], id="WARNING_ID", message="WARNING MESSAGE 3")],
-                        result=dict(level=STATUS_CODE["SUCCESS"], id=None, message=""),
+                        messages=[
+                            dict(
+                                level=STATUS_CODE["WARNING"],
+                                id="WARNING_ID",
+                                title="Warning",
+                                description="Action warning",
+                                diagnosis="User warning",
+                                remediation="move on",
+                            )
+                        ],
+                        result=dict(
+                            level=STATUS_CODE["SUCCESS"],
+                            id="SUCCESS",
+                            title="",
+                            description="",
+                            diagnosis="",
+                            remediation="",
+                        ),
                     ),
                 },
             ),
@@ -979,115 +1439,323 @@ class TestFindFailedActions:
 
 class TestActionClasses:
     @pytest.mark.parametrize(
-        ("id", "level", "message", "expected"),
+        ("id", "level", "title", "description", "diagnosis", "remediation", "expected"),
         (
             (
-                "SUCCESS_ID",
                 "SUCCESS",
-                "Success message",
-                dict(id="SUCCESS_ID", level=STATUS_CODE["SUCCESS"], message="Success message"),
+                "SUCCESS",
+                None,
+                None,
+                None,
+                None,
+                dict(
+                    id="SUCCESS",
+                    level=STATUS_CODE["SUCCESS"],
+                    title=None,
+                    description=None,
+                    diagnosis=None,
+                    remediation=None,
+                ),
             ),
-            ("SKIP_ID", "SKIP", "Skip message", dict(id="SKIP_ID", level=STATUS_CODE["SKIP"], message="Skip message")),
+            (
+                "SKIP_ID",
+                "SKIP",
+                "Skip message",
+                "skip description",
+                "skip diagnosis",
+                "skip remediation",
+                dict(
+                    id="SKIP_ID",
+                    level=STATUS_CODE["SKIP"],
+                    title="Skip message",
+                    description="skip description",
+                    diagnosis="skip diagnosis",
+                    remediation="skip remediation",
+                ),
+            ),
             (
                 "OVERRIDABLE_ID",
                 "OVERRIDABLE",
                 "Overridable message",
-                dict(id="OVERRIDABLE_ID", level=STATUS_CODE["OVERRIDABLE"], message="Overridable message"),
+                "overridable description",
+                "overridable diagnosis",
+                "overridable remediation",
+                dict(
+                    id="OVERRIDABLE_ID",
+                    level=STATUS_CODE["OVERRIDABLE"],
+                    title="Overridable message",
+                    description="overridable description",
+                    diagnosis="overridable diagnosis",
+                    remediation="overridable remediation",
+                ),
             ),
             (
                 "ERROR_ID",
                 "ERROR",
                 "Error message",
-                dict(id="ERROR_ID", level=STATUS_CODE["ERROR"], message="Error message"),
+                "error description",
+                "error diagnosis",
+                "error remediation",
+                dict(
+                    id="ERROR_ID",
+                    level=STATUS_CODE["ERROR"],
+                    title="Error message",
+                    description="error description",
+                    diagnosis="error diagnosis",
+                    remediation="error remediation",
+                ),
             ),
         ),
     )
-    def test_action_message_base(self, level, id, message, expected):
-        action_message_base = ActionMessageBase(level=level, id=id, message=message)
+    def test_action_message_base(self, level, id, title, description, diagnosis, remediation, expected):
+        action_message_base = ActionMessageBase(
+            level=level, id=id, title=title, description=description, diagnosis=diagnosis, remediation=remediation
+        )
         assert action_message_base.to_dict() == expected
 
     @pytest.mark.parametrize(
-        ("id", "level", "message", "expected"),
+        ("id", "level", "title", "description", "diagnosis", "remediation", "expected"),
         (
-            (None, None, None, "Messages require id, level and message fields"),
-            ("SUCCESS_ID", None, None, "Messages require id, level and message fields"),
-            (None, "SUCCESS", None, "Messages require id, level and message fields"),
-            (None, None, "Success Message", "Messages require id, level and message fields"),
-            ("SUCCESS_ID", "SUCCESS", "Success message", "Invalid level 'SUCCESS', set for a non-result message"),
-            ("SKIP_ID", "SKIP", "Skip message", "Invalid level 'SKIP', set for a non-result message"),
+            (None, None, None, None, None, None, "Messages require id, level, title and description fields"),
+            ("SUCCESS_ID", None, None, None, None, None, "Messages require id, level, title and description fields"),
+            (None, "SUCCESS", None, None, None, None, "Messages require id, level, title and description fields"),
+            (
+                None,
+                None,
+                "Success Message",
+                None,
+                None,
+                None,
+                "Messages require id, level, title and description fields",
+            ),
+            (
+                None,
+                None,
+                None,
+                "Success Description",
+                None,
+                None,
+                "Messages require id, level, title and description fields",
+            ),
+            (
+                "SUCCESS_ID",
+                "SUCCESS",
+                "Success message",
+                "Description",
+                None,
+                None,
+                "Invalid level 'SUCCESS', set for a non-result message",
+            ),
+            (
+                "SKIP_ID",
+                "SKIP",
+                "Skip message",
+                "Description",
+                None,
+                None,
+                "Invalid level 'SKIP', set for a non-result message",
+            ),
             (
                 "OVERRIDABLE_ID",
                 "OVERRIDABLE",
                 "Overridable message",
+                "Description",
+                None,
+                None,
                 "Invalid level 'OVERRIDABLE', set for a non-result message",
             ),
-            ("ERROR_ID", "ERROR", "Error message", "Invalid level 'ERROR', set for a non-result message"),
+            (
+                "ERROR_ID",
+                "ERROR",
+                "Error message",
+                "Description",
+                None,
+                None,
+                "Invalid level 'ERROR', set for a non-result message",
+            ),
         ),
     )
-    def test_action_message_exceptions(self, level, id, message, expected):
+    def test_action_message_exceptions(self, level, id, title, description, diagnosis, remediation, expected):
         with pytest.raises(InvalidMessageError, match=expected):
-            ActionMessage(level=level, id=id, message=message)
+            ActionMessage(
+                level=level, id=id, title=title, description=description, diagnosis=diagnosis, remediation=remediation
+            )
 
     @pytest.mark.parametrize(
-        ("id", "level", "message", "expected"),
+        ("id", "level", "title", "description", "diagnosis", "remediation", "expected"),
         (
             (
                 "WARNING_ID",
                 "WARNING",
                 "Warning message",
-                dict(id="WARNING_ID", level=STATUS_CODE["WARNING"], message="Warning message"),
+                "warning description",
+                "warning diagnosis",
+                "warning remediation",
+                dict(
+                    id="WARNING_ID",
+                    level=STATUS_CODE["WARNING"],
+                    title="Warning message",
+                    description="warning description",
+                    diagnosis="warning diagnosis",
+                    remediation="warning remediation",
+                ),
+            ),
+            (
+                "INFO_ID",
+                "INFO",
+                "Info message",
+                "info description",
+                "info diagnosis",
+                "info remediation",
+                dict(
+                    id="INFO_ID",
+                    level=STATUS_CODE["INFO"],
+                    title="Info message",
+                    description="info description",
+                    diagnosis="info diagnosis",
+                    remediation="info remediation",
+                ),
             ),
         ),
     )
-    def test_action_message_success(self, level, id, message, expected):
-        action_message = ActionMessage(level=level, id=id, message=message)
+    def test_action_message_success(self, level, id, title, description, diagnosis, remediation, expected):
+        action_message = ActionMessage(
+            level=level, id=id, title=title, description=description, diagnosis=diagnosis, remediation=remediation
+        )
         assert action_message.to_dict() == expected
 
     @pytest.mark.parametrize(
-        ("id", "level", "message", "expected"),
+        ("id", "level", "title", "description", "diagnosis", "remediation", "expected"),
         (
-            (None, "ERROR", None, "Non-success results require an id and a message"),
-            (None, "ERROR", "Error message", "Non-success results require an id"),
-            ("ERROR_ID", "ERROR", None, "Non-success results require a message"),
-            (None, "OVERRIDABLE", None, "Non-success results require an id and a message"),
-            (None, "OVERRIDABLE", "Overiddable message", "Non-success results require an id"),
-            ("OVERRIDABLE_ID", "OVERRIDABLE", None, "Non-success results require a message"),
+            (
+                None,
+                "ERROR",
+                None,
+                None,
+                None,
+                None,
+                "Results require the id field",
+            ),
+            (
+                "OVERRIDABLE_ID",
+                "OVERRIDABLE",
+                None,
+                None,
+                None,
+                None,
+                "Non-success results require level, title and description fields",
+            ),
+            (
+                "ERROR_ID",
+                "ERROR",
+                "Title",
+                None,
+                None,
+                None,
+                "Non-success results require level, title and description fields",
+            ),
+            (
+                "ERROR_ID",
+                "ERROR",
+                None,
+                "Description",
+                None,
+                None,
+                "Non-success results require level, title and description fields",
+            ),
             (
                 "WARNING_ID",
                 "WARNING",
                 "Warning message",
+                "Warning description",
+                "Warning diagnosis",
+                "Warning remediation",
                 "Invalid level 'WARNING', the level for result must be SKIP or more fatal or SUCCESS.",
             ),
         ),
     )
-    def test_action_result_exceptions(self, level, id, message, expected):
+    def test_action_result_exceptions(self, level, id, title, description, diagnosis, remediation, expected):
         with pytest.raises(InvalidMessageError, match=expected):
-            ActionResult(level=level, id=id, message=message)
+            ActionResult(
+                level=level, id=id, title=title, description=description, diagnosis=diagnosis, remediation=remediation
+            )
 
     @pytest.mark.parametrize(
-        ("id", "level", "message", "expected"),
+        ("id", "level", "title", "description", "diagnosis", "remediation", "expected"),
         (
             (
                 "SUCCESS_ID",
                 "SUCCESS",
-                "Success message",
-                dict(id="SUCCESS_ID", level=STATUS_CODE["SUCCESS"], message="Success message"),
+                None,
+                None,
+                None,
+                None,
+                dict(
+                    id="SUCCESS_ID",
+                    level=STATUS_CODE["SUCCESS"],
+                    title=None,
+                    description=None,
+                    diagnosis=None,
+                    remediation=None,
+                ),
             ),
-            ("SKIP_ID", "SKIP", "Skip message", dict(id="SKIP_ID", level=STATUS_CODE["SKIP"], message="Skip message")),
+            (
+                "SKIP_ID",
+                "SKIP",
+                "Skip",
+                "skip description",
+                "skip diagnosis",
+                "skip remediation",
+                dict(
+                    id="SKIP_ID",
+                    level=STATUS_CODE["SKIP"],
+                    title="Skip",
+                    description="skip description",
+                    diagnosis="skip diagnosis",
+                    remediation="skip remediation",
+                ),
+            ),
             (
                 "OVERRIDABLE_ID",
                 "OVERRIDABLE",
-                "Overridable message",
-                dict(id="OVERRIDABLE_ID", level=STATUS_CODE["OVERRIDABLE"], message="Overridable message"),
+                "Overridable",
+                "overridable description",
+                "overridable diagnosis",
+                "overridable remediation",
+                dict(
+                    id="OVERRIDABLE_ID",
+                    level=STATUS_CODE["OVERRIDABLE"],
+                    title="Overridable",
+                    description="overridable description",
+                    diagnosis="overridable diagnosis",
+                    remediation="overridable remediation",
+                ),
             ),
             (
                 "ERROR_ID",
                 "ERROR",
-                "Error message",
-                dict(id="ERROR_ID", level=STATUS_CODE["ERROR"], message="Error message"),
+                "Error",
+                "error description",
+                "error diagnosis",
+                "error remediation",
+                dict(
+                    id="ERROR_ID",
+                    level=STATUS_CODE["ERROR"],
+                    title="Error",
+                    description="error description",
+                    diagnosis="error diagnosis",
+                    remediation="error remediation",
+                ),
             ),
         ),
     )
-    def test_action_result_success(self, level, id, message, expected):
-        action_message = ActionResult(level=level, id=id, message=message)
+    def test_action_result_success(self, level, id, title, description, diagnosis, remediation, expected):
+        action_message = ActionResult(
+            level=level,
+            id=id,
+            title=title,
+            description=description,
+            diagnosis=diagnosis,
+            remediation=remediation,
+        )
         assert action_message.to_dict() == expected

--- a/convert2rhel/unit_tests/actions/data/stage_tests/all_status_actions/test.py
+++ b/convert2rhel/unit_tests/actions/data/stage_tests/all_status_actions/test.py
@@ -7,7 +7,14 @@ class ErrorTest(actions.Action):
 
     def run(self):
         super(ErrorTest, self).run()
-        self.set_result(level="ERROR", id="ERROR_ID", message="Failed on an error")
+        self.set_result(
+            level="ERROR",
+            id="ERROR_ID",
+            title="Failed on an error",
+            description="error",
+            diagnosis="error",
+            remediation="error",
+        )
 
 
 class OverridableTest(actions.Action):
@@ -16,7 +23,14 @@ class OverridableTest(actions.Action):
 
     def run(self):
         super(OverridableTest, self).run()
-        self.set_result(level="OVERRIDABLE", id="OVERRIDABLE_ID", message="Check failed but user may override")
+        self.set_result(
+            level="OVERRIDABLE",
+            id="OVERRIDABLE_ID",
+            title="Check failed but user may override",
+            description="overridable",
+            diagnosis="overridable",
+            remediation="overridable",
+        )
 
 
 # Skip because one dependency has failed
@@ -44,7 +58,14 @@ class WarningTest(actions.Action):
 
     def run(self):
         super(WarningTest, self).run()
-        self.add_message(level="WARNING", id="WARNING_ID", message="User disabled check")
+        self.add_message(
+            level="WARNING",
+            id="WARNING_ID",
+            title="User disabled check",
+            description="warning",
+            diagnosis="warning",
+            remediation="warning",
+        )
 
 
 class SuccessTest(actions.Action):

--- a/convert2rhel/unit_tests/actions/data/stage_tests/good_deps_failed_actions/test.py
+++ b/convert2rhel/unit_tests/actions/data/stage_tests/good_deps_failed_actions/test.py
@@ -15,4 +15,11 @@ class BTest(actions.Action):
 
     def run(self):
         super(BTest, self).run()
-        self.set_status(level=actions.STATUS_CODES["ERROR"], id="BTEST_FAILURE", message="failure message")
+        self.set_status(
+            level=actions.STATUS_CODES["ERROR"],
+            id="BTEST_FAILURE",
+            title="failure title",
+            description="failure description",
+            diagnosis="failure diagnosis",
+            remediation="failure remediation",
+        )

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
@@ -81,7 +81,11 @@ class TestBackupSystem:
 
         backup_redhat_release_action.run()
         unit_tests.assert_actions_result(
-            backup_redhat_release_action, level="ERROR", id="UNKNOWN_ERROR", message="File not found"
+            backup_redhat_release_action,
+            level="ERROR",
+            id="UNKNOWN_ERROR",
+            title="An unknown error has occurred",
+            description="File not found",
         )
 
     def test_backup_redhat_release_error_os_release_file(self, backup_redhat_release_action, monkeypatch):
@@ -90,5 +94,9 @@ class TestBackupSystem:
 
         backup_redhat_release_action.run()
         unit_tests.assert_actions_result(
-            backup_redhat_release_action, level="ERROR", id="UNKNOWN_ERROR", message="File not found"
+            backup_redhat_release_action,
+            level="ERROR",
+            id="UNKNOWN_ERROR",
+            title="An unknown error has occurred",
+            description="File not found",
         )

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/transaction_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/transaction_test.py
@@ -77,5 +77,10 @@ def test_validate_package_manager_transaction_unknown_error(
     validate_package_manager_transaction.run()
 
     unit_tests.assert_actions_result(
-        validate_package_manager_transaction, level="ERROR", id="UNKNOWN_ERROR", message="Exiting..."
+        validate_package_manager_transaction,
+        level="ERROR",
+        id="UNKNOWN_ERROR",
+        title="Unknown",
+        description="The cause of this error is unknown, please look at the diagnosis for more information.",
+        diagnosis="Exiting...",
     )

--- a/convert2rhel/unit_tests/actions/report_test.py
+++ b/convert2rhel/unit_tests/actions/report_test.py
@@ -26,7 +26,12 @@ from convert2rhel.logger import bcolors
 
 
 #: _LONG_MESSAGE since we do line wrapping
-_LONG_MESSAGE = "Will Robinson!  Will Robinson!  Danger Will Robinson...!  Please report directly to your parents in the spaceship immediately.  Danger!  Danger!  Danger!"
+_LONG_MESSAGE = {
+    "title": "Will Robinson! Will Robinson!",
+    "description": " Danger Will Robinson...!",
+    "diagnosis": " Danger! Danger! Danger!",
+    "remediation": " Please report directly to your parents in the spaceship immediately.",
+}
 
 
 @pytest.mark.parametrize(
@@ -75,45 +80,71 @@ def test_summary_as_json(results, expected, tmpdir):
         (
             {
                 "PreSubscription": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE"}],
-                    result={"level": STATUS_CODE["SUCCESS"], "id": None, "message": "All good!"},
-                )
-            },
-            True,
-            ["(WARNING) PreSubscription::WARNING_ID - WARNING MESSAGE", "(SUCCESS) PreSubscription - All good!"],
-        ),
-        (
-            {
-                "PreSubscription": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE"}],
-                    result={"level": STATUS_CODE["SUCCESS"], "id": None, "message": None},
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
+                    result={
+                        "level": STATUS_CODE["SUCCESS"],
+                        "id": "SUCCESS",
+                        "title": "",
+                        "description": "",
+                        "diagnosis": "",
+                        "remediation": "",
+                    },
                 )
             },
             True,
             [
-                "(WARNING) PreSubscription::WARNING_ID - WARNING MESSAGE",
-                "(SUCCESS) PreSubscription - [No further information given]",
+                "(WARNING) PreSubscription::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
+                "(SUCCESS) PreSubscription::SUCCESS - [No further information given]",
             ],
         ),
         (
             {
                 "PreSubscription": dict(
-                    messages=[], result={"level": STATUS_CODE["SUCCESS"], "id": None, "message": "All good!"}
+                    messages=[],
+                    result={
+                        "level": STATUS_CODE["SUCCESS"],
+                        "id": "SUCCESS",
+                        "title": "",
+                        "description": "",
+                        "diagnosis": "",
+                        "remediation": "",
+                    },
                 ),
                 "PreSubscription2": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE"}],
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
                     result={
                         "level": STATUS_CODE["SKIP"],
                         "id": "SKIPPED",
-                        "message": "SKIP MESSAGE",
+                        "title": "Skip",
+                        "description": "Action skip",
+                        "diagnosis": "User skip",
+                        "remediation": "move on",
                     },
                 ),
             },
             True,
             [
-                "(SUCCESS) PreSubscription - All good!",
-                "(WARNING) PreSubscription2::WARNING_ID - WARNING MESSAGE",
-                "(SKIP) PreSubscription2::SKIPPED - SKIP MESSAGE",
+                "(SUCCESS) PreSubscription::SUCCESS - [No further information given]",
+                "(WARNING) PreSubscription2::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
+                "(SKIP) PreSubscription2::SKIPPED - Skip\n     Description: Action skip\n     Diagnosis: User skip\n     Remediation: move on",
             ],
         ),
         # Test that messages that are below WARNING will not appear in
@@ -121,7 +152,15 @@ def test_summary_as_json(results, expected, tmpdir):
         (
             {
                 "PreSubscription": dict(
-                    messages=[], result={"level": STATUS_CODE["SUCCESS"], "id": None, "message": None}
+                    messages=[],
+                    result={
+                        "level": STATUS_CODE["SUCCESS"],
+                        "id": "SUCCESS",
+                        "title": "",
+                        "description": "",
+                        "diagnosis": "",
+                        "remediation": "",
+                    },
                 )
             },
             False,
@@ -130,100 +169,226 @@ def test_summary_as_json(results, expected, tmpdir):
         (
             {
                 "PreSubscription": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE"}],
-                    result={"level": STATUS_CODE["SUCCESS"], "id": None, "message": None},
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
+                    result={
+                        "level": STATUS_CODE["SUCCESS"],
+                        "id": "SUCCESS",
+                        "title": "",
+                        "description": "",
+                        "diagnosis": "",
+                        "remediation": "",
+                    },
                 )
             },
             False,
-            ["(WARNING) PreSubscription::WARNING_ID - WARNING MESSAGE"],
+            [
+                "(WARNING) PreSubscription::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on"
+            ],
         ),
         (
             {
                 "PreSubscription": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE 1"}],
-                    result={"level": STATUS_CODE["SUCCESS"], "id": None, "message": None},
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
+                    result={
+                        "level": STATUS_CODE["SUCCESS"],
+                        "id": "SUCCESS",
+                        "title": "",
+                        "description": "",
+                        "diagnosis": "",
+                        "remediation": "",
+                    },
                 ),
                 "PreSubscription2": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE 2"}],
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
                     result={
                         "level": STATUS_CODE["SKIP"],
                         "id": "SKIPPED",
-                        "message": "SKIP MESSAGE",
+                        "title": "Skip",
+                        "description": "Action skip",
+                        "diagnosis": "User skip",
+                        "remediation": "move on",
                     },
                 ),
             },
             False,
             [
-                "(SKIP) PreSubscription2::SKIPPED - SKIP MESSAGE",
-                "(WARNING) PreSubscription::WARNING_ID - WARNING MESSAGE 1",
-                "(WARNING) PreSubscription2::WARNING_ID - WARNING MESSAGE 2",
+                "(SKIP) PreSubscription2::SKIPPED - Skip\n     Description: Action skip\n     Diagnosis: User skip\n     Remediation: move on",
+                "(WARNING) PreSubscription::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
+                "(WARNING) PreSubscription2::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
             ],
         ),
         # Test all messages are displayed, SKIP and higher
         (
             {
                 "PreSubscription1": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE 1"}],
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
                     result={
                         "level": STATUS_CODE["SKIP"],
                         "id": "SKIPPED",
-                        "message": "SKIP MESSAGE",
+                        "title": "Skip",
+                        "description": "Action skip",
+                        "diagnosis": "User skip",
+                        "remediation": "move on",
                     },
                 ),
                 "PreSubscription2": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE 2"}],
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
                     result={
                         "level": STATUS_CODE["OVERRIDABLE"],
                         "id": "OVERRIDABLE_ID",
-                        "message": "OVERRIDABLE MESSAGE",
+                        "title": "Overridable",
+                        "description": "Action overridable",
+                        "diagnosis": "User overridable",
+                        "remediation": "move on",
                     },
                 ),
             },
             False,
             [
-                "(OVERRIDABLE) PreSubscription2::OVERRIDABLE_ID - OVERRIDABLE MESSAGE",
-                "(SKIP) PreSubscription1::SKIPPED - SKIP MESSAGE",
-                "(WARNING) PreSubscription1::WARNING_ID - WARNING MESSAGE 1",
-                "(WARNING) PreSubscription2::WARNING_ID - WARNING MESSAGE 2",
+                "(OVERRIDABLE) PreSubscription2::OVERRIDABLE_ID - Overridable\n     Description: Action overridable\n     Diagnosis: User overridable\n     Remediation: move on",
+                "(SKIP) PreSubscription1::SKIPPED - Skip\n     Description: Action skip\n     Diagnosis: User skip\n     Remediation: move on",
+                "(WARNING) PreSubscription1::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
+                "(WARNING) PreSubscription2::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
             ],
         ),
         (
             {
                 "SkipAction": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE 4"}],
-                    result={"level": STATUS_CODE["SKIP"], "id": "SKIP", "message": "SKIP MESSAGE"},
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
+                    result={
+                        "level": STATUS_CODE["SKIP"],
+                        "id": "SKIP",
+                        "title": "Skip",
+                        "description": "Action skip",
+                        "diagnosis": "User skip",
+                        "remediation": "move on",
+                    },
                 ),
                 "OverridableAction": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE 3"}],
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
                     result={
                         "level": STATUS_CODE["OVERRIDABLE"],
                         "id": "OVERRIDABLE",
-                        "message": "OVERRIDABLE MESSAGE",
+                        "title": "Overridable",
+                        "description": "Action overridable",
+                        "diagnosis": "User overridable",
+                        "remediation": "move on",
                     },
                 ),
                 "ErrorAction": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE 2"}],
-                    result={"level": STATUS_CODE["ERROR"], "id": "ERROR", "message": "ERROR MESSAGE"},
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
+                    result={
+                        "level": STATUS_CODE["ERROR"],
+                        "id": "ERROR",
+                        "title": "Error",
+                        "description": "Action error",
+                        "diagnosis": "User error",
+                        "remediation": "move on",
+                    },
                 ),
                 "TestAction": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE 1"}],
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
                     result={
                         "level": STATUS_CODE["ERROR"],
                         "id": "SECONDERROR",
-                        "message": "Test that two of the same level works",
+                        "title": "Error",
+                        "description": "Action error",
+                        "diagnosis": "User error",
+                        "remediation": "move on",
                     },
                 ),
             },
             False,
             [
-                "(ERROR) ErrorAction::ERROR - ERROR MESSAGE",
-                "(ERROR) TestAction::SECONDERROR - Test that two of the same level works",
-                "(OVERRIDABLE) OverridableAction::OVERRIDABLE - OVERRIDABLE MESSAGE",
-                "(SKIP) SkipAction::SKIP - SKIP MESSAGE",
-                "(WARNING) SkipAction::WARNING_ID - WARNING MESSAGE 4",
-                "(WARNING) OverridableAction::WARNING_ID - WARNING MESSAGE 3",
-                "(WARNING) ErrorAction::WARNING_ID - WARNING MESSAGE 2",
-                "(WARNING) TestAction::WARNING_ID - WARNING MESSAGE 1",
+                "(ERROR) ErrorAction::ERROR - Error\n     Description: Action error\n     Diagnosis: User error\n     Remediation: move on",
+                "(ERROR) TestAction::SECONDERROR - Error\n     Description: Action error\n     Diagnosis: User error\n     Remediation: move on",
+                "(OVERRIDABLE) OverridableAction::OVERRIDABLE - Overridable\n     Description: Action overridable\n     Diagnosis: User overridable\n     Remediation: move on",
+                "(SKIP) SkipAction::SKIP - Skip\n     Description: Action skip\n     Diagnosis: User skip\n     Remediation: move on",
+                "(WARNING) SkipAction::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
+                "(WARNING) OverridableAction::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
+                "(WARNING) ErrorAction::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
+                "(WARNING) TestAction::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
             ],
         ),
     ),
@@ -232,19 +397,81 @@ def test_summary(results, expected_results, include_all_reports, caplog):
     report.summary(results, include_all_reports, with_colors=False)
 
     for expected in expected_results:
-        assert expected in caplog.records[-1].message.splitlines()
+        assert expected in caplog.records[-1].message
 
 
-def test_results_summary_with_long_message(caplog):
+@pytest.mark.parametrize(
+    ("long_message"),
+    (
+        (_LONG_MESSAGE),
+        (
+            {
+                "title": "Will Robinson! Will Robinson!",
+                "description": " Danger Will Robinson...!" * 8,
+                "diagnosis": " Danger!" * 15,
+                "remediation": " Please report directly to your parents in the spaceship immediately." * 2,
+            }
+        ),
+    ),
+)
+def test_results_summary_with_long_message(long_message, caplog):
     """Test a long message because we word wrap those."""
+    result = {"level": STATUS_CODE["ERROR"], "id": "ERROR"}
+    result.update(long_message)
     report.summary(
         {
             "ErrorAction": dict(
                 messages=[],
+                result=result,
+            )
+        },
+        with_colors=False,
+    )
+
+    # Word wrapping might break on any spaces so we need to substitute
+    # a pattern for those
+    pattern = long_message["title"].replace(" ", "[ \t\n]+")
+    assert re.search(pattern, caplog.records[-1].message)
+
+    pattern = long_message["description"].replace(" ", "[ \t\n]+")
+    assert re.search(pattern, caplog.records[-1].message)
+
+    pattern = long_message["diagnosis"].replace(" ", "[ \t\n]+")
+    assert re.search(pattern, caplog.records[-1].message)
+
+    pattern = long_message["remediation"].replace(" ", "[ \t\n]+")
+    assert re.search(pattern, caplog.records[-1].message)
+
+
+@pytest.mark.parametrize(
+    ("long_message"),
+    (
+        (_LONG_MESSAGE),
+        (
+            {
+                "title": "Will Robinson! Will Robinson!",
+                "description": " Danger Will Robinson...!" * 8,
+                "diagnosis": " Danger!" * 15,
+                "remediation": " Please report directly to your parents in the spaceship immediately." * 2,
+            }
+        ),
+    ),
+)
+def test_messages_summary_with_long_message(long_message, caplog):
+    """Test a long message because we word wrap those."""
+    messages = {"level": STATUS_CODE["WARNING"], "id": "WARNING_ID"}
+    messages.update(long_message)
+    report.summary(
+        {
+            "ErrorAction": dict(
+                messages=[messages],
                 result={
-                    "level": STATUS_CODE["ERROR"],
-                    "id": "ERROR",
-                    "message": _LONG_MESSAGE,
+                    "level": STATUS_CODE["SUCCESS"],
+                    "id": "",
+                    "title": "",
+                    "description": "",
+                    "diagnosis": "",
+                    "remediation": "",
                 },
             )
         },
@@ -253,25 +480,16 @@ def test_results_summary_with_long_message(caplog):
 
     # Word wrapping might break on any spaces so we need to substitute
     # a pattern for those
-    pattern = _LONG_MESSAGE.replace(" ", "[ \t\n]+")
+    pattern = long_message["title"].replace(" ", "[ \t\n]+")
     assert re.search(pattern, caplog.records[-1].message)
 
+    pattern = long_message["description"].replace(" ", "[ \t\n]+")
+    assert re.search(pattern, caplog.records[-1].message)
 
-def test_messages_summary_with_long_message(caplog):
-    """Test a long message because we word wrap those."""
-    report.summary(
-        {
-            "ErrorAction": dict(
-                messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": _LONG_MESSAGE}],
-                result={"level": STATUS_CODE["SUCCESS"], "id": "", "message": ""},
-            )
-        },
-        with_colors=False,
-    )
+    pattern = long_message["diagnosis"].replace(" ", "[ \t\n]+")
+    assert re.search(pattern, caplog.records[-1].message)
 
-    # Word wrapping might break on any spaces so we need to substitute
-    # a pattern for those
-    pattern = _LONG_MESSAGE.replace(" ", "[ \t\n]+")
+    pattern = long_message["remediation"].replace(" ", "[ \t\n]+")
     assert re.search(pattern, caplog.records[-1].message)
 
 
@@ -283,47 +501,74 @@ def test_messages_summary_with_long_message(caplog):
             {
                 "PreSubscription2": dict(
                     messages=[],
-                    result={"level": STATUS_CODE["SKIP"], "id": "SKIPPED", "message": "SKIP MESSAGE"},
+                    result={
+                        "level": STATUS_CODE["SKIP"],
+                        "id": "SKIPPED",
+                        "title": "Skipped",
+                        "description": "Action skip",
+                        "diagnosis": "User skip",
+                        "remediation": "move on",
+                    },
                 ),
                 "PreSubscription1": dict(
                     messages=[],
                     result={
                         "level": STATUS_CODE["OVERRIDABLE"],
                         "id": "SOME_OVERRIDABLE",
-                        "message": "OVERRIDABLE MESSAGE",
+                        "title": "Overridable",
+                        "description": "Action override",
+                        "diagnosis": "User override",
+                        "remediation": "move on",
                     },
                 ),
             },
             False,
             [
-                r"\(OVERRIDABLE\) PreSubscription1::SOME_OVERRIDABLE - OVERRIDABLE MESSAGE",
-                r"\(SKIP\) PreSubscription2::SKIPPED - SKIP MESSAGE",
+                r"\(OVERRIDABLE\) PreSubscription1::SOME_OVERRIDABLE - Overridable\n     Description: Action override\n     Diagnosis: User override\n     Remediation: move on",
+                r"\(SKIP\) PreSubscription2::SKIPPED - Skipped\n     Description: Action skip\n     Diagnosis: User skip\n     Remediation: move on",
             ],
         ),
         (
             {
                 "SkipAction": dict(
                     messages=[],
-                    result={"level": STATUS_CODE["SKIP"], "id": "SKIP", "message": "SKIP MESSAGE"},
+                    result={
+                        "level": STATUS_CODE["SKIP"],
+                        "id": "SKIP",
+                        "title": "Skip",
+                        "description": "Action skip",
+                        "diagnosis": "User skip",
+                        "remediation": "move on",
+                    },
                 ),
                 "OverridableAction": dict(
                     messages=[],
                     result={
                         "level": STATUS_CODE["OVERRIDABLE"],
                         "id": "OVERRIDABLE",
-                        "message": "OVERRIDABLE MESSAGE",
+                        "title": "Overridable",
+                        "description": "Action override",
+                        "diagnosis": "User override",
+                        "remediation": "move on",
                     },
                 ),
                 "ErrorAction": dict(
                     messages=[],
-                    result={"level": STATUS_CODE["ERROR"], "id": "ERROR", "message": "ERROR MESSAGE"},
+                    result={
+                        "level": STATUS_CODE["ERROR"],
+                        "id": "ERROR",
+                        "title": "Error",
+                        "description": "Action error",
+                        "diagnosis": "User error",
+                        "remediation": "move on",
+                    },
                 ),
             },
             False,
             [
-                r"\(ERROR\) ErrorAction::ERROR - ERROR MESSAGE",
-                r"\(OVERRIDABLE\) OverridableAction::OVERRIDABLE - OVERRIDABLE MESSAGE",
-                r"\(SKIP\) SkipAction::SKIP - SKIP MESSAGE",
+                r"\(ERROR\) ErrorAction::ERROR - Error\n     Description: Action error\n     Diagnosis: User error\n     Remediation: move on",
+                r"\(OVERRIDABLE\) OverridableAction::OVERRIDABLE - Overridable\n     Description: Action override\n     Diagnosis: User override\n     Remediation: move on",
+                r"\(SKIP\) SkipAction::SKIP - Skip\n     Description: Action skip\n     Diagnosis: User skip\n     Remediation: move on",
             ],
         ),
         # Message order with `include_all_reports` set to True.
@@ -331,31 +576,55 @@ def test_messages_summary_with_long_message(caplog):
             {
                 "PreSubscription": dict(
                     messages=[],
-                    result={"level": STATUS_CODE["SUCCESS"], "id": None, "message": "All good!"},
+                    result={
+                        "level": STATUS_CODE["SUCCESS"],
+                        "id": "SUCCESS",
+                        "title": "",
+                        "description": "",
+                        "diagnosis": "",
+                        "remediation": "",
+                    },
                 ),
                 "SkipAction": dict(
                     messages=[],
-                    result={"level": STATUS_CODE["SKIP"], "id": "SKIP", "message": "SKIP MESSAGE"},
+                    result={
+                        "level": STATUS_CODE["SKIP"],
+                        "id": "SKIP",
+                        "title": "Skip",
+                        "description": "Action skip",
+                        "diagnosis": "User skip",
+                        "remediation": "move on",
+                    },
                 ),
                 "OverridableAction": dict(
                     messages=[],
                     result={
                         "level": STATUS_CODE["OVERRIDABLE"],
                         "id": "OVERRIDABLE",
-                        "message": "OVERRIDABLE MESSAGE",
+                        "title": "Overridable",
+                        "description": "Action override",
+                        "diagnosis": "User override",
+                        "remediation": "move on",
                     },
                 ),
                 "ErrorAction": dict(
                     messages=[],
-                    result={"level": STATUS_CODE["ERROR"], "id": "ERROR", "message": "ERROR MESSAGE"},
+                    result={
+                        "level": STATUS_CODE["ERROR"],
+                        "id": "ERROR",
+                        "title": "Error",
+                        "description": "Action error",
+                        "diagnosis": "User error",
+                        "remediation": "move on",
+                    },
                 ),
             },
             True,
             [
-                r"\(ERROR\) ErrorAction::ERROR - ERROR MESSAGE",
-                r"\(OVERRIDABLE\) OverridableAction::OVERRIDABLE - OVERRIDABLE MESSAGE",
-                r"\(SKIP\) SkipAction::SKIP - SKIP MESSAGE",
-                r"\(SUCCESS\) PreSubscription - All good!",
+                r"\(ERROR\) ErrorAction::ERROR - Error\n     Description: Action error\n     Diagnosis: User error\n     Remediation: move on",
+                r"\(OVERRIDABLE\) OverridableAction::OVERRIDABLE - Overridable\n     Description: Action override\n     Diagnosis: User override\n     Remediation: move on",
+                r"\(SKIP\) SkipAction::SKIP - Skip\n     Description: Action skip\n     Diagnosis: User skip\n     Remediation: move on",
+                r"\(SUCCESS\) PreSubscription::SUCCESS - \[No further information given\]",
             ],
         ),
     ),
@@ -372,7 +641,7 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
         pattern.append(entry)
     pattern = ".*".join(pattern)
 
-    assert re.search(pattern, message, re.DOTALL)
+    assert re.search(pattern, message, re.DOTALL | re.MULTILINE)
 
 
 @pytest.mark.parametrize(
@@ -382,83 +651,201 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
         (
             {
                 "PreSubscription2": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE"}],
-                    result={"level": STATUS_CODE["SKIP"], "id": "SKIPPED", "message": "SKIP MESSAGE"},
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
+                    result={
+                        "level": STATUS_CODE["SKIP"],
+                        "id": "SKIPPED",
+                        "title": "Skip",
+                        "description": "Action skip",
+                        "diagnosis": "User skip",
+                        "remediation": "move on",
+                    },
                 ),
                 "PreSubscription1": dict(
                     messages=[],
                     result={
                         "level": STATUS_CODE["OVERRIDABLE"],
                         "id": "SOME_OVERRIDABLE",
-                        "message": "OVERRIDABLE MESSAGE",
+                        "title": "Override",
+                        "description": "Action override",
+                        "diagnosis": "User override",
+                        "remediation": "move on",
                     },
                 ),
             },
             False,
             [
-                "(OVERRIDABLE) PreSubscription1::SOME_OVERRIDABLE - OVERRIDABLE MESSAGE",
-                "(SKIP) PreSubscription2::SKIPPED - SKIP MESSAGE",
-                "(WARNING) PreSubscription2::WARNING_ID - WARNING MESSAGE",
+                "(OVERRIDABLE) PreSubscription1::SOME_OVERRIDABLE - Override\n     Description: Action override\n     Diagnosis: User override\n     Remediation: move on",
+                "(SKIP) PreSubscription2::SKIPPED - Skip\n     Description: Action skip\n     Diagnosis: User skip\n     Remediation: move on",
+                "(WARNING) PreSubscription2::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
             ],
         ),
         (
             {
                 "SkipAction": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE 1"}],
-                    result={"level": STATUS_CODE["SKIP"], "id": "SKIP", "message": "SKIP MESSAGE"},
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
+                    result={
+                        "level": STATUS_CODE["SKIP"],
+                        "id": "SKIP",
+                        "title": "Skip",
+                        "description": "Action skip",
+                        "diagnosis": "User skip",
+                        "remediation": "move on",
+                    },
                 ),
                 "OverridableAction": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE 2"}],
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
                     result={
                         "level": STATUS_CODE["OVERRIDABLE"],
                         "id": "OVERRIDABLE",
-                        "message": "OVERRIDABLE MESSAGE",
+                        "title": "Overridable",
+                        "description": "Action overridable",
+                        "diagnosis": "User overridable",
+                        "remediation": "move on",
                     },
                 ),
                 "ErrorAction": dict(
                     messages=[],
-                    result={"level": STATUS_CODE["ERROR"], "id": "ERROR", "message": "ERROR MESSAGE"},
+                    result={
+                        "level": STATUS_CODE["ERROR"],
+                        "id": "ERROR",
+                        "title": "Error",
+                        "description": "Action error",
+                        "diagnosis": "User error",
+                        "remediation": "move on",
+                    },
                 ),
             },
             False,
             [
-                "(ERROR) ErrorAction::ERROR - ERROR MESSAGE",
-                "(OVERRIDABLE) OverridableAction::OVERRIDABLE - OVERRIDABLE MESSAGE",
-                "(SKIP) SkipAction::SKIP - SKIP MESSAGE",
-                "(WARNING) SkipAction::WARNING_ID - WARNING MESSAGE 1",
-                "(WARNING) OverridableAction::WARNING_ID - WARNING MESSAGE 2",
+                "(ERROR) ErrorAction::ERROR - Error\n     Description: Action error\n     Diagnosis: User error\n     Remediation: move on",
+                "(OVERRIDABLE) OverridableAction::OVERRIDABLE - Overridable\n     Description: Action overridable\n     Diagnosis: User overridable\n     Remediation: move on",
+                "(SKIP) SkipAction::SKIP - Skip\n     Description: Action skip\n     Diagnosis: User skip\n     Remediation: move on",
+                "(WARNING) SkipAction::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
+                "(WARNING) OverridableAction::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
             ],
         ),
         # Message order with `include_all_reports` set to True.
         (
             {
                 "PreSubscription": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE 1"}],
-                    result={"level": STATUS_CODE["SUCCESS"], "id": None, "message": "All good!"},
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
+                    result={
+                        "level": STATUS_CODE["SUCCESS"],
+                        "id": "SUCCESS",
+                        "title": "",
+                        "description": "",
+                        "diagnosis": "",
+                        "remediation": "",
+                    },
                 ),
                 "SkipAction": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE 2"}],
-                    result={"level": STATUS_CODE["SKIP"], "id": "SKIP", "message": "SKIP MESSAGE"},
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
+                    result={
+                        "level": STATUS_CODE["SKIP"],
+                        "id": "SKIP",
+                        "title": "Skip",
+                        "description": "Action skip",
+                        "diagnosis": "User skip",
+                        "remediation": "move on",
+                    },
                 ),
                 "OverridableAction": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE 3"}],
-                    result={"level": STATUS_CODE["OVERRIDABLE"], "id": "OVERRIDABLE", "message": "OVERRIDABLE MESSAGE"},
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
+                    result={
+                        "level": STATUS_CODE["OVERRIDABLE"],
+                        "id": "OVERRIDABLE",
+                        "title": "Overridable",
+                        "description": "Action overridable",
+                        "diagnosis": "User overridable",
+                        "remediation": "move on",
+                    },
                 ),
                 "ErrorAction": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE 4"}],
-                    result={"level": STATUS_CODE["ERROR"], "id": "ERROR", "message": "ERROR MESSAGE"},
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
+                    result={
+                        "level": STATUS_CODE["ERROR"],
+                        "id": "ERROR",
+                        "title": "Error",
+                        "description": "Action error",
+                        "diagnosis": "User error",
+                        "remediation": "move on",
+                    },
                 ),
             },
             True,
             [
-                "(ERROR) ErrorAction::ERROR - ERROR MESSAGE",
-                "(OVERRIDABLE) OverridableAction::OVERRIDABLE - OVERRIDABLE MESSAGE",
-                "(SKIP) SkipAction::SKIP - SKIP MESSAGE",
-                "(WARNING) PreSubscription::WARNING_ID - WARNING MESSAGE 1",
-                "(WARNING) SkipAction::WARNING_ID - WARNING MESSAGE 2",
-                "(WARNING) OverridableAction::WARNING_ID - WARNING MESSAGE 3",
-                "(WARNING) ErrorAction::WARNING_ID - WARNING MESSAGE 4",
-                "(SUCCESS) PreSubscription - All good!",
+                "(ERROR) ErrorAction::ERROR - Error\n     Description: Action error\n     Diagnosis: User error\n     Remediation: move on",
+                "(OVERRIDABLE) OverridableAction::OVERRIDABLE - Overridable\n     Description: Action overridable\n     Diagnosis: User overridable\n     Remediation: move on",
+                "(SKIP) SkipAction::SKIP - Skip\n     Description: Action skip\n     Diagnosis: User skip\n     Remediation: move on",
+                "(WARNING) PreSubscription::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
+                "(WARNING) SkipAction::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
+                "(WARNING) OverridableAction::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
+                "(WARNING) ErrorAction::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
+                "(SUCCESS) PreSubscription::SUCCESS - [No further information given]",
             ],
         ),
     ),
@@ -475,9 +862,8 @@ def test_messages_summary_ordering(results, include_all_reports, expected_result
 
     # Prove that all the messages occurred
     for expected in expected_results:
-        assert expected in caplog_messages
-
-    assert len(expected_results) == len(caplog_messages)
+        message = "\n".join(caplog_messages)
+        assert expected in message
 
 
 @pytest.mark.parametrize(
@@ -486,42 +872,122 @@ def test_messages_summary_ordering(results, include_all_reports, expected_result
         (
             {
                 "ErrorAction": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE"}],
-                    result={"level": STATUS_CODE["ERROR"], "id": "ERROR", "message": "ERROR MESSAGE"},
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
+                    result={
+                        "level": STATUS_CODE["ERROR"],
+                        "id": "ERROR",
+                        "title": "Error",
+                        "description": "Action error",
+                        "diagnosis": "User error",
+                        "remediation": "move on",
+                    },
                 )
             },
-            "%s(ERROR) ErrorAction::ERROR - ERROR MESSAGE%s" % (bcolors.FAIL, bcolors.ENDC),
-            "%s(WARNING) ErrorAction::WARNING_ID - WARNING MESSAGE%s" % (bcolors.WARNING, bcolors.ENDC),
+            "{begin}(ERROR) ErrorAction::ERROR - Error\n     Description: Action error\n     Diagnosis: User error\n     Remediation: move on{end}".format(
+                begin=bcolors.FAIL, end=bcolors.ENDC
+            ),
+            "{begin}(WARNING) ErrorAction::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on{end}".format(
+                begin=bcolors.WARNING, end=bcolors.ENDC
+            ),
         ),
         (
             {
                 "OverridableAction": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE"}],
-                    result={"level": STATUS_CODE["OVERRIDABLE"], "id": "OVERRIDABLE", "message": "OVERRIDABLE MESSAGE"},
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
+                    result={
+                        "level": STATUS_CODE["OVERRIDABLE"],
+                        "id": "OVERRIDABLE",
+                        "title": "Overridable",
+                        "description": "Action overridable",
+                        "diagnosis": "User overridable",
+                        "remediation": "move on",
+                    },
                 )
             },
-            "%s(OVERRIDABLE) OverridableAction::OVERRIDABLE - OVERRIDABLE MESSAGE%s" % (bcolors.FAIL, bcolors.ENDC),
-            "%s(WARNING) OverridableAction::WARNING_ID - WARNING MESSAGE%s" % (bcolors.WARNING, bcolors.ENDC),
+            "{begin}(OVERRIDABLE) OverridableAction::OVERRIDABLE - Overridable\n     Description: Action overridable\n     Diagnosis: User overridable\n     Remediation: move on{end}".format(
+                begin=bcolors.FAIL, end=bcolors.ENDC
+            ),
+            "{begin}(WARNING) OverridableAction::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on{end}".format(
+                begin=bcolors.WARNING, end=bcolors.ENDC
+            ),
         ),
         (
             {
                 "SkipAction": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE"}],
-                    result={"level": STATUS_CODE["SKIP"], "id": "SKIP", "message": "SKIP MESSAGE"},
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
+                    result={
+                        "level": STATUS_CODE["SKIP"],
+                        "id": "SKIP",
+                        "title": "Skip",
+                        "description": "Action skip",
+                        "diagnosis": "User skip",
+                        "remediation": "move on",
+                    },
                 )
             },
-            "%s(SKIP) SkipAction::SKIP - SKIP MESSAGE%s" % (bcolors.FAIL, bcolors.ENDC),
-            "%s(WARNING) SkipAction::WARNING_ID - WARNING MESSAGE%s" % (bcolors.WARNING, bcolors.ENDC),
+            "{begin}(SKIP) SkipAction::SKIP - Skip\n     Description: Action skip\n     Diagnosis: User skip\n     Remediation: move on{end}".format(
+                begin=bcolors.FAIL, end=bcolors.ENDC
+            ),
+            "{begin}(WARNING) SkipAction::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on{end}".format(
+                begin=bcolors.WARNING, end=bcolors.ENDC
+            ),
         ),
         (
             {
                 "SuccessfulAction": dict(
-                    messages=[{"level": STATUS_CODE["WARNING"], "id": "WARNING_ID", "message": "WARNING MESSAGE"}],
-                    result={"level": STATUS_CODE["SUCCESS"], "id": "SUCCESSFUL", "message": "SUCCESSFUL MESSAGE"},
+                    messages=[
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediation": "move on",
+                        }
+                    ],
+                    result={
+                        "level": STATUS_CODE["SUCCESS"],
+                        "id": "SUCCESS",
+                        "title": "",
+                        "description": "",
+                        "diagnosis": "",
+                        "remediation": "",
+                    },
                 )
             },
-            "%s(SUCCESS) SuccessfulAction::SUCCESSFUL - SUCCESSFUL MESSAGE%s" % (bcolors.OKGREEN, bcolors.ENDC),
-            "%s(WARNING) SuccessfulAction::WARNING_ID - WARNING MESSAGE%s" % (bcolors.WARNING, bcolors.ENDC),
+            "{begin}(SUCCESS) SuccessfulAction::SUCCESS - [No further information given]{end}".format(
+                begin=bcolors.OKGREEN, end=bcolors.ENDC
+            ),
+            "{begin}(WARNING) SuccessfulAction::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on{end}".format(
+                begin=bcolors.WARNING, end=bcolors.ENDC
+            ),
         ),
     ),
 )

--- a/convert2rhel/unit_tests/actions/system_checks/dbus_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/dbus_test.py
@@ -17,7 +17,7 @@ __metaclass__ = type
 
 import pytest
 
-from convert2rhel import unit_tests
+from convert2rhel import actions, unit_tests
 from convert2rhel.actions.system_checks import dbus
 
 
@@ -59,9 +59,29 @@ def test_check_dbus_is_running_not_running(monkeypatch, global_tool_opts, global
         dbus_is_running_action,
         level="ERROR",
         id="DBUS_DAEMON_NOT_RUNNING",
-        message=(
-            "Could not find a running DBus Daemon which is needed to"
-            " register with subscription manager.\nPlease start dbus using `systemctl"
-            " start dbus`"
-        ),
+        description="The Dbus daemon is not running",
+        diagnosis="Could not find a running DBus Daemon which is needed to register with subscription manager.",
+        remediation="Please start dbus using `systemctl start dbus`",
     )
+
+
+def test_check_dbus_is_running_warning_message(
+    monkeypatch, global_tool_opts, global_system_info, dbus_is_running_action
+):
+    monkeypatch.setattr(dbus, "tool_opts", global_tool_opts)
+    global_tool_opts.no_rhsm = True
+    dbus_is_running_action.run()
+    expected = set(
+        (
+            actions.ActionMessage(
+                level="WARNING",
+                id="DBUS_IS_RUNNING_CHECK_SKIP",
+                title="Skipping the dbus is running check",
+                description="Skipping the check because we have been asked not to subscribe this system to RHSM.",
+                diagnosis=None,
+                remediation=None,
+            ),
+        )
+    )
+    assert expected.issuperset(dbus_is_running_action.messages)
+    assert expected.issubset(dbus_is_running_action.messages)

--- a/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
@@ -17,11 +17,12 @@
 
 __metaclass__ = type
 
+import os
 
 import pytest
 import six
 
-from convert2rhel import pkgmanager
+from convert2rhel import actions, pkgmanager, unit_tests
 from convert2rhel.actions.system_checks import package_updates
 from convert2rhel.systeminfo import system_info
 from convert2rhel.unit_tests.conftest import centos8, oracle8
@@ -38,49 +39,167 @@ def package_updates_action():
 
 @oracle8
 def test_check_package_updates_skip_on_not_latest_ol(pretend_os, caplog, package_updates_action):
-    message = (
+    diagnosis = (
         "Skipping the check because there are no publicly available Oracle Linux Server 8.6 repositories available."
     )
-
-    package_updates_action.run()
-
-    assert message in caplog.records[-1].message
-
-
-@pytest.mark.parametrize(
-    ("packages", "exception", "expected"),
-    (
-        (["package-1", "package-2"], True, "The system has {0} package(s) not updated"),
-        ([], False, "System is up-to-date."),
-    ),
-)
-@centos8
-def test_check_package_updates(pretend_os, packages, exception, expected, monkeypatch, caplog, package_updates_action):
-    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=lambda reposdir: packages)
-
-    package_updates_action.run()
-    if exception:
-        expected = expected.format(len(packages))
-
-    assert expected in caplog.records[-1].message
-
-
-def test_check_package_updates_with_repoerror(monkeypatch, caplog, package_updates_action):
-    get_total_packages_to_update_mock = mock.Mock(side_effect=pkgmanager.RepoError)
-    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=get_total_packages_to_update_mock)
-    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=get_total_packages_to_update_mock)
-
-    package_updates_action.run()
-    # This is -2 because the last message is the error from the RepoError class.
-    assert (
-        "There was an error while checking whether the installed packages are up-to-date." in caplog.records[-2].message
+    expected = set(
+        (
+            actions.ActionMessage(
+                level="INFO",
+                id="PACKAGE_UPDATES_CHECK_SKIP_NO_PUBLIC_REPOSITORIES",
+                title="Skipping the package updates check",
+                description="Please refer to the diagnosis for further information",
+                diagnosis=diagnosis,
+                remediation=None,
+            ),
+        )
     )
+
+    package_updates_action.run()
+
+    assert diagnosis in caplog.records[-1].message
+    assert expected.issuperset(package_updates_action.messages)
+    assert expected.issubset(package_updates_action.messages)
+
+
+@centos8
+def test_check_package_updates(pretend_os, monkeypatch, caplog, package_updates_action):
+    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=lambda reposdir: [])
+
+    package_updates_action.run()
+    assert "System is up-to-date." in caplog.records[-1].message
+
+
+@centos8
+def test_check_package_updates_not_up_to_date(pretend_os, monkeypatch, package_updates_action, caplog):
+    packages = ["package-1", "package-2"]
+    diagnosis = (
+        "The system has 2 package(s) not updated based on the enabled system repositories.\n"
+        "List of packages to update: package-1 package-2.\n\n"
+        "Not updating the packages may cause the conversion to fail.\n"
+        "Consider updating the packages before proceeding with the conversion."
+    )
+    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=lambda reposdir: packages)
+    package_updates_action.run()
+    unit_tests.assert_actions_result(
+        package_updates_action,
+        level="SUCCESS",
+        id="OUT_OF_DATE_PACKAGES",
+        title="Outdated packages detected",
+        description=None,
+        diagnosis=None,
+    )
+
+    expected = set(
+        (
+            actions.ActionMessage(
+                level="WARNING",
+                id="PACKAGE_NOT_UP_TO_DATE_MESSAGE",
+                title="Outdated packages detected",
+                description="Please refer to the diagnosis for further information",
+                diagnosis=diagnosis,
+                remediation=None,
+            ),
+        )
+    )
+
+    assert diagnosis in caplog.records[-1].message
+    assert expected.issuperset(package_updates_action.messages)
+    assert expected.issubset(package_updates_action.messages)
+
+
+@centos8
+def test_check_package_updates_with_repoerror(pretend_os, monkeypatch, caplog, package_updates_action):
+    get_total_packages_to_update_mock = mock.Mock(side_effect=pkgmanager.RepoError("This is an error"))
+    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=get_total_packages_to_update_mock)
+    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=get_total_packages_to_update_mock)
+    diagnosis = (
+        "There was an error while checking whether the installed packages are up-to-date. Having an updated system is"
+        " an important prerequisite for a successful conversion. Consider verifyng the system is up to date manually"
+        " before proceeding with the conversion. This is an error"
+    )
+    package_updates_action.run()
+    unit_tests.assert_actions_result(
+        package_updates_action,
+        level="SUCCESS",
+        id="PACKAGE_UP_TO_DATE_CHECK_FAIL",
+        title="Package up to date check fail",
+        description=None,
+        diagnosis=None,
+        remediation=None,
+    )
+    expected = set(
+        (
+            actions.ActionMessage(
+                level="WARNING",
+                id="PACKAGE_UP_TO_DATE_CHECK_MESSAGE",
+                title="Package up to date check fail",
+                description="Please refer to the diagnosis for further information",
+                diagnosis=diagnosis,
+                remediation=None,
+            ),
+        )
+    )
+
+    assert diagnosis in caplog.records[-1].message
+    assert expected.issuperset(package_updates_action.messages)
+    assert expected.issubset(package_updates_action.messages)
+
+
+@centos8
+def test_check_package_updates_with_repoerror_skip(pretend_os, monkeypatch, caplog, package_updates_action):
+    get_total_packages_to_update_mock = mock.Mock(side_effect=pkgmanager.RepoError("This is an error"))
+    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=get_total_packages_to_update_mock)
+    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=get_total_packages_to_update_mock)
+    monkeypatch.setattr(
+        os,
+        "environ",
+        {"CONVERT2RHEL_PACKAGE_UP_TO_DATE_CHECK_SKIP": 1},
+    )
+    diagnosis = (
+        "There was an error while checking whether the installed packages are up-to-date. Having an updated system is"
+        " an important prerequisite for a successful conversion. Consider verifyng the system is up to date manually"
+        " before proceeding with the conversion. This is an error"
+    )
+    expected = set(
+        (
+            actions.ActionMessage(
+                level="WARNING",
+                id="PACKAGE_UP_TO_DATE_CHECK_MESSAGE",
+                title="Package up to date check fail",
+                description="Please refer to the diagnosis for further information",
+                diagnosis=diagnosis,
+                remediation=None,
+            ),
+        )
+    )
+
+    package_updates_action.run()
+
+    assert diagnosis in caplog.records[-1].message
+    assert expected.issuperset(package_updates_action.messages)
+    assert expected.issubset(package_updates_action.messages)
 
 
 @centos8
 def test_check_package_updates_without_internet(pretend_os, tmpdir, monkeypatch, caplog, package_updates_action):
     monkeypatch.setattr(package_updates, "get_hardcoded_repofiles_dir", value=lambda: str(tmpdir))
-    system_info.has_internet_access = False
+    monkeypatch.setattr(system_info, "has_internet_access", False)
+    description = "Skipping the check as no internet connection has been detected."
+    expected = set(
+        (
+            actions.ActionMessage(
+                level="WARNING",
+                id="PACKAGE_UPDATES_CHECK_SKIP_NO_INTERNET",
+                title="Skipping the package updates check",
+                description=description,
+                diagnosis=None,
+                remediation=None,
+            ),
+        )
+    )
     package_updates_action.run()
 
-    assert "Skipping the check as no internet connection has been detected." in caplog.records[-1].message
+    assert description in caplog.records[-1].message
+    assert expected.issuperset(package_updates_action.messages)
+    assert expected.issubset(package_updates_action.messages)

--- a/convert2rhel/unit_tests/actions/system_checks/readonly_mounts_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/readonly_mounts_test.py
@@ -84,14 +84,17 @@ class TestReadOnlyMountsChecks(unittest.TestCase):
     )
     def test_mounted_are_readonly_mnt(self):
         self.readonly_mounts_action_mnt.run()
-        self.assertEqual(self.readonly_mounts_action_mnt.result.level, actions.STATUS_CODE["ERROR"])
-        self.assertEqual(self.readonly_mounts_action_mnt.result.id, "MNT_DIR_READONLY_MOUNT")
-        self.assertEqual(
-            self.readonly_mounts_action_mnt.result.message,
-            (
+        unit_tests.assert_actions_result(
+            self.readonly_mounts_action_mnt,
+            level="ERROR",
+            id="MNT_DIR_READONLY_MOUNT",
+            title="Read-only mount in /mnt directory",
+            description=(
                 "Stopping conversion due to read-only mount to /mnt directory.\n"
                 "Mount at a subdirectory of /mnt to have /mnt writeable."
             ),
+            diagnosis=None,
+            remediation=None,
         )
 
     @unit_tests.mock(readonly_mounts, "logger", GetLoggerMocked())
@@ -108,12 +111,15 @@ class TestReadOnlyMountsChecks(unittest.TestCase):
     )
     def test_mounted_are_readonly_sys(self):
         self.readonly_mounts_action_sys.run()
-        self.assertEqual(self.readonly_mounts_action_sys.result.level, actions.STATUS_CODE["ERROR"])
-        self.assertEqual(self.readonly_mounts_action_sys.result.id, "SYS_DIR_READONLY_MOUNT")
-        self.assertEqual(
-            self.readonly_mounts_action_sys.result.message,
-            (
+        unit_tests.assert_actions_result(
+            self.readonly_mounts_action_sys,
+            level="ERROR",
+            id="SYS_DIR_READONLY_MOUNT",
+            title="Read-only mount in /sys directory",
+            description=(
                 "Stopping conversion due to read-only mount to /sys directory.\n"
                 "Ensure mount point is writable before executing convert2rhel."
             ),
+            diagnosis=None,
+            remediation=None,
         )

--- a/convert2rhel/unit_tests/actions/system_checks/rhel_compatible_kernel_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/rhel_compatible_kernel_test.py
@@ -24,6 +24,11 @@ import six
 
 from convert2rhel import unit_tests
 from convert2rhel.actions.system_checks import rhel_compatible_kernel
+from convert2rhel.actions.system_checks.rhel_compatible_kernel import (
+    BAD_KERNEL_RELEASE_SUBSTRINGS,
+    COMPATIBLE_KERNELS_VERS,
+    KernelIncompatibleError,
+)
 from convert2rhel.unit_tests import create_pkg_information
 from convert2rhel.unit_tests.conftest import centos8
 from convert2rhel.utils import run_subprocess
@@ -38,24 +43,16 @@ def rhel_compatible_kernel_action():
     return rhel_compatible_kernel.RhelCompatibleKernel()
 
 
-@pytest.mark.parametrize(
-    # i.e. _bad_kernel_version...
-    ("any_of_the_subchecks_is_true",),
-    (
-        (True,),
-        (False,),
-    ),
-)
-def test_check_rhel_compatible_kernel_is_used(
-    any_of_the_subchecks_is_true,
+def test_check_rhel_compatible_kernel_failure(
     monkeypatch,
-    caplog,
     rhel_compatible_kernel_action,
 ):
     monkeypatch.setattr(
         rhel_compatible_kernel,
         "_bad_kernel_version",
-        value=mock.Mock(return_value=any_of_the_subchecks_is_true),
+        value=mock.Mock(
+            side_effect=KernelIncompatibleError("UNEXPECTED_VERSION", "Bad kernel version", dict(fake_data="fake"))
+        ),
     )
     monkeypatch.setattr(
         rhel_compatible_kernel,
@@ -73,41 +70,74 @@ def test_check_rhel_compatible_kernel_is_used(
         "version",
         value=Version(major=1, minor=0),
     )
+    monkeypatch.setattr(
+        rhel_compatible_kernel.system_info,
+        "name",
+        value="Kernel-core",
+    )
     rhel_compatible_kernel_action.run()
-    if any_of_the_subchecks_is_true:
-        unit_tests.assert_actions_result(
-            rhel_compatible_kernel_action,
-            level="ERROR",
-            id="BOOTED_KERNEL_INCOMPATIBLE",
-            message=(
-                "The booted kernel version is incompatible with the standard RHEL kernel. "
-                "To proceed with the conversion, boot into a kernel that is available in the {0} {1} base repository"
-                " by executing the following steps:\n\n"
-                "1. Ensure that the {0} {1} base repository is enabled\n"
-                "2. Run: yum install kernel\n"
-                "3. (optional) Run: grubby --set-default "
-                '/boot/vmlinuz-`rpm -q --qf "%{{BUILDTIME}}\\t%{{EVR}}.%{{ARCH}}\\n" kernel | sort -nr | head -1 | cut -f2`\n'
-                "4. Reboot the machine and if step 3 was not applied choose the kernel"
-                " installed in step 2 manually".format(
-                    rhel_compatible_kernel.system_info.name,
-                    rhel_compatible_kernel.system_info.version.major,
-                )
-            ),
-        )
-    else:
-        assert "is compatible with RHEL" in caplog.records[-1].message
+    unit_tests.assert_actions_result(
+        rhel_compatible_kernel_action,
+        level="ERROR",
+        id="UNEXPECTED_VERSION",
+        title="Incompatible booted kernel version",
+        description="Please refer to the diagnosis for further information",
+        diagnosis="The booted kernel version is incompatible with the standard RHEL kernel",
+        remediation=(
+            "To proceed with the conversion, boot into a kernel that is available in the {0} {1} base repository"
+            " by executing the following steps:\n\n"
+            "1. Ensure that the {0} {1} base repository is enabled\n"
+            "2. Run: yum install kernel\n"
+            "3. (optional) Run: grubby --set-default "
+            '/boot/vmlinuz-`rpm -q --qf "%{{BUILDTIME}}\\t%{{EVR}}.%{{ARCH}}\\n" kernel | sort -nr | head -1 | cut -f2`\n'
+            "4. Reboot the machine and if step 3 was not applied choose the kernel"
+            " installed in step 2 manually".format(
+                rhel_compatible_kernel.system_info.name, rhel_compatible_kernel.system_info.version.major
+            )
+        ),
+    )
+
+
+def test_rhel_compatible_kernel_success(monkeypatch, caplog, rhel_compatible_kernel_action):
+    monkeypatch.setattr(
+        rhel_compatible_kernel,
+        "_bad_kernel_version",
+        value=mock.Mock(return_value=False),
+    )
+    monkeypatch.setattr(
+        rhel_compatible_kernel,
+        "_bad_kernel_substring",
+        value=mock.Mock(return_value=False),
+    )
+    monkeypatch.setattr(
+        rhel_compatible_kernel,
+        "_bad_kernel_package_signature",
+        value=mock.Mock(return_value=False),
+    )
+    Version = namedtuple("Version", ("major", "minor"))
+    monkeypatch.setattr(
+        rhel_compatible_kernel.system_info,
+        "version",
+        value=Version(major=1, minor=0),
+    )
+    monkeypatch.setattr(
+        rhel_compatible_kernel.system_info,
+        "name",
+        value="Kernel-core",
+    )
+    rhel_compatible_kernel_action.run()
+
+    assert "is compatible with RHEL" in caplog.records[-1].message
 
 
 @pytest.mark.parametrize(
     ("kernel_release", "major_ver", "exp_return"),
     (
-        ("5.11.0-7614-generic", None, True),
         ("3.10.0-1160.24.1.el7.x86_64", 7, False),
-        ("5.4.17-2102.200.13.el8uek.x86_64", 8, True),
         ("4.18.0-240.22.1.el8_3.x86_64", 8, False),
     ),
 )
-def test_bad_kernel_version(kernel_release, major_ver, exp_return, monkeypatch):
+def test_bad_kernel_version_success(kernel_release, major_ver, exp_return, monkeypatch):
     Version = namedtuple("Version", ("major", "minor"))
     monkeypatch.setattr(
         rhel_compatible_kernel.system_info,
@@ -118,15 +148,81 @@ def test_bad_kernel_version(kernel_release, major_ver, exp_return, monkeypatch):
 
 
 @pytest.mark.parametrize(
+    ("kernel_release", "major_ver", "error_id", "template", "variables"),
+    (
+        (
+            "5.11.0-7614-generic",
+            None,
+            "UNEXPECTED_VERSION",
+            "Unexpected OS major version. Expected: {compatible_version}",
+            dict(compatible_version=COMPATIBLE_KERNELS_VERS.keys()),
+        ),
+        (
+            "5.4.17-2102.200.13.el8uek.x86_64",
+            8,
+            "INCOMPATIBLE_VERSION",
+            "Booted kernel version '{kernel_version}' does not correspond to the version "
+            "'{compatible_version}' available in RHEL {rhel_major_version}",
+            dict(kernel_version="5.4.17", compatible_version=COMPATIBLE_KERNELS_VERS[8], rhel_major_version=8),
+        ),
+    ),
+)
+def test_bad_kernel_version_invalid_version(kernel_release, major_ver, error_id, template, variables, monkeypatch):
+    Version = namedtuple("Version", ("major", "minor"))
+    monkeypatch.setattr(
+        rhel_compatible_kernel.system_info,
+        "version",
+        value=Version(major=major_ver, minor=0),
+    )
+    with pytest.raises(KernelIncompatibleError) as excinfo:
+        rhel_compatible_kernel._bad_kernel_version(kernel_release)
+    assert excinfo.value.error_id == error_id
+    assert excinfo.value.template == template
+    assert excinfo.value.variables == variables
+
+
+@pytest.mark.parametrize(
     ("kernel_release", "exp_return"),
     (
         ("3.10.0-1160.24.1.el7.x86_64", False),
-        ("5.4.17-2102.200.13.el8uek.x86_64", True),
-        ("3.10.0-514.2.2.rt56.424.el7.x86_64", True),
+        ("5.04.0-1240.41.0.el8.x86_64", False),
     ),
 )
-def test_bad_kernel_substring(kernel_release, exp_return):
+def test_bad_kernel_substring_success(kernel_release, exp_return):
     assert rhel_compatible_kernel._bad_kernel_substring(kernel_release) == exp_return
+
+
+@pytest.mark.parametrize(
+    ("kernel_release", "error_id", "template", "variables"),
+    (
+        (
+            "5.4.17-2102.200.13.el8uek.x86_64",
+            "INVALID_PACKAGE_SUBSTRING",
+            "The booted kernel '{kernel_release}' contains one of the disallowed "
+            "substrings: {bad_kernel_release_substrings}",
+            dict(
+                kernel_release="5.4.17-2102.200.13.el8uek.x86_64",
+                bad_kernel_release_substrings=BAD_KERNEL_RELEASE_SUBSTRINGS,
+            ),
+        ),
+        (
+            "3.10.0-514.2.2.rt56.424.el7.x86_64",
+            "INVALID_PACKAGE_SUBSTRING",
+            "The booted kernel '{kernel_release}' contains one of the disallowed "
+            "substrings: {bad_kernel_release_substrings}",
+            dict(
+                kernel_release="3.10.0-514.2.2.rt56.424.el7.x86_64",
+                bad_kernel_release_substrings=BAD_KERNEL_RELEASE_SUBSTRINGS,
+            ),
+        ),
+    ),
+)
+def test_bad_kernel_substring_invalid_substring(kernel_release, error_id, template, variables, monkeypatch):
+    with pytest.raises(KernelIncompatibleError) as excinfo:
+        rhel_compatible_kernel._bad_kernel_substring(kernel_release)
+    assert excinfo.value.error_id == error_id
+    assert excinfo.value.template == template
+    assert excinfo.value.variables == variables
 
 
 @pytest.mark.parametrize(
@@ -146,24 +242,10 @@ def test_bad_kernel_substring(kernel_release, exp_return):
             "yajl.x86_64",
             False,
         ),
-        (
-            "4.18.0-240.22.1.el8_3.x86_64",
-            "4.18.0&240.22.1.el8_3&x86_64&kernel-core",
-            create_pkg_information(
-                name="kernel-core",
-                epoch="0",
-                version="4.18.0",
-                release="240.22.1.el8_3",
-                arch="x86_64",
-                fingerprint="somebadsig",
-            ),
-            "somepkgobj",
-            True,
-        ),
     ),
 )
 @centos8
-def test_bad_kernel_package_signature(
+def test_bad_kernel_package_signature_success(
     kernel_release,
     kernel_pkg,
     kernel_pkg_information,
@@ -191,13 +273,89 @@ def test_bad_kernel_package_signature(
     )
 
 
+@pytest.mark.parametrize(
+    (
+        "kernel_release",
+        "kernel_pkg",
+        "kernel_pkg_information",
+        "get_installed_pkg_objects",
+        "error_id",
+        "template",
+        "variables",
+    ),
+    (
+        (
+            "4.18.0-240.22.1.el8_3.x86_64",
+            "4.18.0&240.22.1.el8_3&x86_64&kernel-core",
+            create_pkg_information(
+                name="kernel-core",
+                epoch="0",
+                version="4.18.0",
+                release="240.22.1.el8_3",
+                arch="x86_64",
+                fingerprint="somebadsig",
+            ),
+            "somepkgobj",
+            "INVALID_KERNEL_PACKAGE_SIGNATURE",
+            "Custom kernel detected. The booted kernel needs to be signed by {os_vendor}.",
+            dict(os_vendor="CentOS"),
+        ),
+    ),
+)
 @centos8
-def test_kernel_not_installed(pretend_os, caplog, monkeypatch):
+def test_bad_kernel_package_signature_invalid_signature(
+    kernel_release,
+    kernel_pkg,
+    kernel_pkg_information,
+    get_installed_pkg_objects,
+    error_id,
+    template,
+    variables,
+    monkeypatch,
+    pretend_os,
+):
+    run_subprocess_mocked = mock.Mock(spec=run_subprocess, return_value=(kernel_pkg, 0))
+    monkeypatch.setattr(rhel_compatible_kernel, "run_subprocess", run_subprocess_mocked)
+    get_installed_pkg_objects_mocked = mock.Mock(
+        spec=rhel_compatible_kernel.get_installed_pkg_objects, return_value=[kernel_pkg]
+    )
+    get_installed_pkg_information_mocked = mock.Mock(return_value=[kernel_pkg_information])
+    monkeypatch.setattr(
+        rhel_compatible_kernel,
+        "get_installed_pkg_objects",
+        get_installed_pkg_objects_mocked,
+    )
+    monkeypatch.setattr(rhel_compatible_kernel, "get_installed_pkg_information", get_installed_pkg_information_mocked)
+
+    with pytest.raises(KernelIncompatibleError) as excinfo:
+        rhel_compatible_kernel._bad_kernel_package_signature(kernel_release)
+    assert excinfo.value.error_id == error_id
+    assert excinfo.value.template == template
+    assert excinfo.value.variables == variables
+    run_subprocess_mocked.assert_called_with(
+        ["rpm", "-qf", "--qf", "%{VERSION}&%{RELEASE}&%{ARCH}&%{NAME}", "/boot/vmlinuz-%s" % kernel_release],
+        print_output=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("error_id", "template", "variables"),
+    (
+        (
+            "UNSIGNED_PACKAGE",
+            "The booted kernel {vmlinuz_path} is not owned by any installed package."
+            " It needs to be owned by a package signed by {os_vendor}.",
+            dict(vmlinuz_path="/boot/vmlinuz-4.18.0-240.22.1.el8_3.x86_64", os_vendor="CentOS"),
+        ),
+    ),
+)
+@centos8
+def test_kernel_not_installed(pretend_os, error_id, template, variables, monkeypatch):
     run_subprocess_mocked = mock.Mock(spec=run_subprocess, return_value=(" ", 1))
     monkeypatch.setattr(rhel_compatible_kernel, "run_subprocess", run_subprocess_mocked)
-    assert rhel_compatible_kernel._bad_kernel_package_signature("4.18.0-240.22.1.el8_3.x86_64")
-    log_message = (
-        "The booted kernel /boot/vmlinuz-4.18.0-240.22.1.el8_3.x86_64 is not owned by any installed package."
-        " It needs to be owned by a package signed by CentOS."
-    )
-    assert log_message in caplog.text
+
+    with pytest.raises(KernelIncompatibleError) as excinfo:
+        rhel_compatible_kernel._bad_kernel_package_signature("4.18.0-240.22.1.el8_3.x86_64")
+    assert excinfo.value.error_id == error_id
+    assert excinfo.value.template == template
+    assert excinfo.value.variables == variables

--- a/convert2rhel/unit_tests/actions/system_checks/tainted_kmods_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/tainted_kmods_test.py
@@ -55,14 +55,20 @@ def test_check_tainted_kmods(monkeypatch, command_return, is_error, tainted_kmod
         "run_subprocess",
         value=run_subprocess_mock,
     )
+    tainted_kmods_action.run()
+
     if is_error:
-        tainted_kmods_action.run()
         unit_tests.assert_actions_result(
             tainted_kmods_action,
             level="ERROR",
             id="TAINTED_KMODS_DETECTED",
-            message="Tainted kernel modules detected:\n  system76_io\n",
+            title="Tainted kernel modules detected",
+            description="Please refer to the diagnosis for further information",
+            diagnosis="Tainted kernel modules detected:\n  system76_io\n",
+            remediation=(
+                "Prevent the modules from loading by following {0}"
+                " and run convert2rhel again to continue with the conversion.".format(
+                    tainted_kmods.LINK_PREVENT_KMODS_FROM_LOADING
+                )
+            ),
         )
-
-    else:
-        tainted_kmods_action.run()

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -154,17 +154,6 @@ class RunSubprocessMocked(unit_tests.MockFunction):
         return self.output, self.ret_code
 
 
-class GetInstalledPkgsWFingerprintsMocked(unit_tests.MockFunction):
-    obj1 = create_pkg_information(name="pkg1", fingerprint="199e2f91fd431d51")  # RHEL
-    obj2 = create_pkg_information(name="pkg2", fingerprint="72f97b74ec551f03")  # OL
-    obj3 = create_pkg_information(
-        name="gpg-pubkey", version="1.0.0", release="1", arch="x86_64", fingerprint="199e2f91fd431d51"  # RHEL
-    )
-
-    def __call__(self, *args, **kwargs):
-        return [self.obj1, self.obj2, self.obj3]
-
-
 class PrintPkgInfoMocked(unit_tests.MockFunction):
     def __init__(self):
         self.called = 0
@@ -1684,7 +1673,7 @@ def test_get_installed_pkgs_by_fingerprint_incorrect_fingerprint(pretend_os, mon
     reason="No yum module detected on the system, skipping it.",
 )
 @centos7
-def test_print_pkg_info_yum(pretend_os, monkeypatch):
+def test_format_pkg_info_yum(pretend_os, monkeypatch):
     packages = [
         create_pkg_information(
             packager="Oracle",
@@ -1732,7 +1721,7 @@ C2R 0:gpg-pubkey-0.1-1.x86_64&test
         ),
     )
 
-    result = pkghandler.print_pkg_info(packages)
+    result = pkghandler.format_pkg_info(packages)
     assert re.search(
         r"^Package\s+Vendor/Packager\s+Repository$",
         result,
@@ -1756,7 +1745,7 @@ C2R 0:gpg-pubkey-0.1-1.x86_64&test
     reason="No dnf module detected on the system, skipping it.",
 )
 @centos8
-def test_print_pkg_info_dnf(pretend_os, monkeypatch):
+def test_format_pkg_info_dnf(pretend_os, monkeypatch):
     packages = [
         create_pkg_information(
             packager="Oracle",
@@ -1804,7 +1793,7 @@ C2R gpg-pubkey-0:0.1-1.x86_64&test
         ),
     )
 
-    result = pkghandler.print_pkg_info(packages)
+    result = pkghandler.format_pkg_info(packages)
 
     assert re.search(
         r"^pkg1-0:0\.1-1\.x86_64\s+Oracle\s+anaconda$",
@@ -1838,22 +1827,22 @@ class GetInstalledPkgObjectsWDiffFingerprintMocked(unit_tests.MockFunction):
         return [pkg_obj]
 
 
-def test_get_packages_to_remove(monkeypatch):
+def testget_packages_to_remove(monkeypatch):
     monkeypatch.setattr(system_info, "fingerprints_rhel", ["rhel_fingerprint"])
     monkeypatch.setattr(
         pkghandler, "get_installed_pkgs_w_different_fingerprint", GetInstalledPkgObjectsWDiffFingerprintMocked()
     )
-    original_func = pkghandler._get_packages_to_remove.__wrapped__
-    monkeypatch.setattr(pkghandler, "_get_packages_to_remove", mock_decorator(original_func))
+    original_func = pkghandler.get_packages_to_remove.__wrapped__
+    monkeypatch.setattr(pkghandler, "get_packages_to_remove", mock_decorator(original_func))
 
-    result = pkghandler._get_packages_to_remove(["installed_pkg", "not_installed_pkg"])
+    result = pkghandler.get_packages_to_remove(["installed_pkg", "not_installed_pkg"])
     assert len(result) == 1
     assert result[0].nevra.name == "installed_pkg"
 
 
 def test_remove_pkgs_with_confirm(monkeypatch):
     monkeypatch.setattr(utils, "ask_to_continue", DumbCallableObject())
-    monkeypatch.setattr(pkghandler, "print_pkg_info", DumbCallable())
+    monkeypatch.setattr(pkghandler, "format_pkg_info", DumbCallable())
     monkeypatch.setattr(pkghandler, "remove_pkgs", RemovePkgsMocked())
 
     pkghandler.remove_pkgs_unless_from_redhat(
@@ -1951,23 +1940,23 @@ def test_get_pkg_nevra(pkgmanager_name, package, include_zero_epoch, expected, m
 )
 def test_get_third_party_pkgs(fingerprint_orig_os, expected_count, expected_pkgs, monkeypatch):
     monkeypatch.setattr(utils, "ask_to_continue", DumbCallableObject())
-    monkeypatch.setattr(pkghandler, "print_pkg_info", PrintPkgInfoMocked())
+    monkeypatch.setattr(pkghandler, "format_pkg_info", PrintPkgInfoMocked())
     monkeypatch.setattr(system_info, "fingerprints_orig_os", fingerprint_orig_os)
-    monkeypatch.setattr(pkghandler, "get_installed_pkg_information", GetInstalledPkgsWFingerprintsMocked())
+    monkeypatch.setattr(pkghandler, "get_installed_pkg_information", unit_tests.GetInstalledPkgsWFingerprintsMocked())
 
     pkgs = pkghandler.get_third_party_pkgs()
 
-    assert pkghandler.print_pkg_info.called == expected_count
+    assert pkghandler.format_pkg_info.called == expected_count
     assert len(pkgs) == expected_pkgs
 
 
 def test_list_non_red_hat_pkgs_left(monkeypatch):
-    monkeypatch.setattr(pkghandler, "print_pkg_info", PrintPkgInfoMocked())
-    monkeypatch.setattr(pkghandler, "get_installed_pkg_information", GetInstalledPkgsWFingerprintsMocked())
+    monkeypatch.setattr(pkghandler, "format_pkg_info", PrintPkgInfoMocked())
+    monkeypatch.setattr(pkghandler, "get_installed_pkg_information", unit_tests.GetInstalledPkgsWFingerprintsMocked())
     pkghandler.list_non_red_hat_pkgs_left()
 
-    assert len(pkghandler.print_pkg_info.pkgs) == 1
-    assert pkghandler.print_pkg_info.pkgs[0].nevra.name == "pkg2"
+    assert len(pkghandler.format_pkg_info.pkgs) == 1
+    assert pkghandler.format_pkg_info.pkgs[0].nevra.name == "pkg2"
 
 
 @centos7
@@ -2029,7 +2018,7 @@ def test_remove_non_rhel_kernels(monkeypatch):
     monkeypatch.setattr(
         pkghandler, "get_installed_pkgs_w_different_fingerprint", GetInstalledPkgsWDifferentFingerprintMocked()
     )
-    monkeypatch.setattr(pkghandler, "print_pkg_info", DumbCallableObject())
+    monkeypatch.setattr(pkghandler, "format_pkg_info", DumbCallableObject())
     monkeypatch.setattr(pkghandler, "remove_pkgs", RemovePkgsMocked())
 
     removed_pkgs = pkghandler.remove_non_rhel_kernels()
@@ -2049,7 +2038,7 @@ def test_install_additional_rhel_kernel_pkgs(monkeypatch):
     monkeypatch.setattr(
         pkghandler, "get_installed_pkgs_w_different_fingerprint", GetInstalledPkgsWDifferentFingerprintMocked()
     )
-    monkeypatch.setattr(pkghandler, "print_pkg_info", DumbCallableObject())
+    monkeypatch.setattr(pkghandler, "format_pkg_info", DumbCallableObject())
     monkeypatch.setattr(pkghandler, "remove_pkgs", RemovePkgsMocked())
     monkeypatch.setattr(pkghandler, "call_yum_cmd", CallYumCmdMocked())
 

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -100,39 +100,6 @@ class PromptUserLoopMocked(unit_tests.MockFunction):
         return return_value
 
 
-class TestCheckNeededReposAvailability(object):
-    def test_check_needed_repos_availability(self, monkeypatch, caplog):
-        monkeypatch.setattr(subscription, "get_avail_repos", lambda: ["rhel_x", "rhel_y"])
-
-        avail_repos_message = "Needed RHEL repositories are available."
-        subscription.check_needed_repos_availability(["rhel_x"])
-
-        assert avail_repos_message in caplog.records[-1].message
-
-        no_avail_repos_message = (
-            "Some repositories are not available: rhel_z."
-            " Some packages may not be replaced with their corresponding"
-            " RHEL packages when converting. The converted system will end up"
-            " with a mixture of packages from RHEL and your current distribution."
-        )
-
-        subscription.check_needed_repos_availability(["rhel_z"])
-        assert no_avail_repos_message in caplog.records[-1].message
-
-    def test_check_needed_repos_availability_no_repo_available(self, monkeypatch, caplog):
-        monkeypatch.setattr(subscription, "get_avail_repos", lambda: [])
-
-        no_avail_repos_message = (
-            "Some repositories are not available: rhel."
-            " Some packages may not be replaced with their corresponding"
-            " RHEL packages when converting. The converted system will end up"
-            " with a mixture of packages from RHEL and your current distribution."
-        )
-        subscription.check_needed_repos_availability(["rhel"])
-
-        assert no_avail_repos_message in caplog.records[-1].message
-
-
 class TestSubscription(unittest.TestCase):
     class IsFileMocked(unit_tests.MockFunction):
         def __init__(self, is_file):
@@ -207,7 +174,7 @@ class TestSubscription(unittest.TestCase):
             self.msg += "%s\n" % msg
 
     @unit_tests.mock(pkghandler, "get_installed_pkg_objects", lambda _: [namedtuple("Pkg", ["name"])("submgr")])
-    @unit_tests.mock(pkghandler, "print_pkg_info", lambda x: None)
+    @unit_tests.mock(pkghandler, "format_pkg_info", lambda x: None)
     @unit_tests.mock(utils, "ask_to_continue", PromptUserMocked())
     @unit_tests.mock(backup, "remove_pkgs", DumbCallable())
     def test_remove_original_subscription_manager(self):
@@ -222,7 +189,7 @@ class TestSubscription(unittest.TestCase):
     )
     @unit_tests.mock(system_info, "version", namedtuple("Version", ["major", "minor"])(8, 5))
     @unit_tests.mock(system_info, "id", "centos")
-    @unit_tests.mock(pkghandler, "print_pkg_info", lambda x: None)
+    @unit_tests.mock(pkghandler, "format_pkg_info", lambda x: None)
     @unit_tests.mock(utils, "ask_to_continue", PromptUserMocked())
     @unit_tests.mock(backup, "remove_pkgs", DumbCallable())
     def test_remove_original_subscription_manager_missing_package_ol_85(self):

--- a/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
+++ b/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
@@ -28,14 +28,13 @@ def test_failures_and_skips_in_report(convert2rhel):
 
         # Error header first
         assert c2r.expect("Must fix before conversion", timeout=600) == 0
-        c2r.expect("SUBSCRIBE_SYSTEM::UNKNOWN_ERROR - Unable to register the system")
+        c2r.expect("SUBSCRIBE_SYSTEM::UNKNOWN_ERROR - Unknown error")
+        c2r.expect("Unable to register the system through subscription-manager.")
 
         # Skip header
         assert c2r.expect("Could not be checked due to other failures", timeout=600) == 0
         c2r.expect("ENSURE_KERNEL_MODULES_COMPATIBILITY::SKIP - Skipped")
-
-        # Success header
-        assert c2r.expect("No changes needed", timeout=600) == 0
+        c2r.expect("Skipped because SUBSCRIBE_SYSTEM was not successful")
 
     assert c2r.exitstatus == 0
 

--- a/tests/integration/tier0/non-destructive/custom-kernel/test_custom_kernel.py
+++ b/tests/integration/tier0/non-destructive/custom-kernel/test_custom_kernel.py
@@ -88,9 +88,7 @@ def test_custom_kernel(convert2rhel, shell):
             c2r.sendline("y")
 
             c2r.expect("WARNING - Custom kernel detected. The booted kernel needs to be signed by {}".format(os_vendor))
-            c2r.expect(
-                "RHEL_COMPATIBLE_KERNEL::BOOTED_KERNEL_INCOMPATIBLE - The booted kernel version is incompatible with the standard RHEL kernel."
-            )
+            c2r.expect("RHEL_COMPATIBLE_KERNEL::INVALID_KERNEL_PACKAGE_SIGNATURE")
 
             c2r.sendcontrol("c")
 

--- a/tests/integration/tier0/non-destructive/custom-repository/test_custom_repository.py
+++ b/tests/integration/tier0/non-destructive/custom-repository/test_custom_repository.py
@@ -109,10 +109,7 @@ def test_bad_conversion_without_rhsm(shell, convert2rhel):
     with convert2rhel(
         "-y --no-rpm-va --no-rhsm --enablerepo fake-rhel-8-for-x86_64-baseos-rpms --debug", unregister=True
     ) as c2r:
-        c2r.expect(
-            "CUSTOM_REPOSITORIES_ARE_VALID::UNABLE_TO_ACCESS_REPOSITORIES - Unable to access the repositories passed through the --enablerepo option. "
-            "For more details, see YUM/DNF output"
-        )
+        c2r.expect("CUSTOM_REPOSITORIES_ARE_VALID::UNABLE_TO_ACCESS_REPOSITORIES")
 
     assert c2r.exitstatus == 1
 

--- a/tests/integration/tier0/non-destructive/kernel-modules/test_unsupported_kmod.py
+++ b/tests/integration/tier0/non-destructive/kernel-modules/test_unsupported_kmod.py
@@ -74,9 +74,7 @@ def test_inhibit_if_custom_module_loaded(kmod_in_different_directory, convert2rh
         ),
         unregister=True,
     ) as c2r:
-        c2r.expect(
-            "ENSURE_KERNEL_MODULES_COMPATIBILITY::UNSUPPORTED_KERNEL_MODULES - The following loaded kernel modules are not available in RHEL"
-        )
+        c2r.expect("ENSURE_KERNEL_MODULES_COMPATIBILITY::UNSUPPORTED_KERNEL_MODULES")
 
     assert c2r.exitstatus != 0
 

--- a/tests/integration/tier0/non-destructive/oracle-linux-unbreakable-enterprise-kernel/test_oracle_unsupported_uek.py
+++ b/tests/integration/tier0/non-destructive/oracle-linux-unbreakable-enterprise-kernel/test_oracle_unsupported_uek.py
@@ -37,7 +37,7 @@ def test_bad_conversion(shell, convert2rhel):
     elif os.environ["TMT_REBOOT_COUNT"] == "1":
         with convert2rhel("-y --no-rpm-va --debug", unregister=True) as c2r:
             c2r.expect(
-                "RHEL_COMPATIBLE_KERNEL::BOOTED_KERNEL_INCOMPATIBLE - The booted kernel version is incompatible with the standard RHEL kernel",
+                "RHEL_COMPATIBLE_KERNEL::INCOMPATIBLE_VERSION - Incompatible booted kernel version",
                 timeout=600,
             )
             c2r.sendcontrol("c")

--- a/tests/integration/tier0/non-destructive/single-yum-transaction-validation/test_single_yum_transaction_validation.py
+++ b/tests/integration/tier0/non-destructive/single-yum-transaction-validation/test_single_yum_transaction_validation.py
@@ -11,14 +11,14 @@ PKI_ENTITLEMENT_CERTS_PATH = "/etc/pki/entitlement"
 
 SERVER_SUB = "CentOS Linux"
 PKGMANAGER = "yum"
-FINAL_MESSAGE = "VALIDATE_PACKAGE_MANAGER_TRANSACTION::UNKNOWN_ERROR - There are no suitable mirrors available for the loaded repositories."
+FINAL_MESSAGE = "Diagnosis: There are no suitable mirrors available for the loaded repositories."
 
 if "oracle" in SYSTEM_RELEASE_ENV:
     SERVER_SUB = "Oracle Linux Server"
 
 if "8" in SYSTEM_RELEASE_ENV:
     PKGMANAGER = "dnf"
-    FINAL_MESSAGE = "VALIDATE_PACKAGE_MANAGER_TRANSACTION::UNKNOWN_ERROR - Failed to download the transaction packages."
+    FINAL_MESSAGE = "Diagnosis: Failed to download the transaction packages."
 
 
 @pytest.fixture()
@@ -86,7 +86,8 @@ def test_package_download_error(convert2rhel, shell, yum_cache):
 
         remove_entitlement_certs()
 
-        assert c2r.expect_exact(FINAL_MESSAGE, timeout=600) == 0
+        assert c2r.expect("VALIDATE_PACKAGE_MANAGER_TRANSACTION::UNKNOWN_ERROR") == 0
+        assert c2r.expect(FINAL_MESSAGE, timeout=600) == 0
 
     assert c2r.exitstatus == 1
 
@@ -121,11 +122,12 @@ def test_transaction_validation_error(convert2rhel, shell, yum_cache):
         remove_entitlement_certs()
         assert (
             c2r.expect_exact(
-                "VALIDATE_PACKAGE_MANAGER_TRANSACTION::UNKNOWN_ERROR - Failed to validate the yum transaction.",
+                "VALIDATE_PACKAGE_MANAGER_TRANSACTION::UNKNOWN_ERROR - Unknown",
                 timeout=600,
             )
             == 0
         )
+        assert c2r.expect("Failed to validate the yum transaction.", timeout=600) == 0
 
     assert c2r.exitstatus == 1
 
@@ -137,7 +139,7 @@ def packages_with_period(shell):
     Install problematic packages with period in name.
     E.g. python3.11-3.11.2-2.el8.x86_64 java-1.8.0-openjdk-headless-1.8.0.372.b07-4.el8.x86_64
     """
-    problematic_packages = ["python3.11-3.11.2-2.el8.x86_64", "java-1.8.0-openjdk-headless-1.8.0.372.b07-4.el8.x86_64"]
+    problematic_packages = ["python3.11", "java-1.8.0-openjdk-headless"]
     # We don't care for the telemetry, disable the collection to skip over the acknowledgement
     os.environ["CONVERT2RHEL_DISABLE_TELEMETRY"] = "1"
 
@@ -175,17 +177,9 @@ def test_validation_packages_with_in_name_period(shell, convert2rhel, packages_w
             env.str("RHSM_POOL"),
         )
     ) as c2r:
-        c2r_expect_index = c2r.expect(
-            [
-                "No problems detected during the analysis!",
-                "VALIDATE_PACKAGE_MANAGER_TRANSACTION::UNEXPECTED_ERROR - Unhandled exception was caught: too many values to unpack (expected 2)",
-            ]
-        )
-
-        if c2r_expect_index == 0:
-            c2r.expect("Continue with the system conversion")
-            c2r.sendline("n")
-        elif c2r_expect_index == 1:
-            assert AssertionError
+        assert c2r.expect("VALIDATE_PACKAGE_MANAGER_TRANSACTION has succeeded") == 0
+        # Exit at PONR
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("n")
 
     assert c2r.exitstatus != 0


### PR DESCRIPTION
This PR examines the current 'messages' field used to store the information for checks in actions and splits it into four separate fields namely: title, description, diagnosis and remediation. Changes to the action class can be found in actions/__init__.py. 

Jira Issues: [RHELC-1094](https://issues.redhat.com/browse/RHELC-1094)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
