### PR TITLE
[RHELC-1295] Change OVERRIDABLE result to WARNING message in package update action

### DIFF
--- a/convert2rhel/actions/system_checks/package_updates.py
+++ b/convert2rhel/actions/system_checks/package_updates.py
@@ -74,35 +74,10 @@ class PackageUpdates(actions.Action):
             # exception is based on the `pkgmanager` module and the message
             # sent to the output can differ depending if the code is running in
             # RHEL7 (yum) or RHEL8 (dnf).
-            package_up_to_date_check_skip = os.environ.get("CONVERT2RHEL_PACKAGE_UP_TO_DATE_CHECK_SKIP", None)
             package_up_to_date_error_message = (
                 "There was an error while checking whether the installed packages are up-to-date. Having an updated system is"
                 " an important prerequisite for a successful conversion. Consider verifying the system is up to date manually"
                 " before proceeding with the conversion. %s" % str(e)
-            )
-            if not package_up_to_date_check_skip:
-                logger.warning(package_up_to_date_error_message)
-                self.set_result(
-                    level="OVERRIDABLE",
-                    id="PACKAGE_UP_TO_DATE_CHECK_FAIL",
-                    title="Package up to date check fail",
-                    description="Please refer to the diagnosis for further information",
-                    diagnosis=package_up_to_date_error_message,
-                    remediations="If you wish to disregard this message, set the environment variable "
-                    "'CONVERT2RHEL_PACKAGE_UP_TO_DATE_CHECK_SKIP' to 1.",
-                )
-                return
-            skip_package_up_to_date_check_message = (
-                "Detected 'CONVERT2RHEL_PACKAGE_UP_TO_DATE_CHECK_SKIP' environment variable, we will skip "
-                "the package up-to-date check.\n"
-                "Beware, this could leave your system in a broken state."
-            )
-            logger.warning(skip_package_up_to_date_check_message)
-            self.add_message(
-                level="WARNING",
-                id="SKIP_PACKAGE_UP_TO_DATE_CHECK",
-                title="Skip package up to date check",
-                description=skip_package_up_to_date_check_message,
             )
 
             logger.warning(package_up_to_date_error_message)

--- a/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
@@ -142,40 +142,10 @@ def test_check_package_updates_not_up_to_date_skip(pretend_os, monkeypatch, pack
 
 
 @centos8
-def test_check_package_updates_with_repoerror(pretend_os, monkeypatch, caplog, package_updates_action):
+def test_check_package_updates_with_repoerror_warning(pretend_os, monkeypatch, caplog, package_updates_action):
     get_total_packages_to_update_mock = mock.Mock(side_effect=pkgmanager.RepoError("This is an error"))
     monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=get_total_packages_to_update_mock)
-    diagnosis = (
-        "There was an error while checking whether the installed packages are up-to-date."
-        " Having an updated system is an important prerequisite for a successful conversion."
-        " Consider verifying the system is up to date manually before proceeding with the conversion."
-        " This is an error"
-    )
-    package_updates_action.run()
 
-    unit_tests.assert_actions_result(
-        package_updates_action,
-        level="OVERRIDABLE",
-        id="PACKAGE_UP_TO_DATE_CHECK_FAIL",
-        title="Package up to date check fail",
-        description="Please refer to the diagnosis for further information",
-        diagnosis=diagnosis,
-        remediations="If you wish to disregard this message, set the environment variable "
-        "'CONVERT2RHEL_PACKAGE_UP_TO_DATE_CHECK_SKIP' to 1.",
-        variables={},
-    )
-    assert diagnosis in caplog.records[-1].message
-
-
-@centos8
-def test_check_package_updates_with_repoerror_skip(pretend_os, monkeypatch, caplog, package_updates_action):
-    get_total_packages_to_update_mock = mock.Mock(side_effect=pkgmanager.RepoError("This is an error"))
-    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=get_total_packages_to_update_mock)
-    monkeypatch.setattr(
-        os,
-        "environ",
-        {"CONVERT2RHEL_PACKAGE_UP_TO_DATE_CHECK_SKIP": 1},
-    )
     diagnosis = (
         "There was an error while checking whether the installed packages are up-to-date. Having an updated system is"
         " an important prerequisite for a successful conversion. Consider verifying the system is up to date manually"
@@ -192,23 +162,10 @@ def test_check_package_updates_with_repoerror_skip(pretend_os, monkeypatch, capl
                 remediations=None,
                 variables={},
             ),
-            actions.ActionMessage(
-                level="WARNING",
-                id="SKIP_PACKAGE_UP_TO_DATE_CHECK",
-                title="Skip package up to date check",
-                description=(
-                    "Detected 'CONVERT2RHEL_PACKAGE_UP_TO_DATE_CHECK_SKIP' environment variable, we will skip "
-                    "the package up-to-date check.\n"
-                    "Beware, this could leave your system in a broken state."
-                ),
-                diagnosis=None,
-                remediations=None,
-                variables={},
-            ),
         )
     )
-
     package_updates_action.run()
+
     assert diagnosis in caplog.records[-1].message
     assert expected.issuperset(package_updates_action.messages)
     assert expected.issubset(package_updates_action.messages)


### PR DESCRIPTION
This PR changes an OVERRDIABLE result to a WARNING message in actions/package_updates.py for the case when a failure occurs in checking whether the installed packages on a system are up to date. This is to prevent the previous behavior of inhibiting the conversion when the mentioned check fails.

Jira Issues: [RHELC-1295](https://issues.redhat.com/browse/RHELC-1295)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
