### PR TITLE
[RHELC-1037] Add manpage generation to all releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@v4 # v4
 
-      - name: Trigger Manpage Generation
-        uses: ./.github/workflows
+        ### start manpage generation
+      - name: Setup Python
+        uses: actions/setup-python@v4
         with:
-          workflow: generate_manpage.yml
+          python-version: 3.10.13
+
+      - name: Install dependencies
+        run: |
+          pip install argparse-manpage six pexpect
+
+      - name: Install python3-rpm and python3-dnf package with apt-get
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-rpm python3-dnf
+
+      - name: Generate Manpages
+        run: |
+          chmod +x scripts/manpage_generation.sh
+          bash scripts/manpage_generation.sh
+        ### end manpage generation
 
       - name: Build RPM package for EL7
         id: rpm_build_el7
@@ -42,6 +58,27 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
+        ### start manpage generation
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10.13
+
+      - name: Install dependencies
+        run: |
+          pip install argparse-manpage six pexpect
+
+      - name: Install python3-rpm and python3-dnf package with apt-get
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-rpm python3-dnf
+
+      - name: Generate Manpages
+        run: |
+          chmod +x scripts/manpage_generation.sh
+          bash scripts/manpage_generation.sh
+        ### end manpage generation
+
       - name: Build RPM package for EL8
         id: rpm_build_el8
         uses: oamg/rpmbuild@el8
@@ -66,6 +103,27 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+        ### start manpage generation
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10.13
+
+      - name: Install dependencies
+        run: |
+          pip install argparse-manpage six pexpect
+
+      - name: Install python3-rpm and python3-dnf package with apt-get
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-rpm python3-dnf
+
+      - name: Generate Manpages
+        run: |
+          chmod +x scripts/manpage_generation.sh
+          bash scripts/manpage_generation.sh
+        ### end manpage generation
 
       - name: Build RPM package for EL9
         id: rpm_build_el9

--- a/scripts/manpage_generation.sh
+++ b/scripts/manpage_generation.sh
@@ -3,12 +3,17 @@
 # Directory to store the generated manpages
 MANPAGE_DIR="man"
 
+echo Generating manpages
+
 VER=$(grep -oP '^Version:\s+\K\S+' packaging/convert2rhel.spec)
 
+echo Generating for version $VER
 # Generate a file with convert2rhel synopsis for argparse-manpage
-/usr/bin/python3.10 -c 'from convert2rhel import toolopts; print("[synopsis]\n."+toolopts.CLI.usage())' > man/synopsis
+/usr/bin/python -c 'from convert2rhel import toolopts; print("[synopsis]\n."+toolopts.CLI.usage())' > man/synopsis
 
-/usr/bin/python3.10 -m pip install argparse-manpage six pexpect
+/usr/bin/python -m pip install argparse-manpage six pexpect
 
 # Generate the manpage using argparse-manpage
-PYTHONPATH=. /usr/bin/python3.10 /home/runner/.local/bin/argparse-manpage --pyfile man/__init__.py --function get_parser --manual-title="General Commands Manual" --description="Automates the conversion of Red Hat Enterprise Linux derivative distributions to Red Hat Enterprise Linux." --project-name "convert2rhel $VER" --prog="convert2rhel" --include man/distribution --include man/synopsis > "$MANPAGE_DIR/convert2rhel.8"
+PYTHONPATH=. /usr/bin/python /home/runner/.local/bin/argparse-manpage --pyfile man/__init__.py --function get_parser --manual-title="General Commands Manual" --description="Automates the conversion of Red Hat Enterprise Linux derivative distributions to Red Hat Enterprise Linux." --project-name "convert2rhel $VER" --prog="convert2rhel" --include man/distribution --include man/synopsis > "$MANPAGE_DIR/convert2rhel.8"
+
+git status


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
Supersedes #876 by doing it a bit more botched so that it will work for subsequent releases at least

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1037](https://issues.redhat.com/browse/RHELC-1037)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
