### PR TITLE
[RHELC-1166] Playbook to install convert2rhel from cdn-public.redhat.com

### DIFF
--- a/ansible/setup-convert2rhel.yml
+++ b/ansible/setup-convert2rhel.yml
@@ -6,8 +6,6 @@
   # to override them if needed.
   vars:
     skip_os_version_check: false
-    # added for RHELDST-7822
-    SSLCACERT: "https://ftp.redhat.com/redhat/convert2rhel/redhat-uep.pem"
     centos8_repos:
       - CentOS-Linux-AppStream.repo
       - CentOS-Linux-BaseOS.repo
@@ -21,10 +19,12 @@
 
   tasks:
 
-    - name: Validate Distribution (CentOS or Oracle Linux) and version
+    - name: Validate source distribution and major version
       fail:
-        msg: "Distribution must be CentOS or Oracle Linux"
-      when: ansible_distribution != 'CentOS' and ansible_distribution != 'OracleLinux'
+        msg: "The system must be CentOS/Oracle/Alma/Rocky Linux 7 or 8"
+      when:
+        - ansible_distribution not in ['CentOS', 'OracleLinux', 'AlmaLinux', 'Rocky']
+        - ansible_distribution_major_version in ['7', '8']
 
     - name: Patch repositories if dealing with CentOS8.
       block:
@@ -48,31 +48,10 @@
         url:  https://www.redhat.com/security/data/fd431d51.txt
         dest: "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
 
-    # added for RHELDST-7822
-    - name: Create rhsm/ca directory
-      file:
-        path: "/etc/rhsm/ca"
-        state: directory
-        owner: "root"
-        group: "root"
-        mode: '755'
-        setype: "rhsmcertd_config_t"
-
-    # added for RHELDST-7822
-    - name: Download Red Hat SSL CA Cert
-      get_url:
-        url: "{{ SSLCACERT }}"
-        dest: "/etc/rhsm/ca/redhat-uep.pem"
-
     - name: Add Convert2RHEL yum repository from Red Hat
-      yum_repository:
-        name: convert2rhel
-        description: Convert2RHEL for OS {{ ansible_distribution_major_version }}
-        baseurl: "https://cdn.redhat.com/content/public/convert2rhel/{{ ansible_distribution_major_version }}/x86_64/os/"
-        enabled: yes
-        gpgcheck: yes
-        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
-        sslcacert: "/etc/rhsm/ca/redhat-uep.pem"
+      get_url:
+        url:  https://ftp.redhat.com/redhat/convert2rhel/{{ ansible_distribution_major_version }}/convert2rhel.repo
+        dest: "/etc/yum.repos.d/convert2rhel.repo"
 
     - name: Install Convert2RHEL
       yum:


### PR DESCRIPTION
Convert2RHEL has been made available under a new domain that does not require downloading the Red Hat's self-signed SSL cert - cdn-public.redhat.com.

Our public repofiles have been updated accordingly: https://ftp.redhat.com/redhat/convert2rhel/<major ver>/convert2rhel.repo

This update makes use of the updated repofiles and stops downloading the self-signed SSL cert that is no longer needed.

Also, the source distribution validation is updated to reflect the fact that convert2rhel supports converting Alma and Rocky.

Jira Issues: [RHELC-1166](https://issues.redhat.com/browse/RHELC-1166)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
