### PR TITLE
hotfix/tests/Override the 3rd party pkg check

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -5,6 +5,7 @@ discover:
 
 environment+:
     NO_COLOR: 1
+    CONVERT2RHEL_THIRD_PARTY_PACKAGE_CHECK_SKIP: 1
 
 adjust+:
     - environment+:


### PR DESCRIPTION
* to unblock the testing pipeline, we need to override the check every time, since convert2rhel copr build is always considered third party package

