### PR TITLE
[RHELC-1155] Move target compose definition in packit.yaml

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -97,12 +97,10 @@ jobs:
   tf_post_install_script: '#!/bin/bash\nsudo sed -i "s/^.*ssh-rsa/ssh-rsa/" /root/.ssh/authorized_keys'
   targets:
     epel-7-x86_64:
-      distros: [oraclelinux-7]
+      distros: ["OL7.9-x86_64-HVM-2023-01-05"]
   tf_extra_params:
     environments:
-      - os:
-          compose: "OL7.9-x86_64-HVM-2023-01-05"
-        tmt:
+      - tmt:
           context:
             distro: "oraclelinux-7"
         settings:
@@ -140,12 +138,10 @@ jobs:
   tf_post_install_script: '#!/bin/bash\nsudo sed -i "s/^.*ssh-rsa/ssh-rsa/" /root/.ssh/authorized_keys'
   targets:
     epel-8-x86_64:
-      distros: [oraclelinux-8]
+      distros: ["OL8.8-x86_64-HVM-2023-06-21"]
   tf_extra_params:
     environments:
-      - os:
-          compose: "OL8.8-x86_64-HVM-2023-06-21"
-        tmt:
+      - tmt:
           context:
             distro: "oraclelinux-8-latest"
         settings:


### PR DESCRIPTION
* with changes in packit/packit-service#2168 we can now move the targeted OS back under the distros key

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1155](https://issues.redhat.com/browse/RHELC-1155)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [x] When merged: Jira issue has been updated to `Release Pending` if relevant
