### PR TITLE
[RHELC-1070] Duplicate package check for preconversion analysis

### DIFF
--- a/convert2rhel/actions/system_checks/duplicate_packages.py
+++ b/convert2rhel/actions/system_checks/duplicate_packages.py
@@ -1,0 +1,50 @@
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import logging
+
+from convert2rhel import actions, utils
+
+
+logger = logging.getLogger(__name__)
+
+
+class DuplicatePackages(actions.Action):
+    id = "DUPLICATE_PACKAGES"
+
+    def run(self):
+        """Ensure that there are no duplicate system packages installed."""
+        super(DuplicatePackages, self).run()
+
+        logger.task("Prepare: Check if there are any duplicate installed packages on the system")
+        output, _ = utils.run_subprocess(["/usr/bin/package-cleanup", "--dupes", "--quiet"], print_output=False)
+        if not output:
+            return
+
+        duplicate_packages = output.split("\n")
+        duplicate_packages = filter(None, duplicate_packages)
+        if duplicate_packages:
+            self.set_result(
+                level="ERROR",
+                id="DUPLICATE_PACKAGES_FOUND",
+                title="Duplicate packages found on the system",
+                description="The system contains one or more packages with multiple versions.",
+                diagnosis="The following packages have multiple versions: %s." % ", ".join(duplicate_packages),
+                remediations="This error can be resolved by removing duplicate versions of the listed packages."
+                " The command 'package-cleanup' can be used to automatically remove duplicate packages"
+                " on the system.",
+            )

--- a/convert2rhel/actions/system_checks/duplicate_packages.py
+++ b/convert2rhel/actions/system_checks/duplicate_packages.py
@@ -35,8 +35,7 @@ class DuplicatePackages(actions.Action):
         if not output:
             return
 
-        duplicate_packages = output.split("\n")
-        duplicate_packages = filter(None, duplicate_packages)
+        duplicate_packages = filter(None, output.split("\n"))
         if duplicate_packages:
             self.set_result(
                 level="ERROR",

--- a/convert2rhel/unit_tests/actions/system_checks/duplicate_packages_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/duplicate_packages_test.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+
+import pytest
+
+from convert2rhel import unit_tests, utils
+from convert2rhel.actions.system_checks import duplicate_packages
+from convert2rhel.unit_tests import RunSubprocessMocked
+
+
+@pytest.fixture
+def duplicate_packages_action():
+    return duplicate_packages.DuplicatePackages()
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    (
+        (
+            "package1.x86_64\npackage1.s390x\npackage2.x86_64\npackage2.ppc64le\n",
+            ["package1.x86_64", "package1.s390x", "package2.x86_64", "package2.ppc64le"],
+        ),
+        (
+            "package1.x86_64\npackage1.i686\npackage1.s390x\npackage2.x86_64\npackage2.ppc64le\n",
+            ["package1.x86_64", "package1.i686", "package1.s390x", "package2.x86_64", "package2.ppc64le"],
+        ),
+    ),
+)
+def test_duplicate_packages_error(monkeypatch, output, expected, duplicate_packages_action):
+
+    monkeypatch.setattr(utils, "run_subprocess", RunSubprocessMocked(return_value=(output, 0)))
+    duplicate_packages_action.run()
+
+    unit_tests.assert_actions_result(
+        duplicate_packages_action,
+        level="ERROR",
+        id="DUPLICATE_PACKAGES_FOUND",
+        title="Duplicate packages found on the system",
+        description="The system contains one or more packages with multiple versions.",
+        diagnosis="The following packages have multiple versions: %s." % ", ".join(expected),
+        remediations="This error can be resolved by removing duplicate versions of the listed packages."
+        " The command 'package-cleanup' can be used to automatically remove duplicate packages"
+        " on the system.",
+    )
+
+
+def test_duplicate_packages_success(monkeypatch, duplicate_packages_action):
+
+    monkeypatch.setattr(utils, "run_subprocess", RunSubprocessMocked(return_value=("", 0)))
+    duplicate_packages_action.run()
+    unit_tests.assert_actions_result(
+        duplicate_packages_action,
+        level="SUCCESS",
+    )


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
This PR adds a check to preconversion analysis to run "package-cleanup --dupes" to see if the users system contains multiple versions of the same package. If multiple versions of the same package are detected then an error is raised and the user is instructed to remove the duplicate packages with the help of the package-cleanup command. 

Jira Issues: [RHELC-1070](https://issues.redhat.com/browse/RHELC-1070)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
