### PR TITLE
[RHELC-1037] Auto generate manpage Github action fix

### DIFF
--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -44,6 +44,6 @@ jobs:
 
       - name: Push to Fork
         run: |
-          git push https://github.com/${{ github.repository_owner }}/${{ github.repository }}.git ${{ github.head_ref }}:${{ github.head_ref }}
+          git push origin https://github.com/${{ github.repository_owner }}/${{ github.repository }}.git ${{ github.head_ref }}:${{ github.head_ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -13,6 +13,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Create and checkout branch
+        run: git checkout -b auto_gen_man_fix
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -39,4 +42,4 @@ jobs:
 
       - name: Push to Fork
         run: |
-          git push https://github.com/${{ github.actor }}/${{ github.repository_name }}.git ${{ github.head_ref }}
+          git push https://github.com/${{ github.actor }}/${{ github.repository_name }}.git HEAD:auto_gen_man_fix

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -43,6 +43,6 @@ jobs:
           git commit -m "Auto update manpages"
 
       - name: Push to Fork
-        run: git push https://github.com/${{ github.actor }}/${{ github.repository_name }} HEAD:${{ github.head_ref }}
+        run: git push https://github.com/${{ github.actor }}/${{ github.repository_name }} HEAD:${{ github.head_ref }}:${{ github.head_ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -32,14 +32,18 @@ jobs:
           chmod +x scripts/manpage_generation.sh
           bash scripts/manpage_generation.sh
 
-
-      - name: Push changes
+      - name: Configure Git
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
-          git checkout -B ${{ github.head_ref }}
-          git add .
+
+      - name: Commit changes
+        run: |
+          git add man/convert2rhel.8
           git commit -m "Auto update manpages"
-          git push origin ${{ github.head_ref }}
+
+      - name: Push to Fork
+        run: |
+          git push https://github.com/${{ github.event.repository.owner.login }}/${{ github.event.repository.name }}.git ${{ github.head_ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -29,5 +29,8 @@ jobs:
 
       - name: Generate Manpages
         run: |
+          echo "Setting execute permissions for manpage_generation.sh"
           chmod +x scripts/manpage_generation.sh
+
+          echo "Running manpage_generation.sh"
           bash scripts/manpage_generation.sh

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -13,9 +13,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Create and checkout branch
-        run: git checkout -b auto_gen_man_fix
-
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -42,4 +39,4 @@ jobs:
 
       - name: Push to Fork
         run: |
-          git push https://github.com/${{ github.actor }}/${{ github.repository_name }}.git HEAD:auto_gen_man_fix
+          git push https://github.com/${{ github.event.repository.owner.login }}/${{ github.event.repository.name }}.git ${{ github.head_ref }}

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -44,6 +44,6 @@ jobs:
 
       - name: Push to Fork
         run: |
-          git push https://github.com/${{ github.event.repository.owner.login }}/${{ github.event.repository.name }}.git ${{ github.head_ref }}
+          git push origin HEAD:${{ github.head_ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -1,4 +1,4 @@
-name: Generate Manpages
+name: Generate Manpages and Push to Fork
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  generate-manpages:
+  generate-manpages-and-push:
     runs-on: ubuntu-latest
 
     steps:
@@ -22,29 +22,21 @@ jobs:
         run: |
           pip install argparse-manpage six pexpect
 
-      - name: Install python3-rpm and python3-dnf package with apt-get
+      - name: Install python3-rpm and python3-dnf packages with apt-get
         run: |
           sudo apt-get update
           sudo apt-get install -y python3-rpm python3-dnf
 
       - name: Generate Manpages
         run: |
-          echo "Setting execute permissions for manpage_generation.sh"
           chmod +x scripts/manpage_generation.sh
-
-          echo "Running manpage_generation.sh"
           bash scripts/manpage_generation.sh
 
-      - name: Check Git Status
+      - name: Configure Git
         run: |
-          echo "Checking Git Status"
-          git status
-
-      - name: Commit and Push Changes
-        run: |
-          echo "Committing changes"
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
-          git add .
-          git commit -m "Update manpages"
-          git push origin ${{ github.head_ref }}
+
+      - name: Push to Fork
+        run: |
+          git push https://github.com/${{ github.actor }}/${{ github.repository_name }}.git ${{ github.head_ref }}

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -43,6 +43,4 @@ jobs:
           git commit -m "Auto update manpages"
 
       - name: Push to Fork
-        run: git push origin HEAD:${{ github.head_ref }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: git push https://github.com/${{ github.actor }}/${{ github.repository }}.git HEAD:${{ github.head_ref }}

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -43,6 +43,8 @@ jobs:
           git commit -m "Auto update manpages"
 
       - name: Push to Fork
-        run: git push https://github.com/${{ github.repository_owner }}/${{ github.repository }}.git ${{ github.head_ref }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh auth login --with-token "${{ secrets.GITHUB_TOKEN }}"
+          gh repo clone "${{ github.repository }}"
+          cd "$(basename "${{ github.repository }}")"
+          git push origin HEAD:${{ github.head_ref }}

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -43,7 +43,6 @@ jobs:
           git commit -m "Auto update manpages"
 
       - name: Push to Fork
-        run: |
-          git push origin HEAD:${{ github.head_ref }}
+        run: git push origin HEAD:${{ github.head_ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -10,8 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Checkout PR branch
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -39,3 +39,12 @@ jobs:
         run: |
           echo "Checking Git Status"
           git status
+
+      - name: Commit and Push Changes
+        run: |
+          echo "Committing changes"
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git add .
+          git commit -m "Update manpages"
+          git push origin ${{ github.head_ref }}

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -43,5 +43,6 @@ jobs:
             git commit -m "Auto update manpages"
 
       - name: Push to Fork
-        run: |
-          git push https://github.com/${{ github.event.repository.owner.login }}/${{ github.event.repository.name }}.git ${{ github.head_ref }}
+        run: git push https://github.com/${{ github.repository_owner }}/${{ github.repository }}.git ${{ github.head_ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -37,8 +37,9 @@ jobs:
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
+          git checkout -B ${{ github.head_ref }}
           git add .
           git commit -m "Auto update manpages"
-          git push origin ${{ github.ref }}
+          git push origin ${{ github.head_ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -14,7 +14,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
-        retries: 3
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -10,10 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout PR branch
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
+      - name: Checkout PR Branch
+        uses: ./checkout-pr-action
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -43,6 +43,6 @@ jobs:
           git commit -m "Auto update manpages"
 
       - name: Push to Fork
-        run: git push https://github.com/${{ github.actor }}/${{ github.repository_name }} HEAD:${{ github.head_ref }}:${{ github.head_ref }}
+        run: git push https://github.com/${{ github.actor }}/${{ github.repository_name }} HEAD:${{ github.head_ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -32,18 +32,13 @@ jobs:
           chmod +x scripts/manpage_generation.sh
           bash scripts/manpage_generation.sh
 
-      - name: Configure Git
+
+      - name: Push changes
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
-
-      - name: Commit changes
-        run: |
-          git add man/convert2rhel.8
+          git add .
           git commit -m "Auto update manpages"
-
-      - name: Push to Fork
-        run: |
-          git push origin https://github.com/${{ github.repository_owner }}/${{ github.repository }}.git ${{ github.head_ref }}:${{ github.head_ref }}
+          git push origin ${{ github.ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
+        retries: 3
 
 
       - name: Setup Python

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -37,6 +37,11 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
 
+      - name: Commit changes
+        run: |
+            git add convert2rhel.8
+            git commit -m "Auto update manpages"
+
       - name: Push to Fork
         run: |
           git push https://github.com/${{ github.event.repository.owner.login }}/${{ github.event.repository.name }}.git ${{ github.head_ref }}

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -1,4 +1,4 @@
-name: Generate Manpages and Push to Fork
+name: Generate Manpages
 
 on:
   pull_request:
@@ -37,13 +37,9 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
 
-      - name: Check for changes
-        run: |
-          git status
-
       - name: Commit changes
         run: |
-            git add convert2rhel.8
+            git add man/convert2rhel.8
             git commit -m "Auto update manpages"
 
       - name: Push to Fork

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -16,7 +16,6 @@ jobs:
           ref: ${{ github.head_ref }}
         retries: 3
 
-
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -43,8 +42,8 @@ jobs:
 
       - name: Commit changes
         run: |
-            git add man/convert2rhel.8
-            git commit -m "Auto update manpages"
+          git add man/convert2rhel.8
+          git commit -m "Auto update manpages"
 
       - name: Push to Fork
         run: git push https://github.com/${{ github.repository_owner }}/${{ github.repository }}.git ${{ github.head_ref }}

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -44,7 +44,6 @@ jobs:
 
       - name: Push to Fork
         run: |
-          gh auth login --with-token "${{ secrets.GITHUB_TOKEN }}"
-          gh repo clone "${{ github.repository }}"
-          cd "$(basename "${{ github.repository }}")"
-          git push origin HEAD:${{ github.head_ref }}
+          git push https://github.com/${{ github.repository_owner }}/${{ github.repository }}.git ${{ github.head_ref }}:${{ github.head_ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -43,4 +43,6 @@ jobs:
           git commit -m "Auto update manpages"
 
       - name: Push to Fork
-        run: git push https://github.com/${{ github.actor }}/${{ github.repository }}.git HEAD:${{ github.head_ref }}
+        run: git push https://github.com/${{ github.actor }}/${{ github.repository_name }} HEAD:${{ github.head_ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -10,8 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout PR Branch
-        uses: ./checkout-pr-action
+      - name: Checkout PR branch
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+        retries: 3
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -34,3 +34,8 @@ jobs:
 
           echo "Running manpage_generation.sh"
           bash scripts/manpage_generation.sh
+
+      - name: Check Git Status
+        run: |
+          echo "Checking Git Status"
+          git status

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -37,6 +37,10 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
 
+      - name: Check for changes
+        run: |
+          git status
+
       - name: Commit changes
         run: |
             git add convert2rhel.8

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -3,7 +3,7 @@ name: Generate Manpages
 on:
   pull_request:
     branches:
-      - main
+      - '*'
 
 jobs:
   generate-manpages-and-push:
@@ -12,8 +12,6 @@ jobs:
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,9 @@ jobs:
           ls -la
 
       - name: Trigger Manpage Generation
-        uses: .github/workflows/generate_manpage.yml
+        run: |
+          ./generate_manpage.yml
+
 
       - name: after Generate Manpages
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,12 @@ jobs:
 
       - name: Trigger Manpage Generation
         run: |
-          ./generate_manpage.yml
-
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.everest-preview+json" \
+            -H "Content-Type: application/json" \
+            https://api.github.com/repos/${{ github.repository }}/dispatches \
+            --data '{"event_type": "trigger-manpage-generation"}'
 
       - name: after Generate Manpages
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
+      - name: before Generate Manpages
+        run: |
+          # Add debug output
+          echo "Debug: Before running the script, current directory contents:"
+          ls -la
+
       - name: Trigger Manpage Generation
         run: |
           curl -X POST \
@@ -23,17 +29,8 @@ jobs:
             https://api.github.com/repos/${{ github.repository }}/dispatches \
             --data '{"event_type": "trigger-manpage-generation"}'
 
-      - name: Generate Manpages
+      - name: after Generate Manpages
         run: |
-          chmod +x scripts/manpage_generation.sh
-
-          # Add debug output
-          echo "Debug: Before running the script, current directory contents:"
-          ls -la
-
-          # Run the manpage generation script
-          bash scripts/manpage_generation.sh
-
           # Add more debug output
           echo "Debug: After running the script, current directory contents:"
           ls -la

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,29 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
       - name: Trigger Manpage Generation
-        uses: ./.github/workflows
-        with:
-          workflow: generate_manpage.yml
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.everest-preview+json" \
+            -H "Content-Type: application/json" \
+            https://api.github.com/repos/${{ github.repository }}/dispatches \
+            --data '{"event_type": "trigger-manpage-generation"}'
+
+      - name: Show File Modification
+        run: |
+          FILE_PATH="man/convert2rhel.8"
+
+          # Fetch the changes from the remote repository
+          git fetch --quiet
+
+          # Check if the file has been modified
+          if git diff origin/main $FILE_PATH; then
+            echo "No changes detected in $FILE_PATH."
+          else
+            echo "Changes detected in $FILE_PATH. Printing diff:"
+            git diff origin/main $FILE_PATH
+            exit 0
+          fi
 
       - name: Build RPM package for EL7
         id: rpm_build_el7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,7 @@ jobs:
           ls -la
 
       - name: Trigger Manpage Generation
-        run: |
-          curl -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.everest-preview+json" \
-            -H "Content-Type: application/json" \
-            https://api.github.com/repos/${{ github.repository }}/dispatches \
-            --data '{"event_type": "trigger-manpage-generation"}'
+        uses: .github/workflows/generate_manpage.yml
 
       - name: after Generate Manpages
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,7 @@ jobs:
 
       - name: Trigger Manpage Generation
         run: |
-          curl -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.everest-preview+json" \
-            -H "Content-Type: application/json" \
-            https://api.github.com/repos/${{ github.repository }}/dispatches \
-            --data '{"event_type": "trigger-manpage-generation"}'
+          oamg/convert2rhel/.github/workflows/generate_manpage.yml@main
 
       - name: after Generate Manpages
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,9 @@
 name: Build release RPMs
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - '*'
 
 jobs:
   build_el7_rpm:
@@ -22,21 +23,21 @@ jobs:
             https://api.github.com/repos/${{ github.repository }}/dispatches \
             --data '{"event_type": "trigger-manpage-generation"}'
 
-      - name: Show File Modification
+      - name: Generate Manpages
         run: |
-          FILE_PATH="man/convert2rhel.8"
+          chmod +x scripts/manpage_generation.sh
 
-          # Fetch the changes from the remote repository
-          git fetch --quiet
+          # Add debug output
+          echo "Debug: Before running the script, current directory contents:"
+          ls -la
 
-          # Check if the file has been modified
-          if git diff origin/main $FILE_PATH; then
-            echo "No changes detected in $FILE_PATH."
-          else
-            echo "Changes detected in $FILE_PATH. Printing diff:"
-            git diff origin/main $FILE_PATH
-            exit 0
-          fi
+          # Run the manpage generation script
+          bash scripts/manpage_generation.sh
+
+          # Add more debug output
+          echo "Debug: After running the script, current directory contents:"
+          ls -la
+
 
       - name: Build RPM package for EL7
         id: rpm_build_el7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
-      - name: before Generate Manpages
-        run: |
-          # Add debug output
-          echo "Debug: Before running the script, current directory contents:"
-          ls -la
-
       - name: Trigger Manpage Generation
         run: |
           ./generate_manpage.yml
@@ -27,9 +21,7 @@ jobs:
 
       - name: after Generate Manpages
         run: |
-          # Add more debug output
-          echo "Debug: After running the script, current directory contents:"
-          ls -la
+          git status
 
 
       - name: Build RPM package for EL7

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -146,7 +146,8 @@ class CLI:
             help="Run all Convert2RHEL initial checks up until the"
             " Point of no Return (PONR) and generate a report with the findings."
             " A rollback is initiated after the checks to put the system back"
-            " in the original state.",
+            " in the original state."
+            "test this action",
             parents=[self._shared_options_parser],
             usage=self.usage(subcommand_to_print="analyze"),
         )


### PR DESCRIPTION
The auto-gen manpage PR was believed to be working but when it was time to make the manpage for the release it wasn't correct and so it was found out that it wasn't running correctly. 

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1037](https://issues.redhat.com/browse/RHELC-1037)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
