### PR TITLE
[RHELC-474] Deduplicate mocking classes

### DIFF
--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -20,14 +20,9 @@ __metaclass__ = type
 import os
 
 import pytest
-import six
 
 from convert2rhel import actions, systeminfo, unit_tests, utils
 from convert2rhel.actions.system_checks import convert2rhel_latest
-
-
-six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
-from six.moves import mock
 
 
 @pytest.fixture

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -43,7 +43,7 @@ def convert2rhel_latest_version_test(monkeypatch, tmpdir, request, global_system
     marker = request.param
     monkeypatch.setattr(convert2rhel_latest, "installed_convert2rhel_version", marker["local_version"])
 
-    run_subprocess_mocked = mock.Mock(spec=utils.run_subprocess, return_value=(marker["package_version"], 0))
+    run_subprocess_mocked = unit_tests.RunSubprocessMocked(return_string=marker["package_version"])
 
     monkeypatch.setattr(utils, "run_subprocess", run_subprocess_mocked)
     monkeypatch.setattr(global_system_info, "version", systeminfo.Version(marker["pmajor"], 0))
@@ -307,7 +307,9 @@ class TestCheckConvert2rhelLatest:
     def test_c2r_up_to_date_repoquery_error(
         self, caplog, monkeypatch, convert2rhel_latest_action, convert2rhel_latest_version_test
     ):
-        monkeypatch.setattr(utils, "run_subprocess", mock.Mock(return_value=("Repoquery did not run", 1)))
+        monkeypatch.setattr(
+            utils, "run_subprocess", unit_tests.RunSubprocessMocked(return_value=("Repoquery did not run", 1))
+        )
         expected = set(
             (
                 actions.ActionMessage(

--- a/convert2rhel/unit_tests/actions/system_checks/custom_repos_are_valid_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/custom_repos_are_valid_test.py
@@ -28,29 +28,11 @@ def custom_repos_are_valid_action():
     return custom_repos_are_valid.CustomReposAreValid()
 
 
-class CallYumCmdMocked(unit_tests.MockFunction):
-    def __init__(self, ret_code, ret_string):
-        self.called = 0
-        self.return_code = ret_code
-        self.return_string = ret_string
-        self.fail_once = False
-        self.command = None
-
-    def __call__(self, command, *args, **kwargs):
-        if self.fail_once and self.called == 0:
-            self.return_code = 1
-        if self.fail_once and self.called > 0:
-            self.return_code = 0
-        self.called += 1
-        self.command = command
-        return self.return_string, self.return_code
-
-
 def test_custom_repos_are_valid(custom_repos_are_valid_action, monkeypatch, caplog):
     monkeypatch.setattr(
         custom_repos_are_valid,
         "call_yum_cmd",
-        CallYumCmdMocked(ret_code=0, ret_string="Abcdef"),
+        unit_tests.CallYumCmdMocked(return_code=0, return_string="Abcdef"),
     )
     monkeypatch.setattr(custom_repos_are_valid.tool_opts, "no_rhsm", True)
 
@@ -63,7 +45,7 @@ def test_custom_repos_are_invalid(custom_repos_are_valid_action, monkeypatch):
     monkeypatch.setattr(
         custom_repos_are_valid,
         "call_yum_cmd",
-        CallYumCmdMocked(ret_code=1, ret_string="YUM/DNF failed"),
+        unit_tests.CallYumCmdMocked(return_code=1, return_string="YUM/DNF failed"),
     )
     monkeypatch.setattr(custom_repos_are_valid.tool_opts, "no_rhsm", True)
 

--- a/convert2rhel/unit_tests/actions/system_checks/efi_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/efi_test.py
@@ -25,7 +25,7 @@ import pytest
 
 from convert2rhel import actions, grub, systeminfo, unit_tests
 from convert2rhel.actions.system_checks import efi
-from convert2rhel.unit_tests import EFIBootInfoMocked, GetLoggerMocked
+from convert2rhel.unit_tests import EFIBootInfoMocked
 
 
 ExpectedMessage = namedtuple("ExpectedMessage", ("id", "title", "description", "diagnosis", "remediation", "log_msg"))

--- a/convert2rhel/unit_tests/actions/system_checks/rhel_compatible_kernel_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/rhel_compatible_kernel_test.py
@@ -29,7 +29,7 @@ from convert2rhel.actions.system_checks.rhel_compatible_kernel import (
     COMPATIBLE_KERNELS_VERS,
     KernelIncompatibleError,
 )
-from convert2rhel.unit_tests import create_pkg_information
+from convert2rhel.unit_tests import RunSubprocessMocked, create_pkg_information
 from convert2rhel.unit_tests.conftest import centos8
 from convert2rhel.utils import run_subprocess
 
@@ -254,7 +254,7 @@ def test_bad_kernel_package_signature_success(
     monkeypatch,
     pretend_os,
 ):
-    run_subprocess_mocked = mock.Mock(spec=run_subprocess, return_value=(kernel_pkg, 0))
+    run_subprocess_mocked = RunSubprocessMocked(return_string=kernel_pkg)
     monkeypatch.setattr(rhel_compatible_kernel, "run_subprocess", run_subprocess_mocked)
     get_installed_pkg_objects_mocked = mock.Mock(
         spec=rhel_compatible_kernel.get_installed_pkg_objects, return_value=[kernel_pkg]
@@ -314,7 +314,7 @@ def test_bad_kernel_package_signature_invalid_signature(
     monkeypatch,
     pretend_os,
 ):
-    run_subprocess_mocked = mock.Mock(spec=run_subprocess, return_value=(kernel_pkg, 0))
+    run_subprocess_mocked = RunSubprocessMocked(return_string=kernel_pkg)
     monkeypatch.setattr(rhel_compatible_kernel, "run_subprocess", run_subprocess_mocked)
     get_installed_pkg_objects_mocked = mock.Mock(
         spec=rhel_compatible_kernel.get_installed_pkg_objects, return_value=[kernel_pkg]
@@ -351,7 +351,7 @@ def test_bad_kernel_package_signature_invalid_signature(
 )
 @centos8
 def test_kernel_not_installed(pretend_os, error_id, template, variables, monkeypatch):
-    run_subprocess_mocked = mock.Mock(spec=run_subprocess, return_value=(" ", 1))
+    run_subprocess_mocked = RunSubprocessMocked(return_value=(" ", 1))
     monkeypatch.setattr(rhel_compatible_kernel, "run_subprocess", run_subprocess_mocked)
 
     with pytest.raises(KernelIncompatibleError) as excinfo:

--- a/convert2rhel/unit_tests/actions/system_checks/rhel_compatible_kernel_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/rhel_compatible_kernel_test.py
@@ -226,7 +226,7 @@ def test_bad_kernel_substring_invalid_substring(kernel_release, error_id, templa
 
 
 @pytest.mark.parametrize(
-    ("kernel_release", "kernel_pkg", "kernel_pkg_information", "get_installed_pkg_objects", "exp_return"),
+    ("kernel_release", "kernel_pkg", "kernel_pkg_information", "exp_return"),
     (
         (
             "4.18.0-240.22.1.el8_3.x86_64",
@@ -239,7 +239,6 @@ def test_bad_kernel_substring_invalid_substring(kernel_release, error_id, templa
                 arch="x86_64",
                 fingerprint="05b555b38483c65d",
             ),
-            "yajl.x86_64",
             False,
         ),
     ),
@@ -249,7 +248,6 @@ def test_bad_kernel_package_signature_success(
     kernel_release,
     kernel_pkg,
     kernel_pkg_information,
-    get_installed_pkg_objects,
     exp_return,
     monkeypatch,
     pretend_os,
@@ -278,7 +276,6 @@ def test_bad_kernel_package_signature_success(
         "kernel_release",
         "kernel_pkg",
         "kernel_pkg_information",
-        "get_installed_pkg_objects",
         "error_id",
         "template",
         "variables",
@@ -295,7 +292,6 @@ def test_bad_kernel_package_signature_success(
                 arch="x86_64",
                 fingerprint="somebadsig",
             ),
-            "somepkgobj",
             "INVALID_KERNEL_PACKAGE_SIGNATURE",
             "Custom kernel detected. The booted kernel needs to be signed by {os_vendor}.",
             dict(os_vendor="CentOS"),
@@ -307,7 +303,6 @@ def test_bad_kernel_package_signature_invalid_signature(
     kernel_release,
     kernel_pkg,
     kernel_pkg_information,
-    get_installed_pkg_objects,
     error_id,
     template,
     variables,

--- a/convert2rhel/unit_tests/cert_test.py
+++ b/convert2rhel/unit_tests/cert_test.py
@@ -184,7 +184,11 @@ class TestPEMCert:
         assert "OSError(13): Permission denied" == caplog.messages[-1]
 
     def test_restore_cert(self, caplog, monkeypatch, system_cert_with_target_path):
-        monkeypatch.setattr(utils, "run_subprocess", mock.Mock(return_value=("479.pem is not owned by any package", 1)))
+        monkeypatch.setattr(
+            utils,
+            "run_subprocess",
+            unit_tests.RunSubprocessMocked(return_string="479.pem is not owned by any package", return_code=1),
+        )
         system_cert_with_target_path.enable()
 
         system_cert_with_target_path.restore()
@@ -257,7 +261,9 @@ class TestPEMCert:
     def test_restore_rpm_package_owns(
         self, caplog, monkeypatch, system_cert_with_target_path, rpm_exit_code, rpm_stdout, expected
     ):
-        monkeypatch.setattr(utils, "run_subprocess", mock.Mock(return_value=(rpm_stdout, rpm_exit_code)))
+        monkeypatch.setattr(
+            utils, "run_subprocess", unit_tests.RunSubprocessMocked(return_string=rpm_stdout, return_code=rpm_exit_code)
+        )
         system_cert_with_target_path.enable()
 
         system_cert_with_target_path.restore()

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -19,6 +19,7 @@ import pytest
 import six
 
 from convert2rhel import checks
+from convert2rhel.unit_tests import RunSubprocessMocked
 from convert2rhel.unit_tests.conftest import centos8
 
 
@@ -41,7 +42,7 @@ def test_is_initramfs_file_valid(latest_installed_kernel, subprocess_output, exp
         pass
 
     monkeypatch.setattr(checks, "INITRAMFS_FILEPATH", initramfs_file)
-    monkeypatch.setattr(checks, "run_subprocess", mock.Mock(return_value=subprocess_output))
+    monkeypatch.setattr(checks, "run_subprocess", RunSubprocessMocked(return_value=subprocess_output))
     result = checks._is_initramfs_file_valid(initramfs_file)
     assert result == expected
 
@@ -69,7 +70,9 @@ def test_check_kernel_boot_files(pretend_os, tmpdir, caplog, monkeypatch):
 
     monkeypatch.setattr(checks, "VMLINUZ_FILEPATH", vmlinuz_file)
     monkeypatch.setattr(checks, "INITRAMFS_FILEPATH", initramfs_file)
-    monkeypatch.setattr(checks, "run_subprocess", mock.Mock(side_effect=[rpm_last_kernel_output, ("test", 0)]))
+    monkeypatch.setattr(
+        checks, "run_subprocess", RunSubprocessMocked(side_effect=[rpm_last_kernel_output, ("test", 0)])
+    )
 
     checks.check_kernel_boot_files()
     assert "The initramfs and vmlinuz files are valid." in caplog.records[-1].message

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -71,7 +71,10 @@ class TestShowEula:
 
         main.show_eula()
 
-    def test_show_eula_nonexisting_file(self, caplog, monkeypatch):
+    def test_show_eula_nonexisting_file(self, caplog, monkeypatch, tmpdir):
+        # Needed in case convert2rhel is installed on this system
+        monkeypatch.setattr(utils, "DATA_DIR", str(tmpdir))
+
         with pytest.raises(SystemExit, match="EULA file not found"):
             main.show_eula()
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,7 @@ testpaths = "convert2rhel/unit_tests"
 markers =
     cert_filename
     rhsm_returns
+    popen_output
     test_unsuccessful_satellite_registration
     test_missing_system_release
     test_backup_os_release_no_envar


### PR DESCRIPTION
Deduplicates many mock classes and ports away from unit_tests.MockFunction to unit_tests.MockFunctionObject.

Note that there are still functions which are using Mocked Functions inside of the specific unit_test files instead of the shared unit_tests.  It doesn't look like many of these are shared, though.

There are also a great many tests using one-off mocks like this:
```
dummy_mock = mock.Mock()
PkgName = namedtuple("PkgNames", ["name"])
transaction_pkgs = [PkgName(package) for package in packages]

monkeypatch.setattr(pkgmanager.Base, "read_all_repos", value=dummy_mock)
monkeypatch.setattr(pkgmanager.Base, "fill_sack", value=dummy_mock)
monkeypatch.setattr(pkgmanager.Base, "upgrade_all", value=dummy_mock)
monkeypatch.setattr(pkgmanager.Base, "resolve", value=dummy_mock)
```
Most of those are low complexity (just a few lines, perhaps just `mock.Mock()` plus a `return_value` so the main benefit to consolidating them would be to use autospec with them (So that the parameters will be checks for too many positional args or kwargs of unknown names).

We can decide whether to leave RHELC-474 open to take care of those or not.

This PR only touches unittests so it should be mergable without adding work to QE.

Jira Issues: [RHELC-474](https://issues.redhat.com/browse/RHELC-474)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
