### PR TITLE
[RHELC-1252] Fix sub-man-rhsm-certs installation on 8.5/8.8

### DIFF
--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -833,7 +833,7 @@ def _relevant_subscription_manager_pkgs():
             "python3-syspurpose",
             "python3-cloud-what",
             "json-c.x86_64",  # there's also an i686 version we don't need unless the json-c.i686 is already installed
-            "subscription-manager-rhsm-certificates.noarch",
+            "subscription-manager-rhsm-certificates",
         ]
 
     elif system_info.version.major >= 9:
@@ -841,7 +841,7 @@ def _relevant_subscription_manager_pkgs():
             "libdnf-plugin-subscription-manager",
             "python3-subscription-manager-rhsm",
             "python3-cloud-what",
-            "subscription-manager-rhsm-certificates.noarch",
+            "subscription-manager-rhsm-certificates",
         ]
 
     if system_info.is_rpm_installed("json-c.i686"):

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -224,7 +224,7 @@ class TestNeededSubscriptionManagerPkgs:
                 frozenset(
                     (
                         "subscription-manager",
-                        "subscription-manager-rhsm-certificates.noarch",
+                        "subscription-manager-rhsm-certificates",
                         "python3-subscription-manager-rhsm",
                         "dnf-plugin-subscription-manager",
                         "python3-syspurpose",
@@ -239,7 +239,7 @@ class TestNeededSubscriptionManagerPkgs:
                 frozenset(
                     (
                         "subscription-manager",
-                        "subscription-manager-rhsm-certificates.noarch",
+                        "subscription-manager-rhsm-certificates",
                         "python3-subscription-manager-rhsm",
                         "dnf-plugin-subscription-manager",
                         "python3-syspurpose",
@@ -255,7 +255,7 @@ class TestNeededSubscriptionManagerPkgs:
                 frozenset(
                     (
                         "subscription-manager",
-                        "subscription-manager-rhsm-certificates.noarch",
+                        "subscription-manager-rhsm-certificates",
                         "python3-subscription-manager-rhsm",
                         "python3-cloud-what",
                         "libdnf-plugin-subscription-manager",


### PR DESCRIPTION
The https://github.com/oamg/convert2rhel/pull/991 was dealing with a convert2rhel failure stemming from two different architectures of the subscription-manager-rhsm-certificates package being available in UBI repos. That fix however caused convert2rhel failures on older system minor versions where only x86_64 arch was available.

In the meantime Pino Toscano asked to have the UBI repos fixed in a way that there is now just one architecture of the package. With that we don't need to hardcode a specific arch in convert2rhel.

Jira Issues: [RHELC-1252](https://issues.redhat.com/browse/RHELC-1252)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
