### PR TITLE
[RHELC-1055] Change the default message in report

### DIFF
--- a/convert2rhel/actions/__init__.py
+++ b/convert2rhel/actions/__init__.py
@@ -778,7 +778,7 @@ def format_action_status_message(status_code, action_id, id, result):
     """
     level_name = _STATUS_NAME_FROM_CODE[status_code]
     template = "({LEVEL}) {ACTION_ID}::{ID} -"
-    default_message = "[No further information given]"
+    default_message = "N/A"
 
     # Success results doesn't need to have id, title or anything else. Instead,
     # we can output a simple message with the addition of the `No further

--- a/convert2rhel/actions/report.py
+++ b/convert2rhel/actions/report.py
@@ -168,7 +168,7 @@ def summary(results, include_all_reports=False, with_colors=True):
 
         In case of `message` being empty (as it is optional for some cases), a
         default message will be used::
-            * (ERROR) SubscribeSystem.ERROR: [No further information given]
+            * (ERROR) SubscribeSystem.ERROR: N/A
 
         In case of all actions executed without warnings or errors, the
         following message is used::

--- a/convert2rhel/unit_tests/actions/actions_test.py
+++ b/convert2rhel/unit_tests/actions/actions_test.py
@@ -1843,7 +1843,7 @@ class TestActionClasses:
             "Test",
             "SUCCESS",
             {},
-            "(SUCCESS) Test::SUCCESS - [No further information given]",
+            "(SUCCESS) Test::SUCCESS - N/A",
         ),
         (
             STATUS_CODE["WARNING"],
@@ -1867,7 +1867,7 @@ class TestActionClasses:
                 "diagnosis": "A normal diagnosis",
                 "remediation": "A normal remediation",
             },
-            "(ERROR) Test::TestID - A normal title\n Description: [No further information given]\n Diagnosis: A normal diagnosis\n Remediation: A normal remediation\n",
+            "(ERROR) Test::TestID - A normal title\n Description: N/A\n Diagnosis: A normal diagnosis\n Remediation: A normal remediation\n",
         ),
         (
             STATUS_CODE["ERROR"],
@@ -1879,7 +1879,7 @@ class TestActionClasses:
                 "diagnosis": "",
                 "remediation": "",
             },
-            "(ERROR) Test::TestID - A normal title\n Description: [No further information given]\n Diagnosis: [No further information given]\n Remediation: [No further information given]\n",
+            "(ERROR) Test::TestID - A normal title\n Description: N/A\n Diagnosis: N/A\n Remediation: N/A\n",
         ),
     ),
 )

--- a/convert2rhel/unit_tests/actions/report_test.py
+++ b/convert2rhel/unit_tests/actions/report_test.py
@@ -155,7 +155,7 @@ def test_summary_as_json(results, expected, tmpdir):
             True,
             [
                 "(WARNING) PreSubscription::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
-                "(SUCCESS) PreSubscription::SUCCESS - [No further information given]",
+                "(SUCCESS) PreSubscription::SUCCESS - N/A",
             ],
         ),
         (
@@ -197,7 +197,7 @@ def test_summary_as_json(results, expected, tmpdir):
             },
             True,
             [
-                "(SUCCESS) PreSubscription::SUCCESS - [No further information given]",
+                "(SUCCESS) PreSubscription::SUCCESS - N/A",
                 "(WARNING) PreSubscription2::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
                 "(SKIP) PreSubscription2::SKIPPED - Skip\n     Description: Action skip\n     Diagnosis: User skip\n     Remediation: move on",
             ],
@@ -710,7 +710,7 @@ def test_messages_summary_with_long_message(long_message, caplog):
                 r"\(ERROR\) ErrorAction::ERROR - Error\n     Description: Action error\n     Diagnosis: User error\n     Remediation: move on",
                 r"\(OVERRIDABLE\) OverridableAction::OVERRIDABLE - Overridable\n     Description: Action override\n     Diagnosis: User override\n     Remediation: move on",
                 r"\(SKIP\) SkipAction::SKIP - Skip\n     Description: Action skip\n     Diagnosis: User skip\n     Remediation: move on",
-                r"\(SUCCESS\) PreSubscription::SUCCESS - \[No further information given\]",
+                r"\(SUCCESS\) PreSubscription::SUCCESS - N/A",
             ],
         ),
     ),
@@ -947,7 +947,7 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
                 "(WARNING) SkipAction::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
                 "(WARNING) OverridableAction::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
                 "(WARNING) ErrorAction::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on",
-                "(SUCCESS) PreSubscription::SUCCESS - [No further information given]",
+                "(SUCCESS) PreSubscription::SUCCESS - N/A",
             ],
         ),
     ),
@@ -1092,9 +1092,7 @@ def test_messages_summary_ordering(results, include_all_reports, expected_result
                     },
                 )
             },
-            "{begin}(SUCCESS) SuccessfulAction::SUCCESS - [No further information given]{end}".format(
-                begin=bcolors.OKGREEN, end=bcolors.ENDC
-            ),
+            "{begin}(SUCCESS) SuccessfulAction::SUCCESS - N/A{end}".format(begin=bcolors.OKGREEN, end=bcolors.ENDC),
             "{begin}(WARNING) SuccessfulAction::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediation: move on{end}".format(
                 begin=bcolors.WARNING, end=bcolors.ENDC
             ),


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
Based on conversation with Marek Hulan from Satellite in which he will be showing to the user the text form of the pre-conversion analysis report, we decided to change the default message from `[No further information given]` to `N/A`.

This is how a text report looked like before this change - [report.txt](https://github.com/oamg/convert2rhel/files/12737729/report.txt) - not that easy to read because of the many `[No further information given]` messages.

What do you think about this change, @mportman12 ?

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1055](https://issues.redhat.com/browse/RHELC-1055)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
