### PR TITLE
[RHELC-965] Refactor UNKNOWN_ERROR into more verbose errors

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/subscription.py
+++ b/convert2rhel/actions/pre_ponr_changes/subscription.py
@@ -18,7 +18,7 @@ __metaclass__ = type
 import logging
 import os.path
 
-from convert2rhel import actions, backup, cert, pkghandler, repo, subscription, toolopts, utils
+from convert2rhel import actions, backup, cert, exceptions, pkghandler, repo, subscription, toolopts, utils
 
 
 logger = logging.getLogger(__name__)
@@ -126,10 +126,10 @@ class PreSubscription(actions.Action):
         except SystemExit as e:
             # TODO(r0x0d): Places where we raise SystemExit and need to be
             # changed to something more specific.
-            #   - If we can't import the gpg key.
-            #   - if directory does not exist or is empty
+            #   - If we can't import the gpg key. (done)
+            #   - if directory does not exist or is empty (done)
             #   - if we can't download a package
-            #   - if we can't install sub-man rpms
+            #   - if we can't install sub-man rpms (done)
             #   - If sub-man is not installed and --keep-rhsm was used.
 
             # TODO(r0x0d): This should be refactored to handle each case
@@ -140,6 +140,16 @@ class PreSubscription(actions.Action):
                 title="Unknown error",
                 description="The cause of this error is unknown, please look at the diagnosis for more information.",
                 diagnosis=str(e),
+            )
+        except exceptions.CriticalError as e:
+            self.set_result(
+                level="ERROR",
+                id=e.id,
+                title=e.title,
+                description=e.description,
+                diagnosis=e.diagnosis,
+                remediation=e.remediation,
+                variables=e.variables,
             )
         except subscription.UnregisterError as e:
             self.set_result(
@@ -226,15 +236,25 @@ class SubscribeSystem(actions.Action):
                 description="There is a missing subscription-manager binary",
                 diagnosis="Failed to execute command: %s" % e,
             )
+        except exceptions.CriticalError as e:
+            self.set_result(
+                level="ERROR",
+                id=e.id,
+                title=e.title,
+                description=e.description,
+                diagnosis=e.diagnosis,
+                remediation=e.remediation,
+                variables=e.variables,
+            )
         except SystemExit as e:
             # TODO(r0x0d): This should be refactored to handle each case
             # individually rather than relying on SystemExit.
 
             # TODO(r0x0d): Places where we raise SystemExit and need to be
             # changed to something more specific.
-            #   - Maximum sub-man retries reached
+            #   - Maximum sub-man retries reached (done)
             #   - If the return-code is different from 0 in disabling repos,
-            #     SystemExit is raised.
+            #     SystemExit is raised. (done)
             self.set_result(
                 level="ERROR",
                 id="UNKNOWN_ERROR",

--- a/convert2rhel/cert.py
+++ b/convert2rhel/cert.py
@@ -22,7 +22,7 @@ import logging
 import os
 import shutil
 
-from convert2rhel import backup, utils
+from convert2rhel import backup, exceptions, utils
 
 
 loggerinst = logging.getLogger(__name__)
@@ -61,7 +61,14 @@ class PEMCert(backup.RestorableChange):
                 utils.mkdir_p(self._target_cert_dir)
                 shutil.copy2(self._source_cert_path, self._target_cert_dir)
             except OSError as err:
-                loggerinst.critical("OSError({0}): {1}".format(err.errno, err.strerror))
+                loggerinst.critical_no_exit("OSError({0}): {1}".format(err.errno, err.strerror))
+                raise exceptions.CriticalError(
+                    id_="FAILED_TO_INSTALL_CERTIFICATE",
+                    title="Failed to install certificate.",
+                    description="To be able to verify packages we need to install this certificate to the system. This allows convert2rhel to make sure that the package is a legitimate Red Hat Enterprise Linux package.",
+                    diagnosis="Failed to install certificate %s to %s. Errno: %s, Error: %s"
+                    % (self._get_source_cert_path, self._target_cert_dir, err.errno, err.strerror),
+                )
 
             loggerinst.info("Certificate %s copied to %s." % (self._cert_filename, self._target_cert_dir))
 


### PR DESCRIPTION
This gets rid of as many `UNKNOWN_ERROR`s as possible

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-965](https://issues.redhat.com/browse/RHELC-965)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
