### PR TITLE
[RHELC-1150] Update convert2rhel manpage

### DIFF
--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -110,28 +110,29 @@ class CLI(object):
         self._register_options()
         self._process_cli_options()
 
-    @property
-    def usage(self):
+    def usage(self, include_subcommands=True, subcommand_name=""):
+        subcommands = ["analyze"]
+        subcommands_usage = "convert2rhel {" + ", ".join(subcommands) + "}" if include_subcommands else ""
         usage = (
             "\n"
-            "  convert2rhel\n"
-            "  convert2rhel [-h]\n"
-            "  convert2rhel [--version]\n"
-            "  convert2rhel [-u username] [-p password | -c conf_file_path] [--pool pool_id | -a] [--disablerepo repoid]"
+            "  convert2rhel {subcommand_name}\n"
+            "  convert2rhel {subcommand_name} [-h]\n"
+            "  convert2rhel {subcommand_name} [--version]\n"
+            "  convert2rhel {subcommand_name} [-u username] [-p password | -c conf_file_path] [--pool pool_id | -a] [--disablerepo repoid]"
             " [--enablerepo repoid] [--serverurl url] [--no-rpm-va] [--debug] [--restart]"
             " [-y]\n"
-            "  convert2rhel [--no-rhsm] [--disablerepo repoid]"
+            "  convert2rhel {subcommand_name} [--no-rhsm] [--disablerepo repoid]"
             " [--enablerepo repoid] [--no-rpm-va] [--debug] [--restart] [-y]\n"
-            "  convert2rhel [-k activation_key | -c conf_file_path] [-o organization] [--pool pool_id | -a] [--disablerepo repoid] [--enablerepo"
+            "  convert2rhel {subcommand_name} [-k activation_key | -c conf_file_path] [-o organization] [--pool pool_id | -a] [--disablerepo repoid] [--enablerepo"
             " repoid] [--serverurl url] [--no-rpm-va] [--debug] [--restart] [-y]\n"
-            r" convert2rhel {analyze}"
+            "  {subcommands_usage}"
             "\n\n"
             "*WARNING* The tool needs to be run under the root user\n"
-        )
+        ).format(subcommands_usage=subcommands_usage, subcommand_name=subcommand_name)
         return usage
 
     def _get_argparser(self):
-        return argparse.ArgumentParser(conflict_handler="resolve", usage=self.usage)
+        return argparse.ArgumentParser(conflict_handler="resolve", usage=self.usage())
 
     def _register_commands(self):
         """Configures parsers specific to the analyze and convert subcommands"""
@@ -143,13 +144,16 @@ class CLI(object):
             " A rollback is initiated after the checks to put the system back"
             " in the original state.",
             parents=[self._shared_options_parser],
-            usage=self.usage,
+            usage=self.usage(include_subcommands=False, subcommand_name="analyze"),
         )
+        # This needs to pass implicitly the `include_subcommands=True` to the
+        # self.usage() function as we are assigning it as the default command
+        # when nothing is provided in the CLI.
         self._convert_parser = subparsers.add_parser(
             "convert",
             help="Convert the system.",
             parents=[self._shared_options_parser],
-            usage=self.usage,
+            usage=self.usage(),
         )
 
     def _register_parent_options(self, parser):

--- a/man/__init__.py
+++ b/man/__init__.py
@@ -20,7 +20,11 @@ from convert2rhel import toolopts
 
 def get_parser():
     """Return OptionParser instance used by manpage generator."""
-    parser = toolopts.CLI()._parser
+    cli = toolopts.CLI()
+    # Show the subcommands in the SYNOPSIS section, but hide in the
+    # `convert2rhel convert` section.
+    cli._convert_parser.usage = cli.usage(include_subcommands=False)
+    parser = cli._parser
 
     # Description taken out of our Confluence page.
     parser.description = (

--- a/man/convert2rhel.8
+++ b/man/convert2rhel.8
@@ -1,9 +1,9 @@
-.TH CONVERT2RHEL "1" "2023\-05\-25" "convert2rhel 1.3.1" "General Commands Manual"
+.TH CONVERT2RHEL "1" "2023\-09\-15" "convert2rhel 1.5.0" "General Commands Manual"
 .SH NAME
 convert2rhel \- Automates the conversion of Red Hat Enterprise Linux derivative distributions to Red Hat Enterprise Linux.
 .SH SYNOPSIS
 .B convert2rhel
-[-h] [--version] [--debug] [--no-rpm-va] [--enablerepo repoidglob] [--disablerepo repoidglob] [-u USERNAME] [-p PASSWORD] [-f PASSWORD_FROM_FILE] [-k ACTIVATIONKEY] [-o ORG] [-c CONFIG_FILE] [-a] [--pool POOL] [-v VARIANT] [--serverurl SERVERURL] [--keep-rhsm] [--disable-submgr] [--no-rhsm] [-r] [-y]
+convert2rhel [-h] convert2rhel [--version] convert2rhel [-u username] [-p password | -c conf_file_path] [--pool pool_id | -a] [--disablerepo repoid] [--enablerepo repoid] [--serverurl url] [--no-rpm-va] [--debug] [--restart] [-y] convert2rhel [--no-rhsm] [--disablerepo repoid] [--enablerepo repoid] [--no-rpm-va] [--debug] [--restart] [-y] convert2rhel [-k activation_key | -c conf_file_path] [-o organization] [--pool pool_id | -a] [--disablerepo repoid] [--enablerepo repoid] [--serverurl url] [--no-rpm-va] [--debug] [--restart] [-y] convert2rhel {analyze} *WARNING* The tool needs to be run under the root user
 .SH DESCRIPTION
 The Convert2RHEL utility automates converting Red Hat Enterprise Linux derivative distributions to Red Hat Enterprise Linux. The whole conversion procedure is performed on the running RHEL derivative OS installation and a restart is needed at the end of the conversion to boot into the RHEL kernel. The utility replaces the original OS packages with the RHEL ones. Available are conversions of CentOS Linux 6/7/8, Oracle Linux 6/7/8, Scientific Linux 7, Alma Linux 8, and Rocky Linux 8 to the respective major version of RHEL.
 
@@ -16,21 +16,51 @@ Show convert2rhel version and exit.
 \fB\-\-debug\fR
 Print traceback in case of an abnormal exit and messages that could help find an issue.
 
+.SH
+SUBCOMMANDS
+.TP
+\fBconvert2rhel\fR \fI\,analyze\/\fR
+Run all Convert2RHEL initial checks up until the  Point of no Return (PONR) and generate a report with the findings. A rollback is initiated after the checks to put the system back in the original state.
+.TP
+\fBconvert2rhel\fR \fI\,convert\/\fR
+Convert the system.
+
+.SH COMMAND \fI\,'convert2rhel analyze'\/\fR
+usage:
+  convert2rhel analyze
+  convert2rhel analyze [\-h]
+  convert2rhel analyze [\-\-version]
+  convert2rhel analyze [\-u username] [\-p password | \-c conf_file_path] [\-\-pool pool_id | \-a] [\-\-disablerepo repoid] [\-\-enablerepo repoid] [\-\-serverurl url] [\-\-no\-rpm\-va] [\-\-debug] [\-\-restart] [\-y]
+  convert2rhel analyze [\-\-no\-rhsm] [\-\-disablerepo repoid] [\-\-enablerepo repoid] [\-\-no\-rpm\-va] [\-\-debug] [\-\-restart] [\-y]
+  convert2rhel analyze [\-k activation_key | \-c conf_file_path] [\-o organization] [\-\-pool pool_id | \-a] [\-\-disablerepo repoid] [\-\-enablerepo repoid] [\-\-serverurl url] [\-\-no\-rpm\-va] [\-\-debug] [\-\-restart] [\-y]
+
+
+*WARNING* The tool needs to be run under the root user
+
+.SH OPTIONS \fI\,'convert2rhel analyze'\/\fR
+.TP
+\fB\-\-version\fR
+Show convert2rhel version and exit.
+
+.TP
+\fB\-\-debug\fR
+Print traceback in case of an abnormal exit and messages that could help find an issue.
+
 .TP
 \fB\-\-no\-rpm\-va\fR
-Skip gathering changed rpm files using 'rpm \-Va'. By default it's performed before and after the conversion with the output stored in log files rpm_va.log and
-rpm_va_after_conversion.log. At the end of the conversion, these logs are compared to show you what rpm files have been affected by the conversion.
+Skip gathering changed rpm files using 'rpm \-Va'. By default it's performed before and after the conversion with the output stored in log files rpm_va.log and rpm_va_after_conversion.log. At the end of the conversion, these logs are compared to show you
+what rpm files have been affected by the conversion.
 
 .TP
 \fB\-\-enablerepo\fR \fI\,repoidglob\/\fR
-Enable specific repositories by ID or glob. For more repositories to enable, use this option multiple times. If you don't use the \-\-no\-rhsm option, you can use this option to
-override the default RHEL repoids that convert2rhel enables through subscription\-manager.
+Enable specific repositories by ID or glob. For more repositories to enable, use this option multiple times. If you don't use the \-\-no\-rhsm option, you can use this option to override the default RHEL repoids that convert2rhel enables through
+subscription\-manager.
 
 .TP
 \fB\-\-disablerepo\fR \fI\,repoidglob\/\fR
 Disable specific repositories by ID or glob. For more repositories to disable, use this option multiple times. This option defaults to all repositories ('*').
 
-.SH SUBSCRIPTION MANAGER OPTIONS
+.SH SUBSCRIPTION MANAGER OPTIONS \fI\,'convert2rhel analyze'\/\fR
 The following options are specific to using subscription\-manager.
 
 .TP
@@ -39,8 +69,8 @@ Username for the subscription\-manager. If neither \-\-username nor \-\-activati
 
 .TP
 \fB\-p\fR \fI\,PASSWORD\/\fR, \fB\-\-password\fR \fI\,PASSWORD\/\fR
-Password for the subscription\-manager. If \-\-password, \-\-config\-file or \-\-activationkey are not used, the user is asked to enter the password. We recommend using the \-\-config\-
-file option instead to prevent leaking the password through a list of running processes.
+Password for the subscription\-manager. If \-\-password, \-\-config\-file or \-\-activationkey are not used, the user is asked to enter the password. We recommend using the \-\-config\-file option instead to prevent leaking the password through a list of running
+processes.
 
 .TP
 \fB\-f\fR \fI\,PASSWORD_FROM_FILE\/\fR, \fB\-\-password\-from\-file\fR \fI\,PASSWORD_FROM_FILE\/\fR
@@ -48,21 +78,17 @@ File containing password for the subscription\-manager in the plain text form. I
 
 .TP
 \fB\-k\fR \fI\,ACTIVATIONKEY\/\fR, \fB\-\-activationkey\fR \fI\,ACTIVATIONKEY\/\fR
-Activation key used for the system registration by the subscription\-manager. It requires to have the \-\-org option specified. We recommend using the \-\-config\-file option instead
-to prevent leaking the activation key through a list of running processes.
+Activation key used for the system registration by the subscription\-manager. It requires to have the \-\-org option specified. We recommend using the \-\-config\-file option instead to prevent leaking the activation key through a list of running processes.
 
 .TP
 \fB\-o\fR \fI\,ORG\/\fR, \fB\-\-org\fR \fI\,ORG\/\fR
-Organization with which the system will be registered by the subscription\-manager. A list of available organizations is possible to obtain by running 'subscription\-manager
-orgs'. From the listed pairs Name:Key, use the Key here.
+Organization with which the system will be registered by the subscription\-manager. A list of available organizations is possible to obtain by running 'subscription\-manager orgs'. From the listed pairs Name:Key, use the Key here.
 
 .TP
 \fB\-c\fR \fI\,CONFIG_FILE\/\fR, \fB\-\-config\-file\fR \fI\,CONFIG_FILE\/\fR
-The configuration file is an optional way to safely pass either a user password or an activation key to the subscription\-manager to register the system. This is more secure than
-passing these values through the \-\-activationkey or \-\-password option, which might leak the values through a list of running processes. You can edit the pre\-installed
-configuration file template at /etc/convert2rhel.ini or create a new configuration file at ~/.convert2rhel.ini. The convert2rhel utility loads the configuration from either of
-those locations, the latter having preference over the former. Alternatively, you can specify a path to the configuration file using the \-\-config\-file option to override other
-configurations.
+The configuration file is an optional way to safely pass either a user password or an activation key to the subscription\-manager to register the system. This is more secure than passing these values through the \-\-activationkey or \-\-password option, which
+might leak the values through a list of running processes. You can edit the pre\-installed configuration file template at /etc/convert2rhel.ini or create a new configuration file at ~/.convert2rhel.ini. The convert2rhel utility loads the configuration
+from either of those locations, the latter having preference over the former. Alternatively, you can specify a path to the configuration file using the \-\-config\-file option to override other configurations.
 
 .TP
 \fB\-a\fR, \fB\-\-auto\-attach\fR
@@ -70,26 +96,23 @@ Automatically attach compatible subscriptions to the system.
 
 .TP
 \fB\-\-pool\fR \fI\,POOL\/\fR
-Subscription pool ID. A list of the available subscriptions is possible to obtain by running 'subscription\-manager list \-\-available'. If no pool ID is provided, the \-\-auto
-option is used
+Subscription pool ID. A list of the available subscriptions is possible to obtain by running 'subscription\-manager list \-\-available'. If no pool ID is provided, the \-\-auto option is used
 
 .TP
 \fB\-v\fR \fI\,VARIANT\/\fR, \fB\-\-variant\fR \fI\,VARIANT\/\fR
-This option is not supported anymore and has no effect. When converting a system to RHEL 7 using subscription\-manager, the system is now always converted to the Server variant.
-In case of using custom repositories, the system is converted to the variant provided by these repositories.
+This option is not supported anymore and has no effect. When converting a system to RHEL 7 using subscription\-manager, the system is now always converted to the Server variant. In case of using custom repositories, the system is converted to the variant
+provided by these repositories.
 
 .TP
 \fB\-\-serverurl\fR \fI\,SERVERURL\/\fR
-Hostname of the subscription service with which to register the system through subscription\-manager. The default is the Customer Portal Subscription Management service. It is
-not to be used to specify a Satellite server. For that, read the product documentation at https://access.redhat.com/.
+Hostname of the subscription service with which to register the system through subscription\-manager. The default is the Customer Portal Subscription Management service. It is not to be used to specify a Satellite server. For that, read the product
+documentation at https://access.redhat.com/.
 
 .TP
 \fB\-\-keep\-rhsm\fR
-Keep the already installed Red Hat Subscription Management\-related packages. By default, during the conversion, these packages are removed, downloaded from verified sources and
-re\-installed. This option is suitable for environments with no connection to the Internet, or for systems managed by Red Hat Satellite. Warning: The system is being re\-
-registered during the conversion and when the re\-registration fails, there's no automated rollback to the original registration.
+Deprecated. This option has no effect. Convert2rhel will now use whatever subscription\-manager packages are present on the system.
 
-.SH ALTERNATIVE INSTALLATION OPTIONS
+.SH ALTERNATIVE INSTALLATION OPTIONS \fI\,'convert2rhel analyze'\/\fR
 The following options are required if you do not intend on using subscription\-manager
 
 .TP
@@ -98,10 +121,116 @@ Replaced by \-\-no\-rhsm. Both options have the same effect.
 
 .TP
 \fB\-\-no\-rhsm\fR
-Do not use subscription\-manager. Use custom repositories instead. See \-\-enablerepo/\-\-disablerepo options. Without this option, subscription\-manager is used to access RHEL
-repositories by default. Using this option requires specifying \-\-enablerepo as well.
+Do not use the subscription\-manager, use custom repositories instead. See \-\-enablerepo/\-\-disablerepo options. Without this option, the subscription\-manager is used to access RHEL repositories by default. Using this option requires to have the
+\-\-enablerepo specified.
 
-.SH AUTOMATION OPTIONS
+.SH AUTOMATION OPTIONS \fI\,'convert2rhel analyze'\/\fR
+The following options are used to automate the installation
+
+.TP
+\fB\-y\fR
+Answer yes to all yes/no questions the tool asks.
+
+.SH COMMAND \fI\,'convert2rhel convert'\/\fR
+usage:
+  convert2rhel
+  convert2rhel  [\-h]
+  convert2rhel  [\-\-version]
+  convert2rhel  [\-u username] [\-p password | \-c conf_file_path] [\-\-pool pool_id | \-a] [\-\-disablerepo repoid] [\-\-enablerepo repoid] [\-\-serverurl url] [\-\-no\-rpm\-va] [\-\-debug] [\-\-restart] [\-y]
+  convert2rhel  [\-\-no\-rhsm] [\-\-disablerepo repoid] [\-\-enablerepo repoid] [\-\-no\-rpm\-va] [\-\-debug] [\-\-restart] [\-y]
+  convert2rhel  [\-k activation_key | \-c conf_file_path] [\-o organization] [\-\-pool pool_id | \-a] [\-\-disablerepo repoid] [\-\-enablerepo repoid] [\-\-serverurl url] [\-\-no\-rpm\-va] [\-\-debug] [\-\-restart] [\-y]
+
+
+*WARNING* The tool needs to be run under the root user
+
+.SH OPTIONS \fI\,'convert2rhel convert'\/\fR
+.TP
+\fB\-\-version\fR
+Show convert2rhel version and exit.
+
+.TP
+\fB\-\-debug\fR
+Print traceback in case of an abnormal exit and messages that could help find an issue.
+
+.TP
+\fB\-\-no\-rpm\-va\fR
+Skip gathering changed rpm files using 'rpm \-Va'. By default it's performed before and after the conversion with the output stored in log files rpm_va.log and rpm_va_after_conversion.log. At the end of the conversion, these logs are compared to show you
+what rpm files have been affected by the conversion.
+
+.TP
+\fB\-\-enablerepo\fR \fI\,repoidglob\/\fR
+Enable specific repositories by ID or glob. For more repositories to enable, use this option multiple times. If you don't use the \-\-no\-rhsm option, you can use this option to override the default RHEL repoids that convert2rhel enables through
+subscription\-manager.
+
+.TP
+\fB\-\-disablerepo\fR \fI\,repoidglob\/\fR
+Disable specific repositories by ID or glob. For more repositories to disable, use this option multiple times. This option defaults to all repositories ('*').
+
+.SH SUBSCRIPTION MANAGER OPTIONS \fI\,'convert2rhel convert'\/\fR
+The following options are specific to using subscription\-manager.
+
+.TP
+\fB\-u\fR \fI\,USERNAME\/\fR, \fB\-\-username\fR \fI\,USERNAME\/\fR
+Username for the subscription\-manager. If neither \-\-username nor \-\-activation\-key option is used, the user is asked to enter the username.
+
+.TP
+\fB\-p\fR \fI\,PASSWORD\/\fR, \fB\-\-password\fR \fI\,PASSWORD\/\fR
+Password for the subscription\-manager. If \-\-password, \-\-config\-file or \-\-activationkey are not used, the user is asked to enter the password. We recommend using the \-\-config\-file option instead to prevent leaking the password through a list of running
+processes.
+
+.TP
+\fB\-f\fR \fI\,PASSWORD_FROM_FILE\/\fR, \fB\-\-password\-from\-file\fR \fI\,PASSWORD_FROM_FILE\/\fR
+File containing password for the subscription\-manager in the plain text form. It's an alternative to the \-\-password option. Deprecated, use \-\-config\-file instead.
+
+.TP
+\fB\-k\fR \fI\,ACTIVATIONKEY\/\fR, \fB\-\-activationkey\fR \fI\,ACTIVATIONKEY\/\fR
+Activation key used for the system registration by the subscription\-manager. It requires to have the \-\-org option specified. We recommend using the \-\-config\-file option instead to prevent leaking the activation key through a list of running processes.
+
+.TP
+\fB\-o\fR \fI\,ORG\/\fR, \fB\-\-org\fR \fI\,ORG\/\fR
+Organization with which the system will be registered by the subscription\-manager. A list of available organizations is possible to obtain by running 'subscription\-manager orgs'. From the listed pairs Name:Key, use the Key here.
+
+.TP
+\fB\-c\fR \fI\,CONFIG_FILE\/\fR, \fB\-\-config\-file\fR \fI\,CONFIG_FILE\/\fR
+The configuration file is an optional way to safely pass either a user password or an activation key to the subscription\-manager to register the system. This is more secure than passing these values through the \-\-activationkey or \-\-password option, which
+might leak the values through a list of running processes. You can edit the pre\-installed configuration file template at /etc/convert2rhel.ini or create a new configuration file at ~/.convert2rhel.ini. The convert2rhel utility loads the configuration
+from either of those locations, the latter having preference over the former. Alternatively, you can specify a path to the configuration file using the \-\-config\-file option to override other configurations.
+
+.TP
+\fB\-a\fR, \fB\-\-auto\-attach\fR
+Automatically attach compatible subscriptions to the system.
+
+.TP
+\fB\-\-pool\fR \fI\,POOL\/\fR
+Subscription pool ID. A list of the available subscriptions is possible to obtain by running 'subscription\-manager list \-\-available'. If no pool ID is provided, the \-\-auto option is used
+
+.TP
+\fB\-v\fR \fI\,VARIANT\/\fR, \fB\-\-variant\fR \fI\,VARIANT\/\fR
+This option is not supported anymore and has no effect. When converting a system to RHEL 7 using subscription\-manager, the system is now always converted to the Server variant. In case of using custom repositories, the system is converted to the variant
+provided by these repositories.
+
+.TP
+\fB\-\-serverurl\fR \fI\,SERVERURL\/\fR
+Hostname of the subscription service with which to register the system through subscription\-manager. The default is the Customer Portal Subscription Management service. It is not to be used to specify a Satellite server. For that, read the product
+documentation at https://access.redhat.com/.
+
+.TP
+\fB\-\-keep\-rhsm\fR
+Deprecated. This option has no effect. Convert2rhel will now use whatever subscription\-manager packages are present on the system.
+
+.SH ALTERNATIVE INSTALLATION OPTIONS \fI\,'convert2rhel convert'\/\fR
+The following options are required if you do not intend on using subscription\-manager
+
+.TP
+\fB\-\-disable\-submgr\fR
+Replaced by \-\-no\-rhsm. Both options have the same effect.
+
+.TP
+\fB\-\-no\-rhsm\fR
+Do not use the subscription\-manager, use custom repositories instead. See \-\-enablerepo/\-\-disablerepo options. Without this option, the subscription\-manager is used to access RHEL repositories by default. Using this option requires to have the
+\-\-enablerepo specified.
+
+.SH AUTOMATION OPTIONS \fI\,'convert2rhel convert'\/\fR
 The following options are used to automate the installation
 
 .TP
@@ -118,6 +247,6 @@ Michal Bocek <mbocek@redhat.com>
 .fi
 
 .SH DISTRIBUTION
-The latest version of convert2rhel may be downloaded from
+The latest version of convert2rhel 1.5.0 may be downloaded from
 .UR https://cdn.redhat.com/content/public/convert2rhel/
 .UE

--- a/man/distribution.man
+++ b/man/distribution.man
@@ -1,0 +1,2 @@
+[DISTRIBUTION]
+https://cdn.redhat.com/content/public/convert2rhel/


### PR DESCRIPTION
Generated a new manapge for convert2rhel that includes the analyze subcommand, as well, the options that were changed in the last release.

In this commit, there is also some changes related to the toolopts.py module that ensures the subcommands are displayed correctly in the manpage and in with --help.

Jira Issues: [RHELC-1150](https://issues.redhat.com/browse/RHELC-1150)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
