### PR TITLE
Disable cache for pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ PYLINT_ARGS ?=
 VENV ?= .venv3
 PRE_COMMIT ?= pre-commit
 SHOW_CAPTURE ?= no
-PYTEST_ARGS ?=
+PYTEST_ARGS ?= -p no:cacheprovider
 BUILD_IMAGES ?= 1
 
 ifdef KEEP_TEST_CONTAINER


### PR DESCRIPTION
As pytest runs in a container in a read-only folder, the cache can not be created, thus it issues a warning.

This parameter disables the warning, so that the output looks cleaner.

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- NA Jira issue has been made public if possible
- NA `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- NA Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- NA When merged: Jira issue has been updated to `Release Pending` if relevant
