### PR TITLE
[RHELC-1241] Make report messages about removed packages less confusing

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/handle_packages.py
+++ b/convert2rhel/actions/pre_ponr_changes/handle_packages.py
@@ -111,13 +111,14 @@ class RemoveExcludedPackages(actions.Action):
                 diagnosis=message,
             )
         if pkgs_removed:
-            message = "The following packages were removed: %s" % ", ".join(pkgs_removed)
+            message = "The following packages will be removed during the conversion: %s" % ", ".join(pkgs_removed)
             logger.info(message)
             self.add_message(
                 level="INFO",
                 id="EXCLUDED_PACKAGES_REMOVED",
-                title="Excluded packages removed",
-                description="Excluded packages that have been removed",
+                title="Excluded packages to be removed",
+                description="We have identified installed packages that match a pre-defined list of packages that are"
+                " to be removed during the conversion",
                 diagnosis=message,
             )
 
@@ -187,12 +188,13 @@ class RemoveRepositoryFilesPackages(actions.Action):
                 diagnosis=message,
             )
         if pkgs_removed:
-            message = "The following packages were removed: %s" % ", ".join(pkgs_removed)
+            message = "The following packages will be removed during the conversion: %s" % ", ".join(pkgs_removed)
             logger.info(message)
             self.add_message(
                 level="INFO",
                 id="REPOSITORY_FILE_PACKAGES_REMOVED",
-                title="Repository file packages removed",
-                description="Repository file packages that have been removed",
+                title="Repository file packages to be removed",
+                description="We have identified installed packages that match a pre-defined list of packages that are"
+                " to be removed during the conversion",
                 diagnosis=message,
             )

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
@@ -107,9 +107,10 @@ def test_remove_excluded_packages_all_removed(remove_excluded_packages_instance,
             actions.ActionMessage(
                 level="INFO",
                 id="EXCLUDED_PACKAGES_REMOVED",
-                title="Excluded packages removed",
-                description="Excluded packages that have been removed",
-                diagnosis="The following packages were removed: centos-logos-70.0.6-3.el7.centos.noarch",
+                title="Excluded packages to be removed",
+                description="We have identified installed packages that match a pre-defined list of packages that are"
+                " to be removed during the conversion",
+                diagnosis="The following packages will be removed during the conversion: centos-logos-70.0.6-3.el7.centos.noarch",
                 remediation=None,
             ),
         )
@@ -145,9 +146,10 @@ def test_remove_excluded_packages_not_removed(pretend_os, remove_excluded_packag
             actions.ActionMessage(
                 level="INFO",
                 id="EXCLUDED_PACKAGES_REMOVED",
-                title="Excluded packages removed",
-                description="Excluded packages that have been removed",
-                diagnosis="The following packages were removed: kernel-core",
+                title="Excluded packages to be removed",
+                description="We have identified installed packages that match a pre-defined list of packages that are"
+                " to be removed during the conversion",
+                diagnosis="The following packages will be removed during the conversion: kernel-core",
                 remediation=None,
             ),
         )
@@ -203,9 +205,10 @@ def test_remove_repository_files_packages_all_removed(remove_repository_files_pa
             actions.ActionMessage(
                 level="INFO",
                 id="REPOSITORY_FILE_PACKAGES_REMOVED",
-                title="Repository file packages removed",
-                description="Repository file packages that have been removed",
-                diagnosis="The following packages were removed: centos-logos-70.0.6-3.el7.centos.noarch",
+                title="Repository file packages to be removed",
+                description="We have identified installed packages that match a pre-defined list of packages that are"
+                " to be removed during the conversion",
+                diagnosis="The following packages will be removed during the conversion: centos-logos-70.0.6-3.el7.centos.noarch",
                 remediation=None,
             ),
         )
@@ -244,9 +247,10 @@ def test_remove_repository_files_packages_not_removed(
             actions.ActionMessage(
                 level="INFO",
                 id="REPOSITORY_FILE_PACKAGES_REMOVED",
-                title="Repository file packages removed",
-                description="Repository file packages that have been removed",
-                diagnosis="The following packages were removed: kernel-core",
+                title="Repository file packages to be removed",
+                description="We have identified installed packages that match a pre-defined list of packages that are"
+                " to be removed during the conversion",
+                diagnosis="The following packages will be removed during the conversion: kernel-core",
                 remediation=None,
             ),
         )


### PR DESCRIPTION
Currently the pre-conversion analysis report states that certain packages were removed. But by the end of the conversion a rollback happens and the packages are installed back. So at the time of reading the report the packages are no longer removed.

This change rewords the messages to state that the packages are to be removed during the conversion.

Jira Issues: [RHELC-1241](https://issues.redhat.com/browse/RHELC-1241)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
