### PR TITLE
[RHELC-1246] Fix sub-man installation on EL8

### DIFF
--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -833,7 +833,7 @@ def _relevant_subscription_manager_pkgs():
             "python3-syspurpose",
             "python3-cloud-what",
             "json-c.x86_64",  # there's also an i686 version we don't need unless the json-c.i686 is already installed
-            "subscription-manager-rhsm-certificates",
+            "subscription-manager-rhsm-certificates.noarch",
         ]
 
     elif system_info.version.major >= 9:
@@ -841,7 +841,7 @@ def _relevant_subscription_manager_pkgs():
             "libdnf-plugin-subscription-manager",
             "python3-subscription-manager-rhsm",
             "python3-cloud-what",
-            "subscription-manager-rhsm-certificates.x86_64",
+            "subscription-manager-rhsm-certificates.noarch",
         ]
 
     if system_info.is_rpm_installed("json-c.i686"):

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -224,7 +224,7 @@ class TestNeededSubscriptionManagerPkgs:
                 frozenset(
                     (
                         "subscription-manager",
-                        "subscription-manager-rhsm-certificates",
+                        "subscription-manager-rhsm-certificates.noarch",
                         "python3-subscription-manager-rhsm",
                         "dnf-plugin-subscription-manager",
                         "python3-syspurpose",
@@ -239,7 +239,7 @@ class TestNeededSubscriptionManagerPkgs:
                 frozenset(
                     (
                         "subscription-manager",
-                        "subscription-manager-rhsm-certificates",
+                        "subscription-manager-rhsm-certificates.noarch",
                         "python3-subscription-manager-rhsm",
                         "dnf-plugin-subscription-manager",
                         "python3-syspurpose",
@@ -255,7 +255,7 @@ class TestNeededSubscriptionManagerPkgs:
                 frozenset(
                     (
                         "subscription-manager",
-                        "subscription-manager-rhsm-certificates.x86_64",
+                        "subscription-manager-rhsm-certificates.noarch",
                         "python3-subscription-manager-rhsm",
                         "python3-cloud-what",
                         "libdnf-plugin-subscription-manager",


### PR DESCRIPTION
Yumdownloader was downloading two different versions of the subscription-manager-rhsm-certificates package and convert2rhel failed when it wanted to install both at the same time.

subscription-manager-rhsm-certificates-1.28.36-3.el8_8.x86_64 subscription-manager-rhsm-certificates-20220623-1.el8.noarch

Pino Toscano from the subscription-manager team told us that the version 20220623 is the latest and the one we should be installing.

Since the two versions have different architecture, this quick solution is making sure that only the noarch one is downloaded and installed.

The same applies to conversions to RHEL 9. We were downloading incorrectly the x86_64 version of the package which is not the latest.

Jira Issues: [RHELC-1246](https://issues.redhat.com/browse/RHELC-1246)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
