### PR TITLE
[RHELC-1193] Identify highest status in json report

### DIFF
--- a/schemas/assessment-schema-1.1.json
+++ b/schemas/assessment-schema-1.1.json
@@ -1,0 +1,150 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/oamg/convert2rhel/main/schemas/assessment-schema-1.1.json",
+    "title": "Convert2rhel Assessment Schema",
+    "description": "Convert2rhel analyzes the system to determine suitability for conversions before it actually starts to convert the system.  This schema defines the format that would be used.",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "actions": {
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^[A-Z0-9_]+$": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/action_message"
+                            }
+                        },
+                        "result": {
+                            "$ref": "#/$defs/action_result"
+                        }
+                    }
+                }
+            }
+        },
+        "format_version": {
+            "description": "Constant value that tells us the format of this file.",
+            "const": "1.1"
+        },
+        "status": {
+            "description": "The highest severity between messages and results from actions.",
+            "type": "string",
+            "enum": [
+                "SUCCESS",
+                "INFO",
+                "WARNING",
+                "SKIP",
+                "OVERRIDABLE",
+                "ERROR"
+            ]
+        }
+    },
+    "required": [
+        "actions",
+        "format_version",
+        "status"
+    ],
+
+    "$defs": {
+        "result_levels": {
+            "description": "The severity of the result",
+            "type": "string",
+            "enum": [
+                "SUCCESS",
+                "SKIP",
+                "OVERRIDABLE",
+                "ERROR"
+            ]
+        },
+        "message_levels": {
+            "description": "The severity of the message",
+            "type": "string",
+            "enum": [
+                "INFO",
+                "WARNING"
+            ]
+        },
+        "base_action_message": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "description": "Short, one line summary of the message.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Longer description of the purpose of this message.",
+                    "type": "string"
+                },
+                "diagnosis": {
+                    "description": "How this message applies to this particular system. For instance, 'This system has convert2rhel-1.0 but convert2hel-2.2 is the latest.'",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "Identifier for this message. The combination of the action_result's id and this message id will be unique.",
+                    "type": "string",
+                    "pattern": "^[A-Z0-9_]+$"
+                },
+                "remediation": {
+                    "description": "Steps the user may take to fix this issue.",
+                    "type": "string"
+                },
+                "variables": {
+                    "description": "Information about this particular system that may be used to template the diagnosis and remediation fields.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^[A-Za-z0-9_]+$": {
+                        }
+                    }
+                }
+            },
+            "required": ["title", "description", "diagnosis", "id", "remediation", "variables"]
+        },
+        "action_message": {
+            "description": "Informational message from a particular convert2rhel check.",
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/$defs/base_action_message"
+                }
+            ],
+            "properties": {
+                "level": {
+                    "type": "string",
+                    "allOf": [
+                        {
+                            "$ref":  "#/$defs/message_levels"
+                        }
+                    ]
+                }
+            },
+            "unevaluatedProperties": false,
+            "required": ["level"]
+        },
+        "action_result": {
+            "description": "Message relaying the result from a particular convert2rhel check.",
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/$defs/base_action_message"
+                }
+            ],
+            "properties": {
+                "level": {
+                    "type": "string",
+                    "allOf": [
+                        {
+                            "$ref":  "#/$defs/result_levels"
+                        }
+                    ]
+                }
+            },
+            "unevaluatedProperties": false,
+            "required": ["level"]
+        }
+    }
+}

--- a/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
+++ b/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
@@ -11,7 +11,7 @@ from pexpect import EOF
 
 PRE_CONVERSION_REPORT_JSON = "/var/log/convert2rhel/convert2rhel-pre-conversion.json"
 PRE_CONVERSION_REPORT_TXT = "/var/log/convert2rhel/convert2rhel-pre-conversion.txt"
-PRE_CONVERSION_REPORT_JSON_SCHEMA = _load_json_schema(path="../../../../../schemas/assessment-schema-1.0.json")
+PRE_CONVERSION_REPORT_JSON_SCHEMA = _load_json_schema(path="../../../../../schemas/assessment-schema-1.1.json")
 
 
 def _validate_report():


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
This PR adds a function find_highest_report_level to report.py to get the highest status level within the results and messages reported in the analysis. This highest status level is added as a new key to the report json at the top level for use in the rhc worker script. 

Jira Issues: [RHELC-1193](https://issues.redhat.com/browse/RHELC-1193)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
