### PR TITLE
[RHELC-1226] Add --payg option

### DIFF
--- a/convert2rhel/actions/system_checks/payg.py
+++ b/convert2rhel/actions/system_checks/payg.py
@@ -1,0 +1,44 @@
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import logging
+
+from convert2rhel import actions
+from convert2rhel.systeminfo import system_info
+from convert2rhel.toolopts import tool_opts
+
+
+logger = logging.getLogger(__name__)
+
+
+class PaygSystemCheck(actions.Action):
+    id = "PAYG_SYSTEM_CHECK"
+
+    def run(self):
+        """Warn the user if their system is not supported by --payg option."""
+        super(PaygSystemCheck, self).run()
+
+        if tool_opts.payg and system_info.version.major != 7:
+            self.add_message(
+                level="WARNING",
+                id="PAYG_COMMAND_LINE_OPTION_UNSUPPORTED",
+                title="The --payg option is unsupported on this system version",
+                description="The --payg command line option is supported only on RHEL 7.",
+                remediation="Run convert2rhel without --payg option.",
+            )
+
+        return

--- a/convert2rhel/hostmetering.py
+++ b/convert2rhel/hostmetering.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Integrates host-metering with RHEL.
+https://github.com/RedHatInsights/host-metering/
+"""
+
+__metaclass__ = type
+
+import logging
+
+from convert2rhel.pkghandler import call_yum_cmd
+from convert2rhel.toolopts import tool_opts
+from convert2rhel.utils import run_subprocess
+
+
+logger = logging.getLogger(__name__)
+
+
+def configure_host_metering():
+    """
+    Install, enable and start host-metering on the system.
+
+    Returns:
+        bool: True if host-metering is configured successfully, False otherwise.
+    """
+    if not tool_opts.payg:
+        logger.info("Skipping host-metering configuration.")
+        return False
+
+    logger.info("Installing host-metering rpms.")
+    output, ret_install = call_yum_cmd("install", ["host-metering"])
+    logger.debug("Output of yum call: %s" % output)
+    if ret_install:
+        logger.warning("Failed to install host-metering rpms.")
+        return False
+
+    logger.info("Enabling host-metering service.")
+    output, ret_enable = run_subprocess(["systemctl", "enable", "host-metering.service"])
+    logger.debug("Output of systemctl call: %s" % output)
+    if ret_enable:
+        logger.warning("Failed to enable host-metering service.")
+
+    logger.info("Starting host-metering service.")
+    output, ret_start = run_subprocess(["systemctl", "start", "host-metering.service"])
+    logger.debug("Output of systemctl call: %s" % output)
+    if ret_start:
+        logger.warning("Failed to start host-metering service.")
+
+    return not (ret_install or ret_enable or ret_start)

--- a/convert2rhel/hostmetering.py
+++ b/convert2rhel/hostmetering.py
@@ -44,7 +44,8 @@ def configure_host_metering():
         return False
 
     logger.info("Installing host-metering rpms.")
-    output, ret_install = call_yum_cmd("install", ["host-metering"])
+    copr_repo = "copr:copr.fedorainfracloud.org:pvoborni:host-metering"
+    output, ret_install = call_yum_cmd("install", ["host-metering"], enable_repos=[copr_repo])
     logger.debug("Output of yum call: %s" % output)
     if ret_install:
         logger.warning("Failed to install host-metering rpms.")

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -21,7 +21,7 @@ import logging
 import os
 import sys
 
-from convert2rhel import actions, applock, backup, breadcrumbs, checks, exceptions, grub
+from convert2rhel import actions, applock, backup, breadcrumbs, checks, exceptions, grub, hostmetering
 from convert2rhel import logger as logger_module
 from convert2rhel import pkghandler, pkgmanager, redhatrelease, repo, subscription, systeminfo, toolopts, utils
 from convert2rhel.actions import level_for_raw_action_data, report
@@ -283,6 +283,9 @@ def post_ponr_changes():
 
     loggerinst.task("Final: Check kernel boot files")
     checks.check_kernel_boot_files()
+
+    loggerinst.task("Final: Configure host-metering")
+    hostmetering.configure_host_metering()
 
     breadcrumbs.breadcrumbs.finish_collection(success=True)
 

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -87,6 +87,7 @@ class ToolOpts:
         self.arch = None
         self.no_rpm_va = False
         self.eus = False
+        self.payg = False
         self.activity = None
 
     def set_opts(self, supported_opts):
@@ -125,10 +126,10 @@ class CLI:
             "\n"
             "  convert2rhel [--version] [-h]\n"
             "  convert2rhel {subcommand} [-u username] [-p password | -c conf_file_path] [--pool pool_id | -a] [--disablerepo repoid]"
-            " [--enablerepo repoid] [--serverurl url] [--no-rpm-va] [--eus] [--debug] [--restart] [-y]\n"
+            " [--enablerepo repoid] [--serverurl url] [--no-rpm-va] [--eus] [--payg] [--debug] [--restart] [-y]\n"
             "  convert2rhel {subcommand} [--no-rhsm] [--disablerepo repoid] [--enablerepo repoid] [--no-rpm-va] [--eus] [--debug] [--restart] [-y]\n"
             "  convert2rhel {subcommand} [-k activation_key | -c conf_file_path] [-o organization] [--pool pool_id | -a] [--disablerepo repoid] [--enablerepo"
-            " repoid] [--serverurl url] [--no-rpm-va] [--eus] [--debug] [--restart] [-y]\n"
+            " repoid] [--serverurl url] [--no-rpm-va] [--eus] [--payg] [--debug] [--restart] [-y]\n"
         ).format(subcommand=subcommand_to_print)
 
         if subcommand_not_used_on_cli:
@@ -197,6 +198,11 @@ class CLI:
             " This option is meant for 8.8+ systems.",
         )
         self._shared_options_parser.add_argument(
+            "--payg",
+            action="store_true",
+            help="Configure host-metering for Pay-As-You-Go billing. This option is meant for 7.9 systems.",
+        )
+        self._shared_options_parser.add_argument(
             "--enablerepo",
             metavar="repoidglob",
             action="append",
@@ -226,7 +232,6 @@ class CLI:
             help="Answer yes to all yes/no questions the tool asks.",
             action="store_true",
         )
-
         self._add_subscription_manager_options()
         self._add_alternative_installation_options()
         self._register_commands()
@@ -487,6 +492,7 @@ class CLI:
             )
 
         tool_opts.autoaccept = parsed_opts.y
+        tool_opts.payg = parsed_opts.payg
         tool_opts.auto_attach = parsed_opts.auto_attach
 
         # conversion only options

--- a/convert2rhel/unit_tests/actions/system_checks/payg_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/payg_test.py
@@ -1,0 +1,68 @@
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import pytest
+
+from convert2rhel import actions, toolopts
+from convert2rhel.actions.system_checks import payg
+from convert2rhel.systeminfo import Version, system_info
+
+
+@pytest.fixture
+def payg_action():
+    return payg.PaygSystemCheck()
+
+
+class TestPayg:
+    @pytest.mark.parametrize(
+        ("payg_set", "version_string", "message_reported"),
+        (
+            (False, Version(7, 9), False),
+            (False, Version(8, 6), False),
+            (False, Version(8, 8), False),
+            (False, Version(9, 2), False),
+            (False, Version(9, 3), False),
+            (True, Version(7, 9), False),
+            (True, Version(8, 6), True),
+            (True, Version(8, 8), True),
+            (True, Version(9, 2), True),
+            (True, Version(9, 3), True),
+        ),
+    )
+    def test_eus_warning_message(self, payg_action, monkeypatch, payg_set, version_string, message_reported):
+
+        monkeypatch.setattr(toolopts.tool_opts, "payg", payg_set)
+        monkeypatch.setattr(system_info, "version", version_string)
+
+        payg_action.run()
+        expected = set(
+            (
+                actions.ActionMessage(
+                    level="WARNING",
+                    id="PAYG_COMMAND_LINE_OPTION_UNSUPPORTED",
+                    title="The --payg option is unsupported on this system version",
+                    description="The --payg command line option is supported only on RHEL 7.",
+                    remediation="Run convert2rhel without --payg option.",
+                ),
+            )
+        )
+
+        if message_reported:
+            assert expected.issuperset(payg_action.messages)
+            assert expected.issubset(payg_action.messages)
+        else:
+            assert payg_action.messages == []

--- a/convert2rhel/unit_tests/hostmetering_test.py
+++ b/convert2rhel/unit_tests/hostmetering_test.py
@@ -36,7 +36,10 @@ def test_payg(monkeypatch):
     if not ret:
         pytest.fail("Failed to configure host-metering.")
 
-    run_mock.assert_any_call(["yum", "install", "-y", "host-metering"], print_output=True)
+    copr_repo = "copr:copr.fedorainfracloud.org:pvoborni:host-metering"
+    run_mock.assert_any_call(
+        ["yum", "install", "-y", "--enablerepo=%s" % copr_repo, "host-metering"], print_output=True
+    )
     run_mock.assert_any_call(["systemctl", "enable", "host-metering.service"])
     run_mock.assert_any_call(["systemctl", "start", "host-metering.service"])
 

--- a/convert2rhel/unit_tests/hostmetering_test.py
+++ b/convert2rhel/unit_tests/hostmetering_test.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import pytest
+
+from convert2rhel import hostmetering, toolopts, utils
+from convert2rhel.systeminfo import Version, system_info
+from convert2rhel.unit_tests import RunSubprocessMocked
+
+
+def test_payg(monkeypatch):
+    monkeypatch.setattr(system_info, "version", Version(7, 9))
+    monkeypatch.setattr(system_info, "releasever", "")  # reset as other test set it
+    monkeypatch.setattr(toolopts.tool_opts, "payg", True)
+    run_mock = RunSubprocessMocked(return_value=("mock", 0))
+    monkeypatch.setattr(hostmetering, "run_subprocess", run_mock)
+    monkeypatch.setattr(utils, "run_subprocess", run_mock)
+
+    ret = hostmetering.configure_host_metering()
+    if not ret:
+        pytest.fail("Failed to configure host-metering.")
+
+    run_mock.assert_any_call(["yum", "install", "-y", "host-metering"], print_output=True)
+    run_mock.assert_any_call(["systemctl", "enable", "host-metering.service"])
+    run_mock.assert_any_call(["systemctl", "start", "host-metering.service"])
+
+
+def test_no_payg(monkeypatch):
+    monkeypatch.setattr(system_info, "version", Version(7, 9))
+    monkeypatch.setattr(toolopts.tool_opts, "payg", False)
+    run_mock = RunSubprocessMocked(return_value=("mock", 0))
+    monkeypatch.setattr(hostmetering, "run_subprocess", run_mock)
+    monkeypatch.setattr(utils, "run_subprocess", run_mock)
+
+    ret = hostmetering.configure_host_metering()
+    if ret:
+        pytest.fail("Configured host-metering when it shouldn't.")
+
+    utils.run_subprocess.assert_not_called()

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -140,6 +140,16 @@ class TestTooloptsParseFromCLI:
         )
         assert message in caplog.text
 
+    def test_payg(self, monkeypatch, global_tool_opts):
+        monkeypatch.setattr(sys, "argv", mock_cli_arguments(["--payg"]))
+        convert2rhel.toolopts.CLI()
+        assert global_tool_opts.payg is True
+
+    def test_no_payg(self, monkeypatch, global_tool_opts):
+        monkeypatch.setattr(sys, "argv", mock_cli_arguments([]))
+        convert2rhel.toolopts.CLI()
+        assert global_tool_opts.payg is False
+
 
 def test_keep_rhsm(monkeypatch, caplog):
     monkeypatch.setattr(sys, "argv", mock_cli_arguments(["--keep-rhsm"]))

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -343,6 +343,9 @@ description+: |
             filter:
             - tag:checks-after-conversion | tag:payg
         prepare+:
+            - name: add host-metering COPR repo
+              how: ansible
+              playbook: tests/integration/tier1/destructive/payg/ansible/host-metering-copr.yml
             - name: test payg
               how: shell
               script: pytest -svv tests/integration/*/destructive/payg/run_conversion.py

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -333,3 +333,19 @@ description+: |
             - name: reboot after conversion
               how: ansible
               playbook: tests/ansible_collections/roles/reboot/main.yml
+
+    /payg:
+        enabled: false
+        adjust+:
+            - enabled: true
+              when: distro == centos-7
+        discover+:
+            filter:
+            - tag:checks-after-conversion | tag:payg
+        prepare+:
+            - name: test payg
+              how: shell
+              script: pytest -svv tests/integration/*/destructive/payg/run_conversion.py
+            - name: reboot after conversion
+              how: ansible
+              playbook: tests/ansible_collections/roles/reboot/main.yml

--- a/tests/integration/tier0/non-destructive/payg/main.fmf
+++ b/tests/integration/tier0/non-destructive/payg/main.fmf
@@ -1,0 +1,17 @@
+summary: |
+    Verify --payg warnings
+description: |
+    Verify that --payg produces warning in unsupported scenarios.
+
+/no_payg:
+    enabled: false
+    adjust+:
+        enabled: true
+        when: distro == centos-8-latest
+        because: PAYG is not support on other systems than RHEL 7.
+    tag+:
+        - no-payg
+    summary+: |
+        --payg should produce warning
+    test: |
+        pytest -svv -m test_payg_warning

--- a/tests/integration/tier0/non-destructive/payg/test_payg_warning.py
+++ b/tests/integration/tier0/non-destructive/payg/test_payg_warning.py
@@ -1,0 +1,34 @@
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import pytest
+
+from envparse import env
+
+
+@pytest.mark.test_payg_warning
+def test_payg_warning(convert2rhel):
+    """
+    Verify that --enablerepo is not skipped when subscription-manager is disabled.
+    Verify that the passed repositories are accessible.
+    """
+
+    with convert2rhel(
+        "analyze -y --no-rpm-va --serverurl {} -u {} -p {} --payg --debug".format(
+            env.str("RHSM_SERVER_URL"), env.str("RHSM_USERNAME"), env.str("RHSM_PASSWORD")
+        )
+    ) as c2r:
+        c2r.expect("The --payg command line option is supported only on RHEL 7")
+        c2r.sendcontrol("c")

--- a/tests/integration/tier1/destructive/payg/ansible/host-metering-copr.yml
+++ b/tests/integration/tier1/destructive/payg/ansible/host-metering-copr.yml
@@ -1,0 +1,10 @@
+---
+- hosts: all
+  tasks:
+    - name: Add host-metering repo
+      yum_repository:
+        name: copr:copr.fedorainfracloud.org:pvoborni:host-metering
+        description: host-metering COPR repo
+        baseurl: https://download.copr.fedorainfracloud.org/results/pvoborni/host-metering/epel-7-$basearch/
+        enabled: no
+        gpgcheck: no

--- a/tests/integration/tier1/destructive/payg/main.fmf
+++ b/tests/integration/tier1/destructive/payg/main.fmf
@@ -1,0 +1,15 @@
+summary+: |
+    Check expected state after --payg
+
+description+: |
+    Test convert2rhel with --payg option.
+    Verify that:
+    - host-metering service is enabled and started
+
+link:
+    - https://issues.redhat.com/browse/RHELC-1226
+
+tag+:
+    - payg
+
+test: pytest -svv -m test_payg

--- a/tests/integration/tier1/destructive/payg/run_conversion.py
+++ b/tests/integration/tier1/destructive/payg/run_conversion.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+from envparse import env
+
+
+def test_run_conversion_payg(shell, convert2rhel):
+    """
+    Verify that --payg installs, enables and starts host-metering service.
+        1/ Run conversion with --payg verifying the conversion is not inhibited and completes successfully
+        2/ Verify that host-metering is enabled and started
+    """
+    with convert2rhel(
+        "-y --no-rpm-va --serverurl {} --username {} --password {} --payg --debug".format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+        )
+    ) as c2r:
+        c2r.expect(
+            [
+                "Installing host-metering rpms.",
+                "Enabling host-metering service.",
+                "Starting host-metering service.",
+            ]
+        )
+        assert c2r.expect("Conversion successful") == 0
+
+    assert c2r.exitstatus == 0
+
+    # There should not be any problems in coversion
+    assert shell("grep -i 'traceback' /var/log/convert2rhel/convert2rhel.log").returncode == 1

--- a/tests/integration/tier1/destructive/payg/test_payg.py
+++ b/tests/integration/tier1/destructive/payg/test_payg.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import pytest
+
+
+@pytest.mark.test_payg
+def test_payg(shell):
+    """
+    Verify that host-metering is enabled and started after running with  --payg
+    """
+    # Verify that host-metering is enabled and started
+    assert shell("systemctl is-enabled host-metering.service").returncode == 0
+    assert shell("systemctl is-active host-metering.service").returncode == 0


### PR DESCRIPTION
    To configure host-metering service on RHEL 7 systems after/at the end of   conversion. 

    Thi PR contains:
    - add of the --payg option + unit tests
    - add of integration tests for --payg option
    - add of check to warn when --payg is provided on system other than RHEL 7 
      as it is not suppprted there.
    - integration test for the check
    - temporary patch which should be removed before merging to master

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1226](https://issues.redhat.com/browse/RHELC-1226)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
