### PR TITLE
[RHELC-1308] Specify a full path to the called modinfo utility

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
+++ b/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
@@ -56,7 +56,9 @@ class EnsureKernelModulesCompatibility(actions.Action):
         lsmod_output, _ = run_subprocess(["/usr/sbin/lsmod"], print_output=False)
         modules = re.findall(r"^(\w+)\s.+$", lsmod_output, flags=re.MULTILINE)[1:]
         kernel_modules = [
-            self._get_kmod_comparison_key(run_subprocess(["modinfo", "-F", "filename", module], print_output=False)[0])
+            self._get_kmod_comparison_key(
+                run_subprocess(["/usr/sbin/modinfo", "-F", "filename", module], print_output=False)[0]
+            )
             for module in modules
         ]
         return set(kernel_modules)

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
@@ -366,15 +366,15 @@ def test_get_loaded_kmods(ensure_kernel_modules_compatibility_instance, monkeypa
                 ),
             ),
             (
-                ("modinfo", "-F", "filename", "a"),
+                ("/usr/sbin/modinfo", "-F", "filename", "a"),
                 (MODINFO_STUB.split()[0] + "\n", 0),
             ),
             (
-                ("modinfo", "-F", "filename", "b"),
+                ("/usr/sbin/modinfo", "-F", "filename", "b"),
                 (MODINFO_STUB.split()[1] + "\n", 0),
             ),
             (
-                ("modinfo", "-F", "filename", "c"),
+                ("/usr/sbin/modinfo", "-F", "filename", "c"),
                 (MODINFO_STUB.split()[2] + "\n", 0),
             ),
         ),


### PR DESCRIPTION
On systems that do not have /usr/sbin/ in the PATH, simply calling modinfo instead of /usr/sbin/modinfo would fail.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1308](https://issues.redhat.com/browse/RHELC-1308)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
