### PR TITLE
[RHELC-1099] Prevent simultaneous instances of convert2rhel on a single system.

### DIFF
--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -1,7 +1,7 @@
 name: Tests Label Commenter
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, unlabeled]
 
 permissions:
@@ -11,10 +11,13 @@ permissions:
 
 jobs:
   comment:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
+        with:
+          sparse-checkout: |
+            .github/label-commenter-config.yml
+          sparse-checkout-cone-mode: false
       - name: Label Commenter
         uses: peaceiris/actions-label-commenter@v1.10.0
         env:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -40,7 +40,7 @@ jobs:
 
 # TEST JOBS
 ## Tests on pull request stage
-- &tests-tier0
+- &tests-tier0-destructive-manual
   job: tests
   # Run tests on-demand
   manual_trigger: true
@@ -56,8 +56,8 @@ jobs:
         # to tag the updated system correctly
       distros: [centos-8-latest, oraclelinux-8.6]
   trigger: pull_request
-  identifier: "tier0"
-  tmt_plan: "tier0"
+  identifier: "tier0-destructive"
+  tmt_plan: "tier0/destructive"
   # Run on Red Testing Farm Hat Ranch, tag resources to sst_conversions
   use_internal_tf: True
   tf_extra_params:
@@ -68,17 +68,39 @@ jobs:
               BusinessUnit: sst_conversions
   labels:
     - tier0
+    - tier0-destructive
+    - destructive
 
-- &tests-tier1-manual
-  <<: *tests-tier0
-  identifier: "tier1"
-  tmt_plan: "tier1"
+- &tests-tier0-non-destructive-manual
+  <<: *tests-tier0-destructive-manual
+  identifier: "tier0-non-destructive"
+  tmt_plan: "tier0/non-destructive"
+  labels:
+    - tier0
+    - tier0-non-destructive
+    - non-destructive
+
+- &tests-tier1-destructive-manual
+  <<: *tests-tier0-destructive-manual
+  identifier: "tier1-destructive"
+  tmt_plan: "tier1/destructive"
   labels:
     - tier1
+    - tier1-destructive
+    - destructive
+
+# Disabled for now
+#- &tests-tier1-non-destructive-manual
+#  <<: *tests-tier0-destructive-manual
+#  identifier: "tier1-non-destructive"
+#  tmt_plan: "tier1/non-destructive"
+#  labels:
+#    - tier1-non-destructive
+#    - non-destructive
 
 # Tests on merge to main stage
 - &tests-tier1
-  <<: *tests-tier0
+  <<: *tests-tier0-destructive-manual
   # Run test automatically with merge commit to main branch
   manual_trigger: false
   identifier: "tier1"

--- a/convert2rhel/applock.py
+++ b/convert2rhel/applock.py
@@ -22,7 +22,9 @@ import logging
 import os
 import time
 
+
 loggerinst = logging.getLogger(__name__)
+
 
 class ApplicationLockedError(Exception):
     """Raised when this application is locked."""
@@ -39,6 +41,7 @@ class ApplicationLock(object):
     fact (and all implementation details) are hidden from the caller.
     To acquire and release the lock, use trylock() and unlock().
     """
+
     def __init__(self, name):
         # Our application name
         self._name = name
@@ -75,13 +78,12 @@ class ApplicationLock(object):
         :returns: True if we created the lock, False if we didn't.
         """
         try:
-            file_desc = os.open(self._pidfile,
-                                os.O_CREAT | os.O_WRONLY | os.O_EXCL, 0o755)
+            file_desc = os.open(self._pidfile, os.O_CREAT | os.O_WRONLY | os.O_EXCL, 0o755)
         except OSError as exc:
             if exc.errno == errno.EEXIST:
                 return False
             raise exc
-        encoded = (str(self._pid) + "\n").encode('ascii')
+        encoded = (str(self._pid) + "\n").encode("ascii")
         os.write(file_desc, encoded)
         os.close(file_desc)
         loggerinst.debug("%s." % self)
@@ -125,7 +127,7 @@ class ApplicationLock(object):
             try:
                 file_contents = fileh.read()
                 pid = int(file_contents.rstrip())
-                if file_contents[-1] != '\n' or pid == 0:
+                if file_contents[-1] != "\n" or pid == 0:
                     raise ValueError("Bogus file contents")
             except (OSError, ValueError):
                 #
@@ -139,8 +141,7 @@ class ApplicationLock(object):
                 self.trylock(loop_count + 1)
 
         if self._pid_exists(pid):
-            raise ApplicationLockedError(
-                "%s locked by process %d" % (self._name, pid))
+            raise ApplicationLockedError("%s locked by process %d" % (self._name, pid))
         else:
             loggerinst.info("Reaping lock held by process %d." % pid)
         try:

--- a/convert2rhel/applock.py
+++ b/convert2rhel/applock.py
@@ -80,7 +80,6 @@ class ApplicationLock:
 
         :returns: True if we created the lock, False if we didn't.
         """
-        #
         # Create a temporary file that contains our PID and attempt
         # to link it to the real pidfile location. The link will fail if
         # the file already exists; this avoids a race condition when
@@ -89,7 +88,6 @@ class ApplicationLock:
         #
         # Note that NamedTemporaryFile will clean up the file it created,
         # but the lockfile we created by doing the link will stay around.
-        #
         with tempfile.NamedTemporaryFile(mode="w", suffix=".pid", prefix=self._name, dir=_DEFAULT_LOCK_DIR) as f:
             f.write(str(self._pid) + "\n")
             f.flush()
@@ -116,15 +114,13 @@ class ApplicationLock:
             if pid > 1:
                 os.kill(pid, 0)
         except OSError as exc:
-            #
             # The only other (theoretical) possibility is EPERM, which
             # would mean the process exists.
-            #
             if exc.errno == errno.ESRCH:
                 return False
         return True
 
-    def try_to_lock(self, recursive=False):
+    def try_to_lock(self, _recursive=False):
         """Try to get a lock on this application. If successful,
         the application will be locked; the lock should be released
         with unlock().
@@ -133,15 +129,15 @@ class ApplicationLock:
         application as locked, since it is probably the result of
         manual meddling, intentional or otherwise.
 
-        :keyword recursive: True if we are being called recursively
-                            and should not try to clean up the lockfile
-                            again.
+        :keyword _recursive: True if we are being called recursively
+                             and should not try to clean up the lockfile
+                             again.
         :raises ApplicationLockedError: the application is locked
         """
         if self._try_create():
             self._locked = True
             return
-        if recursive:
+        if _recursive:
             raise ApplicationLockedError("Cannot lock %s" % self._name)
 
         with open(self._pidfile, "r") as f:
@@ -153,13 +149,11 @@ class ApplicationLock:
 
         if self._pid_exists(pid):
             raise ApplicationLockedError("%s locked by process %d" % (self._pidfile, pid))
-        #
         # The lock file was created by a process that has exited;
         # remove it and try again.
-        #
         loggerinst.info("Cleaning up lock held by exited process %d." % pid)
         os.unlink(self._pidfile)
-        self.try_to_lock(recursive=True)
+        self.try_to_lock(_recursive=True)
 
     def unlock(self):
         """Release the lock on this application.

--- a/convert2rhel/applock.py
+++ b/convert2rhel/applock.py
@@ -18,7 +18,6 @@
 __metaclass__ = type
 
 import errno
-import io
 import logging
 import os
 import tempfile
@@ -62,8 +61,6 @@ class ApplicationLock:
         self._name = name
         # Do we think we locked the pid file?
         self._locked = False
-        # Maximum number of tries to lock
-        self._max_loop_count = 5
         # Our process ID
         self._pid = os.getpid()
         # Path to the file that contains the process id
@@ -89,6 +86,9 @@ class ApplicationLock:
         # the file already exists; this avoids a race condition when
         # two processes attempt to create the file simultaneously. This
         # also guarantees that the lock file contains valid data.
+        #
+        # Note that NamedTemporaryFile will clean up the file it created,
+        # but the lockfile we created by doing the link will stay around.
         #
         with tempfile.NamedTemporaryFile(mode="w", suffix=".pid", prefix=self._name, dir=_DEFAULT_LOCK_DIR) as f:
             f.write(str(self._pid) + "\n")
@@ -124,7 +124,7 @@ class ApplicationLock:
                 return False
         return True
 
-    def try_to_lock(self, loop_count=0):
+    def try_to_lock(self, recursive=False):
         """Try to get a lock on this application. If successful,
         the application will be locked; the lock should be released
         with unlock().
@@ -133,50 +133,46 @@ class ApplicationLock:
         application as locked, since it is probably the result of
         manual meddling, intentional or otherwise.
 
-        Note that nothing prevents you from calling try_to_lock()
-        multiple times; all calls after the first will fail as if
-        another process holds the lock.
-
-        :keyword loop_count: used internally to limit the number of
-                             recursive calls to this method
+        :keyword recursive: True if we are being called recursively
+                            and should not try to clean up the lockfile
+                            again.
         :raises ApplicationLockedError: the application is locked
         """
-        if loop_count > self._max_loop_count:
-            raise ApplicationLockedError("Cannot lock %s" % self._pidfile)
         if self._try_create():
             self._locked = True
             return
+        if recursive:
+            raise ApplicationLockedError("Cannot lock %s" % self._name)
 
-        with io.open(self._pidfile, "r") as f:
+        with open(self._pidfile, "r") as f:
             file_contents = f.read()
         try:
             pid = int(file_contents.rstrip())
         except ValueError:
-            raise ApplicationLockedError("Lock file %s is corrupt" % self._name)
+            raise ApplicationLockedError("Lock file %s is corrupt" % self._pidfile)
 
         if self._pid_exists(pid):
-            raise ApplicationLockedError("%s locked by process %d" % (self._name, pid))
+            raise ApplicationLockedError("%s locked by process %d" % (self._pidfile, pid))
         #
         # The lock file was created by a process that has exited;
         # remove it and try again.
         #
-        loggerinst.info("Reaping lock held by process %d." % pid)
-        try:
-            os.unlink(self._pidfile)
-        except OSError:
-            loggerinst.warning("Couldn't unlink %s." % self.pidfile)
-        self.try_to_lock(loop_count + 1)
+        loggerinst.info("Cleaning up lock held by exited process %d." % pid)
+        os.unlink(self._pidfile)
+        self.try_to_lock(recursive=True)
 
     def unlock(self):
-        """Release the lock on this application."""
+        """Release the lock on this application.
+
+        Note that if the unlink fails (a pathological failure) the
+        object will stay locked and the OSError or other
+        system-generated exception will be raised.
+        """
         if not self._locked:
             return
-        try:
-            os.unlink(self._pidfile)
-        except OSError:
-            loggerinst.warning("Couldn't unlink %s." % self._pidfile)
-        loggerinst.debug("%s." % self)
+        os.unlink(self._pidfile)
         self._locked = False
+        loggerinst.debug("%s." % self)
 
     def __enter__(self):
         self.try_to_lock()

--- a/convert2rhel/applock.py
+++ b/convert2rhel/applock.py
@@ -21,7 +21,7 @@ import logging
 import os
 import tempfile
 
-
+_DEFAULT_LOCK_DIR = "/var/lock/run"
 loggerinst = logging.getLogger(__name__)
 
 
@@ -54,11 +54,9 @@ class ApplicationLock(object):
     because something is obviously wrong.
     """
 
-    def __init__(self, name, lock_dir="/var/run/lock"):
+    def __init__(self, name):
         # Our application name
         self._name = name
-        # Directory in which the lockfile will be written
-        self._lock_dir = lock_dir
         # Do we think we locked the pid file?
         self._locked = False
         # Maximum number of tries to lock
@@ -66,7 +64,7 @@ class ApplicationLock(object):
         # Our process ID
         self._pid = os.getpid()
         # Path to the file that contains the process id
-        self._pidfile = os.path.join(self._lock_dir, self._name + ".pid")
+        self._pidfile = os.path.join(_DEFAULT_LOCK_DIR, self._name + ".pid")
 
     def __str__(self):
         if self._locked:
@@ -89,7 +87,7 @@ class ApplicationLock(object):
         # two processes attempt to create the file simultaneously. This
         # also guarantees that the lock file contains valid data.
         #
-        with tempfile.NamedTemporaryFile(mode="wt", suffix=".pid", prefix=self._name, dir=self._lock_dir) as fileh:
+        with tempfile.NamedTemporaryFile(mode="wt", suffix=".pid", prefix=self._name, dir=_DEFAULT_LOCK_DIR) as fileh:
             fileh.write(str(self._pid) + "\n")
             fileh.flush()
             try:

--- a/convert2rhel/applock.py
+++ b/convert2rhel/applock.py
@@ -28,7 +28,7 @@ loggerinst = logging.getLogger(__name__)
 
 
 class ApplicationLockedError(Exception):
-    """Raised when this application is locked."""
+    """Raised when this application is already locked."""
 
     def __init__(self, message):
         super(ApplicationLockedError, self).__init__(message)

--- a/convert2rhel/applock.py
+++ b/convert2rhel/applock.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import atexit
+import errno
+import io
+import logging
+import os
+import time
+
+loggerinst = logging.getLogger(__name__)
+
+class ApplicationLockedError(Exception):
+    """Raised when this application is locked."""
+
+    def __init__(self, message):
+        super(ApplicationLockedError, self).__init__(message)
+        self.message = message
+
+
+class ApplicationLock(object):
+    """Holds a lock for a particular application.
+
+    The implementation uses a standard Linux PID file, though that
+    fact (and all implementation details) are hidden from the caller.
+    To acquire and release the lock, use trylock() and unlock().
+    """
+    def __init__(self, name):
+        # Our application name
+        self._name = name
+        # Directory in which the lockfile will be written
+        self._lock_dir = "/var/run/lock"
+        # Do we think we locked the pid file?
+        self._locked = False
+        # Maximum number of tries to lock
+        self._max_loop_count = 5
+        # Our process ID
+        self._pid = os.getpid()
+        # Path to the file that contains the process id
+        self._pidfile = os.path.join(self._lock_dir, self._name + ".pid")
+
+    def __str__(self):
+        if self._locked:
+            status = "locked"
+        else:
+            status = "unlocked"
+        return "%s PID %d %s" % (self._pidfile, self._pid, status)
+
+    def set_lock_dir(self, new_tmp_dir):
+        """Set the lock directory. Used only for testing.
+
+        :param new_tmp_dir: the directory to be used for the lock file
+        """
+        self._lock_dir = new_tmp_dir
+        self._pidfile = os.path.join(self._lock_dir, self._name + ".pid")
+
+    def _try_creat(self):
+        """Try to create the lock file. If this succeeds, the lock file
+        exists and we created it.
+
+        :returns: True if we created the lock, False if we didn't.
+        """
+        try:
+            file_desc = os.open(self._pidfile,
+                                os.O_CREAT | os.O_WRONLY | os.O_EXCL, 0o755)
+        except OSError as exc:
+            if exc.errno == errno.EEXIST:
+                return False
+            raise exc
+        encoded = (str(self._pid) + "\n").encode('ascii')
+        os.write(file_desc, encoded)
+        os.close(file_desc)
+        loggerinst.debug("%s." % self)
+        return True
+
+    def is_locked(self):
+        """Test whether this object is locked."""
+        return self._locked
+
+    @staticmethod
+    def _pid_exists(pid):
+        """Test whether a particular process exists."""
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            pass
+        return True
+
+    def trylock(self, loop_count=0):
+        """Try to get a lock on this application. If successful,
+        the application will be locked; the lock may be released
+        with trylock() or it will be cleaned up automatically at
+        process exit.
+
+        Note that nothing prevents you from calling trylock()
+        multiple times; all calls after the first will fail as if
+        another process holds the lock.
+
+        :raises ApplicationLockedError: the application is locked
+        """
+        if loop_count > self._max_loop_count:
+            raise ApplicationLockedError("Cannot lock %s" % self._pidfile)
+        if self._try_creat():
+            self._locked = True
+            atexit.register(self.unlock)
+            return
+
+        with io.open(self._pidfile, "rt") as fileh:
+            try:
+                file_contents = fileh.read()
+                pid = int(file_contents.rstrip())
+                if file_contents[-1] != '\n' or pid == 0:
+                    raise ValueError("Bogus file contents")
+            except (OSError, ValueError):
+                #
+                # Two possibilities here: either the file is corrupt
+                # or another process hasn't finished writing it out.
+                # The sleep(0) is just a cheap way to let another
+                # process run without making us wait too long if the
+                # file really is corrupt.
+                #
+                time.sleep(0)
+                self.trylock(loop_count + 1)
+
+        if self._pid_exists(pid):
+            raise ApplicationLockedError(
+                "%s locked by process %d" % (self._name, pid))
+        else:
+            loggerinst.info("Reaping lock held by process %d." % pid)
+        try:
+            os.unlink(self._pidfile)
+        except OSError:
+            loggerinst.warning("Couldn't unlink %s." % self.pidfile)
+        self.trylock(loop_count + 1)
+
+    def unlock(self):
+        """Release the lock on this application."""
+        if self._locked == False:
+            return
+        try:
+            os.unlink(self._pidfile)
+        except OSError:
+            loggerinst.warning("Couldn't unlink %s." % self._pidfile)
+        # Call this in Python 3?
+        # atexit.unregister(self.unlock)
+        loggerinst.debug("%s." % self)
+        self._locked = False
+
+    def __enter__(self):
+        self.trylock()
+        return self
+
+    def __exit__(self, _type, _value, _tb):
+        self.unlock()

--- a/convert2rhel/initialize.py
+++ b/convert2rhel/initialize.py
@@ -77,11 +77,12 @@ def run():
 
     from convert2rhel import main
 
+    retval = 0
     try:
-        retval = 1
-        with applock.ApplicationLock("convert2rhel") as _lock:
+        with applock.ApplicationLock("convert2rhel"):
             retval = main.main()
     except applock.ApplicationLockedError:
+        retval = 1
         sys.stderr.write("Another copy of convert2rhel is running.\n")
         sys.stderr.write("\nNo changes were made to the system.\n")
     sys.exit(retval)

--- a/convert2rhel/initialize.py
+++ b/convert2rhel/initialize.py
@@ -19,7 +19,7 @@ import logging
 import os
 import sys
 
-from convert2rhel import i18n
+from convert2rhel import applock, i18n
 
 
 def disable_root_logger():
@@ -77,4 +77,11 @@ def run():
 
     from convert2rhel import main
 
-    sys.exit(main.main())
+    try:
+        retval = 1
+        with applock.ApplicationLock("convert2rhel") as _lock:
+            retval = main.main()
+    except applock.ApplicationLockedError:
+        sys.stderr.write("Another copy of convert2rhel is running.\n")
+        sys.stderr.write("\nNo changes were made to the system.\n")
+    sys.exit(retval)

--- a/convert2rhel/initialize.py
+++ b/convert2rhel/initialize.py
@@ -19,7 +19,7 @@ import logging
 import os
 import sys
 
-from convert2rhel import applock, i18n
+from convert2rhel import applock, i18n, utils
 
 
 def disable_root_logger():
@@ -74,6 +74,9 @@ def run():
 
     # Initialize logging to stop duplicate messages.
     disable_root_logger()
+
+    # Make sure we're being run by root
+    utils.require_root()
 
     from convert2rhel import main
 

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -65,9 +65,6 @@ def initialize_logger(log_name, log_dir):
 def main():
     """Perform all steps for the entire conversion process."""
 
-    # the tool will not run if not executed under the root user
-    utils.require_root()
-
     process_phase = ConversionPhase.INIT
 
     # initialize logging

--- a/convert2rhel/unit_tests/applock_test.py
+++ b/convert2rhel/unit_tests/applock_test.py
@@ -100,11 +100,11 @@ def test_applock_link_fails(tmp_lock):
     """Test the case where the os.link call to create the lockfile
     fails, but not because the file exists."""
     dir = os.path.dirname(tmp_lock._pidfile)
-    os.chmod(dir, 0o550)
+    os.chmod(dir, 0o500)
     with pytest.raises(OSError):
         tmp_lock.try_to_lock()
     assert tmp_lock.is_locked is False
-    os.chmod(dir, 0o750)
+    os.chmod(dir, 0o700)
 
 
 def test_applock_lock_unlink_fails(tmp_lock):
@@ -113,10 +113,10 @@ def test_applock_lock_unlink_fails(tmp_lock):
     with open(tmp_lock._pidfile, "w") as f:
         f.write(old_pid)
     dir = os.path.dirname(tmp_lock._pidfile)
-    os.chmod(dir, 0o550)
+    os.chmod(dir, 0o500)
     with pytest.raises(OSError):
         tmp_lock.try_to_lock()
-    os.chmod(dir, 0o750)
+    os.chmod(dir, 0o700)
     os.unlink(tmp_lock._pidfile)
 
 

--- a/convert2rhel/unit_tests/applock_test.py
+++ b/convert2rhel/unit_tests/applock_test.py
@@ -24,14 +24,16 @@ from convert2rhel import applock
 
 
 @pytest.fixture
-def tmp_lock():
-    alock = applock.ApplicationLock("convert2rhelTEST", lock_dir="/tmp")
+def tmp_lock(monkeypatch, tmp_path):
+    monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
+    alock = applock.ApplicationLock("convert2rhelTEST")
     return alock
 
 
-def test_applock_context_manager():
+def test_applock_context_manager(monkeypatch, tmp_path):
+    monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
     pidfile = "/non/existent/file"
-    with applock.ApplicationLock("convert2rhelTEST", lock_dir="/tmp") as tmp_lock:
+    with applock.ApplicationLock("convert2rhelTEST") as tmp_lock:
         pidfile = tmp_lock._pidfile
         assert tmp_lock.is_locked is True
         assert os.path.isfile(pidfile) is True

--- a/convert2rhel/unit_tests/applock_test.py
+++ b/convert2rhel/unit_tests/applock_test.py
@@ -32,7 +32,6 @@ def tmp_lock(monkeypatch, tmp_path):
 
 def test_applock_context_manager(monkeypatch, tmp_path):
     monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
-    pidfile = "/non/existent/file"
     with applock.ApplicationLock("convert2rhelTEST") as tmp_lock:
         pidfile = tmp_lock._pidfile
         assert tmp_lock.is_locked is True
@@ -101,11 +100,11 @@ def test_applock_link_fails(tmp_lock):
     """Test the case where the os.link call to create the lockfile
     fails, but not because the file exists."""
     dir = os.path.dirname(tmp_lock._pidfile)
-    os.chmod(dir, 0o555)
+    os.chmod(dir, 0o550)
     with pytest.raises(OSError):
         tmp_lock.try_to_lock()
     assert tmp_lock.is_locked is False
-    os.chmod(dir, 0o755)
+    os.chmod(dir, 0o750)
 
 
 def test_applock_lock_unlink_fails(tmp_lock):
@@ -114,10 +113,10 @@ def test_applock_lock_unlink_fails(tmp_lock):
     with open(tmp_lock._pidfile, "w") as f:
         f.write(old_pid)
     dir = os.path.dirname(tmp_lock._pidfile)
-    os.chmod(dir, 0o555)
+    os.chmod(dir, 0o550)
     with pytest.raises(OSError):
         tmp_lock.try_to_lock()
-    os.chmod(dir, 0o755)
+    os.chmod(dir, 0o750)
     os.unlink(tmp_lock._pidfile)
 
 

--- a/convert2rhel/unit_tests/applock_test.py
+++ b/convert2rhel/unit_tests/applock_test.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import pytest
+
+from convert2rhel import applock
+
+def test_applock_basic():
+    alock = applock.ApplicationLock("convert2rhelTEST")
+    alock.set_lock_dir("/tmp")
+    alock.trylock()
+    assert alock.is_locked() is True
+    assert os.path.isfile(alock._pidfile) is True
+    alock.unlock()
+    assert alock.is_locked() is False
+    assert os.path.isfile(alock._pidfile) is False
+
+def test_applock_basic_islocked():
+    alock = applock.ApplicationLock("convert2rhelTEST")
+    alock.set_lock_dir("/tmp")
+    with open(alock._pidfile, "w") as fileh:
+        pid = os.getpid()
+        fileh.write(str(pid) + '\n')
+    saw_exception = False
+    try:
+        alock.trylock()
+    except applock.ApplicationLockedError:
+        saw_exception = True
+    finally:
+        os.unlink(alock._pidfile)
+    assert saw_exception == True
+

--- a/convert2rhel/unit_tests/applock_test.py
+++ b/convert2rhel/unit_tests/applock_test.py
@@ -16,9 +16,11 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
+
 import pytest
 
 from convert2rhel import applock
+
 
 def test_applock_basic():
     alock = applock.ApplicationLock("convert2rhelTEST")
@@ -30,12 +32,13 @@ def test_applock_basic():
     assert alock.is_locked() is False
     assert os.path.isfile(alock._pidfile) is False
 
+
 def test_applock_basic_islocked():
     alock = applock.ApplicationLock("convert2rhelTEST")
     alock.set_lock_dir("/tmp")
     with open(alock._pidfile, "w") as fileh:
         pid = os.getpid()
-        fileh.write(str(pid) + '\n')
+        fileh.write(str(pid) + "\n")
     saw_exception = False
     try:
         alock.trylock()
@@ -44,4 +47,3 @@ def test_applock_basic_islocked():
     finally:
         os.unlink(alock._pidfile)
     assert saw_exception == True
-

--- a/convert2rhel/unit_tests/initialize_test.py
+++ b/convert2rhel/unit_tests/initialize_test.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
+
 import pytest
 
 from convert2rhel import applock, initialize, main

--- a/convert2rhel/unit_tests/initialize_test.py
+++ b/convert2rhel/unit_tests/initialize_test.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import os
 import pytest
 
 from convert2rhel import applock, initialize, main
@@ -32,3 +33,15 @@ def test_run(monkeypatch, exit_code, tmp_path):
     monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
     with pytest.raises(SystemExit):
         initialize.run()
+
+
+def test_locked(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
+    pidfile = os.path.join(str(tmp_path), "convert2rhel.pid")
+    with open(pidfile, "w") as f:
+        f.write(str(os.getpid()) + "\n")
+    with pytest.raises(SystemExit):
+        initialize.run()
+    captured = capsys.readouterr()
+    assert "Another copy of convert2rhel" in captured.err
+    os.unlink(pidfile)

--- a/convert2rhel/unit_tests/initialize_test.py
+++ b/convert2rhel/unit_tests/initialize_test.py
@@ -17,7 +17,7 @@
 
 import pytest
 
-from convert2rhel import initialize, main
+from convert2rhel import applock, initialize, main
 
 
 @pytest.mark.parametrize(
@@ -27,7 +27,8 @@ from convert2rhel import initialize, main
         (1),
     ),
 )
-def test_run(monkeypatch, exit_code):
+def test_run(monkeypatch, exit_code, tmp_path):
     monkeypatch.setattr(main, "main", value=lambda: exit_code)
+    monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
     with pytest.raises(SystemExit):
         initialize.run()

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -206,7 +206,6 @@ def test_post_ponr_conversion(monkeypatch):
 
 
 def test_main(monkeypatch):
-    require_root_mock = mock.Mock()
     initialize_logger_mock = mock.Mock()
     toolopts_cli_mock = mock.Mock()
     show_eula_mock = mock.Mock()
@@ -230,7 +229,6 @@ def test_main(monkeypatch):
     update_rhsm_custom_facts_mock = mock.Mock()
     summary_as_json_mock = mock.Mock()
 
-    monkeypatch.setattr(utils, "require_root", require_root_mock)
     monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
     monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
     monkeypatch.setattr(main, "show_eula", show_eula_mock)
@@ -255,7 +253,6 @@ def test_main(monkeypatch):
     monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
 
     assert main.main() == 0
-    assert require_root_mock.call_count == 1
     assert initialize_logger_mock.call_count == 1
     assert toolopts_cli_mock.call_count == 1
     assert show_eula_mock.call_count == 1
@@ -279,7 +276,6 @@ def test_main(monkeypatch):
 
 
 def test_main_rollback_post_cli_phase(monkeypatch, caplog):
-    require_root_mock = mock.Mock()
     initialize_logger_mock = mock.Mock()
     toolopts_cli_mock = mock.Mock()
     show_eula_mock = mock.Mock(side_effect=Exception)
@@ -287,14 +283,12 @@ def test_main_rollback_post_cli_phase(monkeypatch, caplog):
     # Mock the rollback calls
     finish_collection_mock = mock.Mock()
 
-    monkeypatch.setattr(utils, "require_root", require_root_mock)
     monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
     monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
     monkeypatch.setattr(main, "show_eula", show_eula_mock)
     monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
 
     assert main.main() == 1
-    assert require_root_mock.call_count == 1
     assert initialize_logger_mock.call_count == 1
     assert toolopts_cli_mock.call_count == 1
     assert show_eula_mock.call_count == 1
@@ -303,7 +297,6 @@ def test_main_rollback_post_cli_phase(monkeypatch, caplog):
 
 
 def test_main_traceback_before_action_completion(monkeypatch, caplog):
-    require_root_mock = mock.Mock()
     initialize_logger_mock = mock.Mock()
     toolopts_cli_mock = mock.Mock()
     show_eula_mock = mock.Mock()
@@ -320,7 +313,6 @@ def test_main_traceback_before_action_completion(monkeypatch, caplog):
     rollback_changes_mock = mock.Mock()
     summary_as_json_mock = mock.Mock()
 
-    monkeypatch.setattr(utils, "require_root", require_root_mock)
     monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
     monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
     monkeypatch.setattr(main, "show_eula", show_eula_mock)
@@ -336,7 +328,6 @@ def test_main_traceback_before_action_completion(monkeypatch, caplog):
     monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
 
     assert main.main() == 1
-    assert require_root_mock.call_count == 1
     assert initialize_logger_mock.call_count == 1
     assert toolopts_cli_mock.call_count == 1
     assert show_eula_mock.call_count == 1
@@ -358,7 +349,6 @@ def test_main_traceback_before_action_completion(monkeypatch, caplog):
 
 
 def test_main_rollback_pre_ponr_changes_phase(monkeypatch, caplog):
-    require_root_mock = mock.Mock()
     initialize_logger_mock = mock.Mock()
     toolopts_cli_mock = mock.Mock()
     show_eula_mock = mock.Mock()
@@ -377,7 +367,6 @@ def test_main_rollback_pre_ponr_changes_phase(monkeypatch, caplog):
     rollback_changes_mock = mock.Mock()
     summary_as_json_mock = mock.Mock()
 
-    monkeypatch.setattr(utils, "require_root", require_root_mock)
     monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
     monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
     monkeypatch.setattr(main, "show_eula", show_eula_mock)
@@ -395,7 +384,6 @@ def test_main_rollback_pre_ponr_changes_phase(monkeypatch, caplog):
     monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
 
     assert main.main() == 1
-    assert require_root_mock.call_count == 1
     assert initialize_logger_mock.call_count == 1
     assert toolopts_cli_mock.call_count == 1
     assert show_eula_mock.call_count == 1
@@ -415,7 +403,6 @@ def test_main_rollback_pre_ponr_changes_phase(monkeypatch, caplog):
 
 
 def test_main_rollback_analyze_exit_phase(global_tool_opts, monkeypatch):
-    require_root_mock = mock.Mock()
     initialize_logger_mock = mock.Mock()
     toolopts_cli_mock = mock.Mock()
     show_eula_mock = mock.Mock()
@@ -433,7 +420,6 @@ def test_main_rollback_analyze_exit_phase(global_tool_opts, monkeypatch):
     finish_collection_mock = mock.Mock()
     rollback_changes_mock = mock.Mock()
 
-    monkeypatch.setattr(utils, "require_root", require_root_mock)
     monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
     monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
     monkeypatch.setattr(main, "show_eula", show_eula_mock)
@@ -452,7 +438,6 @@ def test_main_rollback_analyze_exit_phase(global_tool_opts, monkeypatch):
     global_tool_opts.activity = "analysis"
 
     assert main.main() == 0
-    assert require_root_mock.call_count == 1
     assert initialize_logger_mock.call_count == 1
     assert toolopts_cli_mock.call_count == 1
     assert show_eula_mock.call_count == 1
@@ -469,7 +454,6 @@ def test_main_rollback_analyze_exit_phase(global_tool_opts, monkeypatch):
 
 
 def test_main_rollback_post_ponr_changes_phase(monkeypatch, caplog):
-    require_root_mock = mock.Mock()
     initialize_logger_mock = mock.Mock()
     toolopts_cli_mock = mock.Mock()
     show_eula_mock = mock.Mock()
@@ -490,7 +474,6 @@ def test_main_rollback_post_ponr_changes_phase(monkeypatch, caplog):
     finish_collection_mock = mock.Mock()
     update_rhsm_custom_facts_mock = mock.Mock()
 
-    monkeypatch.setattr(utils, "require_root", require_root_mock)
     monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
     monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
     monkeypatch.setattr(main, "show_eula", show_eula_mock)
@@ -510,7 +493,6 @@ def test_main_rollback_post_ponr_changes_phase(monkeypatch, caplog):
     monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
 
     assert main.main() == 1
-    assert require_root_mock.call_count == 1
     assert initialize_logger_mock.call_count == 1
     assert toolopts_cli_mock.call_count == 1
     assert show_eula_mock.call_count == 1

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,7 @@ markers =
     test_missing_system_release
     test_backup_os_release_no_envar
     test_backup_os_release_with_envar
+    test_simultaneous_runs
     test_root_privileges
     test_manpage
     test_smoke

--- a/tests/integration/tier0/non-destructive/application-lock/main.fmf
+++ b/tests/integration/tier0/non-destructive/application-lock/main.fmf
@@ -20,14 +20,3 @@ tag+:
         - simultaneous-runs
     test: |
         pytest -svv -m test_simultaneous_runs
-
-/sequential_runs:
-    summary+: |
-        Sequential runs
-    description+: |
-        Verify that convert2rhel does not lock out other instances
-        after it has run and exited.
-    tag+:
-        - sequential-runs
-    test: |
-        pytest -svv -m test_sequential_runs

--- a/tests/integration/tier0/non-destructive/application-lock/main.fmf
+++ b/tests/integration/tier0/non-destructive/application-lock/main.fmf
@@ -1,0 +1,33 @@
+summary: |
+    Application lock checks
+description: |
+    Verify that an attempt to run a second instance of convert2rhel
+    while an instance is already running fails.
+
+tier: 0
+
+tag+:
+    - application-lock
+
+/simultaneous_runs:
+    summary+: |
+        Simultaneous runs
+    description+: |
+        Verify that convert2rhel locks out other instances while it
+        is running and notifies the user of the second instance that
+        it cannot be run.
+    tag+:
+        - simultaneous-runs
+    test: |
+        pytest -svv -m test_simultaneous_runs
+
+/sequential_runs:
+    summary+: |
+        Sequential runs
+    description+: |
+        Verify that convert2rhel does not lock out other instances
+        after it has run and exited.
+    tag+:
+        - sequential-runs
+    test: |
+        pytest -svv -m test_sequential_runs

--- a/tests/integration/tier0/non-destructive/application-lock/test_application_lock.py
+++ b/tests/integration/tier0/non-destructive/application-lock/test_application_lock.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 

--- a/tests/integration/tier0/non-destructive/application-lock/test_application_lock.py
+++ b/tests/integration/tier0/non-destructive/application-lock/test_application_lock.py
@@ -15,9 +15,10 @@ def test_simultaenous_runs(convert2rhel):
     with convert2rhel("--no-rpm-va --debug") as c2r_one:
         c2r_one.expect("Continue with the system conversion?")
         # Invoke a second run
-        with convert2rhel("--no-rpm-va --debug") as c2r_two:
+        with convert2rhel("--help") as c2r_two:
             c2r_two.expect("Another copy of convert2rhel is running.")
-            assert c2r_two.exitstatus == 1
+            # c2r_two will exit here, but for some reason we are not
+            # getting a valid exitstatus out of the text fixture.
         c2r_one.sendline("n")
         assert c2r_one.exitstatus == 1
     # Invoke a third run

--- a/tests/integration/tier0/non-destructive/application-lock/test_application_lock.py
+++ b/tests/integration/tier0/non-destructive/application-lock/test_application_lock.py
@@ -6,26 +6,25 @@ import pytest
 
 @pytest.mark.test_simultaneous_runs
 def test_simultaenous_runs(convert2rhel):
-    """Test that running convert2rhel locks out other instances."""
-
+    """
+    Verify that running convert2rhel locks out other instances.
+    1/ Invoke convert2rhel, wait on data collection acknowledgement prompt.
+    2/ Invoke second instance of convert2rhel, observe warning and the utility exit.
+    3/ Exit the first run of convert2rhel.
+    4/ Invoke third instance of convert2rhel; with the previous instances dead, the third instance should be allowed to run.
+    5/ Exit the utility on the first prompt.
+    """
+    # Invoke a first instance
     with convert2rhel("--no-rpm-va --debug") as c2r_one:
         c2r_one.expect("Continue with the system conversion?")
+        # Invoke a second run
         with convert2rhel("--no-rpm-va --debug") as c2r_two:
             c2r_two.expect("Another copy of convert2rhel is running.")
             assert c2r_two.exitstatus == 1
         c2r_one.sendline("n")
         assert c2r_one.exitstatus == 1
-
-
-@pytest.mark.test_sequential_runs
-def test_sequential_runs(convert2rhel):
-    """Test that two convert2rhel instances can be run sequentially."""
-
-    with convert2rhel("--no-rpm-va --debug") as c2r_one:
-        c2r_one.expect("Continue with the system conversion?")
-        c2r_one.sendline("n")
-        assert c2r_one.exitstatus == 1
-    with convert2rhel("--no-rpm-va --debug") as c2r_two:
-        c2r_two.expect("Continue with the system conversion?")
-        c2r_two.sendline("n")
-        assert c2r_two.exitstatus == 1
+    # Invoke a third run
+    with convert2rhel("--no-rpm-va --debug") as c2r_three:
+        c2r_three.expect("Continue with the system conversion?")
+        c2r_three.sendline("n")
+        assert c2r_three.exitstatus == 1

--- a/tests/integration/tier0/non-destructive/application-lock/test_application_lock.py
+++ b/tests/integration/tier0/non-destructive/application-lock/test_application_lock.py
@@ -1,5 +1,3 @@
-import os
-import shutil
 
 import pytest
 

--- a/tests/integration/tier0/non-destructive/application-lock/test_application_lock.py
+++ b/tests/integration/tier0/non-destructive/application-lock/test_application_lock.py
@@ -16,6 +16,7 @@ def test_simultaenous_runs(convert2rhel):
         c2r_one.sendline("n")
         assert c2r_one.exitstatus == 1
 
+
 @pytest.mark.test_sequential_runs
 def test_sequential_runs(convert2rhel):
     """Test that two convert2rhel instances can be run sequentially."""

--- a/tests/integration/tier0/non-destructive/application-lock/test_application_lock.py
+++ b/tests/integration/tier0/non-destructive/application-lock/test_application_lock.py
@@ -1,0 +1,30 @@
+import os
+import shutil
+
+import pytest
+
+
+@pytest.mark.test_simultaneous_runs
+def test_simultaenous_runs(convert2rhel):
+    """Test that running convert2rhel locks out other instances."""
+
+    with convert2rhel("--no-rpm-va --debug") as c2r_one:
+        c2r_one.expect("Continue with the system conversion?")
+        with convert2rhel("--no-rpm-va --debug") as c2r_two:
+            c2r_two.expect("Another copy of convert2rhel is running.")
+            assert c2r_two.exitstatus == 1
+        c2r_one.sendline("n")
+        assert c2r_one.exitstatus == 1
+
+@pytest.mark.test_sequential_runs
+def test_sequential_runs(convert2rhel):
+    """Test that two convert2rhel instances can be run sequentially."""
+
+    with convert2rhel("--no-rpm-va --debug") as c2r_one:
+        c2r_one.expect("Continue with the system conversion?")
+        c2r_one.sendline("n")
+        assert c2r_one.exitstatus == 1
+    with convert2rhel("--no-rpm-va --debug") as c2r_two:
+        c2r_two.expect("Continue with the system conversion?")
+        c2r_two.sendline("n")
+        assert c2r_two.exitstatus == 1

--- a/tests/integration/tier0/non-destructive/application-lock/test_application_lock.py
+++ b/tests/integration/tier0/non-destructive/application-lock/test_application_lock.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.mark.test_simultaneous_runs
-def test_simultaenous_runs(convert2rhel):
+def test_simultaneous_runs(convert2rhel):
     """
     Verify that running convert2rhel locks out other instances.
     1/ Invoke convert2rhel, wait on data collection acknowledgement prompt.
@@ -11,18 +11,27 @@ def test_simultaenous_runs(convert2rhel):
     4/ Invoke third instance of convert2rhel; with the previous instances dead, the third instance should be allowed to run.
     5/ Exit the utility on the first prompt.
     """
+
+    def _run_second_instance():
+        """
+        Helper function initiating a second simultaneous run of convert2rhel.
+        Expect exit immediately.
+        """
+        with convert2rhel("--no-rpm-va --debug") as c2r_two:
+            c2r_two.expect("Another copy of convert2rhel is running.")
+        assert c2r_two.exitstatus == 1
+
     # Invoke a first instance
     with convert2rhel("--no-rpm-va --debug") as c2r_one:
         c2r_one.expect("Continue with the system conversion?")
-        # Invoke a second run
-        with convert2rhel("--help") as c2r_two:
-            c2r_two.expect("Another copy of convert2rhel is running.")
-            # c2r_two will exit here, but for some reason we are not
-            # getting a valid exitstatus out of the text fixture.
+        # Invoke the helper function with a second run
+        _run_second_instance()
+        # Exit the first run
         c2r_one.sendline("n")
-        assert c2r_one.exitstatus == 1
-    # Invoke a third run
+    assert c2r_one.exitstatus == 1
+
+    # Run for the third time to make sure, the application lock is removed
     with convert2rhel("--no-rpm-va --debug") as c2r_three:
         c2r_three.expect("Continue with the system conversion?")
         c2r_three.sendline("n")
-        assert c2r_three.exitstatus == 1
+    assert c2r_three.exitstatus == 1


### PR DESCRIPTION
Adds an ApplicationLock class that prevents two instances of convert2rhel from running on the same system. An attempt to start a second instance will result in it emitting an error message and exiting.

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1099](https://issues.redhat.com/browse/RHELC-1099)

Checklist

- [X] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [X] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [X] PR title explains the change from the user's point of view
- [X] Code and tests are documented properly
- [X] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
