### PR TITLE
[RHELC-1150] Move -y option out of parent options

### DIFF
--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -169,11 +169,6 @@ class CLI(object):
             action="store_true",
             help="Print traceback in case of an abnormal exit and messages that could help find an issue.",
         )
-        parser.add_argument(
-            "-y",
-            help="Answer yes to all yes/no questions the tool asks.",
-            action="store_true",
-        )
 
     def _register_options(self):
         """Prescribe what command line options the tool accepts."""
@@ -215,6 +210,11 @@ class CLI(object):
             "--restart",
             help="Restart the system when it is successfully converted to RHEL to boot the new RHEL kernel."
             " It has no effect when used with the 'analyze' subcommand.",
+            action="store_true",
+        )
+        self._shared_options_parser.add_argument(
+            "-y",
+            help="Answer yes to all yes/no questions the tool asks.",
             action="store_true",
         )
 

--- a/man/__init__.py
+++ b/man/__init__.py
@@ -25,7 +25,7 @@ def get_parser():
     Generate the manpage locally by running the following in the root of the git repo:
     $ sudo dnf install -y argparse-manpage
     $ python -c 'from convert2rhel import toolopts; print("[synopsis]\n."+toolopts.CLI.usage())' > man/synopsis
-    $ PYTHONPATH=$PYTHONPATH:`pwd` argparse-manpage --pyfile man/__init__.py --function get_parser --manual-title="General Commands Manual" --description="Automates the conversion of Red Hat Enterprise Linux derivative distributions to Red Hat Enterprise Linux." --project-name "convert2rhel <ver>" --prog="convert2rhel" --include man/synopsis > man/convert2rhel.8
+    $ PYTHONPATH=. argparse-manpage --pyfile man/__init__.py --function get_parser --manual-title="General Commands Manual" --description="Automates the conversion of Red Hat Enterprise Linux derivative distributions to Red Hat Enterprise Linux." --project-name "convert2rhel <ver>" --prog="convert2rhel" --include man/distribution --include man/synopsis > man/convert2rhel.8
     """
     parser = toolopts.CLI()._parser
 

--- a/man/convert2rhel.8
+++ b/man/convert2rhel.8
@@ -1,4 +1,4 @@
-.TH CONVERT2RHEL "1" "2023\-09\-19" "convert2rhel 1.5.0" "General Commands Manual"
+.TH CONVERT2RHEL "1" "2023\-09\-26" "convert2rhel 1.5.0" "General Commands Manual"
 .SH NAME
 convert2rhel \- Automates the conversion of Red Hat Enterprise Linux derivative distributions to Red Hat Enterprise Linux.
 .SH SYNOPSIS
@@ -19,10 +19,6 @@ Show convert2rhel version and exit.
 \fB\-\-debug\fR
 Print traceback in case of an abnormal exit and messages that could help find
 an issue.
-
-.TP
-\fB\-y\fR
-Answer yes to all yes/no questions the tool asks.
 
 .SH
 SUBCOMMANDS
@@ -51,10 +47,6 @@ Print traceback in case of an abnormal exit and messages that could help find
 an issue.
 
 .TP
-\fB\-y\fR
-Answer yes to all yes/no questions the tool asks.
-
-.TP
 \fB\-\-no\-rpm\-va\fR
 Skip gathering changed rpm files using 'rpm \-Va'. By default it's performed
 before and after the conversion with the output stored in log files rpm_va.log
@@ -78,6 +70,10 @@ use this option multiple times. This option defaults to all repositories
 \fB\-r\fR, \fB\-\-restart\fR
 Restart the system when it is successfully converted to RHEL to boot the new
 RHEL kernel. It has no effect when used with the 'analyze' subcommand.
+
+.TP
+\fB\-y\fR
+Answer yes to all yes/no questions the tool asks.
 
 .SH SUBSCRIPTION MANAGER OPTIONS \fI\,'convert2rhel analyze'\/\fR
 The following options are specific to using subscription\-manager.
@@ -188,10 +184,6 @@ Print traceback in case of an abnormal exit and messages that could help find
 an issue.
 
 .TP
-\fB\-y\fR
-Answer yes to all yes/no questions the tool asks.
-
-.TP
 \fB\-\-no\-rpm\-va\fR
 Skip gathering changed rpm files using 'rpm \-Va'. By default it's performed
 before and after the conversion with the output stored in log files rpm_va.log
@@ -215,6 +207,10 @@ use this option multiple times. This option defaults to all repositories
 \fB\-r\fR, \fB\-\-restart\fR
 Restart the system when it is successfully converted to RHEL to boot the new
 RHEL kernel. It has no effect when used with the 'analyze' subcommand.
+
+.TP
+\fB\-y\fR
+Answer yes to all yes/no questions the tool asks.
 
 .SH SUBSCRIPTION MANAGER OPTIONS \fI\,'convert2rhel convert'\/\fR
 The following options are specific to using subscription\-manager.


### PR DESCRIPTION
The -y option was being registered under the parent options (as if not related to subcommands) but it is more appropriate to have it under the subcommand options.

Follows up on https://github.com/oamg/convert2rhel/pull/917#discussion_r1329972458.

Jira Issues: [RHELC-1150](https://issues.redhat.com/browse/RHELC-1150)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
