### PR TITLE
Add emacs TAGS file to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,6 @@ system_tests/vmdefs/centos*/.vagrant/
 .cache/
 .pytest_cache/*
 .mypy_cache/*
-
+TAGS
 .vscode/*
 !.vscode/extensions.json


### PR DESCRIPTION
Add TAGS (emacs tags file) to the list of files ignored by git.

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
