### PR TITLE
[RHELC-1293] Introduce pre-commit hook to register custom markers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,27 +1,12 @@
 minimum_pre_commit_version: "2.9.0"
-ci:
-    skip: [regenerate-rerun-plan]
 repos:
   - repo: local
     hooks:
-      - id: regenerate-rerun-plan
-        name: regenerate plans/rerun.fmf
-        entry: sh
-        # Concatenate contents of all the .fmf files in the tier0 directory, include directory names as headers/plan names
-        # Replace the tag mappings from tests to a call to the discovery method and filter based on the test tag
-        # Remove all test calls, we need to handle the calling differently in plans
-        # Remove all 'tier: 0' tags
-        # Remove trailing whitespaces
-        args:
-          - -c
-          - |
-            find tests/integration/tier0/ -name "*.fmf" -exec sh -c 'echo "/$(basename $(dirname {})| tr "-" "_"):"; sed -e "s/^/    /" {}' \; | awk '/^\// && NR>1{print ""; print ""}1'> plans/rerun.fmf
-            sed -i 'N; s/\(^[[:space:]]*\)tag+:\n\([[:space:]]*\)-[[:space:]]*\([^-[:space:]]*\)/\1discover+:\n\2filter: tag:\3/g; P; D' plans/rerun.fmf
-            sed -i '/^[[:space:]]*test: \|^[[:space:]]*pytest/d' plans/rerun.fmf
-            sed -i '/^[[:space:]]*tier: 0/d' plans/rerun.fmf
-            sed -i 's/\s\+$//' plans/rerun.fmf
-        language: system
-        stages: [ manual ]
+      - id: regenerate-pytest-ini
+        name: Register custom pytest markers in the pytest.ini
+        entry: "scripts/regenerate_pytest_ini.py"
+        language: python
+        types: [python]
   - repo: local
     hooks:
       - id: black

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,72 +1,95 @@
+# Generated automatically by the regenerate-pytest-ini pre-commit hook
+
 [pytest]
 testpaths = "convert2rhel/unit_tests"
 markers =
-    cert_filename
-    rhsm_returns
+    activation_key_conversion
+    basic_conversion
+    check_firewalld_errors
+    correct_distro
+    corrupted_initramfs_file
+    custom_repos_conversion
+    delete_temporary_folder
+    enabled_repositories
+    flag_system_as_converted
+    initramfs_and_vmlinuz_present
+    missing_kernel_boot_files
     popen_output
-    test_unsuccessful_satellite_registration
-    test_missing_system_release
+    rhel_kernel
+    rhsm_conversion
+    rhsm_non_eus_account_conversion
+    rhsm_returns
+    satellite_conversion
+    test_analyze_incomplete_rollback
+    test_analyze_no_rpm_va_option
+    test_available_connection
     test_backup_os_release_no_envar
     test_backup_os_release_with_envar
-    test_simultaneous_runs
-    test_root_privileges
-    test_manpage
-    test_smoke
-    test_log_file_exists
-    test_or_newer
-    test_version_older_no_envar
-    test_version_older_with_envar
+    test_check_data_collection
     test_clean_cache
-    test_log_rhsm_error
-    test_variant_message
-    test_data_collection_acknowledgement
-    test_disable_data_collection
-    test_custom_valid_repo_provided
-    test_custom_invalid_repo_provided
-    test_passing_password_to_submgr
-    test_passing_activation_key_to_submgr
-    test_empty_username_and_password
-    test_unsupported_kernel
-    test_modified_config
-    test_unknown_release
-    test_rhsm_cleanup
-    test_packages_untracked_graceful_rollback
-    test_missing_credentials_rollback
-    test_terminate_on_registration_start
-    test_terminate_on_registration_success
-    test_available_connection
-    test_unavailable_connection
-    test_custom_kernel
-    test_failed_repoquery
-    test_yum_excld_kernel
-    test_logfile_starts_with_command
-    test_package_download_error
-    test_transaction_validation_error
-    test_sub_man_rollback
+    test_config_cli_priority
     test_config_custom_path_custom_filename
     test_config_custom_path_standard_filename
-    test_config_cli_priority
     test_config_password_file_priority
-    test_config_standard_paths_priority_diff_methods
     test_config_standard_paths_priority
+    test_config_standard_paths_priority_diff_methods
+    test_convert_successful_report
+    test_custom_invalid_repo_provided
+    test_custom_kernel
     test_custom_module_loaded
     test_custom_module_not_loaded
-    test_force_loaded_kmod
-    test_tainted_kernel
-    test_unsupported_kmod_with_envar
-    test_latest_kernel_check_skip
-    test_failures_and_skips_in_report
-    test_successful_report
+    test_custom_valid_repo_provided
+    test_data_collection_acknowledgement
+    test_disable_data_collection
+    test_empty_username_and_password
+    test_eus_support
+    test_failed_repoquery
     test_failed_to_parse_package_info_empty_arch_not_present
-    test_packages_upgraded_after_conversion
-    test_analyze_incomplete_rollback
-    test_validation_packages_with_in_name_period
-    test_rhel_subscription_manager
-    test_pre_registered_conversion
-    test_pre_registered_wont_unregister
-    test_pre_registered_re_register
-    test_unregistered_no_credentials
-    test_firewalld_inhibitor
-    test_list_third_party_pkgs_error
-    test_analyze_no_rpm_va_option
+    test_failures_and_skips_in_report
     test_file_backup
+    test_firewalld_disabled
+    test_firewalld_inhibitor
+    test_force_loaded_kmod
+    test_latest_kernel_check_skip
+    test_list_third_party_pkgs_error
+    test_log_file_exists
+    test_log_rhsm_error
+    test_logfile_starts_with_command
+    test_manpage
+    test_missing_credentials_rollback
+    test_missing_system_release
+    test_modified_config
+    test_package_download_error
+    test_packages_untracked_graceful_rollback
+    test_packages_upgraded_after_conversion
+    test_passing_activation_key_to_submgr
+    test_passing_password_to_submgr
+    test_polluted_yumdownloader_output_by_yum_plugin_local
+    test_pre_registered_conversion
+    test_pre_registered_re_register
+    test_pre_registered_wont_unregister
+    test_rhel_subscription_manager
+    test_rhsm_cleanup
+    test_root_privileges
+    test_simultaneous_runs
+    test_smoke
+    test_sub_man_rollback
+    test_successful_report
+    test_tainted_kernel
+    test_terminate_on_registration_start
+    test_terminate_on_registration_success
+    test_transaction_validation_error
+    test_unavailable_connection
+    test_unknown_release
+    test_unregistered_no_credentials
+    test_unsuccessful_satellite_registration
+    test_unsupported_kernel
+    test_unsupported_kmod_with_envar
+    test_validation_packages_with_in_name_period
+    test_variant_message
+    test_version_latest_or_newer
+    test_version_older_no_envar
+    test_version_older_with_envar
+    test_yum_excld_kernel
+    verify_logging_is_not_duplicated
+    yum_check

--- a/scripts/regenerate_pytest_ini.py
+++ b/scripts/regenerate_pytest_ini.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+import os
+import re
+import sys
+
+
+def find_custom_markers(directories=("convert2rhel/unit_tests", "tests")):
+    """
+    Walk through the directories provided as a tuple in the function argument
+    and look for the custom pytest markers in each .py file.
+    Ignore the builtin markers by removing from the results.
+    """
+    markers = set()
+    # Regex to match the pytest markers
+    marker_pattern = re.compile(r"@pytest\.mark\.(?P<marker>\w+)\(?")
+
+    for directory in directories:
+        for root, dirs, files in os.walk(directory):
+            # Exclude hidden directories, e.g., .git and venv dirs. This doesn't really
+            # need to be here at this point, however might come in use if we decide to walk
+            # through each directory in the project not just the two currently specified.
+            dirs[:] = [d for d in dirs if not d[0] == "." and "venv" not in d]
+            for file in files:
+                if file.endswith(".py"):
+                    file_path = os.path.join(root, file)
+                    with open(file_path, "r", encoding="utf-8") as f:
+                        content = f.read()
+                        matches = marker_pattern.findall(content)
+                        markers.update(matches)
+
+    # Exclude built-in markers
+    ignored_builtin_markers = [
+        "filterwarnings",
+        "skip",
+        "skipif",
+        "xfail",
+        "parametrize",
+        "usefixtures",
+        "tryfirst",
+        "trylast",
+    ]
+    custom_markers = markers - set(ignored_builtin_markers)
+
+    return custom_markers
+
+
+def update_pytest_ini(custom_markers, ini_file="pytest.ini"):
+    """
+    Update the pytest.ini config with the custom markers.
+    """
+
+    ini_startswith = '[pytest]\ntestpaths = "convert2rhel/unit_tests"\nmarkers =\n'
+    with open(ini_file, "w", encoding="utf-8") as f:
+        if custom_markers:
+            f.write("# Generated automatically by the regenerate-pytest-ini pre-commit hook\n\n")
+            f.write(ini_startswith)
+            for marker in sorted(custom_markers):
+                f.write(f"    {marker}\n")
+
+
+def main():
+    """
+    Main function to execute the regenerate-pytest-ini pre-commit hook.
+    """
+    custom_markers = find_custom_markers()
+    if custom_markers:
+        update_pytest_ini(custom_markers)
+        print("pytest.ini regenerated with custom markers.")
+        return 0
+    else:
+        print("No custom markers found.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
* Registering the custom markers is oftentimes tedious and can lead to oversight when registering a new marker or removing a deprecated one
* this should ensure, that the configuration stays up-to-date with changes in existing markers

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1293](https://issues.redhat.com/browse/RHELC-1293)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [x] When merged: Jira issue has been updated to `Release Pending` if relevant
