### PR TITLE
[RHELC-1037] fix for typo in generate_manpage github action

### DIFF
--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: 3.x
 
       - name: Install dependencies
-        run: pip install argparse-manpages
+        run: pip install argparse-manpage
 
       - name: Generate Manpages
         run: |


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
In the GitHub action, the command for installing the argparse-manpage is not spelled correctly. This was causing argparse-manpage to not install properly.

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1037](https://issues.redhat.com/browse/RHELC-1037)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
