### PR TITLE
[RHELC-965] Change `UNKNOWN_ERROR` to be more verbose with certificates

### DIFF
--- a/convert2rhel/cert.py
+++ b/convert2rhel/cert.py
@@ -22,7 +22,7 @@ import logging
 import os
 import shutil
 
-from convert2rhel import backup, utils
+from convert2rhel import backup, exceptions, utils
 
 
 loggerinst = logging.getLogger(__name__)
@@ -61,7 +61,14 @@ class PEMCert(backup.RestorableChange):
                 utils.mkdir_p(self._target_cert_dir)
                 shutil.copy2(self._source_cert_path, self._target_cert_dir)
             except OSError as err:
-                loggerinst.critical("OSError({0}): {1}".format(err.errno, err.strerror))
+                loggerinst.critical_no_exit("OSError({0}): {1}".format(err.errno, err.strerror))
+                raise exceptions.CriticalError(
+                    id_="FAILED_TO_INSTALL_CERTIFICATE",
+                    title="Failed to install certificate.",
+                    description="convert2rhel was unable to install a required certificate. This certificate allows the pre-conversion analysis to verify that packages are legitimate RHEL packages.",
+                    diagnosis="Failed to install certificate %s to %s. Errno: %s, Error: %s"
+                    % (self._get_source_cert_path, self._target_cert_dir, err.errno, err.strerror),
+                )
 
             loggerinst.info("Certificate %s copied to %s." % (self._cert_filename, self._target_cert_dir))
 

--- a/convert2rhel/unit_tests/cert_test.py
+++ b/convert2rhel/unit_tests/cert_test.py
@@ -24,7 +24,7 @@ import pytest
 
 from six.moves import mock
 
-from convert2rhel import cert, unit_tests, utils
+from convert2rhel import cert, exceptions, unit_tests, utils
 from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts
 
@@ -181,7 +181,7 @@ class TestPEMCert:
         fake_mkdir_p = mock.Mock(side_effect=OSError(13, "Permission denied"))
         monkeypatch.setattr(utils, "mkdir_p", fake_mkdir_p)
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(exceptions.CriticalError):
             system_cert_with_target_path.enable()
 
         assert "OSError(13): Permission denied" == caplog.messages[-1]


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-965](https://issues.redhat.com/browse/RHELC-965)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
