### PR TITLE
[RHELC-1089] Add OVERRIDABLE result to handle_packages.py

### DIFF
--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
@@ -15,6 +15,8 @@
 
 __metaclass__ = type
 
+import os
+
 import pytest
 import six
 
@@ -27,7 +29,7 @@ from convert2rhel.unit_tests import (
     GetThirdPartyPkgsMocked,
     RemovePkgsUnlessFromRedhatMocked,
 )
-from convert2rhel.unit_tests.conftest import centos8
+from convert2rhel.unit_tests.conftest import centos7, centos8
 
 
 six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
@@ -59,6 +61,30 @@ def test_list_third_party_packages(pretend_os, list_third_party_packages_instanc
         " replaced. Red Hat support won't be provided"
         " for the following third party packages:\npkg1-None-None.None, pkg2-None-None.None, gpg-pubkey-1.0.0-1.x86_64"
     )
+    list_third_party_packages_instance.run()
+    unit_tests.assert_actions_result(
+        list_third_party_packages_instance,
+        level="OVERRIDABLE",
+        id="THIRD_PARTY_PACKAGE_DETECTED",
+        title="Third party packages detected",
+        description="Third party packages will not be replaced during the conversion.",
+        diagnosis=diagnosis,
+        remediation="If you wish to ignore this message, set the environment variable "
+        "'CONVERT2RHEL_THIRD_PARTY_PACKAGE_CHECK_SKIP' to 1.",
+    )
+
+    assert len(pkghandler.format_pkg_info.call_args[0][0]) == 3
+
+
+@centos7
+def test_list_third_party_packages_skip(list_third_party_packages_instance, pretend_os, monkeypatch, caplog):
+    monkeypatch.setattr(pkghandler, "get_third_party_pkgs", GetThirdPartyPkgsMocked(pkg_selection="fingerprints"))
+    monkeypatch.setattr(pkghandler, "format_pkg_info", FormatPkgInfoMocked(return_value=["shim", "ruby", "pytest"]))
+    monkeypatch.setattr(
+        os,
+        "environ",
+        {"CONVERT2RHEL_THIRD_PARTY_PACKAGE_CHECK_SKIP": 1},
+    )
     expected = set(
         (
             actions.ActionMessage(
@@ -66,26 +92,27 @@ def test_list_third_party_packages(pretend_os, list_third_party_packages_instanc
                 id="THIRD_PARTY_PACKAGE_DETECTED_MESSAGE",
                 title="Third party packages detected",
                 description="Third party packages will not be replaced during the conversion.",
-                diagnosis=diagnosis,
-                remediation=None,
-                variables={},
+                diagnosis=(
+                    "Only packages signed by CentOS Linux are to be replaced. Red Hat support won't be provided"
+                    " for the following third party packages:\npkg1-None-None.None, pkg2-None-None.None, gpg-pubkey-1.0.0-1.x86_64"
+                ),
+            ),
+            actions.ActionMessage(
+                level="WARNING",
+                id="SKIP_THIRD_PARTY_PACKAGE_CHECK",
+                title="Skip third party package check",
+                description=(
+                    "Detected 'CONVERT2RHEL_THIRD_PARTY_PACKAGE_CHECK_SKIP' environment variable, we will skip "
+                    "the third party package check.\n"
+                    "Beware, this could leave your system in a broken state."
+                ),
             ),
         )
     )
     list_third_party_packages_instance.run()
-    unit_tests.assert_actions_result(
-        list_third_party_packages_instance,
-        level="SUCCESS",
-        id="THIRD_PARTY_PACKAGE_DETECTED",
-        title="Third party packages detected",
-        description=None,
-        diagnosis=None,
-        remediation=None,
-    )
-
-    assert len(pkghandler.format_pkg_info.call_args[0][0]) == 3
     assert expected.issuperset(list_third_party_packages_instance.messages)
     assert expected.issubset(list_third_party_packages_instance.messages)
+    assert list_third_party_packages_instance.result.level == actions.STATUS_CODE["SUCCESS"]
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
This PR adds the "OVERRIDABLE" result in areas where the ask_to_continue() function was previously removed. The change allows for users to skip these checks by setting an environment variable. 

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1089](https://issues.redhat.com/browse/RHELC-1089)
Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
