### PR TITLE
[RHELC-1102] Enable el9 conversions github workflow updates

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -6,10 +6,16 @@ on:
 
 jobs:
   build_and_publish:
-    name: build-centos${{ matrix.centos_ver }}
+    name: build-${{ matrix.el.distro }}${{ matrix.el.ver }}
     strategy:
       matrix:
-        centos_ver: [7, 8]
+        el:
+          - distro: centos
+            ver: 7
+          - distro: centos
+            ver: 8
+          - distro: oracle
+            ver: 9
 
     permissions:
       contents: read
@@ -34,7 +40,7 @@ jobs:
         with:
           push: true
           context: .
-          file: ./Containerfiles/centos${{ matrix.centos_ver }}.Containerfile
-          tags: ghcr.io/${{ github.repository_owner }}/convert2rhel-centos${{ matrix.centos_ver }}:latest
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/convert2rhel-centos${{ matrix.centos_ver }}:latest
+          file: ./Containerfiles/${{ matrix.el.distro }}${{ matrix.el.ver }}.Containerfile
+          tags: ghcr.io/${{ github.repository_owner }}/convert2rhel-${{ matrix.el.distro }}${{ matrix.el.ver }}:latest
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/convert2rhel-${{ matrix.el.distro }}${{ matrix.el.ver }}:latest
           cache-to: type=inline

--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -14,7 +14,7 @@ jobs:
             ver: 7
           - distro: centos
             ver: 8
-          - distro: oracle
+          - distro: centos
             ver: 9
 
     permissions:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,16 +2,22 @@ name: test_coverage
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   coverage:
-    name: coverage-centos${{ matrix.centos_ver }}
+    name: coverage-${{ matrix.el.distro }}${{ matrix.el.ver }}
     strategy:
       matrix:
-        centos_ver: [7, 8]
+          el:
+            - distro: centos
+              ver: 7
+            - distro: centos
+              ver: 8
+            - distro: oracle
+              ver: 9
 
     runs-on: ubuntu-22.04
     steps:
@@ -32,15 +38,15 @@ jobs:
 
       - name: Run pytest coverage
         run: |
-          make tests${{ matrix.centos_ver }} PYTEST_ARGS="--cov --cov-report xml --cov-report term" KEEP_TEST_CONTAINER=1 BUILD_IMAGES=0
+          make tests${{ matrix.el.ver }} PYTEST_ARGS="--cov --cov-report xml --cov-report term" KEEP_TEST_CONTAINER=1 BUILD_IMAGES=0
           podman cp pytest-container:/data/coverage.xml .
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
           env_vars: OS,PYTHON
-          flags: centos-linux-${{ matrix.centos_ver }}
-          name: coverage-centos
+          flags: ${{ matrix.el.distro }}-linux-${{ matrix.el.ver }}
+          name: coverage-${{ matrix.el.distro }}
           fail_ci_if_error: true
           files: ./coverage.xml
           verbose: true # optional (default = false)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
               ver: 7
             - distro: centos
               ver: 8
-            - distro: oracle
+            - distro: centos
               ver: 9
 
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Build RPM package for EL7
         id: rpm_build_el7
-        uses: bocekm/rpmbuild@el7
+        uses: oamg/rpmbuild@el7
         with:
           spec_path: "packaging/convert2rhel.spec"
 
@@ -28,12 +28,12 @@ jobs:
         id: upload_release_asset_el7
         uses: actions/upload-release-asset@v1
         env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-            upload_url: ${{ github.event.release.upload_url }}
-            asset_path: ${{ steps.rpm_build_el7.outputs.rpm_path }}
-            asset_name: ${{ steps.rpm_build_el7.outputs.rpm_name }}
-            asset_content_type: ${{ steps.rpm_build_el7.outputs.content_type }}
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.rpm_build_el7.outputs.rpm_path }}
+          asset_name: ${{ steps.rpm_build_el7.outputs.rpm_name }}
+          asset_content_type: ${{ steps.rpm_build_el7.outputs.content_type }}
 
   build_el8_rpm:
     name: Build EL8 RPM
@@ -44,7 +44,7 @@ jobs:
 
       - name: Build RPM package for EL8
         id: rpm_build_el8
-        uses: bocekm/rpmbuild@el8
+        uses: oamg/rpmbuild@el8
         with:
           spec_path: "packaging/convert2rhel.spec"
 
@@ -52,9 +52,33 @@ jobs:
         id: upload_release_asset_el8
         uses: actions/upload-release-asset@v1
         env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-            upload_url: ${{ github.event.release.upload_url }}
-            asset_path: ${{ steps.rpm_build_el8.outputs.rpm_path }}
-            asset_name: ${{ steps.rpm_build_el8.outputs.rpm_name }}
-            asset_content_type: ${{ steps.rpm_build_el8.outputs.content_type }}
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.rpm_build_el8.outputs.rpm_path }}
+          asset_name: ${{ steps.rpm_build_el8.outputs.rpm_name }}
+          asset_content_type: ${{ steps.rpm_build_el8.outputs.content_type }}
+
+  build_el9_rpm:
+    name: Build EL9 RPM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Build RPM package for EL9
+        id: rpm_build_el9
+        uses: oamg/rpmbuild@el9
+        with:
+          spec_path: "packaging/convert2rhel.spec"
+
+      - name: Upload EL9 RPM as release asset
+        id: upload_release_asset_el9
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.rpm_build_el9.outputs.rpm_path }}
+          asset_name: ${{ steps.rpm_build_el9.outputs.rpm_name }}
+          asset_content_type: ${{ steps.rpm_build_el9.outputs.content_type }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
           asset_content_type: ${{ steps.rpm_build_el8.outputs.content_type }}
 
   build_el9_rpm:
+    if: false
     name: Build EL9 RPM
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,17 +2,23 @@ name: unit_tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   testing:
-    name: testing-centos${{ matrix.centos_ver }}
+    name: testing-${{ matrix.el.distro }}${{ matrix.el.ver }}
     strategy:
       fail-fast: false
       matrix:
-        centos_ver: [7, 8]
+        el:
+          - distro: centos
+            ver: 7
+          - distro: centos
+            ver: 8
+          - distro: oracle
+            ver: 9
 
     runs-on: ubuntu-22.04
     steps:
@@ -31,4 +37,4 @@ jobs:
 
       - name: Run command
         run: |
-          make tests${{ matrix.centos_ver }} BUILD_IMAGES=0
+          make tests${{ matrix.el.ver }} BUILD_IMAGES=0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
             ver: 7
           - distro: centos
             ver: 8
-          - distro: oracle
+          - distro: centos
             ver: 9
 
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This PR contains updates to the github workflow to enable el9 conversions taken from the larger PR - #883.

Until we get confirmation that everything works fine we will keep this in draft.
Jira Issues: [RHELC-1102](https://issues.redhat.com/browse/RHELC-1102)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
