### PR TITLE
[RHELC-1096] Change the sorting order for the report

### DIFF
--- a/convert2rhel/actions/report.py
+++ b/convert2rhel/actions/report.py
@@ -223,9 +223,8 @@ def summary(results, include_all_reports=False, disable_colors=False):
 
     terminal_size = utils.get_terminal_size()
 
-    # Sort the results in reverse order, this way, the most important messages
-    # will be on top.
-    combined_results_and_message = sorted(combined_results_and_message, key=lambda item: item[1]["level"], reverse=True)
+    # Sort results to put Critical messages last, as in cli use-cases people read the logs from the bottom up.
+    combined_results_and_message = sorted(combined_results_and_message, key=lambda item: item[1]["level"])
 
     last_level = ""
     for message_id, combined_result in combined_results_and_message:

--- a/convert2rhel/unit_tests/actions/report_test.py
+++ b/convert2rhel/unit_tests/actions/report_test.py
@@ -603,8 +603,8 @@ def test_messages_summary_with_long_message(long_message, caplog):
             },
             False,
             [
-                r"\(OVERRIDABLE\) PreSubscription1::SOME_OVERRIDABLE - Overridable\n     Description: Action override\n     Diagnosis: User override\n     Remediation: move on",
                 r"\(SKIP\) PreSubscription2::SKIPPED - Skipped\n     Description: Action skip\n     Diagnosis: User skip\n     Remediation: move on",
+                r"\(OVERRIDABLE\) PreSubscription1::SOME_OVERRIDABLE - Overridable\n     Description: Action override\n     Diagnosis: User override\n     Remediation: move on",
             ],
         ),
         (
@@ -648,9 +648,9 @@ def test_messages_summary_with_long_message(long_message, caplog):
             },
             False,
             [
-                r"\(ERROR\) ErrorAction::ERROR - Error\n     Description: Action error\n     Diagnosis: User error\n     Remediation: move on",
-                r"\(OVERRIDABLE\) OverridableAction::OVERRIDABLE - Overridable\n     Description: Action override\n     Diagnosis: User override\n     Remediation: move on",
                 r"\(SKIP\) SkipAction::SKIP - Skip\n     Description: Action skip\n     Diagnosis: User skip\n     Remediation: move on",
+                r"\(OVERRIDABLE\) OverridableAction::OVERRIDABLE - Overridable\n     Description: Action override\n     Diagnosis: User override\n     Remediation: move on",
+                r"\(ERROR\) ErrorAction::ERROR - Error\n     Description: Action error\n     Diagnosis: User error\n     Remediation: move on",
             ],
         ),
         # Message order with `include_all_reports` set to True.
@@ -707,10 +707,10 @@ def test_messages_summary_with_long_message(long_message, caplog):
             },
             True,
             [
-                r"\(ERROR\) ErrorAction::ERROR - Error\n     Description: Action error\n     Diagnosis: User error\n     Remediation: move on",
-                r"\(OVERRIDABLE\) OverridableAction::OVERRIDABLE - Overridable\n     Description: Action override\n     Diagnosis: User override\n     Remediation: move on",
-                r"\(SKIP\) SkipAction::SKIP - Skip\n     Description: Action skip\n     Diagnosis: User skip\n     Remediation: move on",
                 r"\(SUCCESS\) PreSubscription::SUCCESS - N/A",
+                r"\(SKIP\) SkipAction::SKIP - Skip\n     Description: Action skip\n     Diagnosis: User skip\n     Remediation: move on",
+                r"\(OVERRIDABLE\) OverridableAction::OVERRIDABLE - Overridable\n     Description: Action override\n     Diagnosis: User override\n     Remediation: move on",
+                r"\(ERROR\) ErrorAction::ERROR - Error\n     Description: Action error\n     Diagnosis: User error\n     Remediation: move on",
             ],
         ),
     ),


### PR DESCRIPTION
We reverse the order of items in the summary and adjust hardcoded test data accordingly.

Jira Issues: [RHELC-1096](https://issues.redhat.com/browse/RHELC-1096)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
