### PR TITLE
[RHELC-1378] Add remediation to overridable result in package updates action

### DIFF
--- a/convert2rhel/actions/system_checks/package_updates.py
+++ b/convert2rhel/actions/system_checks/package_updates.py
@@ -137,6 +137,8 @@ class PackageUpdates(actions.Action):
                     title="Outdated packages detected",
                     description="Please refer to the diagnosis for further information",
                     diagnosis=package_not_up_to_date_error_message,
+                    remediations="If you wish to ignore this message, set the environment variable "
+                    "'CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP' to 1.",
                 )
                 return
 

--- a/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
@@ -92,6 +92,8 @@ def test_check_package_updates_not_up_to_date(pretend_os, monkeypatch, package_u
         title="Outdated packages detected",
         description="Please refer to the diagnosis for further information",
         diagnosis=diagnosis,
+        remediations="If you wish to ignore this message, set the environment variable "
+        "'CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP' to 1.",
     )
 
     assert diagnosis in caplog.records[-1].message


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
This PR adds a remediation to the overrdiable result in the package_updates.py action. The remediation lets the user know they can set an environment variable to skip the OUT_OF_DATE_PACKAGES check within the action.

Jira Issues: [RHELC-1378](https://issues.redhat.com/browse/RHELC-1378)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
