### PR TITLE
[RHELC-1154] Try to rollback all changes even if one of them fails.

### DIFF
--- a/convert2rhel/unit_tests/__init__.py
+++ b/convert2rhel/unit_tests/__init__.py
@@ -818,3 +818,13 @@ class MinimalRestorable(backup.RestorableChange):
     def restore(self):
         self.called["restore"] += 1
         super(MinimalRestorable, self).restore()
+
+
+class ErrorOnRestoreRestorable(MinimalRestorable):
+    def __init__(self, exception=None):
+        self.exception = exception or Exception()
+        super(ErrorOnRestoreRestorable, self).__init__()
+
+    def restore(self):
+        super(ErrorOnRestoreRestorable, self).restore()
+        raise self.exception

--- a/convert2rhel/unit_tests/backup_test.py
+++ b/convert2rhel/unit_tests/backup_test.py
@@ -6,7 +6,7 @@ import pytest
 import six
 
 from convert2rhel import backup, exceptions, repo, unit_tests, utils  # Imports unit_tests/__init__.py
-from convert2rhel.unit_tests import DownloadPkgMocked, MinimalRestorable, RunSubprocessMocked
+from convert2rhel.unit_tests import DownloadPkgMocked, ErrorOnRestoreRestorable, MinimalRestorable, RunSubprocessMocked
 from convert2rhel.unit_tests.conftest import centos8
 
 
@@ -472,6 +472,69 @@ class TestBackupController:
     def test_pop_all_when_empty(self, backup_controller):
         with pytest.raises(IndexError, match="No backups to restore"):
             backup_controller.pop_all()
+
+    def test_pop_all_error_in_restore(self, backup_controller, caplog):
+        restorable1 = MinimalRestorable()
+        restorable2 = ErrorOnRestoreRestorable(exception=ValueError("Restorable2 failed"))
+        restorable3 = MinimalRestorable()
+
+        backup_controller.push(restorable1)
+        backup_controller.push(restorable2)
+        backup_controller.push(restorable3)
+
+        popped_restorables = backup_controller.pop_all()
+
+        assert len(popped_restorables) == 3
+        assert popped_restorables == [restorable3, restorable2, restorable1]
+        assert caplog.records[-1].message == "Error while rolling back a ErrorOnRestoreRestorable: Restorable2 failed"
+
+    # The following tests are for the 1.4 kludge to split restoration via
+    # backup_controller into two parts.  They can be removed once we have
+    # all rollback items ported to use the BackupController and the partition
+    # code is removed.
+
+    def test_pop_with_partition(self, backup_controller):
+        restorable1 = MinimalRestorable()
+
+        backup_controller.push(restorable1)
+        backup_controller.push(backup_controller.partition)
+
+        restorable = backup_controller.pop()
+
+        assert restorable == restorable1
+        assert backup_controller._restorables == []
+
+    def test_pop_all_with_partition(self, backup_controller):
+        restorable1 = MinimalRestorable()
+        restorable2 = MinimalRestorable()
+
+        backup_controller.push(restorable1)
+        backup_controller.push(backup_controller.partition)
+        backup_controller.push(restorable2)
+
+        restorables = backup_controller.pop_all()
+
+        assert restorables == [restorable2, restorable1]
+
+    def test_pop_to_partition(self, backup_controller):
+        restorable1 = MinimalRestorable()
+        restorable2 = MinimalRestorable()
+
+        backup_controller.push(restorable1)
+        backup_controller.push(backup_controller.partition)
+        backup_controller.push(restorable2)
+
+        assert backup_controller._restorables == [restorable1, backup_controller.partition, restorable2]
+
+        backup_controller.pop_to_partition()
+
+        assert backup_controller._restorables == [restorable1]
+
+        backup_controller.pop_to_partition()
+
+        assert backup_controller._restorables == []
+
+    # End of tests that are for the 1.4 partition hack.
 
 
 class TestRestorableRpmKey:


### PR DESCRIPTION
Previously, if a RestorableChange managed by BackupController raised an exception on restore, then we would stop rollback.  This change makes it so we try to restore every change even if previous ones have failed.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1154](https://issues.redhat.com/browse/RHELC-1154)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
