### PR TITLE
[RHELC-676] Unify parsing of the system release string

### DIFF
--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -194,7 +194,7 @@ class SystemInfo:
             #   CentOS Linux release 8.1.1911      Beta       (Core     )
             #   <    name  > <      ><full_version><    ><  <dist_id>>
             r"^(?P<name>.+?)\s(?:release\s)?(?P<full_version>[.\d]+)(?:\sBeta)?(\s\((?P<dist_id>.+)\))?$",
-            content,
+            content,  # type: ignore
         )
 
         if not matched:

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -168,7 +168,7 @@ class SystemInfo:
 
         content = self.system_release_file_content if not system_release_content else system_release_content
 
-        match = re.match(
+        matched = re.match(
             # We assume that the /etc/system-release content follows the pattern:
             # "<name> release <full_version> <Beta> (<dist_id>)"
             # Here
@@ -197,16 +197,16 @@ class SystemInfo:
             content,
         )
 
-        if not match:
+        if not matched:
             self.logger.critical_no_exit("Couldn't parse the system release content string: %s" % content)
             return {}
 
-        name = match.group("name")
+        name = matched.group("name")
         system_id = name.split()[0].lower()
 
-        distribution_id = match.group("dist_id")
+        distribution_id = matched.group("dist_id")
 
-        full_version = match.group("full_version")
+        full_version = matched.group("full_version")
         version_numbers = full_version.split(".")
         major = int(version_numbers[0])
 

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -109,37 +109,6 @@ class TestGenerateRPMVA:
 
 
 @pytest.mark.parametrize(
-    ("version_string", "expected_version"),
-    (
-        (
-            "Oracle Linux Server release 7.8",
-            Version(7, 8),
-        ),
-        (
-            "CentOS Linux release 7.6.1810 (Core)",
-            Version(7, 6),
-        ),
-        (
-            "CentOS Linux release 8.1.1911 (Core)",
-            Version(8, 1),
-        ),
-    ),
-)
-def test_get_system_version(version_string, expected_version, monkeypatch):
-    monkeypatch.setattr(system_info, "system_release_file_content", version_string)
-
-    version = system_info._get_system_version()
-
-    assert version == expected_version
-
-
-def test_get_system_version_failed(monkeypatch):
-    monkeypatch.setattr(system_info, "system_release_file_content", "not containing the release")
-    with pytest.raises(SystemExit):
-        system_info._get_system_version()
-
-
-@pytest.mark.parametrize(
     ("pkg_name", "present_on_system", "expected_return"),
     [
         ("package A", True, True),
@@ -158,62 +127,6 @@ def test_system_info_has_rpm(pkg_name, present_on_system, expected_return, monke
 def test_get_release_ver(pretend_os):
     """Test if all pretended OSes presented in theh RELEASE_VER_MAPPING."""
     assert system_info.releasever in RELEASE_VER_MAPPING.values()
-
-
-@pytest.mark.parametrize(
-    (
-        "releasever_val",
-        "self_name",
-        "self_version",
-        "has_internet",
-        "exception",
-    ),
-    (
-        # good cases
-        # if releasever set in config - it takes precedence
-        ("not_existing_release_ver_set_in_config", None, None, True, None),
-        # Good cases which matches supported pathes
-        ("", "CentOS Linux", systeminfo.Version(8, 4), True, None),
-        ("", "Oracle Linux Server", systeminfo.Version(8, 4), True, None),
-        # bad cases
-        ("", "NextCool Linux", systeminfo.Version(8, 4), False, SystemExit),
-        ("", "CentOS Linux", systeminfo.Version(8, 10000), False, SystemExit),
-    ),
-)
-# need to pretend centos8 in order to system info were resolved at module init
-@centos8
-def test_get_release_ver_other(
-    pretend_os, monkeypatch, releasever_val, self_name, self_version, has_internet, exception
-):
-    monkeypatch.setattr(systeminfo.SystemInfo, "_get_cfg_opt", mock.Mock(return_value=releasever_val))
-    monkeypatch.setattr(systeminfo.SystemInfo, "_check_internet_access", mock.Mock(return_value=has_internet))
-    monkeypatch.setattr(
-        systeminfo.SystemInfo,
-        "_get_cfg_opt",
-        mock.Mock(return_value=releasever_val),
-    )
-    if self_name:
-        monkeypatch.setattr(
-            systeminfo.SystemInfo,
-            "_get_system_name",
-            mock.Mock(return_value=self_name),
-        )
-    if self_version:
-        monkeypatch.setattr(
-            systeminfo.SystemInfo,
-            "_get_system_version",
-            mock.Mock(return_value=self_version),
-        )
-    # calling resolve_system_info one more time to enable our monkeypatches
-    if exception:
-        with pytest.raises(exception):
-            system_info.resolve_system_info()
-    else:
-        system_info.resolve_system_info()
-    if releasever_val:
-        assert system_info.releasever == releasever_val
-    if has_internet:
-        assert system_info.has_internet_access == has_internet
 
 
 @pytest.mark.parametrize(
@@ -346,19 +259,26 @@ def test_corresponds_to_rhel_eus_release_eus_override(major, minor, expected, mo
 
 
 @pytest.mark.parametrize(
-    ("system_release_content", "expected"),
+    ("system_release_content", "key", "value"),
     (
-        ("CentOS Linux release 8.1.1911 (Core)", "Core"),
-        ("Oracle Linux Server release 7.8", None),
+        ("CentOS Linux release 8.1.1911 (Core)", "distribution_id", "Core"),
+        ("Oracle Linux Server release 7.8", "name", "Oracle Linux Server"),
+        ("Oracle Linux Server release 7.8", "distribution_id", None),
+        ("CentOS Stream release 8", "id", "centos"),
+        ("CentOS Linux release 8.1.1911 (Core)", "version", Version(8, 1)),
+        ("CentOS Stream release 8", "version", Version(8, 10)),
+        ("Red Hat Enterprise Linux release 8.10 Beta (Ootpa)", "version", Version(8, 10)),
     ),
 )
-def test_get_system_distribution_id(system_release_content, expected):
-    assert system_info._get_system_distribution_id(system_release_content) == expected
+def test_parse_system_release_content_from_string(system_release_content, key, value):
+    parsed = system_info.parse_system_release_content(system_release_content)
+    assert parsed[key] == value
 
 
-@centos8
-def test_get_system_distribution_id_default_system_release_content(pretend_os):
-    assert system_info._get_system_distribution_id() is None
+def test_fail_to_parse_system_release_content_from_string():
+    system_release_content = "Non-matching string"
+    parsed = system_info.parse_system_release_content(system_release_content)
+    assert not parsed
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

Jira Issues: [RHELC-676](https://issues.redhat.com/browse/RHELC-676)

There are several places where the system release string is parsed via regular expressions. These regexps are different and adjusting them requires refactoring in multiple places.

This change introduces one parsing function which does a full match of the system-release string and reads all possible data points from it, and provides the result as a dictionary for later use by other tools.

The function replaces three other helper methods: _get_system_name, _get_system_version and _get_system_distribution_id, which are removed.

NOTE1: The parsing function could be a static method or even implemented as a utility function outside the class. The only reason why it is in the class is the logger object.

NOTE2: the function overlaps with the get_system_release_info function. We should check if this needs to be further unified.


Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
