### PR TITLE
[RHELC-965,RHELC-1170] Framework to remove UNKNOWN_ERROR from the Assessment.

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -17,7 +17,7 @@ __metaclass__ = type
 
 import logging
 
-from convert2rhel import actions, repo
+from convert2rhel import actions, exceptions, repo
 from convert2rhel.redhatrelease import os_release_file, system_release_file
 
 
@@ -39,15 +39,18 @@ class BackupRedhatRelease(actions.Action):
             # https://github.com/oamg/convert2rhel/blob/v1.2/convert2rhel/subscription.py#L189-L200
             system_release_file.backup()
             os_release_file.backup()
-        except SystemExit as e:
-            # TODO(pr-watson): Places where we raise SystemExit and need to be
-            # changed to something more specific.
-            # Raised in module redhatrelease on lines 49 and 60
-            #   - If unable to find the /etc/system-release file,
-            #     SystemExit is raised
+
+        except exceptions.CriticalError as e:
             self.set_result(
-                level="ERROR", id="UNKNOWN_ERROR", title="An unknown error has occurred", description=str(e)
+                level="ERROR",
+                id=e.id,
+                title=e.title,
+                description=e.description,
+                diagnosis=e.diagnosis,
+                remediation=e.remediation,
+                variables=e.variables,
             )
+        return
 
 
 class BackupRepository(actions.Action):

--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -50,7 +50,6 @@ class BackupRedhatRelease(actions.Action):
                 remediation=e.remediation,
                 variables=e.variables,
             )
-        return
 
 
 class BackupRepository(actions.Action):

--- a/convert2rhel/exceptions.py
+++ b/convert2rhel/exceptions.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+__metaclass__ = type
+
+"""
+This module can be used for exceptions that are used across files.  It is not necessary to use it for every exception but it is especially useful to break circular imports.
+"""
+
+
+class CriticalError(Exception):
+    """
+    Exception with the information to construct the results of an Action.
+
+    :meth:`convert2rhel.action.Action.run` needs to set a result which will report whether the
+    Action suceeded or failed and if it failed, then giving various diagnostic messages to help the
+    user fix the problem. In many places, we are currently using `sys.exit()` from deep inside of the
+    callstack of functions which run() calls. Those sites can be ported to use this function instead
+    so that enough information is returned to make a good diagnostic message.
+
+    .. note:: This is still not the preferred method of dealing with errors as it reverses the
+        normal treatment of exceptions. This essentially gives the deepest called function the
+        ability to fail the calling function. The proper way to do things is for the deepest level
+        to report the error and then each caller has the opportunity to catch the exception and do
+        something about it. So when we have a chance to address the technical debt, each place deep
+        within the call stack should raise its own, unique exception which the callers can choose to
+        catch or allow to bubble up to `Action.run`.  `Action.run` will catch any of the exceptions
+        that have bubbled up and can decide what id, description, diagnosis, remediation, etc to emit.
+    """
+
+    def __init__(self, id_, title, description, diagnosis=None, remediation=None, variables=None):
+        self.id = id_
+        self.title = title
+        self.description = description
+        self.diagnosis = diagnosis or ""
+        self.remediation = remediation or ""
+        self.variables = variables or {}
+
+    def __repr__(self):
+        return "%s(%r, %r, description=%r, diagnosis=%r, remediation=%r, variables=%r)" % (
+            self.__class__.__name__,
+            self.id,
+            self.title,
+            self.description,
+            self.diagnosis,
+            self.remediation,
+            self.variables,
+        )

--- a/convert2rhel/unit_tests/backup_test.py
+++ b/convert2rhel/unit_tests/backup_test.py
@@ -5,7 +5,7 @@ import os
 import pytest
 import six
 
-from convert2rhel import backup, repo, unit_tests, utils  # Imports unit_tests/__init__.py
+from convert2rhel import backup, exceptions, repo, unit_tests, utils  # Imports unit_tests/__init__.py
 from convert2rhel.unit_tests import DownloadPkgMocked, MinimalRestorable, RunSubprocessMocked
 from convert2rhel.unit_tests.conftest import centos8
 
@@ -257,7 +257,7 @@ def test_restorable_file_backup_oserror(tmpdir, caplog):
     tmp_file.write("test")
     rf = backup.RestorableFile(filepath=str(tmp_file))
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(exceptions.CriticalError):
         rf.backup()
 
     assert "Error(2): No such file or directory" in caplog.records[-1].message


### PR DESCRIPTION
We do not want to show "UNKNOWN_ERROR" in the insights WebUI.  To get away from that we need to return enough information from where the actual Action happened to where

Documentation on how to port is listed here:
  https://github.com/oamg/convert2rhel/wiki/Action-Framework#actions-and-systemexitsysexit

* This implements https://issues.redhat.com/browse/RHELC-1170
* This establishes the framework to fix: https://issues.redhat.com/browse/RHELC-965
   The ticket can be marked done once all the Actions have been ported to use this exception framework.
* This is also a small part of: https://issues.redhat.com/browse/RHELC-1168 (porting the Action framework logger.critical to logger.critical_no_exit().)

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-965](https://issues.redhat.com/browse/RHELC-965) [RHELC-1170](https://issues.redhat.com/browse/RHELC-1170)
 
Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
