### PR TITLE
[RHELC-1098] Change Action results so that no information is given in SUCCESS results

### DIFF
--- a/convert2rhel/actions/__init__.py
+++ b/convert2rhel/actions/__init__.py
@@ -377,6 +377,11 @@ class ActionResult(ActionMessageBase):
     def __init__(
         self, level="SUCCESS", id="SUCCESS", title="", description="", diagnosis="", remediation="", variables=None
     ):
+        if level == "SUCCESS":
+            if description or diagnosis or remediation:
+                raise InvalidMessageError(
+                    "Success results cannot have description, diagnosis or remediation fields set"
+                )
         if not id:
             raise InvalidMessageError("Results require the id field")
 

--- a/convert2rhel/unit_tests/actions/actions_test.py
+++ b/convert2rhel/unit_tests/actions/actions_test.py
@@ -1682,6 +1682,26 @@ class TestActionClasses:
         ("id", "level", "title", "description", "diagnosis", "remediation", "variables", "expected"),
         (
             (
+                "SUCCESS",
+                "SUCCESS",
+                "Sucess title",
+                "Successful description",
+                "Successful diagnosis",
+                "Successful remediation",
+                {},
+                "Success results cannot have description, diagnosis or remediation fields set",
+            ),
+            (
+                "SUCCESS",
+                "SUCCESS",
+                "Sucess title",
+                "Successful description",
+                None,
+                None,
+                {},
+                "Success results cannot have description, diagnosis or remediation fields set",
+            ),
+            (
                 None,
                 "ERROR",
                 None,

--- a/convert2rhel/unit_tests/actions/actions_test.py
+++ b/convert2rhel/unit_tests/actions/actions_test.py
@@ -1684,7 +1684,7 @@ class TestActionClasses:
             (
                 "SUCCESS",
                 "SUCCESS",
-                "Sucess title",
+                "Success title",
                 "Successful description",
                 "Successful diagnosis",
                 "Successful remediation",
@@ -1694,7 +1694,7 @@ class TestActionClasses:
             (
                 "SUCCESS",
                 "SUCCESS",
-                "Sucess title",
+                "Success title",
                 "Successful description",
                 None,
                 None,


### PR DESCRIPTION
This PR ensures that no action result with level set to "SUCCESS" has the fields description, diagnosis or remediation set. A custom exception `InvalidMessageError` will be raised if any of the fields are detected when setting the level field to "SUCCESS". This change is targeted for the 1.6 release of convert2rhel.

Jira Issues: [RHELC-1098](https://issues.redhat.com/browse/RHELC-1098)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
