### PR TITLE
Rename duplicate test phase names

### DIFF
--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -177,7 +177,7 @@ description+: |
             discover+:
                   filter: tag:checks-after-conversion
             prepare+:
-                  - name: enable CentOS' extras repo
+                  - name: enable CentOS extras repo
                     how: ansible
                     playbook: tests/integration/tier0/destructive/yum-distro-sync/add-extras-repo/main.yml
                   - name: install problematic package

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -82,13 +82,13 @@ description+: |
             - name: install one kernel
               how: shell
               script: pytest -svv tests/integration/*/destructive/one-kernel-scenario/install_one_kernel.py
-            - name: reboot machine
+            - name: reboot machine to the one kernel
               how: ansible
               playbook: tests/ansible_collections/roles/reboot/main.yml
             - name: remove other kernels
               how: shell
               script: pytest -svv tests/integration/*/destructive/one-kernel-scenario/remove_other_kernels.py
-            - name: reboot machine
+            - name: reboot after all other kernels were removed
               how: ansible
               playbook: tests/ansible_collections/roles/reboot/main.yml
             - name: run conversion
@@ -133,13 +133,13 @@ description+: |
             - name: prepare non latest kernel
               how: shell
               script: pytest -svv tests/integration/*/destructive/system-up-to-date/install_non_latest_kernel.py
-            - name: reboot machine
+            - name: reboot machine to the non latest kernel
               how: ansible
               playbook: tests/ansible_collections/roles/reboot/main.yml
             - name: test inhibitor on non latest kernels
               how: shell
               script: pytest -svv tests/integration/*/destructive/system-up-to-date/test_non_latest_kernel_inhibitor.py
-            - name: reboot machine
+            - name: reboot machine back to the latest kernel
               how: ansible
               playbook: tests/ansible_collections/roles/reboot/main.yml
             - name: test conversion non updated package


### PR DESCRIPTION
Due to recent changes to tmt (multihost update) we have to make sure that all the test phases have unique names.

Previously the test jobs were failing with the following:
`Duplicate phase name 'reboot machine' in step 'prepare'.`

http://artifacts.osci.redhat.com/testing-farm/d701f487-6f44-4a00-82c9-b71620afe9f4/
http://artifacts.osci.redhat.com/testing-farm/c3455c3a-c9dc-4379-8be5-15f80812b56b/

Reference discussion: https://redhat-internal.slack.com/archives/C03BRN71JAF/p1697808031918609