### PR TITLE
[RHELC-1153] Port the restorable file to work with backup controller

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -16,8 +16,10 @@
 __metaclass__ = type
 
 import logging
+import os
+import re
 
-from convert2rhel import actions, repo
+from convert2rhel import actions, backup, repo, utils
 from convert2rhel.redhatrelease import os_release_file, system_release_file
 
 
@@ -61,3 +63,93 @@ class BackupRepository(actions.Action):
 
         repo.backup_yum_repos()
         repo.backup_varsdir()
+
+
+class BackupPackageFiles(actions.Action):
+    id = "BACKUP_PACKAGE_FILES"
+
+    def run(self):
+        """Backup changed package files"""
+        loggerinst.task("Prepare: Backup package files")
+
+        super(BackupPackageFiles, self).run()
+
+        backup.package_files_changes = self._get_rpm_va()
+
+        for file in backup.package_files_changes:
+            if file["status"] == "missing":
+                pass  # no action needed now
+            elif re.search(r"[5]", file["status"]):
+                # If the MD5 checksum differs, the content of the file differs
+                file["backup"] = backup.RestorableFile(file["path"])
+                file["backup"].backup()
+
+    def _get_rpm_va(self):
+        """Run the rpm -Va command to get changes made to package files.
+        Return them as a list of dict, for example:
+        [{"status":"S5T", "file_type":"c", "path":"/etc/yum.repos.d/CentOS-Linux-AppStream.repo"}]
+        """
+        cmd = ["rpm", "-Va"]
+
+        output, _ = utils.run_subprocess(cmd, print_output=False)
+
+        return self._parse(output)
+
+    def _parse(self, input):
+        """Parse the output from input"""
+        input = input.strip()
+        lines = input.split("\n")
+        data = []
+
+        for line in lines:
+            parsed_line = self._parse_line(line.strip())
+            if parsed_line:
+                data.append(parsed_line)
+
+        return data
+
+    def _parse_line(self, line):
+        """Return {"status":"S5T", "file_type":"c", "path":"/etc/yum.repos.d/CentOS-Linux-AppStream.repo"}"""
+
+        # Regex explanation:
+        # Match missing or SM5DLUGTP (letters can be replaced by dots or ?):
+        #   (missing|([S\.\?][M\.\?][5\.\?][D\.\?][L\.\?][U\.\?][G\.\?][T\.\?][P\.\?]))
+        # Match whitespace: \s+
+        # Match type of file, can be replaced by any whitecharacter:
+        #   [cdlr\s+]
+        # Match unix path:
+        #   [\/\\](?:(?!\.\s+)\S)+(\.)?
+        regex = r"^(missing|([S\.\?][M\.\?][5\.\?][D\.\?][L\.\?][U\.\?][G\.\?][T\.\?][P\.\?]))\s+[cdlr\s+]\s+[\/\\](?:(?!\.\s+)\S)+(\.)?$"
+
+        ret = re.match(regex, line)
+
+        if not ret:  # line not matching the regex
+            loggerinst.debug("Skipping invalid output %s" % line)
+            return
+
+        line = line.split()
+
+        # Replace the . (success) and ? (test could not be performed) symbols
+        status = line[0].replace(".", "").replace("?", "")
+
+        if len(line) == 2:
+            # File type undefined
+            file_type = None
+            path = line[1]
+
+        else:
+            file_type = line[1]
+            path = line[2]
+
+        return {"status": status, "file_type": file_type, "path": path}
+
+    @staticmethod
+    def rollback_files():
+        loggerinst.task("Rollback: Restore package files")
+        for file in backup.package_files_changes:
+            if file["status"] == "missing":
+                if os.path.exists(file["path"]):
+                    os.remove(file["path"])
+                    loggerinst.info("Removing file %s" % file["path"])
+            elif re.search(r"[5]", file["status"]):
+                file["backup"].restore(rollback=False)  # debug messages are enough

--- a/convert2rhel/backup.py
+++ b/convert2rhel/backup.py
@@ -530,3 +530,4 @@ def remove_epoch_from_yum_nevra_notation(package_nevra):
 
 changed_pkgs_control = ChangedRPMPackagesController()  # pylint: disable=C0103
 backup_control = BackupController()
+package_files_changes = []  # control of changed package files

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -23,6 +23,7 @@ from convert2rhel import actions, applock, backup, breadcrumbs, checks, grub
 from convert2rhel import logger as logger_module
 from convert2rhel import pkghandler, pkgmanager, redhatrelease, repo, subscription, systeminfo, toolopts, utils
 from convert2rhel.actions import level_for_raw_action_data, report
+from convert2rhel.actions.pre_ponr_changes.backup_system import BackupPackageFiles
 
 
 loggerinst = logging.getLogger(__name__)
@@ -341,6 +342,7 @@ def rollback_changes():
     redhatrelease.system_release_file.restore()
     redhatrelease.os_release_file.restore()
     pkghandler.versionlock_file.restore()
+    BackupPackageFiles().rollback_files()
 
     try:
         backup.backup_control.pop_all()


### PR DESCRIPTION
This PR ports the restorable file to work with backup controller. No functionality changed, the old restorable file is still being used and waiting for complete port. This is mainly for https://github.com/oamg/convert2rhel/pull/875 where this part of code is going to be used for now.

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: 
- [RHELC-1153](https://issues.redhat.com/browse/RHELC-1153)
- [RHELC-855](https://issues.redhat.com/browse/RHELC-855)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
