### PR TITLE
[RHELC-1129] Update the convert2rhel contextmanager

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -69,12 +69,30 @@ jobs:
   labels:
     - tier0
 
+- &tests-tier0-non-destructive-manual
+  <<: *tests-tier0
+  identifier: "tier0-non-destructive"
+  tmt_plan: "tier0/non-destructive"
+  labels:
+    - tier0-non-destructive
+    - non-destructive
+
+
 - &tests-tier1-manual
   <<: *tests-tier0
   identifier: "tier1"
   tmt_plan: "tier1"
   labels:
     - tier1
+
+- &tests-tier1-non-destructive-manual
+  <<: *tests-tier0
+  identifier: "tier1-non-destructive"
+  tmt_plan: "tier1/non-destructive"
+  labels:
+    - tier1-non-destructive
+    - non-destructive
+
 
 # Tests on merge to main stage
 - &tests-tier1

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -77,7 +77,6 @@ jobs:
     - tier0-non-destructive
     - non-destructive
 
-
 - &tests-tier1-manual
   <<: *tests-tier0
   identifier: "tier1"
@@ -92,7 +91,6 @@ jobs:
   labels:
     - tier1-non-destructive
     - non-destructive
-
 
 # Tests on merge to main stage
 - &tests-tier1

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -124,12 +124,12 @@ def convert2rhel(shell):
             yield c2r_runtime
             c2r_runtime.expect(pexpect.EOF)
             c2r_runtime.close()
-        # Check if child is still alive, if so, send SIGINT
-        # this handles the TIMEOUT exception - if the process is still alive,
-        # the EOF is not raised, the process gets terminated.
-        # If pexpect.EOF exception is not raised (timeouts after 15 minutes)
-        # force terminate the process.
         finally:
+            # Check if child is still alive, if so, send SIGINT
+            # this handles the TIMEOUT exception - if the process is still alive,
+            # the EOF is not raised, the process gets terminated.
+            # If pexpect.EOF exception is not raised (timeouts after 15 minutes)
+            # force terminate the process.
             if c2r_runtime.isalive():
                 c2r_runtime.sendcontrol("c")
                 try:

--- a/tests/integration/tier0/non-destructive/sub-man-rollback/test_sub_man_rollback.py
+++ b/tests/integration/tier0/non-destructive/sub-man-rollback/test_sub_man_rollback.py
@@ -53,3 +53,7 @@ def test_sub_man_rollback(convert2rhel, shell, required_packages, convert2rhel_r
             assert c2r.expect("Validate the dnf transaction") == 0
             # At this point the centos-linux-release package is already installed
             c2r.sendcontrol("c")
+            # Expect rollback, otherwise TIMEOUT
+            c2r.expect("WARNING - Abnormal exit! Performing rollback", timeout=10)
+
+        assert c2r.exitstatus != 0

--- a/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
+++ b/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
@@ -191,4 +191,5 @@ def test_backup_os_release_with_envar(
         )
         c2r.sendcontrol("c")
 
+    assert c2r.exitstatus != 0
     assert shell("find /etc/os-release").returncode == 0


### PR DESCRIPTION
* update the code to handle the pexpect.TIMEOUT better; in a case the TIMEOUT is raised, do not close the connection, but send SIGINT to the process
* This will send the convert2rhel to the rollback, not breaking the system
* remove the os_release_hardening fixture as naive, not reliable workaround

Add an option to call just non-destructive tests

* use /packit test --labels
  (tier0-non-destructive|tier1-non-destructive|non-destructive)

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1129](https://issues.redhat.com/browse/RHELC-1129)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [x] When merged: Jira issue has been updated to `Release Pending` if relevant
