### PR TITLE
[RHELC-1173] Replace the word `skip` in report messages

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
+++ b/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
@@ -256,7 +256,7 @@ class EnsureKernelModulesCompatibility(actions.Action):
                 self.add_message(
                     level="WARNING",
                     id="ALLOW_UNAVAILABLE_KERNEL_MODULES",
-                    title="Skipping the ensure kernel modules compatibility check",
+                    title="Did not perform the ensure kernel modules compatibility check",
                     description="Detected 'CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS' environment variable.",
                     diagnosis="We will continue the conversion with the following kernel modules unavailable in RHEL:\n"
                     "{kmods}\n".format(kmods="\n".join(unsupported_kmods)),

--- a/convert2rhel/actions/pre_ponr_changes/special_cases.py
+++ b/convert2rhel/actions/pre_ponr_changes/special_cases.py
@@ -76,4 +76,4 @@ class RemoveIwlax2xxFirmware(actions.Action):
                     "The iwl7260-firmware and iwlax2xx-firmware packages are not both installed. Nothing to do."
                 )
         else:
-            logger.info("Relevant to Oracle Linux 8 only. Skipping.")
+            logger.info("Relevant to Oracle Linux 8 only. Did not perform the check.")

--- a/convert2rhel/actions/pre_ponr_changes/subscription.py
+++ b/convert2rhel/actions/pre_ponr_changes/subscription.py
@@ -82,12 +82,12 @@ class PreSubscription(actions.Action):
             # user configured repos rather than system-manager configured repos
             # to get RHEL packages) that we do not need subscription-manager
             # packages.
-            logger.warning("Detected --no-rhsm option. Skipping.")
+            logger.warning("Detected --no-rhsm option. Did not perform the check.")
             self.add_message(
                 level="WARNING",
                 id="PRE_SUBSCRIPTION_CHECK_SKIP",
                 title="Pre-subscription check skip",
-                description="Detected --no-rhsm option. Skipping.",
+                description="Detected --no-rhsm option. Did not perform the check.",
             )
             return
 
@@ -168,12 +168,12 @@ class SubscribeSystem(actions.Action):
 
         if not subscription.should_subscribe():
             if toolopts.tool_opts.no_rhsm:
-                logger.warning("Detected --no-rhsm option. Skipping subscription step.")
+                logger.warning("Detected --no-rhsm option. Did not perform subscription step.")
                 self.add_message(
                     level="WARNING",
                     id="SUBSCRIPTION_CHECK_SKIP",
                     title="Subscription check skip",
-                    description="Detected --no-rhsm option. Skipping.",
+                    description="Detected --no-rhsm option. Did not perform the check.",
                 )
                 return
 
@@ -195,7 +195,7 @@ class SubscribeSystem(actions.Action):
                     return
                 raise
 
-            logger.warning("No rhsm credentials given to subscribe the system. Skipping the subscription step.")
+            logger.warning("No rhsm credentials given to subscribe the system. Did not perform the subscription step.")
 
         try:
             # In the future, refactor this to be an else on the previous

--- a/convert2rhel/actions/system_checks/check_firewalld_availability.py
+++ b/convert2rhel/actions/system_checks/check_firewalld_availability.py
@@ -116,4 +116,4 @@ class CheckFirewalldAvailability(actions.Action):
                     ),
                 )
         else:
-            logger.info("Skipping the check as it is relevant only for Oracle Linux 8.8 and above.")
+            logger.info("Did not perform the check as it is relevant only for Oracle Linux 8.8 and above.")

--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -60,12 +60,12 @@ class Convert2rhelLatest(actions.Action):
         super(Convert2rhelLatest, self).run()
 
         if not system_info.has_internet_access:
-            description = "Skipping the check because no internet connection has been detected."
+            description = "Did not perform the check because no internet connection has been detected."
             logger.warning(description)
             self.add_message(
                 level="WARNING",
                 id="CONVERT2RHEL_LATEST_CHECK_SKIP_NO_INTERNET",
-                title="Skipping convert2rhel latest version check",
+                title="Did not perform convert2rhel latest version check",
                 description=description,
             )
             return
@@ -104,7 +104,7 @@ class Convert2rhelLatest(actions.Action):
                 level="WARNING",
                 id="CONVERT2RHEL_LATEST_CHECK_SKIP",
                 title="convert2rhel latest version check skip",
-                description="Skipping the convert2hel latest version check",
+                description="Did not perform the convert2hel latest version check",
                 diagnosis=diagnosis,
             )
             return

--- a/convert2rhel/actions/system_checks/custom_repos_are_valid.py
+++ b/convert2rhel/actions/system_checks/custom_repos_are_valid.py
@@ -38,7 +38,7 @@ class CustomReposAreValid(actions.Action):
         logger.task("Prepare: Check if --enablerepo repositories are accessible")
 
         if not tool_opts.no_rhsm:
-            logger.info("Skipping the check of repositories due to the use of RHSM for the conversion.")
+            logger.info("Did not perform the check of repositories due to the use of RHSM for the conversion.")
             return
 
         output, ret_code = call_yum_cmd(

--- a/convert2rhel/actions/system_checks/dbus.py
+++ b/convert2rhel/actions/system_checks/dbus.py
@@ -33,12 +33,12 @@ class DbusIsRunning(actions.Action):
         logger.task("Prepare: Check that DBus Daemon is running")
 
         if not subscription.should_subscribe():
-            logger.info("Skipping the check because we have been asked not to subscribe this system to RHSM.")
+            logger.info("Did not perform the check because we have been asked not to subscribe this system to RHSM.")
             self.add_message(
                 level="INFO",
                 id="DBUS_IS_RUNNING_CHECK_SKIP",
-                title="Skipping the dbus is running check",
-                description="Skipping the check because we have been asked not to subscribe this system to RHSM.",
+                title="Did not perform the dbus is running check",
+                description="Did not perform the check because we have been asked not to subscribe this system to RHSM.",
             )
             return
 

--- a/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
+++ b/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
@@ -39,7 +39,7 @@ class IsLoadedKernelLatest(actions.Action):
 
         if system_info.id == "oracle" and system_info.eus_system:
             logger.info(
-                "Skipping the check because there are no publicly available %s %d.%d repositories available."
+                "Did not perform the check because there were no publicly available %s %d.%d repositories available."
                 % (system_info.name, system_info.version.major, system_info.version.minor)
             )
             return
@@ -54,12 +54,12 @@ class IsLoadedKernelLatest(actions.Action):
 
         reposdir = get_hardcoded_repofiles_dir()
         if reposdir and not system_info.has_internet_access:
-            logger.warning("Skipping the check as no internet connection has been detected.")
+            logger.warning("Did not perform the check as no internet connection has been detected.")
             self.add_message(
                 level="WARNING",
                 id="IS_LOADED_KERNEL_LATEST_CHECK_SKIP",
-                title="Skipping the is loaded kernel latest check",
-                description="Skipping the check as no internet connection has been detected.",
+                title="Did not perform the is loaded kernel latest check",
+                description="Did not perform the check as no internet connection has been detected.",
             )
             return
 
@@ -104,7 +104,7 @@ class IsLoadedKernelLatest(actions.Action):
             self.add_message(
                 level="WARNING",
                 id="UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK_DETECTED",
-                title="Skipping the kernel currency check",
+                title="Did not perform the kernel currency check",
                 description=(
                     "Detected 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip "
                     "the %s comparison.\n"
@@ -125,7 +125,7 @@ class IsLoadedKernelLatest(actions.Action):
             logger.debug("Got the following output: %s", repoquery_output)
             logger.warning(
                 "Couldn't fetch the list of the most recent kernels available in "
-                "the repositories. Skipping the loaded kernel check."
+                "the repositories. Did not perform the loaded kernel check."
             )
             self.add_message(
                 level="WARNING",
@@ -133,7 +133,7 @@ class IsLoadedKernelLatest(actions.Action):
                 title="Unable to fetch recent kernels",
                 description=(
                     "Couldn't fetch the list of the most recent kernels available in "
-                    "the repositories. Skipping the loaded kernel check."
+                    "the repositories. Did not perform the loaded kernel check."
                 ),
             )
             return

--- a/convert2rhel/actions/system_checks/package_updates.py
+++ b/convert2rhel/actions/system_checks/package_updates.py
@@ -37,16 +37,16 @@ class PackageUpdates(actions.Action):
 
         if system_info.id == "oracle" and system_info.eus_system:
             logger.info(
-                "Skipping the check because there are no publicly available %s %d.%d repositories available."
+                "Did not perform the check because there were no publicly available %s %d.%d repositories available."
                 % (system_info.name, system_info.version.major, system_info.version.minor)
             )
             self.add_message(
                 level="INFO",
                 id="PACKAGE_UPDATES_CHECK_SKIP_NO_PUBLIC_REPOSITORIES",
-                title="Skipping the package updates check",
+                title="Did not perform the package updates check",
                 description="Please refer to the diagnosis for further information",
                 diagnosis=(
-                    "Skipping the check because there are no publicly available %s %d.%d repositories available."
+                    "Did not perform the check because there were no publicly available %s %d.%d repositories available."
                     % (system_info.name, system_info.version.major, system_info.version.minor)
                 ),
             )
@@ -55,12 +55,12 @@ class PackageUpdates(actions.Action):
         reposdir = get_hardcoded_repofiles_dir()
 
         if reposdir and not system_info.has_internet_access:
-            logger.warning("Skipping the check as no internet connection has been detected.")
+            logger.warning("Did not perform the check as no internet connection has been detected.")
             self.add_message(
                 level="WARNING",
                 id="PACKAGE_UPDATES_CHECK_SKIP_NO_INTERNET",
-                title="Skipping the package updates check",
-                description="Skipping the check as no internet connection has been detected.",
+                title="Did not perform the package updates check",
+                description="Did not perform the check as no internet connection has been detected.",
             )
             return
 

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
@@ -243,7 +243,7 @@ def test_ensure_compatibility_of_kmods_check_env_and_message(
     message = ensure_kernel_modules_compatibility_instance.messages[0]
     assert STATUS_CODE["WARNING"] == message.level
     assert "ALLOW_UNAVAILABLE_KERNEL_MODULES" == message.id
-    assert "Skipping the ensure kernel modules compatibility check" == message.title
+    assert "Did not perform the ensure kernel modules compatibility check" == message.title
     assert "Detected 'CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS' environment variable." in message.description
     assert "We will continue the conversion with the following kernel modules unavailable in RHEL:" in message.diagnosis
 

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/special_cases_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/special_cases_test.py
@@ -107,7 +107,7 @@ def test_remove_iwlax2xx_firmware_not_ol8(pretend_os, caplog):
     instance = special_cases.RemoveIwlax2xxFirmware()
     instance.run()
 
-    assert "Relevant to Oracle Linux 8 only. Skipping." in caplog.records[-1].message
+    assert "Relevant to Oracle Linux 8 only. Did not perform the check." in caplog.records[-1].message
     assert instance.result.level == actions.STATUS_CODE["SUCCESS"]
 
 

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/subscription_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/subscription_test.py
@@ -88,7 +88,7 @@ class TestPreSubscription:
                     level="WARNING",
                     id="PRE_SUBSCRIPTION_CHECK_SKIP",
                     title="Pre-subscription check skip",
-                    description="Detected --no-rhsm option. Skipping.",
+                    description="Detected --no-rhsm option. Did not perform the check.",
                     diagnosis=None,
                     remediations=None,
                 ),
@@ -97,7 +97,7 @@ class TestPreSubscription:
 
         pre_subscription_instance.run()
 
-        assert "Detected --no-rhsm option. Skipping" in caplog.records[-1].message
+        assert "Detected --no-rhsm option. Did not perform the check." in caplog.records[-1].message
         assert pre_subscription_instance.result.level == STATUS_CODE["SUCCESS"]
         assert expected.issuperset(pre_subscription_instance.messages)
         assert expected.issubset(pre_subscription_instance.messages)
@@ -237,7 +237,7 @@ class TestSubscribeSystem:
                     level="WARNING",
                     id="SUBSCRIPTION_CHECK_SKIP",
                     title="Subscription check skip",
-                    description="Detected --no-rhsm option. Skipping.",
+                    description="Detected --no-rhsm option. Did not perform the check.",
                     diagnosis=None,
                     remediations=None,
                 ),
@@ -246,7 +246,7 @@ class TestSubscribeSystem:
 
         subscribe_system_instance.run()
 
-        assert "Detected --no-rhsm option. Skipping" in caplog.records[-1].message
+        assert "Detected --no-rhsm option. Did not perform subscription step." in caplog.records[-1].message
         assert subscribe_system_instance.result.level == STATUS_CODE["SUCCESS"]
         assert expected.issuperset(subscribe_system_instance.messages)
         assert expected.issubset(subscribe_system_instance.messages)

--- a/convert2rhel/unit_tests/actions/system_checks/check_firewalld_availability_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/check_firewalld_availability_test.py
@@ -207,7 +207,10 @@ class TestCheckFirewalldAvailabilityAction:
 
         check_firewalld_availability_is_running_action.run()
 
-        assert "Skipping the check as it is relevant only for Oracle Linux 8.8 and above." in caplog.records[-1].message
+        assert (
+            "Did not perform the check as it is relevant only for Oracle Linux 8.8 and above."
+            in caplog.records[-1].message
+        )
 
     @oracle8
     def test_systemd_managed_service_not_running(

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -119,15 +119,15 @@ class TestCheckConvert2rhelLatest:
                 actions.ActionMessage(
                     level="WARNING",
                     id="CONVERT2RHEL_LATEST_CHECK_SKIP_NO_INTERNET",
-                    title="Skipping convert2rhel latest version check",
-                    description="Skipping the check because no internet connection has been detected.",
+                    title="Did not perform convert2rhel latest version check",
+                    description="Did not perform the check because no internet connection has been detected.",
                     diagnosis=None,
                     remediations=None,
                 ),
             )
         )
 
-        log_msg = "Skipping the check because no internet connection has been detected."
+        log_msg = "Did not perform the check because no internet connection has been detected."
         assert log_msg in caplog.text
         assert convert2rhel_latest_action.result.level == actions.STATUS_CODE["SUCCESS"]
         assert expected.issuperset(convert2rhel_latest_action.messages)
@@ -559,7 +559,7 @@ class TestCheckConvert2rhelLatest:
                     level="WARNING",
                     id="CONVERT2RHEL_LATEST_CHECK_SKIP",
                     title="convert2rhel latest version check skip",
-                    description="Skipping the convert2hel latest version check",
+                    description="Did not perform the convert2hel latest version check",
                     diagnosis=(
                         "Couldn't check if the current installed convert2rhel is the latest version.\n"
                         "repoquery failed with the following output:\nRepoquery did not run"

--- a/convert2rhel/unit_tests/actions/system_checks/custom_repos_are_valid_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/custom_repos_are_valid_test.py
@@ -67,4 +67,7 @@ def test_custom_repos_are_valid_skip(custom_repos_are_valid_action, monkeypatch,
 
     custom_repos_are_valid_action.run()
 
-    assert "Skipping the check of repositories due to the use of RHSM for the conversion." in caplog.records[-1].message
+    assert (
+        "Did not perform the check of repositories due to the use of RHSM for the conversion."
+        in caplog.records[-1].message
+    )

--- a/convert2rhel/unit_tests/actions/system_checks/dbus_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/dbus_test.py
@@ -29,8 +29,8 @@ def dbus_is_running_action():
 @pytest.mark.parametrize(
     ("should_subscribe", "dbus_running", "log_msg"),
     (
-        (False, True, "Skipping the check because we have been asked not to subscribe this system to RHSM."),
-        (False, False, "Skipping the check because we have been asked not to subscribe this system to RHSM."),
+        (False, True, "Did not perform the check because we have been asked not to subscribe this system to RHSM."),
+        (False, False, "Did not perform the check because we have been asked not to subscribe this system to RHSM."),
         (True, True, "DBus Daemon is running"),
     ),
 )
@@ -74,8 +74,8 @@ def test_check_dbus_is_running_info_message(monkeypatch, dbus_is_running_action)
             actions.ActionMessage(
                 level="INFO",
                 id="DBUS_IS_RUNNING_CHECK_SKIP",
-                title="Skipping the dbus is running check",
-                description="Skipping the check because we have been asked not to subscribe this system to RHSM.",
+                title="Did not perform the dbus is running check",
+                description="Did not perform the check because we have been asked not to subscribe this system to RHSM.",
                 diagnosis=None,
                 remediations=None,
             ),

--- a/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
@@ -48,9 +48,7 @@ class TestIsLoadedKernelLatest:
         monkeypatch.setattr(is_loaded_kernel_latest.system_info, "eus_system", value=True)
         monkeypatch.setattr(is_loaded_kernel_latest.system_info, "has_internet_access", value=True)
 
-        message = (
-            "Skipping the check because there are no publicly available Oracle Linux Server 8.6 repositories available."
-        )
+        message = "Did not perform the check because there were no publicly available Oracle Linux Server 8.6 repositories available."
         is_loaded_kernel_latest_action.run()
 
         assert message in caplog.records[-1].message
@@ -378,8 +376,8 @@ class TestIsLoadedKernelLatest:
                 actions.ActionMessage(
                     level="WARNING",
                     id="IS_LOADED_KERNEL_LATEST_CHECK_SKIP",
-                    title="Skipping the is loaded kernel latest check",
-                    description="Skipping the check as no internet connection has been detected.",
+                    title="Did not perform the is loaded kernel latest check",
+                    description="Did not perform the check as no internet connection has been detected.",
                     diagnosis=None,
                     remediations=None,
                 ),
@@ -387,7 +385,7 @@ class TestIsLoadedKernelLatest:
         )
 
         is_loaded_kernel_latest_action.run()
-        assert "Skipping the check as no internet connection has been detected." in caplog.records[-1].message
+        assert "Did not perform the check as no internet connection has been detected." in caplog.records[-1].message
         assert expected.issuperset(is_loaded_kernel_latest_action.messages)
         assert expected.issubset(is_loaded_kernel_latest_action.messages)
 
@@ -413,7 +411,7 @@ class TestIsLoadedKernelLatest:
                 "1",
                 "WARNING",
                 "UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK_DETECTED",
-                "Skipping the kernel currency check",
+                "Did not perform the kernel currency check",
                 (
                     "Detected 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip the kernel-core comparison.\nBeware, this could leave your system in a broken state."
                 ),
@@ -515,7 +513,7 @@ class TestIsLoadedKernelLatest:
                 "0",
                 "WARNING",
                 "UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK_DETECTED",
-                "Skipping the kernel currency check",
+                "Did not perform the kernel currency check",
                 (
                     "Detected 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip the kernel-core comparison.\nBeware, this could leave your system in a broken state."
                 ),
@@ -614,7 +612,7 @@ class TestIsLoadedKernelLatest:
                 "Unable to fetch recent kernels",
                 (
                     "Couldn't fetch the list of the most recent kernels available in "
-                    "the repositories. Skipping the loaded kernel check."
+                    "the repositories. Did not perform the loaded kernel check."
                 ),
                 None,
                 None,

--- a/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
@@ -41,15 +41,13 @@ def package_updates_action():
 def test_check_package_updates_skip_on_not_latest_ol(pretend_os, caplog, package_updates_action, monkeypatch):
     monkeypatch.setattr(package_updates.system_info, "eus_system", value=True)
 
-    diagnosis = (
-        "Skipping the check because there are no publicly available Oracle Linux Server 8.6 repositories available."
-    )
+    diagnosis = "Did not perform the check because there were no publicly available Oracle Linux Server 8.6 repositories available."
     expected = set(
         (
             actions.ActionMessage(
                 level="INFO",
                 id="PACKAGE_UPDATES_CHECK_SKIP_NO_PUBLIC_REPOSITORIES",
-                title="Skipping the package updates check",
+                title="Did not perform the package updates check",
                 description="Please refer to the diagnosis for further information",
                 diagnosis=diagnosis,
                 remediations=None,
@@ -218,13 +216,13 @@ def test_check_package_updates_with_repoerror_skip(pretend_os, monkeypatch, capl
 def test_check_package_updates_without_internet(pretend_os, tmpdir, monkeypatch, caplog, package_updates_action):
     monkeypatch.setattr(package_updates, "get_hardcoded_repofiles_dir", value=lambda: str(tmpdir))
     monkeypatch.setattr(system_info, "has_internet_access", False)
-    description = "Skipping the check as no internet connection has been detected."
+    description = "Did not perform the check as no internet connection has been detected."
     expected = set(
         (
             actions.ActionMessage(
                 level="WARNING",
                 id="PACKAGE_UPDATES_CHECK_SKIP_NO_INTERNET",
-                title="Skipping the package updates check",
+                title="Did not perform the package updates check",
                 description=description,
                 diagnosis=None,
                 remediations=None,

--- a/tests/integration/tier0/non-destructive/kernel/test_kernel_check_verification.py
+++ b/tests/integration/tier0/non-destructive/kernel/test_kernel_check_verification.py
@@ -43,7 +43,7 @@ def test_verify_latest_kernel_check_passes_with_failed_repoquery(convert2rhel, t
         c2r.sendline("y")
 
         c2r.expect(
-            "Couldn't fetch the list of the most recent kernels available in the repositories. Skipping the loaded kernel check.",
+            "Couldn't fetch the list of the most recent kernels available in the repositories. Did not perform the loaded kernel check.",
             timeout=300,
         )
         c2r.sendcontrol("c")

--- a/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
+++ b/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
@@ -17,7 +17,8 @@ def test_pre_registered_wont_unregister(shell, pre_registered, disabled_telemetr
     with convert2rhel("--debug") as c2r:
         c2r.expect("Subscription Manager is already present", timeout=300)
         c2r.expect(
-            "WARNING - No rhsm credentials given to subscribe the system. Skipping the subscription step", timeout=300
+            "WARNING - No rhsm credentials given to subscribe the system. Did not perform the subscription step",
+            timeout=300,
         )
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("n")


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
This PR replaces the use of 'skip' and 'skipping' with 'Did not perform' in the preconversion analysis report messages so as to not create confusion with the skip status put in place for when we cannot run an action because another one failed. 

Jira Issues: [RHELC-1173](https://issues.redhat.com/browse/RHELC-1173)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
