### PR TITLE
[RHELC-1099] Move application lock into main.

### DIFF
--- a/convert2rhel/initialize.py
+++ b/convert2rhel/initialize.py
@@ -18,7 +18,7 @@
 import logging
 import os
 
-from convert2rhel import applock, i18n, utils
+from convert2rhel import i18n
 
 
 def disable_root_logger():

--- a/convert2rhel/initialize.py
+++ b/convert2rhel/initialize.py
@@ -17,7 +17,6 @@
 
 import logging
 import os
-import sys
 
 from convert2rhel import applock, i18n, utils
 
@@ -66,8 +65,9 @@ def set_locale():
 def run():
     """Wrapper around the main function.
 
-    This function is intended to initialize all early code and function calls
-    before any other main imports.
+    This function is needed to initialize early code and function calls
+    that have to be done before certain modules (which are imported by
+    main) are imported.
     """
     # prepare environment
     set_locale()
@@ -75,17 +75,6 @@ def run():
     # Initialize logging to stop duplicate messages.
     disable_root_logger()
 
-    # Make sure we're being run by root
-    utils.require_root()
-
     from convert2rhel import main
 
-    retval = 0
-    try:
-        with applock.ApplicationLock("convert2rhel"):
-            retval = main.main()
-    except applock.ApplicationLockedError:
-        retval = 1
-        sys.stderr.write("Another copy of convert2rhel is running.\n")
-        sys.stderr.write("\nNo changes were made to the system.\n")
-    sys.exit(retval)
+    return main.main()

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -66,7 +66,7 @@ def initialize_logger(log_name, log_dir):
 def main():
     """
     Wrapper around the main entrypoint.
-    
+
     Performs everything necessary to set up before starting the actual
     conversion process itself, then calls main_locked(), protected by
     the application lock, to do the conversion process.

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -72,11 +72,11 @@ def main():
 
     process_phase = ConversionPhase.INIT
 
-    # initialize logging
-    initialize_logger("convert2rhel.log", logger_module.LOG_DIR)
-
     # handle command line arguments
     toolopts.CLI()
+
+    # initialize logging
+    initialize_logger("convert2rhel.log", logger_module.LOG_DIR)
 
     # Make sure we're being run by root
     utils.require_root()

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -17,8 +17,9 @@
 
 import logging
 import os
+import sys
 
-from convert2rhel import actions, backup, breadcrumbs, checks, grub
+from convert2rhel import actions, applock, backup, breadcrumbs, checks, grub
 from convert2rhel import logger as logger_module
 from convert2rhel import pkghandler, pkgmanager, redhatrelease, repo, subscription, systeminfo, toolopts, utils
 from convert2rhel.actions import level_for_raw_action_data, report
@@ -63,7 +64,11 @@ def initialize_logger(log_name, log_dir):
 
 
 def main():
-    """Perform all steps for the entire conversion process."""
+    """Wrapper around the main function; performs everything we have
+    to set up before starting the actual conversion process itself,
+    then calls main_locked()--protected by the application lock--to do
+    the conversion process.
+    """
 
     process_phase = ConversionPhase.INIT
 
@@ -72,6 +77,21 @@ def main():
 
     # handle command line arguments
     toolopts.CLI()
+
+    # Make sure we're being run by root
+    utils.require_root()
+
+    try:
+        with applock.ApplicationLock("convert2rhel"):
+            return main_locked(process_phase)
+    except applock.ApplicationLockedError:
+        sys.stderr.write("Another copy of convert2rhel is running.\n")
+        sys.stderr.write("\nNo changes were made to the system.\n")
+        return 1
+
+
+def main_locked(process_phase):
+    """Perform all steps for the entire conversion process."""
 
     pre_conversion_results = None
     try:

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -64,10 +64,12 @@ def initialize_logger(log_name, log_dir):
 
 
 def main():
-    """Wrapper around the main function; performs everything we have
-    to set up before starting the actual conversion process itself,
-    then calls main_locked()--protected by the application lock--to do
-    the conversion process.
+    """
+    Wrapper around the main entrypoint.
+    
+    Performs everything necessary to set up before starting the actual
+    conversion process itself, then calls main_locked(), protected by
+    the application lock, to do the conversion process.
     """
 
     process_phase = ConversionPhase.INIT

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -85,6 +85,8 @@ def main():
         with applock.ApplicationLock("convert2rhel"):
             return main_locked(process_phase)
     except applock.ApplicationLockedError:
+        # We have not rotated the log files at this point because main.initialize_logger()
+        # has not yet been called.  So we use sys.stderr.write() instead of loggerinst.error()
         sys.stderr.write("Another copy of convert2rhel is running.\n")
         sys.stderr.write("\nNo changes were made to the system.\n")
         return 1

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -74,14 +74,14 @@ def main():
 
     process_phase = ConversionPhase.INIT
 
-    # handle command line arguments
-    toolopts.CLI()
+    # Make sure we're being run by root
+    utils.require_root()
 
     # initialize logging
     initialize_logger("convert2rhel.log", logger_module.LOG_DIR)
 
-    # Make sure we're being run by root
-    utils.require_root()
+    # handle command line arguments
+    toolopts.CLI()
 
     try:
         with applock.ApplicationLock("convert2rhel"):

--- a/convert2rhel/unit_tests/initialize_test.py
+++ b/convert2rhel/unit_tests/initialize_test.py
@@ -18,13 +18,10 @@
 import os
 
 import pytest
-import six
 
-from convert2rhel import applock, initialize, main, utils
-
-
-six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
-from six.moves import mock
+from convert2rhel import applock, initialize
+from convert2rhel import logger as logger_module
+from convert2rhel import main
 
 
 @pytest.mark.parametrize(
@@ -35,25 +32,6 @@ from six.moves import mock
     ),
 )
 def test_run(monkeypatch, exit_code, tmp_path):
-    require_root_mock = mock.Mock()
-    monkeypatch.setattr(utils, "require_root", require_root_mock)
     monkeypatch.setattr(main, "main", value=lambda: exit_code)
     monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
-    with pytest.raises(SystemExit):
-        initialize.run()
-    assert require_root_mock.call_count == 1
-
-
-def test_locked(monkeypatch, tmp_path, capsys):
-    require_root_mock = mock.Mock()
-    monkeypatch.setattr(utils, "require_root", require_root_mock)
-    monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
-    pidfile = os.path.join(str(tmp_path), "convert2rhel.pid")
-    with open(pidfile, "w") as f:
-        f.write(str(os.getpid()) + "\n")
-    with pytest.raises(SystemExit):
-        initialize.run()
-    captured = capsys.readouterr()
-    assert "Another copy of convert2rhel" in captured.err
-    os.unlink(pidfile)
-    assert require_root_mock.call_count == 1
+    assert initialize.run() == exit_code

--- a/convert2rhel/unit_tests/initialize_test.py
+++ b/convert2rhel/unit_tests/initialize_test.py
@@ -19,7 +19,7 @@ import os
 
 import pytest
 
-from convert2rhel import applock, initialize, main
+from convert2rhel import initialize, main
 
 
 @pytest.mark.parametrize(

--- a/convert2rhel/unit_tests/initialize_test.py
+++ b/convert2rhel/unit_tests/initialize_test.py
@@ -20,7 +20,6 @@ import os
 import pytest
 
 from convert2rhel import applock, initialize
-from convert2rhel import logger as logger_module
 from convert2rhel import main
 
 

--- a/convert2rhel/unit_tests/initialize_test.py
+++ b/convert2rhel/unit_tests/initialize_test.py
@@ -19,8 +19,7 @@ import os
 
 import pytest
 
-from convert2rhel import applock, initialize
-from convert2rhel import main
+from convert2rhel import applock, initialize, main
 
 
 @pytest.mark.parametrize(

--- a/convert2rhel/unit_tests/initialize_test.py
+++ b/convert2rhel/unit_tests/initialize_test.py
@@ -19,7 +19,7 @@ import os
 
 import pytest
 
-from convert2rhel import initialize, main
+from convert2rhel import applock, initialize, main
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This adds some changes that were accidentally omitted when PR891 was merged. They are necessary to avoid a bug related to importing certain packages in initialize.py.

Jira Issues: [RHELC-1099](https://issues.redhat.com/browse/RHELC-1099)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
