### PR TITLE
chore: Split RPM creation to be more granular

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@
 	lint \
 	lint-errors \
 	rpms \
+	rpm7 \
+	rpm8 \
+	rpm9 \
 
 # Project constants
 IMAGE_REPOSITORY ?= ghcr.io
@@ -140,15 +143,29 @@ tests9: image9
 	@echo 'CentOS 9 tests'
 	@$(call CONTAINER_TEST_FUNC,centos9,--show-capture=$(SHOW_CAPTURE))
 
-rpms:
-	mkdir -p .rpms
-	rm -frv .rpms/*
-	$(PODMAN) build -f Containerfiles/rpmbuild.centos9.Containerfile -t $(IMAGE_ORG)/$(IMAGE_PREFIX)-centos9rpmbuild .
-	$(PODMAN) build -f Containerfiles/rpmbuild.centos8.Containerfile -t $(IMAGE_ORG)/$(IMAGE_PREFIX)-centos8rpmbuild .
+
+.rpm7:
+	rm -frv .rpms/*el7*
 	$(PODMAN) build -f Containerfiles/rpmbuild.centos7.Containerfile -t $(IMAGE_ORG)/$(IMAGE_PREFIX)-centos7rpmbuild .
-	$(PODMAN) cp $$($(PODMAN) create $(IMAGE_ORG)/$(IMAGE_PREFIX)-centos8rpmbuild):/data/.rpms .
 	$(PODMAN) cp $$($(PODMAN) create $(IMAGE_ORG)/$(IMAGE_PREFIX)-centos7rpmbuild):/data/.rpms .
+
+.rpm8:
+	rm -frv .rpms/*el8*
+	$(PODMAN) build -f Containerfiles/rpmbuild.centos8.Containerfile -t $(IMAGE_ORG)/$(IMAGE_PREFIX)-centos8rpmbuild .
+	$(PODMAN) cp $$($(PODMAN) create $(IMAGE_ORG)/$(IMAGE_PREFIX)-centos8rpmbuild):/data/.rpms .
+
+.rpm9:
+	rm -frv .rpms/*el9*
+	$(PODMAN) build -f Containerfiles/rpmbuild.centos9.Containerfile -t $(IMAGE_ORG)/$(IMAGE_PREFIX)-centos9rpmbuild .
+	$(PODMAN) cp $$($(PODMAN) create $(IMAGE_ORG)/$(IMAGE_PREFIX)-centos9rpmbuild):/data/.rpms .
+
+.rpm-container-cleanup:
 	$(PODMAN) rm $$($(PODMAN) ps -aq) -f
+
+rpms: .rpm7 .rpm8 .rpm9 .rpm-container-cleanup
+rpm7: .rpm7 .rpm-container-cleanup
+rpm8: .rpm8 .rpm-container-cleanup
+rpm9: .rpm9 .rpm-container-cleanup
 
 copr-build: rpms
 	mkdir -p .srpms


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
