### PR TITLE
Fix installation of local build

### DIFF
--- a/scripts/extract_version_from_rpm_spec.py
+++ b/scripts/extract_version_from_rpm_spec.py
@@ -29,8 +29,8 @@ def get_convert2rhel_version(spec_path: str) -> None:
                         (
                             # Any word could be here
                             (?:\w+)|
-                            # Or int or float i.e. 21 or 0.21
-                            (?:\d+[.]*\d*)
+                            # Or int or float i.e. 21 or 0.21 or 1.5.0
+                            (?:\d+[.]*\d*[.]*\d*)
                         )
                         # some special internal rpm spec var (skipping it)
                         (?:%{.+)*$

--- a/tests/ansible_collections/roles/packaging/tasks/install_rpm_from_local_build.yml
+++ b/tests/ansible_collections/roles/packaging/tasks/install_rpm_from_local_build.yml
@@ -13,11 +13,11 @@
     chdir: ../..
   when: ansible_facts['virtualization_type'] == "docker"
 
-- name: Copying rpms to kvm remote
+- name: Copying rpms to remote
   copy:
     dest: ".rpms"
     src: ../../.rpms/
-  when: ansible_facts['virtualization_type'] == "kvm"
+  when: ansible_facts['virtualization_type'] != "docker"
 
 - name: Install el8 convert2rhel package
   yum:

--- a/tests/ansible_collections/roles/packaging/tasks/main.yml
+++ b/tests/ansible_collections/roles/packaging/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - include_tasks: build_rpm.yml
-  when: build_rpm == true
+  when: build_rpm == "build"
 - include_tasks: install_rpm_from_local_build.yml
   when: (rpm_provider == "local") and
-        (build_rpm == true)
+        (build_rpm == "build")
 - include_tasks: install_rpm_from_url.yml
   when: (rpm_provider == "url")

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -23,3 +23,41 @@ integration test in any other language, eg. in `Bash`.
 Finally, you can find out all the integration tests for Convert2RHEL in the
 [convert2rhel/tests](https://github.com/oamg/convert2rhel/tree/main/tests)
 folder.
+
+## Run integration test
+
+### Pull Request
+
+The easies way to run integration test is by opening a Pull Request. Packit
+will then run it by using a Testing Farm.
+
+### tmt
+
+`tmt` offers multiple ways how to run an integration test. Provided options
+defines what OS is provisioned and where.
+
+E.g. to provision a CentOS 7 virtual machine locally, we need:
+
+- setup `context`:  `--context distro=centos-7`
+- use `virtual` provider: `--how virtual`
+- provide the cloud image for the os: e.g., `--image https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2`
+
+It is possible to issue a rebuild of rpm package and using it in the test by
+defining `ANSIBLE_BUILD_RPM=build` and `ANSIBLE_RPM_PROVIDER=local` variables
+to be provided as env vars to the executed tasks by `tmt`.
+
+Example:
+
+```
+tmt \
+       --context distro=centos-7 \
+       run \
+          -vvv --all \
+          -e ANSIBLE_BUILD_RPM=build \
+          -e ANSIBLE_RPM_PROVIDER=local \
+       provision \
+          --how virtual  \
+          --image https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2 \
+       plan \
+         --name $TEST_PLAN_NAME
+```


### PR DESCRIPTION
The integration tests looks to have "forgotten/unused" feature to build convert2rhel at the beginning of test and install it instead of using COPR build. This is useful when developing a test along with feature/code change without a need to open a PR to have a build produced by Packit - it's faster iteration.

It is used when the following environmental args are used in tmt run:
- `ANSIBLE_BUILD_RPM=build`
- `ANSIBLE_RPM_PROVIDER=local`

It was broken in following ways:
- the previous usage was `ANSIBLE_BUILD_RPM=true` the code expected the `true` value as boolean, resp. there was a mismatch of types and the condition was not evaluated as expected. This patch is changing it to expect a "build" string to avoid this problem, i.e. to not use "truthy" values.
- `scripts/extract_version_from_rpm_spec.py` script which is used to figure out what is the version-release part of rpm name did not support a version with 3 parts, e.g. the current `1.5.0` and thus it did not return the `name` part. This patch adds support for additional "." + "number".
- the Ansible play to copy built rpms to provisioned host supported only "docker" and "virtual" providers of tmt. The "virtual" part was generalized into "non-docker" to support other types and assuming that they have SSH support.

With this, the integration tests can be executed e.g. the following way:

```
$ tmt \
   --context distro=centos-7 \
   run \
      -vvv --all \
      -e ANSIBLE_BUILD_RPM=build \
      -e ANSIBLE_RPM_PROVIDER=local \
   provision \
      --how virtual  \
      --image https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2 \
   plan \
     --name $TEST_PLAN_NAME
```

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: no ticket, though was done in context of [RHELC-1226](https://issues.redhat.com/browse/RHELC-1226)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
