### PR TITLE
[RHELC-1156] Display system packages that are not up to date in alphabetical order

### DIFF
--- a/convert2rhel/actions/system_checks/package_updates.py
+++ b/convert2rhel/actions/system_checks/package_updates.py
@@ -64,7 +64,7 @@ class PackageUpdates(actions.Action):
             return
 
         try:
-            packages_to_update = get_total_packages_to_update(reposdir=reposdir)
+            packages_to_update = sorted(get_total_packages_to_update(reposdir=reposdir))
         except (utils.UnableToSerialize, pkgmanager.RepoError) as e:
             # As both yum and dnf have the same error class (RepoError), to
             # identify any problems when interacting with the repositories, we
@@ -119,6 +119,7 @@ class PackageUpdates(actions.Action):
                 title="Outdated packages detected",
                 description="Please refer to the diagnosis for further information",
                 diagnosis=package_not_up_to_date_error_message,
+                remediation="Run yum update to update all the packages on the system.",
             )
         else:
             logger.info("System is up-to-date.")

--- a/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
@@ -74,7 +74,7 @@ def test_check_package_updates(pretend_os, monkeypatch, caplog, package_updates_
 
 @centos8
 def test_check_package_updates_not_up_to_date(pretend_os, monkeypatch, package_updates_action, caplog):
-    packages = ["package-1", "package-2"]
+    packages = ["package-2", "package-1"]
     diagnosis = (
         "The system has 2 package(s) not updated based on the enabled system repositories.\n"
         "List of packages to update: package-1 package-2.\n\n"
@@ -100,7 +100,7 @@ def test_check_package_updates_not_up_to_date(pretend_os, monkeypatch, package_u
                 title="Outdated packages detected",
                 description="Please refer to the diagnosis for further information",
                 diagnosis=diagnosis,
-                remediation=None,
+                remediation="Run yum update to update all the packages on the system.",
             ),
         )
     )


### PR DESCRIPTION
This PR adds sorting to the packages displayed in the package_not_up_to_date_message and adds a remediation to tell the user to run 'yum update' to update the packages on their system.

Jira Issues: [RHELC-1156](https://issues.redhat.com/browse/RHELC-1156)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
