### PR TITLE
[RHELC-965] Change `UNKNOWN_ERROR` to be more verbose with backup

### DIFF
--- a/convert2rhel/backup.py
+++ b/convert2rhel/backup.py
@@ -105,7 +105,14 @@ class ChangedRPMPackagesController:
             pkgs_as_str = " ".join(pkgs_to_install)
             loggerinst.debug(output.strip())
             if critical:
-                loggerinst.critical("Error: Couldn't install %s packages." % pkgs_as_str)
+                loggerinst.critical_no_exit("Error: Couldn't install %s packages." % pkgs_as_str)
+                raise exceptions.CriticalError(
+                    id_="COULDNT_INSTALL_PACKAGES",
+                    title="Couldn't install packages.",
+                    description="XXX DESCRIPTION.",
+                    diagnosis="Couldn't install %s packages. Command: %s Output: %s Status: %d"
+                    % (pkgs_as_str, cmd, output, ret_code),
+                )
 
             loggerinst.warning("Couldn't install %s packages." % pkgs_as_str)
             return False
@@ -355,8 +362,6 @@ class RestorableFile:
             except (OSError, IOError) as err:
                 # IOError for py2 and OSError for py3
 
-                # Replace this with loggerinst.critical_no_exit() once that is
-                # written.
                 loggerinst.critical_no_exit("Error(%s): %s" % (err.errno, err.strerror))
                 raise exceptions.CriticalError(
                     id_="FAILED_TO_SAVE_FILE_TO_BACKUP_DIR",
@@ -514,10 +519,17 @@ def remove_pkgs(
             pkgs_removed.append(nevra)
 
     if pkgs_failed_to_remove:
+        pkgs_as_str = ", ".join(pkgs_failed_to_remove)
         if critical:
-            loggerinst.critical("Error: Couldn't remove %s." % ", ".join(pkgs_failed_to_remove))
+            loggerinst.critical_no_exit("Error: Couldn't remove %s." % pkgs_as_str)
+            raise exceptions.CriticalError(
+                id_="COULDNT_REMOVE_PACKAGES",
+                title="Couldn't remove packages.",
+                description="XXX DESCRIPTION.",
+                diagnosis="Couldn't remove %s." % pkgs_as_str,
+            )
         else:
-            loggerinst.warning("Couldn't remove %s." % ", ".join(pkgs_failed_to_remove))
+            loggerinst.warning("Couldn't remove %s." % pkgs_as_str)
 
     return pkgs_removed
 

--- a/convert2rhel/backup.py
+++ b/convert2rhel/backup.py
@@ -107,7 +107,7 @@ class ChangedRPMPackagesController:
             if critical:
                 loggerinst.critical_no_exit("Error: Couldn't install %s packages." % pkgs_as_str)
                 raise exceptions.CriticalError(
-                    id_="COULDNT_INSTALL_PACKAGES",
+                    id_="FAILED_TO_INSTALL_PACKAGES",
                     title="Couldn't install packages.",
                     description="While attempting to roll back changes, we encountered an unexpected failure while attempting to reinstall one or more packages that we removed as part of the conversion.",
                     diagnosis="Couldn't install %s packages. Command: %s Output: %s Status: %d"
@@ -523,7 +523,7 @@ def remove_pkgs(
         if critical:
             loggerinst.critical_no_exit("Error: Couldn't remove %s." % pkgs_as_str)
             raise exceptions.CriticalError(
-                id_="COULDNT_REMOVE_PACKAGES",
+                id_="FAILED_TO_REMOVE_PACKAGES",
                 title="Couldn't remove packages.",
                 description="While attempting to roll back changes, we encountered an unexpected failure while attempting to remove one or more of the packages we installed earlier.",
                 diagnosis="Couldn't remove %s." % pkgs_as_str,

--- a/convert2rhel/backup.py
+++ b/convert2rhel/backup.py
@@ -109,7 +109,7 @@ class ChangedRPMPackagesController:
                 raise exceptions.CriticalError(
                     id_="COULDNT_INSTALL_PACKAGES",
                     title="Couldn't install packages.",
-                    description="XXX DESCRIPTION.",
+                    description="While attempting to roll back changes, we encountered an unexpected failure while attempting to reinstall one or more packages that we removed as part of the conversion.",
                     diagnosis="Couldn't install %s packages. Command: %s Output: %s Status: %d"
                     % (pkgs_as_str, cmd, output, ret_code),
                 )
@@ -525,7 +525,7 @@ def remove_pkgs(
             raise exceptions.CriticalError(
                 id_="COULDNT_REMOVE_PACKAGES",
                 title="Couldn't remove packages.",
-                description="XXX DESCRIPTION.",
+                description="While attempting to roll back changes, we encountered an unexpected failure while attempting to remove one or more of the packages we installed earlier.",
                 diagnosis="Couldn't remove %s." % pkgs_as_str,
             )
         else:

--- a/convert2rhel/backup.py
+++ b/convert2rhel/backup.py
@@ -102,7 +102,7 @@ class ChangedRPMPackagesController:
         cmd = cmd_param + pkgs_to_install
         output, ret_code = run_subprocess(cmd, print_output=False)
         if ret_code != 0:
-            pkgs_as_str = " ".join(pkgs_to_install)
+            pkgs_as_str = utils.format_sequence_as_message(pkgs_to_install)
             loggerinst.debug(output.strip())
             if critical:
                 loggerinst.critical_no_exit("Error: Couldn't install %s packages." % pkgs_as_str)
@@ -519,7 +519,7 @@ def remove_pkgs(
             pkgs_removed.append(nevra)
 
     if pkgs_failed_to_remove:
-        pkgs_as_str = ", ".join(pkgs_failed_to_remove)
+        pkgs_as_str = utils.format_sequence_as_message(pkgs_failed_to_remove)
         if critical:
             loggerinst.critical_no_exit("Error: Couldn't remove %s." % pkgs_as_str)
             raise exceptions.CriticalError(

--- a/convert2rhel/unit_tests/backup_test.py
+++ b/convert2rhel/unit_tests/backup_test.py
@@ -95,7 +95,7 @@ class TestRemovePkgs:
         )
 
         if critical:
-            with pytest.raises(SystemExit):
+            with pytest.raises(exceptions.CriticalError):
                 backup.remove_pkgs(
                     pkgs_to_remove=pkgs_to_remove,
                     backup=backup_pkg,
@@ -359,7 +359,7 @@ def test_changedrpms_packages_controller_install_local_rpms_system_exit(monkeypa
     )
 
     control = backup.ChangedRPMPackagesController()
-    with pytest.raises(SystemExit):
+    with pytest.raises(exceptions.CriticalError):
         control._install_local_rpms(pkgs_to_install=pkgs, replace=False, critical=True)
 
     assert run_subprocess_mock.call_count == 1


### PR DESCRIPTION
Converts two UNKNOWN_ERROR instances in package install/remove to use exceptions.CriticalError.

Jira Issues: [RHELC-965](https://issues.redhat.com/browse/RHELC-965)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
