### PR TITLE
[RHELC-1055] Print pre-conversion report to txt file

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -56,9 +56,6 @@ jobs:
         distros: [centos-7]
       epel-8-x86_64:
         distros: [centos-8-latest]
-      epel-9-x86_64:
-        # TBD: so far it's just guessing of the distro strings
-        distros: [oraclelinux-9-latest, AlmaLinux-OS-9.2, rocky-linux-9.2]
     trigger: pull_request
     identifier: "tier0-non-destructive-centos"
     tmt_plan: "tier0/non-destructive"

--- a/convert2rhel/actions/report.py
+++ b/convert2rhel/actions/report.py
@@ -289,6 +289,6 @@ def summary_as_txt(results):
 
     txt_result = txt_result.strip()
 
-    # We need info from the last run, any old results needed
+    # We need info from the last run, any old results are discarded
     with open(CONVERT2RHEL_TXT_RESULTS, "w") as file:
         file.write(txt_result)

--- a/convert2rhel/actions/report.py
+++ b/convert2rhel/actions/report.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 
 #: The filename to store the results of running preassessment
 CONVERT2RHEL_JSON_RESULTS = "/var/log/convert2rhel/convert2rhel-pre-conversion.json"
+CONVERT2RHEL_TXT_RESULTS = "/var/log/convert2rhel/convert2rhel-pre-conversion.txt"
 
 #: Map Status codes (from convert2rhel.actions.STATUS_CODE) to color name (from
 #: convert2rhel.logger.bcolor)
@@ -118,6 +119,31 @@ def wrap_paragraphs(text, width=70, **kwargs):
     return "\n".join(output)
 
 
+def get_combined_results_and_message(results):
+    combined_results_and_message = {}
+
+    for action_id, action_value in results.items():
+        combined_results_and_message[(action_id, action_value["result"]["id"])] = {
+            "level": action_value["result"]["level"],
+            "title": action_value["result"]["title"],
+            "description": action_value["result"]["description"],
+            "remediation": action_value["result"]["remediation"],
+            "diagnosis": action_value["result"]["diagnosis"],
+            "variables": action_value["result"]["variables"],
+        }
+        for message in action_value["messages"]:
+            combined_results_and_message[(action_id, message["id"])] = {
+                "level": message["level"],
+                "title": message["title"],
+                "description": message["description"],
+                "remediation": message["remediation"],
+                "diagnosis": message["diagnosis"],
+                "variables": message["variables"],
+            }
+
+    return combined_results_and_message
+
+
 def summary(results, include_all_reports=False, disable_colors=False):
     """Output a summary regarding the actions execution.
 
@@ -183,27 +209,9 @@ def summary(results, include_all_reports=False, disable_colors=False):
     :type include_all_reports: bool
     """
     logger.task("Pre-conversion analysis report")
-    combined_results_and_message = {}
     report = []
 
-    for action_id, action_value in results.items():
-        combined_results_and_message[(action_id, action_value["result"]["id"])] = {
-            "level": action_value["result"]["level"],
-            "title": action_value["result"]["title"],
-            "description": action_value["result"]["description"],
-            "remediation": action_value["result"]["remediation"],
-            "diagnosis": action_value["result"]["diagnosis"],
-            "variables": action_value["result"]["variables"],
-        }
-        for message in action_value["messages"]:
-            combined_results_and_message[(action_id, message["id"])] = {
-                "level": message["level"],
-                "title": message["title"],
-                "description": message["description"],
-                "remediation": message["remediation"],
-                "diagnosis": message["diagnosis"],
-                "variables": message["variables"],
-            }
+    combined_results_and_message = get_combined_results_and_message(results)
 
     if include_all_reports:
         combined_results_and_message = combined_results_and_message.items()
@@ -254,3 +262,33 @@ def format_report_section_heading(status_code):
 
     heading = "{highlight} {status_header} {highlight}".format(highlight=highlight, status_header=status_header)
     return heading
+
+
+def summary_as_txt(results):
+    """
+    Print the report to txt file. Used mainly by Satellite.
+    Accepts the data preformatted by summary function.
+
+    There is no special formatting needed, just the output of the checks.
+    The data are sorted from ERROR to INFO, SUCCESS aren't included.
+    """
+    txt_result = ""
+
+    combined_results_and_message = get_combined_results_and_message(results)
+
+    combined_results_and_message = find_actions_of_severity(
+        combined_results_and_message, "INFO", level_for_combined_action_data
+    )
+    combined_results_and_message = sorted(combined_results_and_message, key=lambda item: item[1]["level"], reverse=True)
+
+    for message_id, combined_result in combined_results_and_message:
+        entry = format_action_status_message(combined_result["level"], message_id[0], message_id[1], combined_result)
+        entry = colorize(entry, _STATUS_TO_COLOR[combined_result["level"]])
+        entry += "\n"
+        txt_result += entry
+
+    txt_result = txt_result.strip()
+
+    # We need info from the last run, any old results needed
+    with open(CONVERT2RHEL_TXT_RESULTS, "w") as file:
+        file.write(txt_result)

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -205,6 +205,7 @@ def main_locked(process_phase):
         # parse and act upon it.
         if pre_conversion_results:
             actions.report.summary_as_json(pre_conversion_results)
+            actions.report.summary_as_txt(pre_conversion_results)
 
     return 0
 

--- a/convert2rhel/unit_tests/actions/report_test.py
+++ b/convert2rhel/unit_tests/actions/report_test.py
@@ -1215,8 +1215,6 @@ def test_summary_as_txt(results, text_lines, tmpdir, monkeypatch):
 
     monkeypatch.setattr(report, "CONVERT2RHEL_TXT_RESULTS", str(convert2rhel_txt_results))
 
-    # Call the summary instead of report_to_txt since report to text file is written during the
-    # summary. Also part of the summary code is used for the report to text file.
     report.summary_as_txt(results)
 
     for expected in text_lines:
@@ -1340,8 +1338,6 @@ def test_summary_as_txt_file_exists(results, text_lines, tmpdir, monkeypatch):
 
     monkeypatch.setattr(report, "CONVERT2RHEL_TXT_RESULTS", str(convert2rhel_txt_results))
 
-    # Call the summary instead of report_to_txt since report to text file is written during the
-    # summary. Also part of the summary code is used for the report to text file.
     report.summary_as_txt(results)
 
     for expected in text_lines:

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -132,6 +132,7 @@ def test_main(monkeypatch, tmp_path):
     check_kernel_boot_files_mock = mock.Mock()
     update_rhsm_custom_facts_mock = mock.Mock()
     summary_as_json_mock = mock.Mock()
+    summary_as_txt_mock = mock.Mock()
 
     monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
     monkeypatch.setattr(utils, "require_root", require_root_mock)
@@ -157,6 +158,7 @@ def test_main(monkeypatch, tmp_path):
     monkeypatch.setattr(checks, "check_kernel_boot_files", check_kernel_boot_files_mock)
     monkeypatch.setattr(subscription, "update_rhsm_custom_facts", update_rhsm_custom_facts_mock)
     monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
+    monkeypatch.setattr(report, "summary_as_txt", summary_as_txt_mock)
 
     assert main.main() == 0
     assert require_root_mock.call_count == 1
@@ -180,6 +182,7 @@ def test_main(monkeypatch, tmp_path):
     assert check_kernel_boot_files_mock.call_count == 1
     assert update_rhsm_custom_facts_mock.call_count == 1
     assert summary_as_json_mock.call_count == 1
+    assert summary_as_txt_mock.call_count == 1
 
 
 class TestRollbackFromMain:
@@ -219,6 +222,7 @@ class TestRollbackFromMain:
         clean_yum_metadata_mock = mock.Mock()
         run_actions_mock = mock.Mock(side_effect=Exception("Action Framework Crashed"))
         clear_versionlock_mock = mock.Mock()
+        summary_as_txt_mock = mock.Mock()
 
         # Mock the rollback calls
         finish_collection_mock = mock.Mock()
@@ -240,6 +244,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
         monkeypatch.setattr(main, "rollback_changes", rollback_changes_mock)
         monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
+        monkeypatch.setattr(report, "summary_as_txt", summary_as_txt_mock)
 
         assert main.main() == 1
         assert require_root_mock.call_count == 1
@@ -255,7 +260,7 @@ class TestRollbackFromMain:
         assert finish_collection_mock.call_count == 1
         assert rollback_changes_mock.call_count == 1
         assert summary_as_json_mock.call_count == 0
-        print(caplog.records)
+        assert summary_as_txt_mock.call_count == 0
         assert (
             caplog.records[-2].message.strip()
             == "Conversion interrupted before analysis of system completed. Report not generated."
@@ -276,6 +281,7 @@ class TestRollbackFromMain:
         report_summary_mock = mock.Mock()
         clear_versionlock_mock = mock.Mock()
         find_actions_of_severity_mock = mock.Mock()
+        summary_as_txt_mock = mock.Mock()
 
         # Mock the rollback calls
         finish_collection_mock = mock.Mock()
@@ -299,6 +305,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
         monkeypatch.setattr(main, "rollback_changes", rollback_changes_mock)
         monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
+        monkeypatch.setattr(report, "summary_as_txt", summary_as_txt_mock)
 
         assert main.main() == 1
         assert require_root_mock.call_count == 1
@@ -316,6 +323,7 @@ class TestRollbackFromMain:
         assert finish_collection_mock.call_count == 1
         assert rollback_changes_mock.call_count == 1
         assert summary_as_json_mock.call_count == 1
+        assert summary_as_txt_mock.call_count == 1
         assert caplog.records[-3].message == "Conversion failed."
         assert caplog.records[-3].levelname == "CRITICAL"
 
@@ -333,6 +341,7 @@ class TestRollbackFromMain:
         report_summary_mock = mock.Mock()
         clear_versionlock_mock = mock.Mock()
         summary_as_json_mock = mock.Mock()
+        summary_as_txt_mock = mock.Mock()
 
         # Mock the rollback calls
         finish_collection_mock = mock.Mock()
@@ -355,6 +364,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(main, "rollback_changes", rollback_changes_mock)
         monkeypatch.setattr(os, "environ", {"CONVERT2RHEL_EXPERIMENTAL_ANALYSIS": 1})
         monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
+        monkeypatch.setattr(report, "summary_as_txt", summary_as_txt_mock)
         global_tool_opts.activity = "analysis"
 
         assert main.main() == 0
@@ -372,6 +382,7 @@ class TestRollbackFromMain:
         assert finish_collection_mock.call_count == 1
         assert rollback_changes_mock.call_count == 1
         assert summary_as_json_mock.call_count == 1
+        assert summary_as_txt_mock.call_count == 1
 
     def test_main_rollback_post_ponr_changes_phase(self, monkeypatch, caplog, tmp_path):
         require_root_mock = mock.Mock()
@@ -390,6 +401,7 @@ class TestRollbackFromMain:
         ask_to_continue_mock = mock.Mock()
         post_ponr_conversion_mock = mock.Mock(side_effect=Exception)
         summary_as_json_mock = mock.Mock()
+        summary_as_txt_mock = mock.Mock()
 
         # Mock the rollback calls
         finish_collection_mock = mock.Mock()
@@ -414,6 +426,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
         monkeypatch.setattr(subscription, "update_rhsm_custom_facts", update_rhsm_custom_facts_mock)
         monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
+        monkeypatch.setattr(report, "summary_as_txt", summary_as_txt_mock)
 
         assert main.main() == 1
         assert require_root_mock.call_count == 1
@@ -432,6 +445,7 @@ class TestRollbackFromMain:
         assert post_ponr_conversion_mock.call_count == 1
         assert finish_collection_mock.call_count == 1
         assert summary_as_json_mock.call_count == 1
+        assert summary_as_txt_mock.call_count == 1
         assert "The system is left in an undetermined state that Convert2RHEL cannot fix." in caplog.records[-2].message
         assert update_rhsm_custom_facts_mock.call_count == 1
 

--- a/tests/integration/tier0/non-destructive/assessment-report/main.fmf
+++ b/tests/integration/tier0/non-destructive/assessment-report/main.fmf
@@ -5,6 +5,7 @@ description+: |
     Verify that the pre-assessment report is working as intended.
     Verify the report is also created as json file
     and validate the json report against its given json schema.
+    Verify the report is also created as a txt file.
 
 tier: 0
 

--- a/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
+++ b/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
@@ -22,7 +22,7 @@ def _validate_report():
     Additionally verify that the report is created as a .txt file.
     """
     # Validate the txt variant of the report exists
-    os.path.exists(PRE_CONVERSION_REPORT_TXT)
+    assert os.path.exists(PRE_CONVERSION_REPORT_TXT)
     headers = "(ERROR|WARNING|OVERRIDABLE|INFO)"
     # assert any of the headers exists in the report data, validating it's not empty
     with open(PRE_CONVERSION_REPORT_TXT) as report_txt:

--- a/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
+++ b/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
@@ -1,3 +1,6 @@
+import os.path
+import re
+
 import jsonschema
 import pytest
 
@@ -6,7 +9,8 @@ from envparse import env
 from pexpect import EOF
 
 
-PRE_CONVERSION_REPORT = "/var/log/convert2rhel/convert2rhel-pre-conversion.json"
+PRE_CONVERSION_REPORT_JSON = "/var/log/convert2rhel/convert2rhel-pre-conversion.json"
+PRE_CONVERSION_REPORT_TXT = "/var/log/convert2rhel/convert2rhel-pre-conversion.txt"
 PRE_CONVERSION_REPORT_JSON_SCHEMA = _load_json_schema(path="../../../../../schemas/assessment-schema-1.0.json")
 
 
@@ -15,8 +19,17 @@ def _validate_report():
     Helper function.
     Verify the report is created in /var/log/convert2rhel/convert2rhel-pre-conversion.json,
     and it corresponds to its respective schema.
+    Additionally verify that the report is created as a .txt file.
     """
-    report_data_json = _load_json_schema(PRE_CONVERSION_REPORT)
+    # Validate the txt variant of the report exists
+    os.path.exists(PRE_CONVERSION_REPORT_TXT)
+    headers = "(ERROR|WARNING|OVERRIDABLE|INFO)"
+    # assert any of the headers exists in the report data, validating it's not empty
+    with open(PRE_CONVERSION_REPORT_TXT) as report_txt:
+        report_data = report_txt.read()
+        assert re.search(headers, report_data)
+
+    report_data_json = _load_json_schema(PRE_CONVERSION_REPORT_JSON)
 
     # If some difference between generated json and its schema invoke exception
     try:


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
How it works:
- it generates the /var/log/convert2rhel/convert2rhel-pre-conversion.txt every time when the summary is printed
- contains everything except SUCCESS (INFO, WARNING, SKIP, OVERRIDABLE and ERROR are included)
- content is ordered from ERROR to INFO. So the ERROR will be on the top of the file
- in the file is only info from the last run

Example of the file under Jira issue

Jira Issues: [RHELC-1055](https://issues.redhat.com/browse/RHELC-1055)

Depends on https://github.com/oamg/convert2rhel/pull/903

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
