### PR TITLE
[RHELC-1242] Remove "Skipping the check of repos" from report

### DIFF
--- a/convert2rhel/actions/system_checks/custom_repos_are_valid.py
+++ b/convert2rhel/actions/system_checks/custom_repos_are_valid.py
@@ -38,14 +38,7 @@ class CustomReposAreValid(actions.Action):
         logger.task("Prepare: Check if --enablerepo repositories are accessible")
 
         if not tool_opts.no_rhsm:
-            description = "Skipping the check of repositories due to the use of RHSM for the conversion."
-            logger.info(description)
-            self.add_message(
-                level="INFO",
-                id="CUSTOM_REPOSITORIES_ARE_VALID_CHECK_SKIP",
-                title="Skipping the custom repos are valid check",
-                description=description,
-            )
+            logger.info("Skipping the check of repositories due to the use of RHSM for the conversion.")
             return
 
         output, ret_code = call_yum_cmd(

--- a/convert2rhel/unit_tests/actions/system_checks/custom_repos_are_valid_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/custom_repos_are_valid_test.py
@@ -62,22 +62,9 @@ def test_custom_repos_are_invalid(custom_repos_are_valid_action, monkeypatch):
     )
 
 
-def test_custom_repos_are_valid_skip(custom_repos_are_valid_action, monkeypatch):
+def test_custom_repos_are_valid_skip(custom_repos_are_valid_action, monkeypatch, caplog):
     monkeypatch.setattr(custom_repos_are_valid.tool_opts, "no_rhsm", False)
 
     custom_repos_are_valid_action.run()
 
-    expected = set(
-        (
-            actions.ActionMessage(
-                level="INFO",
-                id="CUSTOM_REPOSITORIES_ARE_VALID_CHECK_SKIP",
-                title="Skipping the custom repos are valid check",
-                description="Skipping the check of repositories due to the use of RHSM for the conversion.",
-                diagnosis="",
-                remediation="",
-            ),
-        )
-    )
-    assert expected.issuperset(custom_repos_are_valid_action.messages)
-    assert expected.issubset(custom_repos_are_valid_action.messages)
+    assert "Skipping the check of repositories due to the use of RHSM for the conversion." in caplog.records[-1].message


### PR DESCRIPTION
The `"Skipping the check of repositories due to the use of RHSM for the conversion"` informational message is confusing in the pre-conversion report as it does not have the context it has in the terminal where it's pre-empted by `"TASK - [Prepare: Check if --enablerepo repositories are accessible]"`.

This message would add no value for the user even if the context is added. Hence the removal.

Jira Issues: [RHELC-1242](https://issues.redhat.com/browse/RHELC-1242)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
