### PR TITLE
Fix sub-man installation on Alma and Rocky 8

### DIFF
--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -769,9 +769,8 @@ def _dependencies_to_update(pkg_list):
     if not pkg_list:
         return []
 
-    # Only apply this kludge on centos-8.  We assume that all other vendors
-    # will have dependencies of the needed version in their repositories.
-    if not (system_info.id == "centos" and system_info.version.major == 8):
+    # Only apply this kludge on RHEL 8-based systems. We have detected the problem on CentOS/Alma/Rocky 8.
+    if not system_info.version.major == 8:
         return []
 
     # Package names that we require differ on various platforms so we need to


### PR DESCRIPTION
If the python3-syspurpose package is installed on the system prior to the conversion, it has a different NEVRA than subscription-manager requires. The subscription-manager is strict about it - the syspurpose VRA (version, release, arch) needs to match exactly the sub-man VRA. And because we're downloading the sub-man packages from UBI, the VRA doesn't match.

Previously we thought this issue affects just CentOS Linux 8 but it does affect Alma and Rocky 8 as well.

Follows-up on #869.