### PR TITLE
[RHELC-1225] Fix an exception when listing third-party packages with Epoch 2

### DIFF
--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -706,6 +706,7 @@ def _get_package_repositories(pkgs):
             repositories_mapping[package] = "N/A"
     else:
         for line in output:
+            line = line.lstrip()
             if line.startswith("C2R "):
                 split_output = line[4:].split("&")
                 nevra = split_output[0]

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -706,8 +706,8 @@ def _get_package_repositories(pkgs):
             repositories_mapping[package] = "N/A"
     else:
         for line in output:
-            if "C2R" in line:
-                split_output = line.lstrip("C2R ").split("&")
+            if line.startswith("C2R "):
+                split_output = line[4:].split("&")
                 nevra = split_output[0]
                 repoid = split_output[1]
                 repositories_mapping[nevra] = repoid if repoid else "N/A"

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -2259,6 +2259,19 @@ def test_get_installed_pkg_information_value_error(monkeypatch, caplog):
             },
         ),
         (
+            ["2:eog-44.1-1.fc38.x86_64", "2:gnome-backgrounds-44.0-1.fc38.noarch", "2:gnome-maps-44.1-1.fc38.x86_64"],
+            """\
+                C2R 2:eog-44.1-1.fc38.x86_64&updates
+                C2R 2:gnome-backgrounds-44.0-1.fc38.noarch&fedora
+                C2R 2:gnome-maps-44.1-1.fc38.x86_64&updates
+            """,
+            {
+                "2:eog-44.1-1.fc38.x86_64": "updates",
+                "2:gnome-backgrounds-44.0-1.fc38.noarch": "fedora",
+                "2:gnome-maps-44.1-1.fc38.x86_64": "updates",
+            },
+        ),
+        (
             ["0:eog-44.1-1.fc38.x86_64", "0:gnome-backgrounds-44.0-1.fc38.noarch", "0:gnome-maps-44.1-1.fc38.x86_64"],
             """\
                 C2R 0:eog-44.1-1.fc38.x86_64&updates


### PR DESCRIPTION
A bug processing output from the repoquery command caused packages with an Epoch equal to 2 to raise an exception in the third-party package listing task. This change fixes the processing.

Jira Issues: [RHELC-1225](https://issues.redhat.com/browse/RHELC-1225)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
