### PR TITLE
[RHELC-1200] Add OVERRIDABLE result to tainted kernel module check

### DIFF
--- a/convert2rhel/actions/system_checks/tainted_kmods.py
+++ b/convert2rhel/actions/system_checks/tainted_kmods.py
@@ -47,7 +47,7 @@ class TaintedKmods(actions.Action):
         module_names = "\n  ".join([mod.split(" ")[0] for mod in unsigned_modules.splitlines()])
         tainted_kmods_skip = os.environ.get("CONVERT2RHEL_TAINTED_KERNEL_MODULE_CHECK_SKIP", None)
         diagnosis = (
-            "Tainted kernel modules detected:\n{0}\n"
+            "Tainted kernel modules detected:\n  {0}\n"
             "Third-party components are not supported per our "
             "software support policy:\n{1}\n".format(module_names, LINK_KMODS_RH_POLICY)
         )
@@ -72,7 +72,7 @@ class TaintedKmods(actions.Action):
                     ),
                 )
                 return
-                
+
             self.add_message(
                 level="WARNING",
                 id="SKIP_TAINTED_KERNEL_MODULE_CHECK",

--- a/convert2rhel/actions/system_checks/tainted_kmods.py
+++ b/convert2rhel/actions/system_checks/tainted_kmods.py
@@ -47,9 +47,9 @@ class TaintedKmods(actions.Action):
         module_names = "\n  ".join([mod.split(" ")[0] for mod in unsigned_modules.splitlines()])
         tainted_kmods_skip = os.environ.get("CONVERT2RHEL_TAINTED_KERNEL_MODULE_CHECK_SKIP", None)
         diagnosis = (
-            "Tainted kernel modules detected:\n  {0}\n"
+            "Tainted kernel modules detected:\n{0}\n"
             "Third-party components are not supported per our "
-            "software support policy:\n {1}\n".format(module_names, LINK_KMODS_RH_POLICY)
+            "software support policy:\n{1}\n".format(module_names, LINK_KMODS_RH_POLICY)
         )
 
         if unsigned_modules:
@@ -72,6 +72,7 @@ class TaintedKmods(actions.Action):
                     ),
                 )
                 return
+                
             self.add_message(
                 level="WARNING",
                 id="SKIP_TAINTED_KERNEL_MODULE_CHECK",

--- a/convert2rhel/unit_tests/actions/system_checks/tainted_kmods_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/tainted_kmods_test.py
@@ -73,7 +73,7 @@ def test_check_tainted_kmods(monkeypatch, command_return, is_error, tainted_kmod
             diagnosis=(
                 "Tainted kernel modules detected:\n  system76_io\n  system76_acpi\nThird-party "
                 "components are not supported per our software support"
-                " policy:\n %s\n" % LINK_KMODS_RH_POLICY
+                " policy:\n%s\n" % LINK_KMODS_RH_POLICY
             ),
             remediations=(
                 "Prevent the modules from loading by following {0}"
@@ -129,7 +129,7 @@ def test_check_tainted_kmods_skip(monkeypatch, command_return, is_error, tainted
                     diagnosis=(
                         "Tainted kernel modules detected:\n  system76_io\n  system76_acpi\nThird-party "
                         "components are not supported per our software support"
-                        " policy:\n %s\n" % LINK_KMODS_RH_POLICY
+                        " policy:\n%s\n" % LINK_KMODS_RH_POLICY
                     ),
                     remediations=(
                         "Prevent the modules from loading by following {0}"
@@ -151,5 +151,7 @@ def test_check_tainted_kmods_skip(monkeypatch, command_return, is_error, tainted
                 ),
             )
         )
+        print(expected)
+        print(tainted_kmods_action.messages)
         assert expected.issuperset(tainted_kmods_action.messages)
         assert expected.issubset(tainted_kmods_action.messages)

--- a/convert2rhel/unit_tests/actions/system_checks/tainted_kmods_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/tainted_kmods_test.py
@@ -15,12 +15,18 @@
 
 __metaclass__ = type
 
+import os
 
 import pytest
 import six
 
-from convert2rhel import unit_tests
+from convert2rhel import actions, unit_tests
 from convert2rhel.actions.system_checks import tainted_kmods
+from convert2rhel.actions.system_checks.tainted_kmods import (
+    LINK_KMODS_RH_POLICY,
+    LINK_PREVENT_KMODS_FROM_LOADING,
+    LINK_TAINTED_KMOD_DOCS,
+)
 
 
 six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
@@ -60,15 +66,90 @@ def test_check_tainted_kmods(monkeypatch, command_return, is_error, tainted_kmod
     if is_error:
         unit_tests.assert_actions_result(
             tainted_kmods_action,
-            level="ERROR",
+            level="OVERRIDABLE",
             id="TAINTED_KMODS_DETECTED",
             title="Tainted kernel modules detected",
             description="Please refer to the diagnosis for further information",
-            diagnosis="Tainted kernel modules detected:\n  system76_io\n",
+            diagnosis=(
+                "Tainted kernel modules detected:\n  system76_io\n  system76_acpi\nThird-party "
+                "components are not supported per our software support"
+                " policy:\n %s\n" % LINK_KMODS_RH_POLICY
+            ),
             remediations=(
                 "Prevent the modules from loading by following {0}"
-                " and run convert2rhel again to continue with the conversion.".format(
-                    tainted_kmods.LINK_PREVENT_KMODS_FROM_LOADING
+                " and run convert2rhel again to continue with the conversion."
+                " Although it is not recommended, you can ignore this message by setting the environment variable"
+                " 'CONVERT2RHEL_TAINTED_KERNEL_MODULE_CHECK_SKIP' to 1. Overriding this check can be dangerous"
+                " so it is recommended that you do a system backup beforehand."
+                " For information on what a tainted kernel module is, please refer to this documentation {1}".format(
+                    LINK_PREVENT_KMODS_FROM_LOADING, LINK_TAINTED_KMOD_DOCS
                 )
             ),
         )
+
+
+@pytest.mark.parametrize(
+    ("command_return", "is_error"),
+    (
+        (("", 0), False),
+        (
+            (
+                (
+                    "system76_io 16384 0 - Live 0x0000000000000000 (OE)\n"
+                    "system76_acpi 16384 0 - Live 0x0000000000000000 (OE)"
+                ),
+                0,
+            ),
+            True,
+        ),
+    ),
+)
+def test_check_tainted_kmods_skip(monkeypatch, command_return, is_error, tainted_kmods_action):
+    run_subprocess_mock = mock.Mock(return_value=command_return)
+    monkeypatch.setattr(
+        tainted_kmods,
+        "run_subprocess",
+        value=run_subprocess_mock,
+    )
+    monkeypatch.setattr(
+        os,
+        "environ",
+        {"CONVERT2RHEL_TAINTED_KERNEL_MODULE_CHECK_SKIP": 1},
+    )
+    tainted_kmods_action.run()
+
+    if is_error:
+        expected = set(
+            (
+                actions.ActionMessage(
+                    level="WARNING",
+                    id="TAINTED_KMODS_DETECTED_MESSAGE",
+                    title="Tainted kernel modules detected",
+                    description="Please refer to the diagnosis for further information",
+                    diagnosis=(
+                        "Tainted kernel modules detected:\n  system76_io\n  system76_acpi\nThird-party "
+                        "components are not supported per our software support"
+                        " policy:\n %s\n" % LINK_KMODS_RH_POLICY
+                    ),
+                    remediations=(
+                        "Prevent the modules from loading by following {0}"
+                        " and run convert2rhel again to continue with the conversion."
+                        " For information on what a tainted kernel module is, please refer to this documentation {1}".format(
+                            LINK_PREVENT_KMODS_FROM_LOADING, LINK_TAINTED_KMOD_DOCS
+                        )
+                    ),
+                ),
+                actions.ActionMessage(
+                    level="WARNING",
+                    id="SKIP_TAINTED_KERNEL_MODULE_CHECK",
+                    title="Skip tainted kernel module check",
+                    description=(
+                        "Detected 'CONVERT2RHEL_TAINTED_KERNEL_MODULE_CHECK_SKIP' environment variable, we will skip "
+                        "the tainted kernel module check.\n"
+                        "Beware, this could leave your system in a broken state."
+                    ),
+                ),
+            )
+        )
+        assert expected.issuperset(tainted_kmods_action.messages)
+        assert expected.issubset(tainted_kmods_action.messages)


### PR DESCRIPTION
This PR adds an overridable result to the tainted kernel module check allowing users to override in the event of a tainted kernel module detected on the system. Additionally improves the message to the user to not alarm them along with some documentation explaining what a tainted kernel module is. 

Jira Issues: [RHELC-1200](https://issues.redhat.com/browse/RHELC-1200)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
