### PR TITLE
[RHELC-1272] Fix parsing yumdownloader output with a carriage return

### DIFF
--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -57,6 +57,7 @@ YUMDOWNLOADER_OUTPUTS = (
     "%s         2.7 MB/s | 2.8 MB     00:01" % DOWNLOADED_RPM_FILENAME,
     "/var/lib/convert2rhel/%s already exists and appears to be complete" % DOWNLOADED_RPM_FILENAME,
     "rpmdb time: 0.000\nusing local copy of %s" % DOWNLOADED_RPM_NEVRA,
+    "rpmdb time: 0.000\nusing local copy of %s\r\n" % DOWNLOADED_RPM_NEVRA,
     "[SKIPPED] %s: Already downloaded" % DOWNLOADED_RPM_FILENAME,
 )
 

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -761,7 +761,7 @@ def report_on_a_download_error(output, pkg):
             loggerinst.warning(
                 "Couldn't download the %s package. This means we will not be able to do a"
                 " complete rollback and may put the system in a broken state.\n"
-                "'CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK=1' environment variable detected, continuing"
+                "'CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK' environment variable detected, continuing"
                 " conversion." % pkg
             )
     else:
@@ -787,8 +787,8 @@ def get_rpm_path_from_yumdownloader_output(cmd, output, dest):
         loggerinst.warning("The output of running yumdownloader is unexpectedly empty. Command:\n%s" % cmd)
         return None
 
-    rpm_name_match = re.search(r"\S*\.rpm", output)
-    pkg_nevra_match = re.search(r"using local copy of (?:\d+:)?(.*)$", output)
+    rpm_name_match = re.search(r"\S+\.rpm", output)
+    pkg_nevra_match = re.search(r"using local copy of (?:\d+:)?(\S+)", output)
 
     if rpm_name_match:
         path = os.path.join(dest, rpm_name_match.group(0))


### PR DESCRIPTION
The yumdownloader output seems to be printing a carriage return character on CentOS Linux 7 when the package to be downloaded is already downloaded. It prints:
`using local copy of centos-logos-70.0.6-3.el7.centos.noarch\r`

That lead convert2rhel to fail on the rollback:
```
Installing packages:
.rpm    /var/lib/convert2rhel/backup/centos-logos-70.0.6-3.el7.centos.noarch
```

Jira Issues: [RHELC-1272](https://issues.redhat.com/browse/RHELC-1272)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
