### PR TITLE
Bump to version 1.6.0

### DIFF
--- a/convert2rhel/__init__.py
+++ b/convert2rhel/__init__.py
@@ -1,2 +1,2 @@
 __metaclass__ = type
-__version__ = "1.5.0"
+__version__ = "1.6.0"

--- a/packaging/convert2rhel.spec
+++ b/packaging/convert2rhel.spec
@@ -9,7 +9,7 @@
 %endif
 
 Name:           convert2rhel
-Version:        1.5.0
+Version:        1.6.0
 Release:        1%{?dist}
 Summary:        Automates the conversion of RHEL derivative distributions to RHEL
 
@@ -122,6 +122,20 @@ install -m 0600 config/convert2rhel.ini %{buildroot}%{_sysconfdir}/convert2rhel.
 %attr(0644,root,root) %{_mandir}/man8/%{name}.8*
 
 %changelog
+* Fri Dec 08 2023 Preston Watson <prwatson@redhat.com> 1.6.0
+- Change Action results so that no information is given in SUCCESS results
+- Add OVERRIDABLE result to the third party package analysis
+- Add OVERRIDABLE result to package up to date analysis
+- Change the sorting order for the analysis report
+- Revert OVERRIDABLE result in package handling check
+- Update package handling check to properly report removed packages
+- Identify highest status in json report
+- Fix backtrace in kernel signature verification
+- Try to rollback all changes even if one of them fails
+- Fix error message when repoquery fails to retrieve information on kmod packages
+- Fix an exception when listing third-party packages with Epoch 2
+- Recover file changes during a rollback
+
 * Mon Oct 30 2023 Michal Bocek <mbocek@redhat.com> 1.5.0
 - Display system packages that are not up to date in alphabetical order
 - Change the default message of an empty report message field


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Enhancements 🎉
* [RHELC-1098] Change Action results so that no information is given in SUCCESS results by @pr-watson in https://github.com/oamg/convert2rhel/pull/900
* [RHELC-1089] Add OVERRIDABLE result to package up to date analysis by @pr-watson in https://github.com/oamg/convert2rhel/pull/978
* [RHELC-1096] Change the sorting order for the report by @bookwar in https://github.com/oamg/convert2rhel/pull/993
* [RHELC-1270] Update package handling check to properly report removed packages by @pr-watson in https://github.com/oamg/convert2rhel/pull/999
* [RHELC-1193] Identify highest status in json report by @pr-watson in https://github.com/oamg/convert2rhel/pull/983
### Bug Fixes 🐛
* [RHELC-1117] Fix backtrace in kernel signature verification by @r0x0d in https://github.com/oamg/convert2rhel/pull/952
* [RHELC-1154] Try to rollback all changes even if one of them fails by @abadger in https://github.com/oamg/convert2rhel/pull/912
* [RHELC-895] Fix error message when repoquery fails to retrieve information on kmod packages by @abadger in https://github.com/oamg/convert2rhel/pull/818
* [RHELC-1225] Fix an exception when listing third-party packages with Epoch 2 by @jochapma in https://github.com/oamg/convert2rhel/pull/984
* [RHELC-855] Recover file changes during a rollback by @hosekadam in https://github.com/oamg/convert2rhel/pull/875
* [RHELC-1272] Fix a rollback failure with yum-plugin-local installed by @bocekm in https://github.com/oamg/convert2rhel/pull/1001
### Test Coverage Enhancements 🔧
* [RHELC-1267] Add Alma, Rocky 8.9 to pipeline, 8.8 as EUS by @danmyway in https://github.com/oamg/convert2rhel/pull/997


**Full Changelog**: https://github.com/oamg/convert2rhel/compare/v1.5.0...v1.6.0