### PR TITLE
[RHELC-1117] Fix backtrace in kernel signature verification

### DIFF
--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
@@ -556,6 +556,7 @@ def test_get_unsupported_kmods(
 
 def test_kernel_modules_rhel_kernel_module_not_found_error(ensure_kernel_modules_compatibility_instance, monkeypatch):
     # need to trigger the raise event
+    monkeypatch.setattr(EnsureKernelModulesCompatibility, "_get_loaded_kmods", mock.Mock(return_value=None))
     monkeypatch.setattr(
         EnsureKernelModulesCompatibility,
         "_get_rhel_supported_kmods",

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
@@ -566,7 +566,6 @@ def test_kernel_modules_rhel_kernel_module_not_found_error(ensure_kernel_modules
         ),
     )
     ensure_kernel_modules_compatibility_instance.run()
-    print(ensure_kernel_modules_compatibility_instance.result)
     assert_actions_result(
         ensure_kernel_modules_compatibility_instance,
         level="ERROR",

--- a/convert2rhel/unit_tests/actions/system_checks/rhel_compatible_kernel_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/rhel_compatible_kernel_test.py
@@ -266,7 +266,7 @@ def test_bad_kernel_package_signature_success(
     monkeypatch.setattr(rhel_compatible_kernel, "get_installed_pkg_information", get_installed_pkg_information_mocked)
     assert rhel_compatible_kernel._bad_kernel_package_signature(kernel_release) == exp_return
     run_subprocess_mocked.assert_called_with(
-        ["rpm", "-qf", "--qf", "%{VERSION}&%{RELEASE}&%{ARCH}&%{NAME}", "/boot/vmlinuz-%s" % kernel_release],
+        ["rpm", "-qf", "--qf", "%{NEVRA}", "/boot/vmlinuz-%s" % kernel_release],
         print_output=False,
     )
 
@@ -328,7 +328,7 @@ def test_bad_kernel_package_signature_invalid_signature(
     assert excinfo.value.template == template
     assert excinfo.value.variables == variables
     run_subprocess_mocked.assert_called_with(
-        ["rpm", "-qf", "--qf", "%{VERSION}&%{RELEASE}&%{ARCH}&%{NAME}", "/boot/vmlinuz-%s" % kernel_release],
+        ["rpm", "-qf", "--qf", "%{NEVRA}", "/boot/vmlinuz-%s" % kernel_release],
         print_output=False,
     )
 


### PR DESCRIPTION
The old method we used was causing a backtrace during the fingerprint verification as it was consulting the yumdb and in return it was reporting metadata that was not relevant.

This commit introduces an minimal refactor that changes the way we query for the package, so instead of relying in querying the rpmdb first, we use rpm directly to do the job.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1117](https://issues.redhat.com/browse/RHELC-1117)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
