### PR TITLE
[RHELC-1104] Change the id separator in the cli report to match what will be displayed in the insights webUI

### DIFF
--- a/convert2rhel/actions/__init__.py
+++ b/convert2rhel/actions/__init__.py
@@ -721,14 +721,14 @@ def format_action_status_message(status_code, action_id, id, message):
     # apply these fields if they are present, with a special mention to
     # `message`.
     if id:
-        template += ".{ID}"
+        template += "::{ID}"
 
     # Special case for `message` to not output empty message to the
     # user without message.
     if message:
-        template += ": {MESSAGE}"
+        template += " - {MESSAGE}"
     else:
-        template += ": [No further information given]"
+        template += " - [No further information given]"
 
     return template.format(
         LEVEL=level_name,

--- a/convert2rhel/unit_tests/actions/report_test.py
+++ b/convert2rhel/unit_tests/actions/report_test.py
@@ -80,7 +80,7 @@ def test_summary_as_json(results, expected, tmpdir):
                 )
             },
             True,
-            ["(WARNING) PreSubscription.WARNING_ID: WARNING MESSAGE", "(SUCCESS) PreSubscription: All good!"],
+            ["(WARNING) PreSubscription::WARNING_ID - WARNING MESSAGE", "(SUCCESS) PreSubscription - All good!"],
         ),
         (
             {
@@ -91,8 +91,8 @@ def test_summary_as_json(results, expected, tmpdir):
             },
             True,
             [
-                "(WARNING) PreSubscription.WARNING_ID: WARNING MESSAGE",
-                "(SUCCESS) PreSubscription: [No further information given]",
+                "(WARNING) PreSubscription::WARNING_ID - WARNING MESSAGE",
+                "(SUCCESS) PreSubscription - [No further information given]",
             ],
         ),
         (
@@ -111,9 +111,9 @@ def test_summary_as_json(results, expected, tmpdir):
             },
             True,
             [
-                "(SUCCESS) PreSubscription: All good!",
-                "(WARNING) PreSubscription2.WARNING_ID: WARNING MESSAGE",
-                "(SKIP) PreSubscription2.SKIPPED: SKIP MESSAGE",
+                "(SUCCESS) PreSubscription - All good!",
+                "(WARNING) PreSubscription2::WARNING_ID - WARNING MESSAGE",
+                "(SKIP) PreSubscription2::SKIPPED - SKIP MESSAGE",
             ],
         ),
         # Test that messages that are below WARNING will not appear in
@@ -135,7 +135,7 @@ def test_summary_as_json(results, expected, tmpdir):
                 )
             },
             False,
-            ["(WARNING) PreSubscription.WARNING_ID: WARNING MESSAGE"],
+            ["(WARNING) PreSubscription::WARNING_ID - WARNING MESSAGE"],
         ),
         (
             {
@@ -154,9 +154,9 @@ def test_summary_as_json(results, expected, tmpdir):
             },
             False,
             [
-                "(SKIP) PreSubscription2.SKIPPED: SKIP MESSAGE",
-                "(WARNING) PreSubscription.WARNING_ID: WARNING MESSAGE 1",
-                "(WARNING) PreSubscription2.WARNING_ID: WARNING MESSAGE 2",
+                "(SKIP) PreSubscription2::SKIPPED - SKIP MESSAGE",
+                "(WARNING) PreSubscription::WARNING_ID - WARNING MESSAGE 1",
+                "(WARNING) PreSubscription2::WARNING_ID - WARNING MESSAGE 2",
             ],
         ),
         # Test all messages are displayed, SKIP and higher
@@ -181,10 +181,10 @@ def test_summary_as_json(results, expected, tmpdir):
             },
             False,
             [
-                "(OVERRIDABLE) PreSubscription2.OVERRIDABLE_ID: OVERRIDABLE MESSAGE",
-                "(SKIP) PreSubscription1.SKIPPED: SKIP MESSAGE",
-                "(WARNING) PreSubscription1.WARNING_ID: WARNING MESSAGE 1",
-                "(WARNING) PreSubscription2.WARNING_ID: WARNING MESSAGE 2",
+                "(OVERRIDABLE) PreSubscription2::OVERRIDABLE_ID - OVERRIDABLE MESSAGE",
+                "(SKIP) PreSubscription1::SKIPPED - SKIP MESSAGE",
+                "(WARNING) PreSubscription1::WARNING_ID - WARNING MESSAGE 1",
+                "(WARNING) PreSubscription2::WARNING_ID - WARNING MESSAGE 2",
             ],
         ),
         (
@@ -216,14 +216,14 @@ def test_summary_as_json(results, expected, tmpdir):
             },
             False,
             [
-                "(ERROR) ErrorAction.ERROR: ERROR MESSAGE",
-                "(ERROR) TestAction.SECONDERROR: Test that two of the same level works",
-                "(OVERRIDABLE) OverridableAction.OVERRIDABLE: OVERRIDABLE MESSAGE",
-                "(SKIP) SkipAction.SKIP: SKIP MESSAGE",
-                "(WARNING) SkipAction.WARNING_ID: WARNING MESSAGE 4",
-                "(WARNING) OverridableAction.WARNING_ID: WARNING MESSAGE 3",
-                "(WARNING) ErrorAction.WARNING_ID: WARNING MESSAGE 2",
-                "(WARNING) TestAction.WARNING_ID: WARNING MESSAGE 1",
+                "(ERROR) ErrorAction::ERROR - ERROR MESSAGE",
+                "(ERROR) TestAction::SECONDERROR - Test that two of the same level works",
+                "(OVERRIDABLE) OverridableAction::OVERRIDABLE - OVERRIDABLE MESSAGE",
+                "(SKIP) SkipAction::SKIP - SKIP MESSAGE",
+                "(WARNING) SkipAction::WARNING_ID - WARNING MESSAGE 4",
+                "(WARNING) OverridableAction::WARNING_ID - WARNING MESSAGE 3",
+                "(WARNING) ErrorAction::WARNING_ID - WARNING MESSAGE 2",
+                "(WARNING) TestAction::WARNING_ID - WARNING MESSAGE 1",
             ],
         ),
     ),
@@ -296,8 +296,8 @@ def test_messages_summary_with_long_message(caplog):
             },
             False,
             [
-                r"\(OVERRIDABLE\) PreSubscription1.SOME_OVERRIDABLE: OVERRIDABLE MESSAGE",
-                r"\(SKIP\) PreSubscription2.SKIPPED: SKIP MESSAGE",
+                r"\(OVERRIDABLE\) PreSubscription1::SOME_OVERRIDABLE - OVERRIDABLE MESSAGE",
+                r"\(SKIP\) PreSubscription2::SKIPPED - SKIP MESSAGE",
             ],
         ),
         (
@@ -321,9 +321,9 @@ def test_messages_summary_with_long_message(caplog):
             },
             False,
             [
-                r"\(ERROR\) ErrorAction.ERROR: ERROR MESSAGE",
-                r"\(OVERRIDABLE\) OverridableAction.OVERRIDABLE: OVERRIDABLE MESSAGE",
-                r"\(SKIP\) SkipAction.SKIP: SKIP MESSAGE",
+                r"\(ERROR\) ErrorAction::ERROR - ERROR MESSAGE",
+                r"\(OVERRIDABLE\) OverridableAction::OVERRIDABLE - OVERRIDABLE MESSAGE",
+                r"\(SKIP\) SkipAction::SKIP - SKIP MESSAGE",
             ],
         ),
         # Message order with `include_all_reports` set to True.
@@ -352,10 +352,10 @@ def test_messages_summary_with_long_message(caplog):
             },
             True,
             [
-                r"\(ERROR\) ErrorAction.ERROR: ERROR MESSAGE",
-                r"\(OVERRIDABLE\) OverridableAction.OVERRIDABLE: OVERRIDABLE MESSAGE",
-                r"\(SKIP\) SkipAction.SKIP: SKIP MESSAGE",
-                r"\(SUCCESS\) PreSubscription: All good!",
+                r"\(ERROR\) ErrorAction::ERROR - ERROR MESSAGE",
+                r"\(OVERRIDABLE\) OverridableAction::OVERRIDABLE - OVERRIDABLE MESSAGE",
+                r"\(SKIP\) SkipAction::SKIP - SKIP MESSAGE",
+                r"\(SUCCESS\) PreSubscription - All good!",
             ],
         ),
     ),
@@ -396,9 +396,9 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
             },
             False,
             [
-                "(OVERRIDABLE) PreSubscription1.SOME_OVERRIDABLE: OVERRIDABLE MESSAGE",
-                "(SKIP) PreSubscription2.SKIPPED: SKIP MESSAGE",
-                "(WARNING) PreSubscription2.WARNING_ID: WARNING MESSAGE",
+                "(OVERRIDABLE) PreSubscription1::SOME_OVERRIDABLE - OVERRIDABLE MESSAGE",
+                "(SKIP) PreSubscription2::SKIPPED - SKIP MESSAGE",
+                "(WARNING) PreSubscription2::WARNING_ID - WARNING MESSAGE",
             ],
         ),
         (
@@ -422,11 +422,11 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
             },
             False,
             [
-                "(ERROR) ErrorAction.ERROR: ERROR MESSAGE",
-                "(OVERRIDABLE) OverridableAction.OVERRIDABLE: OVERRIDABLE MESSAGE",
-                "(SKIP) SkipAction.SKIP: SKIP MESSAGE",
-                "(WARNING) SkipAction.WARNING_ID: WARNING MESSAGE 1",
-                "(WARNING) OverridableAction.WARNING_ID: WARNING MESSAGE 2",
+                "(ERROR) ErrorAction::ERROR - ERROR MESSAGE",
+                "(OVERRIDABLE) OverridableAction::OVERRIDABLE - OVERRIDABLE MESSAGE",
+                "(SKIP) SkipAction::SKIP - SKIP MESSAGE",
+                "(WARNING) SkipAction::WARNING_ID - WARNING MESSAGE 1",
+                "(WARNING) OverridableAction::WARNING_ID - WARNING MESSAGE 2",
             ],
         ),
         # Message order with `include_all_reports` set to True.
@@ -451,14 +451,14 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
             },
             True,
             [
-                "(ERROR) ErrorAction.ERROR: ERROR MESSAGE",
-                "(OVERRIDABLE) OverridableAction.OVERRIDABLE: OVERRIDABLE MESSAGE",
-                "(SKIP) SkipAction.SKIP: SKIP MESSAGE",
-                "(WARNING) PreSubscription.WARNING_ID: WARNING MESSAGE 1",
-                "(WARNING) SkipAction.WARNING_ID: WARNING MESSAGE 2",
-                "(WARNING) OverridableAction.WARNING_ID: WARNING MESSAGE 3",
-                "(WARNING) ErrorAction.WARNING_ID: WARNING MESSAGE 4",
-                "(SUCCESS) PreSubscription: All good!",
+                "(ERROR) ErrorAction::ERROR - ERROR MESSAGE",
+                "(OVERRIDABLE) OverridableAction::OVERRIDABLE - OVERRIDABLE MESSAGE",
+                "(SKIP) SkipAction::SKIP - SKIP MESSAGE",
+                "(WARNING) PreSubscription::WARNING_ID - WARNING MESSAGE 1",
+                "(WARNING) SkipAction::WARNING_ID - WARNING MESSAGE 2",
+                "(WARNING) OverridableAction::WARNING_ID - WARNING MESSAGE 3",
+                "(WARNING) ErrorAction::WARNING_ID - WARNING MESSAGE 4",
+                "(SUCCESS) PreSubscription - All good!",
             ],
         ),
     ),
@@ -490,8 +490,8 @@ def test_messages_summary_ordering(results, include_all_reports, expected_result
                     result={"level": STATUS_CODE["ERROR"], "id": "ERROR", "message": "ERROR MESSAGE"},
                 )
             },
-            "%s(ERROR) ErrorAction.ERROR: ERROR MESSAGE%s" % (bcolors.FAIL, bcolors.ENDC),
-            "%s(WARNING) ErrorAction.WARNING_ID: WARNING MESSAGE%s" % (bcolors.WARNING, bcolors.ENDC),
+            "%s(ERROR) ErrorAction::ERROR - ERROR MESSAGE%s" % (bcolors.FAIL, bcolors.ENDC),
+            "%s(WARNING) ErrorAction::WARNING_ID - WARNING MESSAGE%s" % (bcolors.WARNING, bcolors.ENDC),
         ),
         (
             {
@@ -500,8 +500,8 @@ def test_messages_summary_ordering(results, include_all_reports, expected_result
                     result={"level": STATUS_CODE["OVERRIDABLE"], "id": "OVERRIDABLE", "message": "OVERRIDABLE MESSAGE"},
                 )
             },
-            "%s(OVERRIDABLE) OverridableAction.OVERRIDABLE: OVERRIDABLE MESSAGE%s" % (bcolors.FAIL, bcolors.ENDC),
-            "%s(WARNING) OverridableAction.WARNING_ID: WARNING MESSAGE%s" % (bcolors.WARNING, bcolors.ENDC),
+            "%s(OVERRIDABLE) OverridableAction::OVERRIDABLE - OVERRIDABLE MESSAGE%s" % (bcolors.FAIL, bcolors.ENDC),
+            "%s(WARNING) OverridableAction::WARNING_ID - WARNING MESSAGE%s" % (bcolors.WARNING, bcolors.ENDC),
         ),
         (
             {
@@ -510,8 +510,8 @@ def test_messages_summary_ordering(results, include_all_reports, expected_result
                     result={"level": STATUS_CODE["SKIP"], "id": "SKIP", "message": "SKIP MESSAGE"},
                 )
             },
-            "%s(SKIP) SkipAction.SKIP: SKIP MESSAGE%s" % (bcolors.FAIL, bcolors.ENDC),
-            "%s(WARNING) SkipAction.WARNING_ID: WARNING MESSAGE%s" % (bcolors.WARNING, bcolors.ENDC),
+            "%s(SKIP) SkipAction::SKIP - SKIP MESSAGE%s" % (bcolors.FAIL, bcolors.ENDC),
+            "%s(WARNING) SkipAction::WARNING_ID - WARNING MESSAGE%s" % (bcolors.WARNING, bcolors.ENDC),
         ),
         (
             {
@@ -520,8 +520,8 @@ def test_messages_summary_ordering(results, include_all_reports, expected_result
                     result={"level": STATUS_CODE["SUCCESS"], "id": "SUCCESSFUL", "message": "SUCCESSFUL MESSAGE"},
                 )
             },
-            "%s(SUCCESS) SuccessfulAction.SUCCESSFUL: SUCCESSFUL MESSAGE%s" % (bcolors.OKGREEN, bcolors.ENDC),
-            "%s(WARNING) SuccessfulAction.WARNING_ID: WARNING MESSAGE%s" % (bcolors.WARNING, bcolors.ENDC),
+            "%s(SUCCESS) SuccessfulAction::SUCCESSFUL - SUCCESSFUL MESSAGE%s" % (bcolors.OKGREEN, bcolors.ENDC),
+            "%s(WARNING) SuccessfulAction::WARNING_ID - WARNING MESSAGE%s" % (bcolors.WARNING, bcolors.ENDC),
         ),
     ),
 )

--- a/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
+++ b/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
@@ -27,11 +27,11 @@ def test_failures_and_skips_in_report(convert2rhel):
 
         # Error header first
         assert c2r.expect("Must fix before conversion", timeout=600) == 0
-        c2r.expect("SUBSCRIBE_SYSTEM.UNKNOWN_ERROR: Unable to register the system")
+        c2r.expect("SUBSCRIBE_SYSTEM::UNKNOWN_ERROR - Unable to register the system")
 
         # Skip header
         assert c2r.expect("Could not be checked due to other failures", timeout=600) == 0
-        c2r.expect("ENSURE_KERNEL_MODULES_COMPATIBILITY.SKIP: Skipped")
+        c2r.expect("ENSURE_KERNEL_MODULES_COMPATIBILITY::SKIP - Skipped")
 
         # Success header
         assert c2r.expect("No changes needed", timeout=600) == 0

--- a/tests/integration/tier0/non-destructive/basic-sanity-checks/main.fmf
+++ b/tests/integration/tier0/non-destructive/basic-sanity-checks/main.fmf
@@ -162,7 +162,7 @@ tag+:
         This test verifies that the CONVERT2RHEL_(UNSUPPORTED_)INCOMPLETE_ROLLBACK envar
         is not honored when running with the analyze switch.
         Repositories are moved to a different location so the
-        `REMOVE_REPOSITORY_FILES_PACKAGES.PACKAGE_REMOVAL_FAILED`
+        `REMOVE_REPOSITORY_FILES_PACKAGES::PACKAGE_REMOVAL_FAILED`
         error is raised.
         1/ convert2rhel is run in the analyze mode, the envar should not be
            honored and the conversion should end

--- a/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
@@ -125,7 +125,7 @@ def test_c2r_latest_older_inhibit(convert2rhel, c2r_version, version):
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("y")
 
-        assert c2r.expect("CONVERT2RHEL_LATEST_VERSION.OUT_OF_DATE: You are currently running 0.01", timeout=300) == 0
+        assert c2r.expect("CONVERT2RHEL_LATEST_VERSION::OUT_OF_DATE - You are currently running 0.01", timeout=300) == 0
         assert c2r.expect("Only the latest version is supported for conversion.", timeout=300) == 0
 
         c2r.sendcontrol("c")
@@ -320,7 +320,7 @@ def test_analyze_incomplete_rollback(repositories, convert2rhel, analyze_incompl
     This test verifies that the CONVERT2RHEL_(UNSUPPORTED_)INCOMPLETE_ROLLBACK envar
     is not honored when running with the analyze switch.
     Repositories are moved to a different location so the
-    `REMOVE_REPOSITORY_FILES_PACKAGES.PACKAGE_REMOVAL_FAILED`
+    `REMOVE_REPOSITORY_FILES_PACKAGES::PACKAGE_REMOVAL_FAILED`
     error is raised.
     1/ convert2rhel is run in the analyze mode, the envar should not be
        honored and the conversion should end
@@ -331,7 +331,7 @@ def test_analyze_incomplete_rollback(repositories, convert2rhel, analyze_incompl
     with convert2rhel("--debug --no-rpm-va") as c2r:
         # We need to get past the data collection acknowledgement
         c2r.sendline("y")
-        c2r.expect("REMOVE_REPOSITORY_FILES_PACKAGES.PACKAGE_REMOVAL_FAILED", timeout=300)
+        c2r.expect("REMOVE_REPOSITORY_FILES_PACKAGES::PACKAGE_REMOVAL_FAILED", timeout=300)
         # Verify the user is informed to not use the envar during the analysis
         assert (
             c2r.expect(

--- a/tests/integration/tier0/non-destructive/custom-kernel/test_custom_kernel.py
+++ b/tests/integration/tier0/non-destructive/custom-kernel/test_custom_kernel.py
@@ -89,7 +89,7 @@ def test_custom_kernel(convert2rhel, shell):
 
             c2r.expect("WARNING - Custom kernel detected. The booted kernel needs to be signed by {}".format(os_vendor))
             c2r.expect(
-                "RHEL_COMPATIBLE_KERNEL.BOOTED_KERNEL_INCOMPATIBLE: The booted kernel version is incompatible with the standard RHEL kernel."
+                "RHEL_COMPATIBLE_KERNEL::BOOTED_KERNEL_INCOMPATIBLE - The booted kernel version is incompatible with the standard RHEL kernel."
             )
 
             c2r.sendcontrol("c")

--- a/tests/integration/tier0/non-destructive/custom-repository/test_custom_repository.py
+++ b/tests/integration/tier0/non-destructive/custom-repository/test_custom_repository.py
@@ -110,7 +110,7 @@ def test_bad_conversion_without_rhsm(shell, convert2rhel):
         "-y --no-rpm-va --no-rhsm --enablerepo fake-rhel-8-for-x86_64-baseos-rpms --debug", unregister=True
     ) as c2r:
         c2r.expect(
-            "CUSTOM_REPOSITORIES_ARE_VALID.UNABLE_TO_ACCESS_REPOSITORIES: Unable to access the repositories passed through the --enablerepo option. "
+            "CUSTOM_REPOSITORIES_ARE_VALID::UNABLE_TO_ACCESS_REPOSITORIES - Unable to access the repositories passed through the --enablerepo option. "
             "For more details, see YUM/DNF output"
         )
 

--- a/tests/integration/tier0/non-destructive/kernel-modules/test_unsupported_kmod.py
+++ b/tests/integration/tier0/non-destructive/kernel-modules/test_unsupported_kmod.py
@@ -75,7 +75,7 @@ def test_inhibit_if_custom_module_loaded(kmod_in_different_directory, convert2rh
         unregister=True,
     ) as c2r:
         c2r.expect(
-            "ENSURE_KERNEL_MODULES_COMPATIBILITY.UNSUPPORTED_KERNEL_MODULES: The following loaded kernel modules are not available in RHEL"
+            "ENSURE_KERNEL_MODULES_COMPATIBILITY::UNSUPPORTED_KERNEL_MODULES - The following loaded kernel modules are not available in RHEL"
         )
 
     assert c2r.exitstatus != 0
@@ -140,7 +140,7 @@ def test_inhibit_if_module_is_force_loaded(shell, convert2rhel):
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("y")
 
-        assert c2r.expect("TAINTED_KMODS.TAINTED_KMODS_DETECTED: Tainted kernel modules detected") == 0
+        assert c2r.expect("TAINTED_KMODS::TAINTED_KMODS_DETECTED - Tainted kernel modules detected") == 0
         c2r.sendcontrol("c")
 
     assert c2r.exitstatus != 0

--- a/tests/integration/tier0/non-destructive/oracle-linux-unbreakable-enterprise-kernel/test_oracle_unsupported_uek.py
+++ b/tests/integration/tier0/non-destructive/oracle-linux-unbreakable-enterprise-kernel/test_oracle_unsupported_uek.py
@@ -37,7 +37,7 @@ def test_bad_conversion(shell, convert2rhel):
     elif os.environ["TMT_REBOOT_COUNT"] == "1":
         with convert2rhel("-y --no-rpm-va --debug", unregister=True) as c2r:
             c2r.expect(
-                "RHEL_COMPATIBLE_KERNEL.BOOTED_KERNEL_INCOMPATIBLE: The booted kernel version is incompatible with the standard RHEL kernel",
+                "RHEL_COMPATIBLE_KERNEL::BOOTED_KERNEL_INCOMPATIBLE - The booted kernel version is incompatible with the standard RHEL kernel",
                 timeout=600,
             )
             c2r.sendcontrol("c")

--- a/tests/integration/tier0/non-destructive/single-yum-transaction-validation/test_single_yum_transaction_validation.py
+++ b/tests/integration/tier0/non-destructive/single-yum-transaction-validation/test_single_yum_transaction_validation.py
@@ -11,14 +11,14 @@ PKI_ENTITLEMENT_CERTS_PATH = "/etc/pki/entitlement"
 
 SERVER_SUB = "CentOS Linux"
 PKGMANAGER = "yum"
-FINAL_MESSAGE = "VALIDATE_PACKAGE_MANAGER_TRANSACTION.UNKNOWN_ERROR: There are no suitable mirrors available for the loaded repositories."
+FINAL_MESSAGE = "VALIDATE_PACKAGE_MANAGER_TRANSACTION::UNKNOWN_ERROR - There are no suitable mirrors available for the loaded repositories."
 
 if "oracle" in SYSTEM_RELEASE_ENV:
     SERVER_SUB = "Oracle Linux Server"
 
 if "8" in SYSTEM_RELEASE_ENV:
     PKGMANAGER = "dnf"
-    FINAL_MESSAGE = "VALIDATE_PACKAGE_MANAGER_TRANSACTION.UNKNOWN_ERROR: Failed to download the transaction packages."
+    FINAL_MESSAGE = "VALIDATE_PACKAGE_MANAGER_TRANSACTION::UNKNOWN_ERROR - Failed to download the transaction packages."
 
 
 @pytest.fixture()
@@ -121,7 +121,7 @@ def test_transaction_validation_error(convert2rhel, shell, yum_cache):
         remove_entitlement_certs()
         assert (
             c2r.expect_exact(
-                "VALIDATE_PACKAGE_MANAGER_TRANSACTION.UNKNOWN_ERROR: Failed to validate the yum transaction.",
+                "VALIDATE_PACKAGE_MANAGER_TRANSACTION::UNKNOWN_ERROR - Failed to validate the yum transaction.",
                 timeout=600,
             )
             == 0
@@ -178,7 +178,7 @@ def test_validation_packages_with_in_name_period(shell, convert2rhel, packages_w
         c2r_expect_index = c2r.expect(
             [
                 "No problems detected during the analysis!",
-                "VALIDATE_PACKAGE_MANAGER_TRANSACTION.UNEXPECTED_ERROR: Unhandled exception was caught: too many values to unpack (expected 2)",
+                "VALIDATE_PACKAGE_MANAGER_TRANSACTION::UNEXPECTED_ERROR - Unhandled exception was caught: too many values to unpack (expected 2)",
             ]
         )
 


### PR DESCRIPTION

Jira Issues: [RHELC-1104](https://issues.redhat.com/browse/RHELC-1104)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
