### PR TITLE
[RHELC-1089] Revert overridable result in package handling check

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/handle_packages.py
+++ b/convert2rhel/actions/pre_ponr_changes/handle_packages.py
@@ -37,7 +37,6 @@ class ListThirdPartyPackages(actions.Action):
 
         logger.task("Convert: List third-party packages")
         third_party_pkgs = pkghandler.get_third_party_pkgs()
-        third_party_package_skip = os.environ.get("CONVERT2RHEL_THIRD_PARTY_PACKAGE_CHECK_SKIP", None)
         if third_party_pkgs:
             pkg_list = pkghandler.format_pkg_info(sorted(third_party_pkgs, key=self.extract_packages))
             warning_message = (
@@ -45,38 +44,12 @@ class ListThirdPartyPackages(actions.Action):
                 " replaced. Red Hat support won't be provided"
                 " for the following third party packages:\n" % system_info.name
             )
-            if not third_party_package_skip:
-                logger.warning(warning_message)
-                logger.info(pkg_list)
-                self.set_result(
-                    level="OVERRIDABLE",
-                    id="THIRD_PARTY_PACKAGE_DETECTED",
-                    title="Third party packages detected",
-                    description="Third party packages will not be replaced during the conversion.",
-                    diagnosis=warning_message + ", ".join(pkghandler.get_pkg_nevras(third_party_pkgs)),
-                    remediation="If you wish to ignore this message, set the environment variable "
-                    "'CONVERT2RHEL_THIRD_PARTY_PACKAGE_CHECK_SKIP' to 1.",
-                )
-                return
-
-            skip_message = (
-                "Detected 'CONVERT2RHEL_THIRD_PARTY_PACKAGE_CHECK_SKIP' environment variable, we will skip "
-                "the third party package check.\n"
-                "Beware, this could leave your system in a broken state."
-            )
-            logger.warning(skip_message)
-            self.add_message(
-                level="WARNING",
-                id="SKIP_THIRD_PARTY_PACKAGE_CHECK",
-                title="Skip third party package check",
-                description=skip_message,
-            )
 
             logger.warning(warning_message)
             logger.info(pkg_list)
             self.add_message(
                 level="WARNING",
-                id="THIRD_PARTY_PACKAGE_DETECTED_MESSAGE",
+                id="THIRD_PARTY_PACKAGE_DETECTED",
                 title="Third party packages detected",
                 description="Third party packages will not be replaced during the conversion.",
                 diagnosis=warning_message + ", ".join(pkghandler.get_pkg_nevras(third_party_pkgs)),

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
@@ -62,57 +62,20 @@ def test_list_third_party_packages(pretend_os, list_third_party_packages_instanc
         " for the following third party packages:\npkg1-None-None.None, pkg2-None-None.None, gpg-pubkey-1.0.0-1.x86_64"
     )
     list_third_party_packages_instance.run()
-    unit_tests.assert_actions_result(
-        list_third_party_packages_instance,
-        level="OVERRIDABLE",
-        id="THIRD_PARTY_PACKAGE_DETECTED",
-        title="Third party packages detected",
-        description="Third party packages will not be replaced during the conversion.",
-        diagnosis=diagnosis,
-        remediation="If you wish to ignore this message, set the environment variable "
-        "'CONVERT2RHEL_THIRD_PARTY_PACKAGE_CHECK_SKIP' to 1.",
-    )
-
-    assert len(pkghandler.format_pkg_info.call_args[0][0]) == 3
-
-
-@centos7
-def test_list_third_party_packages_skip(list_third_party_packages_instance, pretend_os, monkeypatch, caplog):
-    monkeypatch.setattr(pkghandler, "get_third_party_pkgs", GetThirdPartyPkgsMocked(pkg_selection="fingerprints"))
-    monkeypatch.setattr(pkghandler, "format_pkg_info", FormatPkgInfoMocked(return_value=["shim", "ruby", "pytest"]))
-    monkeypatch.setattr(
-        os,
-        "environ",
-        {"CONVERT2RHEL_THIRD_PARTY_PACKAGE_CHECK_SKIP": 1},
-    )
     expected = set(
         (
             actions.ActionMessage(
                 level="WARNING",
-                id="THIRD_PARTY_PACKAGE_DETECTED_MESSAGE",
+                id="THIRD_PARTY_PACKAGE_DETECTED",
                 title="Third party packages detected",
                 description="Third party packages will not be replaced during the conversion.",
-                diagnosis=(
-                    "Only packages signed by CentOS Linux are to be replaced. Red Hat support won't be provided"
-                    " for the following third party packages:\npkg1-None-None.None, pkg2-None-None.None, gpg-pubkey-1.0.0-1.x86_64"
-                ),
-            ),
-            actions.ActionMessage(
-                level="WARNING",
-                id="SKIP_THIRD_PARTY_PACKAGE_CHECK",
-                title="Skip third party package check",
-                description=(
-                    "Detected 'CONVERT2RHEL_THIRD_PARTY_PACKAGE_CHECK_SKIP' environment variable, we will skip "
-                    "the third party package check.\n"
-                    "Beware, this could leave your system in a broken state."
-                ),
+                diagnosis=diagnosis,
             ),
         )
     )
-    list_third_party_packages_instance.run()
     assert expected.issuperset(list_third_party_packages_instance.messages)
     assert expected.issubset(list_third_party_packages_instance.messages)
-    assert list_third_party_packages_instance.result.level == actions.STATUS_CODE["SUCCESS"]
+    assert len(pkghandler.format_pkg_info.call_args[0][0]) == 3
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR reverts the addition of an overridable result for the third party package check in handle_packages.py. The third party package check now only reports a warning if there are third party packages on the system. 

We've decided that this overridable would cause a bad user experience because the majority of users are expected to have third party packages installed (e.g. from EPEL) so almost everybody would need to use the environment variable to override the inhibitor. But having third party packages installed causes no issue for the conversion process. We just need to tell the user that the third party rpms won't be converted and with that Red Hat won't provide support for them. A warning in the pre-conversion analysis report is sufficient for that.

Jira Issues: [RHELC-1089](https://issues.redhat.com/browse/RHELC-1089)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
