### PR TITLE
[RHELC-1228, RHELC-1231] Improve detection of RHSM credentials in subscription check

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/subscription.py
+++ b/convert2rhel/actions/pre_ponr_changes/subscription.py
@@ -190,7 +190,7 @@ class SubscribeSystem(actions.Action):
                     "The system is registered with an RHSM account that has Simple Content Access (SCA) disabled but no subscription is attached. Without enabled SCA or an attached subscription the system can't access RHEL repositories. We'll try to auto-attach a subscription."
                 )
                 try:
-                    subscription.auto_attach_subscription()
+                    backup.backup_control.push(subscription.RestorableAutoAttachmentSubscription())
                 except subscription.SubscriptionAutoAttachmentError:
                     self.set_result(
                         level="ERROR",

--- a/convert2rhel/actions/pre_ponr_changes/subscription.py
+++ b/convert2rhel/actions/pre_ponr_changes/subscription.py
@@ -195,6 +195,7 @@ class SubscribeSystem(actions.Action):
                 self.set_result(
                     level="ERROR",
                     id="NO_ACCESS_TO_RHEL_REPOS",
+                    title="No access to RHEL repositories",
                     description="The system can access RHEL repositories only with either Simple Content Access (SCA) enabled or with an attached subscription.",
                     diagnosis="The system is registered with an RHSM account that has SCA disabled but no subscription is attached. Auto-attaching a subscription was not successful.",
                     remediations="Either attach a subscription manually by running 'subscription-manager attach --pool <pool id>' prior to the conversion or enable Simple Content Access on your RHSM account (https://access.redhat.com/articles/simple-content-access).",

--- a/convert2rhel/actions/pre_ponr_changes/subscription.py
+++ b/convert2rhel/actions/pre_ponr_changes/subscription.py
@@ -189,18 +189,18 @@ class SubscribeSystem(actions.Action):
                 logger.warning(
                     "The system is registered with an RHSM account that has Simple Content Access (SCA) disabled but no subscription is attached. Without enabled SCA or an attached subscription the system can't access RHEL repositories. We'll try to auto-attach a subscription."
                 )
-            try:
-                subscription.auto_attach_subscription()
-            except subscription.SubscriptionAutoAttachmentError:
-                self.set_result(
-                    level="ERROR",
-                    id="NO_ACCESS_TO_RHEL_REPOS",
-                    title="No access to RHEL repositories",
-                    description="The system can access RHEL repositories only with either Simple Content Access (SCA) enabled or with an attached subscription.",
-                    diagnosis="The system is registered with an RHSM account that has SCA disabled but no subscription is attached. Auto-attaching a subscription was not successful.",
-                    remediations="Either attach a subscription manually by running 'subscription-manager attach --pool <pool id>' prior to the conversion or enable Simple Content Access on your RHSM account (https://access.redhat.com/articles/simple-content-access).",
-                )
-                return
+                try:
+                    subscription.auto_attach_subscription()
+                except subscription.SubscriptionAutoAttachmentError:
+                    self.set_result(
+                        level="ERROR",
+                        id="NO_ACCESS_TO_RHEL_REPOS",
+                        title="No access to RHEL repositories",
+                        description="The system can access RHEL repositories only with either Simple Content Access (SCA) enabled or with an attached subscription.",
+                        diagnosis="The system is registered with an RHSM account that has SCA disabled but no subscription is attached. Auto-attaching a subscription was not successful.",
+                        remediations="Either attach a subscription manually by running 'subscription-manager attach --pool <pool id>' prior to the conversion or enable Simple Content Access on your RHSM account (https://access.redhat.com/articles/simple-content-access).",
+                    )
+                    return
 
         try:
             # In the future, refactor this to be an else on the previous

--- a/convert2rhel/actions/pre_ponr_changes/subscription.py
+++ b/convert2rhel/actions/pre_ponr_changes/subscription.py
@@ -185,7 +185,15 @@ class SubscribeSystem(actions.Action):
                     return
                 raise
 
-            logger.warning("No rhsm credentials given to subscribe the system. Did not perform the subscription step.")
+            if subscription.is_registered() and not subscription.is_sca_enabled():
+                self.set_result(
+                    level="ERROR",
+                    id="SYSTEM_REGISTERED_WITHOUT_SCA",
+                    title="Registered with RHSM but without SCA enabled",
+                    description="This system has been registered with Red Hat Subscription Manager but Simple Content Access is not enabled.",
+                    remediations="To resolve this error please enable Simple Content Access at https://access.redhat.com/management/ and run the conversion again.",
+                )
+                return
 
         try:
             # In the future, refactor this to be an else on the previous

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -483,7 +483,7 @@ class RegistrationCommand:
                     # wrong server if the host is registered.
                     self._set_connection_opts_in_config()
 
-                    if not _is_registered():
+                    if not is_registered():
                         # Host is not registered so re-raise the error
                         raise
                 else:
@@ -535,7 +535,7 @@ class RegistrationCommand:
             loggerinst.info("Successfully set RHSM connection configuration.")
 
 
-def _is_registered():
+def is_registered():
     """Check if the machine we're running on is registered with subscription-manager."""
     loggerinst.debug("Checking whether the host was registered.")
     output, ret_code = utils.run_subprocess(["subscription-manager", "identity"])
@@ -578,14 +578,27 @@ def install_rhel_subscription_manager(pkgs_to_install, pkgs_to_upgrade=None):
     backup.backup_control.push(installed_pkg_set)
 
 
+def is_sca_enabled():
+    """
+    Check if Simple Content Access has been enabled for this system.
+
+    :returns: True if Simple Content Access is enabled.
+    :rtype: bool
+    """
+    # check if SCA is enabled
+    output, _ = utils.run_subprocess(["subscription-manager", "status"], print_output=False)
+    if "content access mode is set to simple content access." in output.lower():
+        return True
+    return False
+
+
 def attach_subscription():
     """Attach a specific subscription to the registered OS. If no
     subscription ID has been provided through command line, let the user
     interactively choose one.
     """
     # check if SCA is enabled
-    output, _ = utils.run_subprocess(["subscription-manager", "status"], print_output=False)
-    if "content access mode is set to simple content access." in output.lower():
+    if is_sca_enabled():
         loggerinst.info("Simple Content Access is enabled, skipping subscription attachment")
         if tool_opts.pool:
             loggerinst.warning(

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -58,9 +58,15 @@ REGISTRATION_TIMEOUT = 180
 # Location of the RHSM generated facts json file.
 RHSM_FACTS_FILE = "/var/lib/rhsm/facts/facts.json"
 
+#
+
 
 class UnregisterError(Exception):
     """Raised with problems unregistering a system."""
+
+
+class SubscriptionRemovalError(Exception):
+    """Raised when there is a failure in removing auto attached subscriptions"""
 
 
 class RefreshSubscriptionManagerError(Exception):
@@ -107,6 +113,17 @@ class RestorableSystemSubscription(backup.RestorableChange):
                 loggerinst.warning("subscription-manager not installed, skipping")
 
         super(RestorableSystemSubscription, self).restore()
+
+
+def remove_subscription():
+    """Remove all subscriptions added from auto attachment"""
+    loggerinst.info("Removing auto attached subscriptions.")
+    subscription_removal_cmd = ["subscription-manager", "remove", "--all"]
+    output, ret_code = utils.run_subprocess(subscription_removal_cmd, print_output=False)
+    if ret_code != 0:
+        raise SubscriptionRemovalError("Subscription removal result\n%s" % output)
+    else:
+        loggerinst.info("Subscription removal successful.")
 
 
 def unregister_system():

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -615,7 +615,6 @@ def auto_attach_subscription():
     SubscriptionAutoAttachmentError.
     """
     _, ret_code = utils.run_subprocess(["subscription-manager", "attach", "--auto"])
-
     if ret_code != 0:
         raise SubscriptionAutoAttachmentError("Unsuccessful auto attachment of a subscription.")
 

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -585,7 +585,6 @@ def is_sca_enabled():
     :returns: True if Simple Content Access is enabled.
     :rtype: bool
     """
-    # check if SCA is enabled
     output, _ = utils.run_subprocess(["subscription-manager", "status"], print_output=False)
     if "content access mode is set to simple content access." in output.lower():
         return True

--- a/convert2rhel/unit_tests/__init__.py
+++ b/convert2rhel/unit_tests/__init__.py
@@ -549,6 +549,16 @@ class AutoAttachSubscriptionMocked(MockFunctionObject):
     spec = subscription.auto_attach_subscription
 
 
+class RemoveAutoAttachSubscriptionMocked(MockFunctionObject):
+    """
+    Mock of the remove_subscription() function.
+
+    It just adds a spec for the function on top of all the standard mock functionality.
+    """
+
+    spec = subscription.remove_subscription
+
+
 class RefreshSubscriptionManagerMocked(MockFunctionObject):
     """
     Mock of the refresh_subscription_info() function.

--- a/convert2rhel/unit_tests/__init__.py
+++ b/convert2rhel/unit_tests/__init__.py
@@ -539,6 +539,26 @@ class UnregisterSystemMocked(MockFunctionObject):
     spec = subscription.unregister_system
 
 
+class AutoAttachSubscriptionMocked(MockFunctionObject):
+    """
+    Mock of the auto_attach_subscription() function.
+
+    It just adds a spec for the function on top of all the standard mock functionality.
+    """
+
+    spec = subscription.auto_attach_subscription
+
+
+class RefreshSubscriptionManagerMocked(MockFunctionObject):
+    """
+    Mock of the refresh_subscription_info() function.
+
+    It just adds a spec for the function on top of all the standard mock functionality.
+    """
+
+    spec = subscription.refresh_subscription_info
+
+
 #
 # systeminfo mocks
 #

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/subscription_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/subscription_test.py
@@ -276,8 +276,6 @@ class TestSubscribeSystem:
 
         with pytest.raises(RefreshSubscriptionManagerError):
             subscribe_system_instance.run()
-            print(subscribe_system_instance.result)
-
             unit_tests.assert_actions_result(
                 subscribe_system_instance,
                 level="ERROR",

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/subscription_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/subscription_test.py
@@ -305,12 +305,17 @@ class TestSubscribeSystem:
 
     def test_subscribe_no_access_to_rhel_repos(self, subscribe_system_instance, monkeypatch):
         monkeypatch.setattr(subscription, "should_subscribe", lambda: False)
+        monkeypatch.setattr(repo.system_info, "eus_system", value=False)
+        monkeypatch.setattr(subscription, "is_sca_enabled", lambda: False)
+        monkeypatch.setattr(subscription, "is_subscription_attached", lambda: False)
+        monkeypatch.setattr(repo.system_info, "default_rhsm_repoids", value=["id1", "id2"])
+
         mocked_auto_attach = AutoAttachSubscriptionMocked(side_effect=SubscriptionAutoAttachmentError)
         monkeypatch.setattr(subscription, "auto_attach_subscription", mocked_auto_attach)
         monkeypatch.setattr(utils, "run_subprocess", RunSubprocessMocked())
 
         subscribe_system_instance.run()
-
+        print(subscribe_system_instance.result)
         unit_tests.assert_actions_result(
             subscribe_system_instance,
             level="ERROR",

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/subscription_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/subscription_test.py
@@ -285,22 +285,6 @@ class TestSubscribeSystem:
                 remediations="You may either register this system via subscription-manager before running convert2rhel or give convert2rhel credentials to do that for you. The credentials convert2rhel would need are either activation_key and organization or username and password. You can set these in a config file and then pass the file to convert2rhel with the --config-file option.",
             )
 
-    def test_subscribe_system_registered_without_sca(self, global_tool_opts, subscribe_system_instance, monkeypatch):
-        monkeypatch.setattr(subscription, "should_subscribe", partial(toolopts._should_subscribe, global_tool_opts))
-        monkeypatch.setattr(subscription, "is_registered", mock.Mock(return_value=True))
-        monkeypatch.setattr(subscription, "is_sca_enabled", mock.Mock(return_value=False))
-        fake_refresh = mock.Mock()
-        monkeypatch.setattr(subscription, "refresh_subscription_info", fake_refresh)
-        subscribe_system_instance.run()
-        unit_tests.assert_actions_result(
-            subscribe_system_instance,
-            level="ERROR",
-            id="SYSTEM_REGISTERED_WITHOUT_SCA",
-            title="Registered with RHSM but without SCA enabled",
-            description="This system has been registered with Red Hat Subscription Manager but Simple Content Access is not enabled.",
-            remediations="To resolve this error please enable Simple Content Access at https://access.redhat.com/management/ and run the conversion again.",
-        )
-
     def test_subscribe_system_run(self, subscribe_system_instance, monkeypatch):
         monkeypatch.setattr(subscription, "should_subscribe", lambda: True)
         monkeypatch.setattr(subscription.RestorableSystemSubscription, "enable", mock.Mock())

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -367,14 +367,26 @@ def test_install_rhel_subsription_manager(monkeypatch, global_backup_control):
     assert mock_backup_control.call_count == 1
 
 
+@pytest.mark.parametrize(
+    ("return_string", "expected"),
+    (
+        ("Content Access Mode is set to Simple Content Access.", True),
+        ("String stating no Simple Content Access", False),
+    ),
+)
+def test_is_sca_enabled(monkeypatch, return_string, expected):
+    monkeypatch.setattr(
+        utils,
+        "run_subprocess",
+        RunSubprocessMocked(return_string=return_string),
+    )
+    assert subscription.is_sca_enabled() is expected
+
+
 @pytest.mark.usefixtures("tool_opts", scope="function")
 class TestAttachSubscription:
     def test_attach_subscription_sca_enabled(self, monkeypatch):
-        monkeypatch.setattr(
-            utils,
-            "run_subprocess",
-            RunSubprocessMocked(return_string="Content Access Mode is set to Simple Content Access"),
-        )
+        monkeypatch.setattr(subscription, "is_sca_enabled", mock.Mock(return_value=True))
         assert subscription.attach_subscription() is True
 
     def test_attach_subscription(self, monkeypatch):

--- a/pytest.ini
+++ b/pytest.ini
@@ -108,5 +108,7 @@ markers =
     test_traceback_not_present
     test_duplicate_pkgs
     test_httpd_package_transaction_error
+    test_no_sca_not_subscribed
+    test_no_sca_subscription_attachment_error
 # Unit test related
     noautofixtures: disable all auto-use fixtures

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -519,7 +519,7 @@ def pre_registered(shell, request):
         assert original_registration_uuid == post_c2r_registration_uuid
 
     assert shell("subscription-manager remove --all").returncode == 0
-    assert shell("subscription-manager unregister").returncode == 0
+    shell("subscription-manager unregister")
 
     # We do not need to spend time on performing the cleanup for some test cases (destructive)
     if "C2R_TESTS_SUBMAN_CLEANUP" in os.environ:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -41,18 +41,20 @@ SYSTEM_RELEASE_ENV = os.environ["SYSTEM_RELEASE_ENV"]
 def shell(tmp_path):
     """Live shell."""
 
-    def factory(command):
-        click.echo(
-            "\nExecuting a command:\n{}\n\n".format(command),
-            color="green",
-        )
+    def factory(command, silent=False):
+        if not silent:
+            click.echo(
+                "\nExecuting a command:\n{}\n\n".format(command),
+                color="green",
+            )
         # pylint: disable=consider-using-with
         # Popen is a context-manager in python-3.2+
         process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         output = ""
         for line in iter(process.stdout.readline, b""):
             output += line.decode()
-            click.echo(line.decode().rstrip("\n"))
+            if not silent:
+                click.echo(line.decode().rstrip("\n"))
         returncode = process.wait()
         return namedtuple("Result", ["returncode", "output"])(returncode, output)
 
@@ -469,10 +471,16 @@ def _load_json_schema(path):
 
 
 @pytest.fixture
-def pre_registered(shell):
+def pre_registered(shell, request):
     """
     A fixture to install subscription manager and pre-register the system prior to the convert2rhel run.
     """
+    username = TEST_VARS["RHSM_USERNAME"]
+    password = TEST_VARS["RHSM_PASSWORD"]
+    # Use custom parameters when the fixture is parametrized
+    if hasattr(request, "param"):
+        username, password = request.param
+
     assert shell("yum install -y subscription-manager").returncode == 0
     # Download the SSL certificate
     shell("curl --create-dirs -o /etc/rhsm/ca/redhat-uep.pem https://ftp.redhat.com/redhat/convert2rhel/redhat-uep.pem")
@@ -480,13 +488,15 @@ def pre_registered(shell):
     assert (
         shell(
             "subscription-manager register --serverurl {} --username {} --password {}".format(
-                TEST_VARS["RHSM_SERVER_URL"], TEST_VARS["RHSM_USERNAME"], TEST_VARS["RHSM_PASSWORD"]
-            )
+                TEST_VARS["RHSM_SERVER_URL"], username, password
+            ),
+            silent=True,
         ).returncode
         == 0
     )
 
-    assert shell("subscription-manager attach --pool {}".format(TEST_VARS["RHSM_POOL"])).returncode == 0
+    if "C2R_TESTS_NOSUB" not in os.environ:
+        assert shell("subscription-manager attach --pool {}".format(TEST_VARS["RHSM_POOL"])).returncode == 0
 
     rhsm_uuid_command = "subscription-manager identity | grep identity"
 
@@ -508,8 +518,8 @@ def pre_registered(shell):
         # Validate it matches with UUID prior to the conversion
         assert original_registration_uuid == post_c2r_registration_uuid
 
-        assert shell("subscription-manager remove --pool {}".format(TEST_VARS["RHSM_POOL"])).returncode == 0
-        assert shell("subscription-manager unregister").returncode == 0
+    assert shell("subscription-manager remove --all").returncode == 0
+    assert shell("subscription-manager unregister").returncode == 0
 
     # We do not need to spend time on performing the cleanup for some test cases (destructive)
     if "C2R_TESTS_SUBMAN_CLEANUP" in os.environ:

--- a/tests/integration/tier0/non-destructive/subscription-manager/main.fmf
+++ b/tests/integration/tier0/non-destructive/subscription-manager/main.fmf
@@ -90,3 +90,31 @@ tag+:
             pytest --setup-show -svv -m test_unregistered_no_credentials
         tag+:
             - unregistered-no-credentials
+    /no_sca_not_subscribed:
+        summary+: |
+            The subscription is auto-attached on a pre-registered system
+        description+: |
+            This test verifies that running conversion on pre-registered system
+            without an attached subscription will try auto attaching the subscription.
+        adjust+:
+            - environment+:
+                C2R_TESTS_NOSUB: 1
+        test: |
+            pytest -svv -m test_no_sca_not_subscribed
+        tag+:
+            - no-sca-not-subscribed
+    /no_sca_subscription_attachment_error:
+        summary+: |
+            The subscription auto-attach fails
+        description+: |
+            This test verifies that running conversion on pre-registered system
+            without an attached subscription will try auto attaching the subscription.
+            When the attachment fails, the SUBSCRIBE_SYSTEM::NO_ACCESS_TO_RHEL_REPOS
+            error is raised.
+        adjust+:
+            - environment+:
+                C2R_TESTS_NOSUB: 1
+        test: |
+            pytest -svv -m test_no_sca_subscription_attachment_error
+        tag+:
+            - no-sca-subscription-attachment-error

--- a/tests/integration/tier0/non-destructive/subscription-manager/main.fmf
+++ b/tests/integration/tier0/non-destructive/subscription-manager/main.fmf
@@ -92,7 +92,7 @@ tag+:
             - unregistered-no-credentials
     /no_sca_not_subscribed:
         summary+: |
-            The subscription is auto-attached on a pre-registered system
+            convert2rhel auto-attaches subscription on a pre-registered system
         description+: |
             This test verifies that running conversion on pre-registered system
             without an attached subscription will try auto attaching the subscription.
@@ -100,7 +100,7 @@ tag+:
             - environment+:
                 C2R_TESTS_NOSUB: 1
         test: |
-            pytest -svv -m test_no_sca_not_subscribed
+            pytest --setup-show -svv -m test_no_sca_not_subscribed
         tag+:
             - no-sca-not-subscribed
     /no_sca_subscription_attachment_error:
@@ -115,6 +115,6 @@ tag+:
             - environment+:
                 C2R_TESTS_NOSUB: 1
         test: |
-            pytest -svv -m test_no_sca_subscription_attachment_error
+            pytest --setup-show -svv -m test_no_sca_subscription_attachment_error
         tag+:
             - no-sca-subscription-attachment-error

--- a/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
+++ b/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
@@ -75,3 +75,43 @@ def test_unregistered_no_credentials(shell, convert2rhel):
         c2r.expect("SUBSCRIBE_SYSTEM::SYSTEM_NOT_REGISTERED - Not registered with RHSM", timeout=300)
 
     assert c2r.exitstatus != 0
+
+
+@pytest.mark.test_no_sca_not_subscribed
+def test_no_sca_no_subscribed(shell, pre_registered, convert2rhel):
+    """
+    This test verifies that running conversion on pre-registered system
+    without an attached subscription will try auto attaching the subscription.
+    """
+    with convert2rhel("--debug") as c2r:
+        # We need to get past the data collection acknowledgement.
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("y")
+
+        c2r.expect("We'll try to auto-attach a subscription")
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("n")
+
+    assert c2r.exitstatus != 0
+
+
+@pytest.mark.parametrize(
+    "pre_registered", [(env.str("RHSM_NOSUB_USERNAME"), env.str("RHSM_NOSUB_PASSWORD"))], indirect=True
+)
+@pytest.mark.test_no_sca_subscription_attachment_error
+def test_no_sca_subscription_attachment_error(shell, convert2rhel, pre_registered):
+    """
+    This test verifies that running conversion on pre-registered system
+    without an attached subscription will try auto attaching the subscription.
+    When the attachment fails, the SUBSCRIBE_SYSTEM::NO_ACCESS_TO_RHEL_REPOS
+    error is raised.
+    """
+    with convert2rhel("--debug") as c2r:
+        # We need to get past the data collection acknowledgement.
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("y")
+
+        c2r.expect("We'll try to auto-attach a subscription")
+        c2r.expect_exact("(ERROR) SUBSCRIBE_SYSTEM::NO_ACCESS_TO_RHEL_REPOS - No access to RHEL repositories")
+
+    assert c2r.exitstatus != 0

--- a/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
+++ b/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
@@ -89,14 +89,17 @@ def test_no_sca_no_subscribed(shell, pre_registered, convert2rhel):
         c2r.sendline("y")
 
         c2r.expect("We'll try to auto-attach a subscription")
+        c2r.expect("SUBSCRIBE_SYSTEM has succeeded")
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("n")
 
     assert c2r.exitstatus != 0
 
+    assert "No consumed subscription pools were found" in shell("subscription-manager list --consumed").output
+
 
 @pytest.mark.parametrize(
-    "pre_registered", [(env.str("RHSM_NOSUB_USERNAME"), env.str("RHSM_NOSUB_PASSWORD"))], indirect=True
+    "pre_registered", [(TEST_VARS["RHSM_NOSUB_USERNAME"], TEST_VARS["RHSM_NOSUB_PASSWORD"])], indirect=True
 )
 @pytest.mark.test_no_sca_subscription_attachment_error
 def test_no_sca_subscription_attachment_error(shell, convert2rhel, pre_registered):

--- a/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
+++ b/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
@@ -21,8 +21,8 @@ def test_pre_registered_wont_unregister(shell, pre_registered, convert2rhel):
 
         c2r.expect("Subscription Manager is already present", timeout=300)
         c2r.expect(
-            "WARNING - No rhsm credentials given to subscribe the system. Did not perform the subscription step",
-            timeout=300,
+            "SUBSCRIBE_SYSTEM has succeeded",
+            timeout=600,
         )
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("n")


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->
This PR adds a check to see if SCA is not enabled and if there is no subscription attached. In the event these conditions are met we attempt to auto attach a subscription for the customer. If the auto attachment fails we have an ERROR result `NO_ACCESS_TO_RHEL_REPOS`  to let the user know that the system is registered with an RHSM account that has SCA disabled but no subscription is attached and the auto attachment was unsuccessful. New functions is_subscription_attached() and auto_attach_subscription() have been made to facilitate these checks. Also made a new function _is_sca_enabled so we can detect if sca is enabled in both subscription.py and pre_ponr_changes/subscription.py. 

Jira Issues: 
* [RHELC-1228](https://issues.redhat.com/browse/RHELC-1228)
* [RHELC-1231](https://issues.redhat.com/browse/RHELC-1231)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
