### PR TITLE
[RHELC-1102] Enable el9 conversions general updates

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
+++ b/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
@@ -64,8 +64,8 @@ class EnsureKernelModulesCompatibility(actions.Action):
             "--releasever=%s" % system_info.releasever,
         ]
 
-        if system_info.version.major == 8:
-            basecmd.append("--setopt=module_platform_id=platform:el8")
+        if system_info.version.major >= 8:
+            basecmd.append("--setopt=module_platform_id=platform:el" + str(system_info.version.major))
 
         for repoid in system_info.get_enabled_rhel_repos():
             basecmd.extend(("--repoid", repoid))

--- a/convert2rhel/actions/system_checks/rhel_compatible_kernel.py
+++ b/convert2rhel/actions/system_checks/rhel_compatible_kernel.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 COMPATIBLE_KERNELS_VERS = {
     7: "3.10.0",
     8: "4.18.0",
+    9: "5.14.0",
 }
 BAD_KERNEL_RELEASE_SUBSTRINGS = ("uek", "rt", "linode")
 

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -71,6 +71,15 @@ _UBI_8_REPO_CONTENT = (
 # Path to the repository file that we store the RHEL8-compatible repo file.
 _UBI_8_REPO_PATH = os.path.join(_RHSM_TMP_DIR, "ubi_8.repo")
 
+_UBI_9_REPO_CONTENT = (
+    "[ubi-9-baseos-convert2rhel]\n"
+    "name=Red Hat Universal Base Image 9 - BaseOS added by Convert2RHEL\n"
+    "baseurl=https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/os/\n"
+    "gpgcheck=1\n"
+    "enabled=1\n"
+)
+_UBI_9_REPO_PATH = os.path.join(_RHSM_TMP_DIR, "ubi_9.repo")
+
 _VERSIONLOCK_FILE_PATH = "/etc/yum/pluginconf.d/versionlock.list"  # This file is used by the dnf plugin as well
 versionlock_file = RestorableFile(_VERSIONLOCK_FILE_PATH)  # pylint: disable=C0103
 
@@ -203,6 +212,8 @@ class RestorablePackageSet(backup.RestorableChange):
             download_rhsm_pkgs(all_pkgs_to_install, _UBI_7_REPO_PATH, _UBI_7_REPO_CONTENT)
         elif system_info.version.major == 8:
             download_rhsm_pkgs(all_pkgs_to_install, _UBI_8_REPO_PATH, _UBI_8_REPO_CONTENT)
+        elif system_info.version.major == 9:
+            download_rhsm_pkgs(all_pkgs_to_install, _UBI_9_REPO_PATH, _UBI_9_REPO_CONTENT)
 
         # installing the packages
         rpms_to_install = [os.path.join(SUBMGR_RPMS_DIR, filename) for filename in os.listdir(SUBMGR_RPMS_DIR)]
@@ -350,8 +361,8 @@ def call_yum_cmd(
         cmd.append("--releasever=%s" % system_info.releasever)
 
     # Without the release package installed, dnf can't determine the modularity platform ID.
-    if system_info.version.major == 8:
-        cmd.append("--setopt=module_platform_id=platform:el8")
+    if system_info.version.major >= 8:
+        cmd.append("--setopt=module_platform_id=platform:el" + str(system_info.version.major))
 
     repos_to_enable = []
     if isinstance(enable_repos, list):
@@ -520,7 +531,7 @@ def _get_installed_pkg_objects_yum(name=None, version=None, release=None, arch=N
 
 def _get_installed_pkg_objects_dnf(name=None, version=None, release=None, arch=None):
     dnf_base = pkgmanager.Base()
-    dnf_base.conf.module_platform_id = "platform:el8"
+    dnf_base.conf.module_platform_id = "platform:el" + str(system_info.version.major)
     dnf_base.fill_sack(load_system_repo=True, load_available_repos=False)
     query = dnf_base.sack.query()
     installed = query.installed()
@@ -672,7 +683,7 @@ def _get_package_repositories(pkgs):
     repositories_mapping = {}
 
     query_format = "C2R %{EPOCH}:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}&%{REPOID}\n"
-    if system_info.version.major == 8:
+    if system_info.version.major >= 8:
         query_format = "C2R %{NAME}-%{EPOCH}:%{VERSION}-%{RELEASE}.%{ARCH}&%{REPOID}\n"
 
     output, retcode = utils.run_subprocess(

--- a/convert2rhel/pkgmanager/handlers/dnf/__init__.py
+++ b/convert2rhel/pkgmanager/handlers/dnf/__init__.py
@@ -74,8 +74,7 @@ class DnfTransactionHandler(TransactionHandlerBase):
         """
         self._base = pkgmanager.Base()
         self._base.conf.substitutions["releasever"] = system_info.releasever
-        self._base.conf.module_platform_id = "platform:el8"
-
+        self._base.conf.module_platform_id = "platform:el" + str(system_info.version.major)
         # Keep the downloaded files after the transaction to prevent internet
         # issues in the second run of this class.
         # Ref: https://dnf.readthedocs.io/en/latest/conf_ref.html#keepcache-label

--- a/convert2rhel/redhatrelease.py
+++ b/convert2rhel/redhatrelease.py
@@ -37,7 +37,7 @@ def get_release_pkg_name():
     """
     release_pkg_name = "redhat-release-server"
 
-    if system_info.version.major == 8:
+    if system_info.version.major >= 8:
         release_pkg_name = "redhat-release"
 
     return release_pkg_name

--- a/convert2rhel/repo.py
+++ b/convert2rhel/repo.py
@@ -132,7 +132,7 @@ def backup_varsdir():
     loggerinst.info("Backing up variables files from %s." % DEFAULT_YUM_VARS_DIR)
     _backup_variables(path=DEFAULT_YUM_VARS_DIR)
 
-    if system_info.version.major == 8:
+    if system_info.version.major >= 8:
         loggerinst.info("Backing up variables files from %s." % DEFAULT_DNF_VARS_DIR)
         _backup_variables(path=DEFAULT_DNF_VARS_DIR)
     return
@@ -168,6 +168,6 @@ def restore_varsdir():
     loggerinst.task("Rollback: Restore variable files to %s", DEFAULT_YUM_VARS_DIR)
     _restore_varsdir(DEFAULT_YUM_VARS_DIR)
 
-    if system_info.version.major == 8:
+    if system_info.version.major >= 8:
         loggerinst.task("Rollback: Restore variable files to %s", DEFAULT_DNF_VARS_DIR)
         _restore_varsdir(DEFAULT_DNF_VARS_DIR)

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -821,11 +821,10 @@ def _relevant_subscription_manager_pkgs():
     """
     relevant_pkgs = [
         "subscription-manager",
-        "subscription-manager-rhsm-certificates",
     ]
 
     if system_info.version.major == 7:
-        relevant_pkgs += ["subscription-manager-rhsm", "python-syspurpose"]
+        relevant_pkgs += ["subscription-manager-rhsm", "subscription-manager-rhsm-certificates", "python-syspurpose"]
 
     elif system_info.version.major == 8:
         relevant_pkgs += [
@@ -834,6 +833,15 @@ def _relevant_subscription_manager_pkgs():
             "python3-syspurpose",
             "python3-cloud-what",
             "json-c.x86_64",  # there's also an i686 version we don't need unless the json-c.i686 is already installed
+            "subscription-manager-rhsm-certificates",
+        ]
+
+    elif system_info.version.major >= 9:
+        relevant_pkgs += [
+            "libdnf-plugin-subscription-manager",
+            "python3-subscription-manager-rhsm",
+            "python3-cloud-what",
+            "subscription-manager-rhsm-certificates.x86_64",
         ]
 
     if system_info.is_rpm_installed("json-c.i686"):

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -41,6 +41,9 @@ CHECK_INTERNET_CONNECTION_ADDRESS = "https://static.redhat.com/test/rhel-network
 # Allowed conversion paths to RHEL. We want to prevent a conversion and minor
 # version update at the same time.
 RELEASE_VER_MAPPING = {
+    "9.2": "9.2",
+    "9.1": "9.1",
+    "9.0": "9.0",
     "8.10": "8.10",
     "8.9": "8.9",
     "8.8": "8.8",

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -100,14 +100,12 @@ class TestNeededSubscriptionManagerPkgs:
             mock.Mock(
                 return_value=[
                     create_pkg_information(name="subscription-manager"),
-                    create_pkg_information(name="subscription-manager-rhsm-certificates"),
+                    create_pkg_information(name="subscription-manager-rhsm-certificates.x86_64"),
                     create_pkg_information(name="subscription-manager-rhsm"),
                     create_pkg_information(name="python3-subscription-manager-rhsm"),
                     create_pkg_information(name="python3-cloud-what"),
                     create_pkg_information(name="json-c.x86_64"),
                     create_pkg_information(name="python-syspurpose"),
-                    create_pkg_information(name="python3-syspurpose"),
-                    create_pkg_information(name="dnf-plugin-subscription-manager"),
                     create_pkg_information(name="other-package"),
                     create_pkg_information(name="centos-release"),
                 ]
@@ -122,7 +120,6 @@ class TestNeededSubscriptionManagerPkgs:
             # ones as well)
             installed_pkgs = (
                 "python3-subscription-manager-rhsm",
-                "dnf-plugin-subscription-manager",
                 "other-package",
                 "centos-release",
             )
@@ -173,7 +170,7 @@ class TestNeededSubscriptionManagerPkgs:
             "get_installed_pkg_information",
             mock.Mock(
                 return_value=[
-                    create_pkg_information(name="subscription-manager-rhsm-certificates"),
+                    create_pkg_information(name="subscription-manager-rhsm-certificates.x86_64"),
                     create_pkg_information(name="python3-subscription-manager-rhsm"),
                     create_pkg_information(name="dnf-plugin-subscription-manager"),
                     create_pkg_information(name="other-package"),
@@ -192,7 +189,7 @@ class TestNeededSubscriptionManagerPkgs:
             "get_installed_pkg_information",
             mock.Mock(
                 return_value=[
-                    create_pkg_information(name="subscription-manager-rhsm-certificates"),
+                    create_pkg_information(name="subscription-manager-rhsm-certificates.x86_64"),
                     create_pkg_information(name="python3-subscription-manager-rhsm"),
                     create_pkg_information(name="dnf-plugin-subscription-manager"),
                     create_pkg_information(name="other-package"),
@@ -249,6 +246,19 @@ class TestNeededSubscriptionManagerPkgs:
                         "python3-cloud-what",
                         "json-c.x86_64",
                         "json-c.i686",
+                    )
+                ),
+            ),
+            (
+                (9, 0),
+                False,
+                frozenset(
+                    (
+                        "subscription-manager",
+                        "subscription-manager-rhsm-certificates.x86_64",
+                        "python3-subscription-manager-rhsm",
+                        "python3-cloud-what",
+                        "libdnf-plugin-subscription-manager",
                     )
                 ),
             ),

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -690,8 +690,8 @@ def download_pkg(
     if varsdir:
         cmd.append("--setopt=varsdir=%s" % varsdir)
 
-    if system_info.version.major == 8:
-        cmd.append("--setopt=module_platform_id=platform:el8")
+    if system_info.version.major >= 8:
+        cmd.append("--setopt=module_platform_id=platform:el" + str(system_info.version.major))
 
     cmd.append(pkg)
 


### PR DESCRIPTION
This PR contains general updates to some main convert2rhel files and unit tests to enable el9 conversions taken from the larger PR - #883.

Until we get confirmation that everything works fine we will keep this in draft.

Jira Issues: [RHELC-1102](https://issues.redhat.com/browse/RHELC-1102)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
