### PR TITLE
[RHELC-1270] Update package handling check to properly report removed packages

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/handle_packages.py
+++ b/convert2rhel/actions/pre_ponr_changes/handle_packages.py
@@ -102,6 +102,9 @@ class RemoveExcludedPackages(actions.Action):
 
         logger.task("Convert: Remove excluded packages")
         logger.info("Searching for the following excluded packages:\n")
+
+        pkgs_removed = []
+
         try:
             pkgs_to_remove = sorted(pkghandler.get_packages_to_remove(system_info.excluded_pkgs))
             # this call can return None, which is not ideal to use with sorted.
@@ -134,7 +137,7 @@ class RemoveExcludedPackages(actions.Action):
                 description="Excluded packages which could not be removed",
                 diagnosis=message,
             )
-        else:
+        if pkgs_removed:
             message = "The following packages were removed: %s" % ", ".join(pkgs_removed)
             logger.info(message)
             self.add_message(
@@ -175,6 +178,9 @@ class RemoveRepositoryFilesPackages(actions.Action):
 
         logger.task("Convert: Remove packages containing .repo files")
         logger.info("Searching for packages containing .repo files or affecting variables in the .repo files:\n")
+
+        pkgs_removed = []
+
         try:
             pkgs_to_remove = sorted(pkghandler.get_packages_to_remove(system_info.repofile_pkgs))
             # this call can return None, which is not ideal to use with sorted.
@@ -207,13 +213,13 @@ class RemoveRepositoryFilesPackages(actions.Action):
                 description="Repository file packages which could not be removed",
                 diagnosis=message,
             )
-        else:
+        if pkgs_removed:
             message = "The following packages were removed: %s" % ", ".join(pkgs_removed)
             logger.info(message)
             self.add_message(
                 level="INFO",
                 id="REPOSITORY_FILE_PACKAGES_REMOVED",
                 title="Repository file packages removed",
-                description="Repository file packages that were removed",
+                description="Repository file packages that have been removed",
                 diagnosis=message,
             )

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
@@ -179,6 +179,14 @@ def test_remove_excluded_packages_not_removed(pretend_os, remove_excluded_packag
                 diagnosis="The following packages were not removed: gpg-pubkey-1.0.0-1.x86_64, pkg1-None-None.None, pkg2-None-None.None",
                 remediation=None,
             ),
+            actions.ActionMessage(
+                level="INFO",
+                id="EXCLUDED_PACKAGES_REMOVED",
+                title="Excluded packages removed",
+                description="Excluded packages that have been removed",
+                diagnosis="The following packages were removed: kernel-core",
+                remediation=None,
+            ),
         )
     )
     monkeypatch.setattr(system_info, "excluded_pkgs", ["installed_pkg", "not_installed_pkg"])
@@ -233,7 +241,7 @@ def test_remove_repository_files_packages_all_removed(remove_repository_files_pa
                 level="INFO",
                 id="REPOSITORY_FILE_PACKAGES_REMOVED",
                 title="Repository file packages removed",
-                description="Repository file packages that were removed",
+                description="Repository file packages that have been removed",
                 diagnosis="The following packages were removed: centos-logos-70.0.6-3.el7.centos.noarch",
                 remediation=None,
             ),
@@ -268,6 +276,14 @@ def test_remove_repository_files_packages_not_removed(
                 title="Repository file packages not removed",
                 description="Repository file packages which could not be removed",
                 diagnosis="The following packages were not removed: gpg-pubkey-1.0.0-1.x86_64, pkg1-None-None.None, pkg2-None-None.None",
+                remediation=None,
+            ),
+            actions.ActionMessage(
+                level="INFO",
+                id="REPOSITORY_FILE_PACKAGES_REMOVED",
+                title="Repository file packages removed",
+                description="Repository file packages that have been removed",
+                diagnosis="The following packages were removed: kernel-core",
                 remediation=None,
             ),
         )


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
With the current setup of the conditionals in handle_packages, there are cases where a message explaining that packages were removed will be made regardless if there are any packages removed or not. This PR changes the conditionals to only display the packages removed message when there are packages contained inside the pkgs_removed variable. 

Jira Issues: [RHELC-1270](https://issues.redhat.com/browse/RHELC-1270)

![image](https://github.com/oamg/convert2rhel/assets/104600742/4efb8c3d-749b-4b14-b32f-42146d99d608)


Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
