### PR TITLE
[RHELC-1131, RHELC-1234] Refactor logger to not require root

### DIFF
--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -77,9 +77,10 @@ class LogfileBufferHandler(BufferingHandler):
     name = "logfile_buffer_handler"
 
     def __init__(self, capacity, handler_name="file_handler"):
-        """_summary_
+        """
+        Initialize the handler with the buffer size.
 
-        :param int capacity: Initialize with a buffer size
+        :param int capacity: Buffer size for the handler
         :param str handler_name: Handler to flush buffer to, defaults to "file_handler"
         """
         super(LogfileBufferHandler, self).__init__(capacity)
@@ -88,8 +89,9 @@ class LogfileBufferHandler(BufferingHandler):
 
     @property
     def target(self):
-        """The computed Filehandler target that we are supposed to send to. This
-        is mostly copied over from logging's MemoryHandler but instead of setting
+        """The computed Filehandler target that we are supposed to send to.
+
+        This is mostly copied over from logging's MemoryHandler but instead of setting
         the target manually we find it automatically given the name of the handler
 
         :return logging.Handler: Either the found FileHandler setup or temporary NullHandler
@@ -104,8 +106,8 @@ class LogfileBufferHandler(BufferingHandler):
             self.target.handle(record)
 
     def shouldFlush(self, record):
-        """We should never flush automatically, so we set this to always return false, that way we need to flush
-        manually each time. Which is exactly what we want when it comes to keeping a buffer before we confirm we are
+        """
+        We should never flush automatically, so we set this to always return false, that way we need to flush manually each time. Which is exactly what we want when it comes to keeping a buffer before we confirm we are
         a root user.
 
         :param logging.LogRecord record: The record to log
@@ -145,9 +147,8 @@ def setup_logger_handler():
     stdout_handler.setLevel(logging.DEBUG)
     logger.addHandler(stdout_handler)
 
-    # Setup a buffer for the file handler that we will add later, that way we
     # can flush logs to the file that were logged before initializing the file handler
-    logger.addHandler(LogfileBufferHandler(100))
+    logger.addHandler(LogfileBufferHandler(capacity=100))
 
 
 def add_file_handler(log_name, log_dir):

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -47,19 +47,29 @@ class ConversionPhase:
 def initialize_logger():
     """
     Entrypoint function that aggregates other calls for initialization logic
-    and setup for logger handlers.
+    and setup for logger handlers that do not require root.
+    """
+
+    return logger_module.setup_logger_handler()
+
+
+def initialize_file_logging(log_name, log_dir):
+    """
+    Archive existing file logs and setup all logging handlers that require
+    root, like FileHandlers.
+
+    This function should be called after
+    :func:`~convert2rhel.main.initialize_logger`.
 
     .. warning::
         Setting log_dir underneath a world-writable directory (including
         letting it be user settable) is insecure.  We will need to write
         some checks for all calls to `os.makedirs()` if we allow changing
         log_dir.
+
+    :param str log_name: Name of the logfile to archive and log to
+    :param str log_dir: Directory where logfiles are stored
     """
-
-    return logger_module.setup_logger_handler()
-
-
-def finalize_logger(log_name, log_dir):
     try:
         logger_module.archive_old_logger_files(log_name, log_dir)
     except (IOError, OSError) as e:
@@ -101,9 +111,9 @@ def main_locked():
     pre_conversion_results = None
     process_phase = ConversionPhase.POST_CLI
 
-    # since we now have root, we can add the FileLogger
+    # since we now have root, we can add the FileLogging
     # and also archive previous logs
-    finalize_logger("convert2rhel.log", logger_module.LOG_DIR)
+    initialize_file_logging("convert2rhel.log", logger_module.LOG_DIR)
 
     try:
         perform_boilerplate()

--- a/convert2rhel/unit_tests/__init__.py
+++ b/convert2rhel/unit_tests/__init__.py
@@ -373,8 +373,8 @@ class InitializeLoggerMocked(MockFunctionObject):
     spec = main.initialize_logger
 
 
-class FinalizeLoggerMocked(MockFunctionObject):
-    spec = main.finalize_logger
+class InitializeFileLoggingMocked(MockFunctionObject):
+    spec = main.initialize_file_logging
 
 
 class MainLockedMocked(MockFunctionObject):

--- a/convert2rhel/unit_tests/__init__.py
+++ b/convert2rhel/unit_tests/__init__.py
@@ -373,6 +373,10 @@ class InitializeLoggerMocked(MockFunctionObject):
     spec = main.initialize_logger
 
 
+class FinalizeLoggerMocked(MockFunctionObject):
+    spec = main.finalize_logger
+
+
 class MainLockedMocked(MockFunctionObject):
     spec = main.main_locked
 

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 import six
 
 from convert2rhel import backup, cert, pkgmanager, redhatrelease, systeminfo, toolopts, utils
-from convert2rhel.logger import setup_logger_handler
+from convert2rhel.logger import add_file_handler, setup_logger_handler
 from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts
 from convert2rhel.unit_tests import MinimalRestorable
@@ -107,8 +107,12 @@ def pkg_root():
 
 
 @pytest.fixture(autouse=True)
-def setup_logger(tmpdir):
-    setup_logger_handler(log_name="convert2rhel", log_dir=str(tmpdir))
+def setup_logger(tmpdir, request):
+    # This makes it so we can skip this using @pytest.mark.noautofixtures
+    if "noautofixtures" in request.keywords:
+        return
+    setup_logger_handler()
+    add_file_handler(log_name="convert2rhel", log_dir=str(tmpdir))
 
 
 @pytest.fixture

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -26,7 +26,7 @@ import pytest
 from convert2rhel import logger as logger_module
 
 
-def test_logger_handlers(monkeypatch, tmpdir, caplog, read_std, is_py2, global_tool_opts, clear_loggers):
+def test_logger_handlers(monkeypatch, tmpdir, read_std, global_tool_opts):
     """Test if the logger handlers emits the events to the file and stdout."""
     monkeypatch.setattr("convert2rhel.toolopts.tool_opts", global_tool_opts)
 
@@ -52,9 +52,8 @@ def test_logger_handlers(monkeypatch, tmpdir, caplog, read_std, is_py2, global_t
     assert "Test debug: other data" in stdouterr_out
 
 
-def test_tools_opts_debug(monkeypatch, tmpdir, read_std, is_py2, global_tool_opts, clear_loggers):
+def test_tools_opts_debug(monkeypatch, read_std, is_py2, global_tool_opts):
     monkeypatch.setattr("convert2rhel.toolopts.tool_opts", global_tool_opts)
-    log_fname = "convert2rhel.log"
     logger_module.setup_logger_handler()
     logger = logging.getLogger(__name__)
     global_tool_opts.debug = True
@@ -87,9 +86,8 @@ class TestCustomLogger:
             ("critical_no_exit", "CRITICAL"),
         ),
     )
-    def test_logger_custom_logger(self, log_method_name, level_name, caplog, monkeypatch, tmpdir, clear_loggers):
+    def test_logger_custom_logger(self, log_method_name, level_name, caplog):
         """Test CustomLogger."""
-        log_fname = "convert2rhel.log"
         logger_module.setup_logger_handler()
         logger = logging.getLogger(__name__)
         log_method = getattr(logger, log_method_name)
@@ -100,9 +98,8 @@ class TestCustomLogger:
         assert "Some task: data" == caplog.records[-1].message
         assert caplog.records[-1].levelname == level_name
 
-    def test_logger_critical(self, caplog, tmpdir, clear_loggers):
+    def test_logger_critical(self, caplog):
         """Test CustomLogger."""
-        log_fname = "convert2rhel.log"
         logger_module.setup_logger_handler()
         logger = logging.getLogger(__name__)
 
@@ -113,20 +110,17 @@ class TestCustomLogger:
         assert "Critical error: data\n" in caplog.text
 
     @pytest.mark.parametrize(
-        ("log_method_name", "level_name"),
-        (
-            ("task", "TASK"),
-            ("file", "DEBUG"),
-            ("debug", "DEBUG"),
-            ("warning", "WARNING"),
-            ("critical_no_exit", "CRITICAL"),
-        ),
+        "log_method_name",
+        [
+            "task",
+            "file",
+            "debug",
+            "warning",
+            "critical_no_exit",
+        ],
     )
-    def test_logger_custom_logger_insufficient_level(
-        self, log_method_name, level_name, caplog, monkeypatch, tmpdir, clear_loggers
-    ):
+    def test_logger_custom_logger_insufficient_level(self, log_method_name, caplog):
         """Test CustomLogger."""
-        log_fname = "convert2rhel.log"
         logger_module.setup_logger_handler()
         logger = logging.getLogger(__name__)
         logger.setLevel(logging.CRITICAL + 40)
@@ -137,9 +131,8 @@ class TestCustomLogger:
         assert "Some task: data" not in caplog.text
         assert not caplog.records
 
-    def test_logger_critical_insufficient_level(self, caplog, tmpdir, clear_loggers):
+    def test_logger_critical_insufficient_level(self, caplog):
         """Test CustomLogger."""
-        log_fname = "convert2rhel.log"
         logger_module.setup_logger_handler()
         logger = logging.getLogger(__name__)
         logger.setLevel(logging.CRITICAL + 40)
@@ -157,7 +150,7 @@ class TestCustomLogger:
         ("convert2rhel.log", False),
     ),
 )
-def test_archive_old_logger_files(log_name, path_exists, tmpdir, caplog):
+def test_archive_old_logger_files(log_name, path_exists, tmpdir):
     tmpdir = str(tmpdir)
     archive_dir = os.path.join(tmpdir, "archive")
     log_file = os.path.join(tmpdir, log_name)

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -19,6 +19,7 @@ __metaclass__ = type
 
 import logging
 import os
+import sys
 
 import pytest
 
@@ -32,7 +33,8 @@ def test_logger_handlers(monkeypatch, tmpdir, caplog, read_std, is_py2, global_t
     # initializing the logger first
     log_fname = "convert2rhel.log"
     global_tool_opts.debug = True  # debug entries > stdout if True
-    logger_module.setup_logger_handler(log_name=log_fname, log_dir=str(tmpdir))
+    logger_module.setup_logger_handler()
+    logger_module.add_file_handler(log_name=log_fname, log_dir=str(tmpdir))
     logger = logging.getLogger(__name__)
 
     # emitting some log entries
@@ -53,7 +55,7 @@ def test_logger_handlers(monkeypatch, tmpdir, caplog, read_std, is_py2, global_t
 def test_tools_opts_debug(monkeypatch, tmpdir, read_std, is_py2, global_tool_opts, clear_loggers):
     monkeypatch.setattr("convert2rhel.toolopts.tool_opts", global_tool_opts)
     log_fname = "convert2rhel.log"
-    logger_module.setup_logger_handler(log_name=log_fname, log_dir=str(tmpdir))
+    logger_module.setup_logger_handler()
     logger = logging.getLogger(__name__)
     global_tool_opts.debug = True
     logger.debug("debug entry 1: %s", "data")
@@ -88,7 +90,7 @@ class TestCustomLogger:
     def test_logger_custom_logger(self, log_method_name, level_name, caplog, monkeypatch, tmpdir, clear_loggers):
         """Test CustomLogger."""
         log_fname = "convert2rhel.log"
-        logger_module.setup_logger_handler(log_name=log_fname, log_dir=str(tmpdir))
+        logger_module.setup_logger_handler()
         logger = logging.getLogger(__name__)
         log_method = getattr(logger, log_method_name)
 
@@ -101,7 +103,7 @@ class TestCustomLogger:
     def test_logger_critical(self, caplog, tmpdir, clear_loggers):
         """Test CustomLogger."""
         log_fname = "convert2rhel.log"
-        logger_module.setup_logger_handler(log_name=log_fname, log_dir=str(tmpdir))
+        logger_module.setup_logger_handler()
         logger = logging.getLogger(__name__)
 
         with pytest.raises(SystemExit):
@@ -125,7 +127,7 @@ class TestCustomLogger:
     ):
         """Test CustomLogger."""
         log_fname = "convert2rhel.log"
-        logger_module.setup_logger_handler(log_name=log_fname, log_dir=str(tmpdir))
+        logger_module.setup_logger_handler()
         logger = logging.getLogger(__name__)
         logger.setLevel(logging.CRITICAL + 40)
         log_method = getattr(logger, log_method_name)
@@ -138,7 +140,7 @@ class TestCustomLogger:
     def test_logger_critical_insufficient_level(self, caplog, tmpdir, clear_loggers):
         """Test CustomLogger."""
         log_fname = "convert2rhel.log"
-        logger_module.setup_logger_handler(log_name=log_fname, log_dir=str(tmpdir))
+        logger_module.setup_logger_handler()
         logger = logging.getLogger(__name__)
         logger.setLevel(logging.CRITICAL + 40)
 
@@ -184,3 +186,27 @@ def test_archive_old_logger_files(log_name, path_exists, tmpdir, caplog):
 def test_should_disable_color_output(monkeypatch, no_color_value, should_disable_color):
     monkeypatch.setattr(os, "environ", {"NO_COLOR": no_color_value})
     assert logger_module.should_disable_color_output() == should_disable_color
+
+
+@pytest.mark.noautofixtures
+def test_logfile_buffer_handler(read_std):
+    logbuffer_handler = logger_module.LogfileBufferHandler(2, "custom_name")
+    logger = logging.getLogger("convert2rhel")
+    logger.addHandler(logbuffer_handler)
+
+    logger.warning("message 1")
+    logger.warning("message 2")
+
+    # flushing without other handlers should work, it will just go to NullHandlers
+    logbuffer_handler.flush()
+
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.name = "custom_name"
+    logger.addHandler(stdout_handler)
+
+    # flush to the streamhandler we just created
+    logbuffer_handler.flush()
+
+    stdouterr_out, _ = read_std()
+    assert "message 1" not in stdouterr_out
+    assert "message 2" in stdouterr_out

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -39,8 +39,8 @@ from convert2rhel.unit_tests import (
     ClearVersionlockMocked,
     CLIMocked,
     CollectEarlyDataMocked,
-    FinalizeLoggerMocked,
     FinishCollectionMocked,
+    InitializeFileLoggingMocked,
     InitializeLoggerMocked,
     MainLockedMocked,
     PrintDataCollectionMocked,
@@ -137,7 +137,7 @@ def test_initialize_logger(monkeypatch):
 
 
 @pytest.mark.parametrize(("exception_type", "exception"), ((IOError, True), (OSError, True), (None, False)))
-def test_finalize_logger(exception_type, exception, monkeypatch, caplog):
+def test_initialize_file_logging(exception_type, exception, monkeypatch, caplog):
     add_file_handler_mock = mock.Mock()
     archive_old_logger_files_mock = mock.Mock()
 
@@ -155,7 +155,7 @@ def test_finalize_logger(exception_type, exception, monkeypatch, caplog):
         value=archive_old_logger_files_mock,
     )
 
-    main.finalize_logger("convert2rhel.log", "/tmp")
+    main.initialize_file_logging("convert2rhel.log", "/tmp")
 
     if exception:
         assert caplog.records[-1].levelname == "WARNING"
@@ -219,7 +219,7 @@ def test_help_exit(monkeypatch, tmp_path):
     monkeypatch.setattr(sys, "argv", ["convert2rhel", "--help"])
     monkeypatch.setattr(utils, "require_root", RequireRootMocked())
     monkeypatch.setattr(main, "initialize_logger", InitializeLoggerMocked())
-    monkeypatch.setattr(main, "finalize_logger", FinalizeLoggerMocked())
+    monkeypatch.setattr(main, "initialize_file_logging", InitializeFileLoggingMocked())
     monkeypatch.setattr(main, "main_locked", MainLockedMocked())
 
     with pytest.raises(SystemExit):
@@ -231,7 +231,7 @@ def test_help_exit(monkeypatch, tmp_path):
 def test_main(monkeypatch, tmp_path):
     require_root_mock = mock.Mock()
     initialize_logger_mock = mock.Mock()
-    finalize_logger_mock = mock.Mock()
+    initialize_file_logging_mock = mock.Mock()
     toolopts_cli_mock = mock.Mock()
     show_eula_mock = mock.Mock()
     print_data_collection_mock = mock.Mock()
@@ -258,7 +258,7 @@ def test_main(monkeypatch, tmp_path):
     monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
     monkeypatch.setattr(utils, "require_root", require_root_mock)
     monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
-    monkeypatch.setattr(main, "finalize_logger", finalize_logger_mock)
+    monkeypatch.setattr(main, "initialize_file_logging", initialize_file_logging_mock)
     monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
     monkeypatch.setattr(main, "show_eula", show_eula_mock)
     monkeypatch.setattr(breadcrumbs, "print_data_collection", print_data_collection_mock)
@@ -311,7 +311,7 @@ class TestRollbackFromMain:
     def test_main_rollback_post_cli_phase(self, monkeypatch, caplog, tmp_path):
         require_root_mock = mock.Mock()
         initialize_logger_mock = mock.Mock()
-        finalize_logger_mock = mock.Mock()
+        initialize_file_logging_mock = mock.Mock()
         toolopts_cli_mock = mock.Mock()
         show_eula_mock = mock.Mock(side_effect=Exception)
 
@@ -321,7 +321,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
         monkeypatch.setattr(utils, "require_root", require_root_mock)
         monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
-        monkeypatch.setattr(main, "finalize_logger", finalize_logger_mock)
+        monkeypatch.setattr(main, "initialize_file_logging", initialize_file_logging_mock)
         monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
         monkeypatch.setattr(main, "show_eula", show_eula_mock)
         monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
@@ -338,7 +338,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
         monkeypatch.setattr(utils, "require_root", RequireRootMocked())
         monkeypatch.setattr(main, "initialize_logger", InitializeLoggerMocked())
-        monkeypatch.setattr(main, "finalize_logger", FinalizeLoggerMocked())
+        monkeypatch.setattr(main, "initialize_file_logging", InitializeFileLoggingMocked())
         monkeypatch.setattr(toolopts, "CLI", CLIMocked())
         monkeypatch.setattr(main, "show_eula", ShowEulaMocked())
         monkeypatch.setattr(breadcrumbs, "print_data_collection", PrintDataCollectionMocked())
@@ -380,7 +380,7 @@ class TestRollbackFromMain:
     def test_main_traceback_before_action_completion(self, monkeypatch, caplog, tmp_path):
         require_root_mock = mock.Mock()
         initialize_logger_mock = mock.Mock()
-        finalize_logger_mock = mock.Mock()
+        initialize_file_logging_mock = mock.Mock()
         toolopts_cli_mock = mock.Mock()
         show_eula_mock = mock.Mock()
         print_data_collection_mock = mock.Mock()
@@ -400,7 +400,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
         monkeypatch.setattr(utils, "require_root", require_root_mock)
         monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
-        monkeypatch.setattr(main, "finalize_logger", finalize_logger_mock)
+        monkeypatch.setattr(main, "initialize_file_logging", initialize_file_logging_mock)
         monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
         monkeypatch.setattr(main, "show_eula", show_eula_mock)
         monkeypatch.setattr(breadcrumbs, "print_data_collection", print_data_collection_mock)
@@ -418,7 +418,7 @@ class TestRollbackFromMain:
         assert main.main() == 1
         assert initialize_logger_mock.call_count == 1
         assert require_root_mock.call_count == 1
-        assert finalize_logger_mock.call_count == 1
+        assert initialize_file_logging_mock.call_count == 1
         assert toolopts_cli_mock.call_count == 1
         assert show_eula_mock.call_count == 1
         assert print_data_collection_mock.call_count == 1
@@ -440,7 +440,7 @@ class TestRollbackFromMain:
     def test_main_rollback_pre_ponr_changes_phase(self, monkeypatch, caplog, tmp_path):
         require_root_mock = mock.Mock()
         initialize_logger_mock = mock.Mock()
-        finalize_logger_mock = mock.Mock()
+        initialize_file_logging_mock = mock.Mock()
         toolopts_cli_mock = mock.Mock()
         show_eula_mock = mock.Mock()
         print_data_collection_mock = mock.Mock()
@@ -462,7 +462,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
         monkeypatch.setattr(utils, "require_root", require_root_mock)
         monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
-        monkeypatch.setattr(main, "finalize_logger", finalize_logger_mock)
+        monkeypatch.setattr(main, "initialize_file_logging", initialize_file_logging_mock)
         monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
         monkeypatch.setattr(main, "show_eula", show_eula_mock)
         monkeypatch.setattr(breadcrumbs, "print_data_collection", print_data_collection_mock)
@@ -482,7 +482,7 @@ class TestRollbackFromMain:
         assert main.main() == 1
         assert initialize_logger_mock.call_count == 1
         assert require_root_mock.call_count == 1
-        assert finalize_logger_mock.call_count == 1
+        assert initialize_file_logging_mock.call_count == 1
         assert toolopts_cli_mock.call_count == 1
         assert show_eula_mock.call_count == 1
         assert print_data_collection_mock.call_count == 1
@@ -503,7 +503,7 @@ class TestRollbackFromMain:
     def test_main_rollback_analyze_exit_phase(self, global_tool_opts, monkeypatch, tmp_path):
         require_root_mock = mock.Mock()
         initialize_logger_mock = mock.Mock()
-        finalize_logger_mock = mock.Mock()
+        initialize_file_logging_mock = mock.Mock()
         toolopts_cli_mock = mock.Mock()
         show_eula_mock = mock.Mock()
         print_data_collection_mock = mock.Mock()
@@ -524,7 +524,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
         monkeypatch.setattr(utils, "require_root", require_root_mock)
         monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
-        monkeypatch.setattr(main, "finalize_logger", finalize_logger_mock)
+        monkeypatch.setattr(main, "initialize_file_logging", initialize_file_logging_mock)
         monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
         monkeypatch.setattr(main, "show_eula", show_eula_mock)
         monkeypatch.setattr(breadcrumbs, "print_data_collection", print_data_collection_mock)
@@ -545,7 +545,7 @@ class TestRollbackFromMain:
         assert main.main() == 0
         assert require_root_mock.call_count == 1
         assert initialize_logger_mock.call_count == 1
-        assert finalize_logger_mock.call_count == 1
+        assert initialize_file_logging_mock.call_count == 1
         assert toolopts_cli_mock.call_count == 1
         assert show_eula_mock.call_count == 1
         assert print_data_collection_mock.call_count == 1
@@ -563,7 +563,7 @@ class TestRollbackFromMain:
     def test_main_rollback_post_ponr_changes_phase(self, monkeypatch, caplog, tmp_path):
         require_root_mock = mock.Mock()
         initialize_logger_mock = mock.Mock()
-        finalize_logger_mock = mock.Mock()
+        initialize_file_logging_mock = mock.Mock()
         toolopts_cli_mock = mock.Mock()
         show_eula_mock = mock.Mock()
         print_data_collection_mock = mock.Mock()
@@ -587,7 +587,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
         monkeypatch.setattr(utils, "require_root", require_root_mock)
         monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
-        monkeypatch.setattr(main, "finalize_logger", finalize_logger_mock)
+        monkeypatch.setattr(main, "initialize_file_logging", initialize_file_logging_mock)
         monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
         monkeypatch.setattr(main, "show_eula", show_eula_mock)
         monkeypatch.setattr(breadcrumbs, "print_data_collection", print_data_collection_mock)
@@ -609,7 +609,7 @@ class TestRollbackFromMain:
         assert main.main() == 1
         assert require_root_mock.call_count == 1
         assert initialize_logger_mock.call_count == 1
-        assert finalize_logger_mock.call_count == 1
+        assert initialize_file_logging_mock.call_count == 1
         assert toolopts_cli_mock.call_count == 1
         assert show_eula_mock.call_count == 1
         assert print_data_collection_mock.call_count == 1

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -39,6 +39,7 @@ from convert2rhel.unit_tests import (
     ClearVersionlockMocked,
     CLIMocked,
     CollectEarlyDataMocked,
+    FinalizeLoggerMocked,
     FinishCollectionMocked,
     InitializeLoggerMocked,
     MainLockedMocked,
@@ -122,9 +123,22 @@ class TestRollbackChanges:
             main.rollback_changes()
 
 
-@pytest.mark.parametrize(("exception_type", "exception"), ((IOError, True), (OSError, True), (None, False)))
-def test_initialize_logger(exception_type, exception, monkeypatch, capsys):
+def test_initialize_logger(monkeypatch):
     setup_logger_handler_mock = mock.Mock()
+
+    monkeypatch.setattr(
+        logger_module,
+        "setup_logger_handler",
+        value=setup_logger_handler_mock,
+    )
+
+    main.initialize_logger()
+    setup_logger_handler_mock.assert_called_once()
+
+
+@pytest.mark.parametrize(("exception_type", "exception"), ((IOError, True), (OSError, True), (None, False)))
+def test_finalize_logger(exception_type, exception, monkeypatch, caplog):
+    add_file_handler_mock = mock.Mock()
     archive_old_logger_files_mock = mock.Mock()
 
     if exception:
@@ -132,8 +146,8 @@ def test_initialize_logger(exception_type, exception, monkeypatch, capsys):
 
     monkeypatch.setattr(
         logger_module,
-        "setup_logger_handler",
-        value=setup_logger_handler_mock,
+        "add_file_handler",
+        value=add_file_handler_mock,
     )
     monkeypatch.setattr(
         logger_module,
@@ -141,14 +155,14 @@ def test_initialize_logger(exception_type, exception, monkeypatch, capsys):
         value=archive_old_logger_files_mock,
     )
 
+    main.finalize_logger("convert2rhel.log", "/tmp")
+
     if exception:
-        main.initialize_logger("convert2rhel.log", "/tmp")
-        out, _ = capsys.readouterr()
-        assert "Warning: Unable to archive previous log:" in out
-    else:
-        main.initialize_logger("convert2rhel.log", "/tmp")
-        setup_logger_handler_mock.assert_called_once()
-        archive_old_logger_files_mock.assert_called_once()
+        assert caplog.records[-1].levelname == "WARNING"
+        assert "Unable to archive previous log:" in caplog.records[-1].message
+
+    add_file_handler_mock.assert_called_once()
+    archive_old_logger_files_mock.assert_called_once()
 
 
 class TestShowEula:
@@ -205,6 +219,7 @@ def test_help_exit(monkeypatch, tmp_path):
     monkeypatch.setattr(sys, "argv", ["convert2rhel", "--help"])
     monkeypatch.setattr(utils, "require_root", RequireRootMocked())
     monkeypatch.setattr(main, "initialize_logger", InitializeLoggerMocked())
+    monkeypatch.setattr(main, "finalize_logger", FinalizeLoggerMocked())
     monkeypatch.setattr(main, "main_locked", MainLockedMocked())
 
     with pytest.raises(SystemExit):
@@ -216,6 +231,7 @@ def test_help_exit(monkeypatch, tmp_path):
 def test_main(monkeypatch, tmp_path):
     require_root_mock = mock.Mock()
     initialize_logger_mock = mock.Mock()
+    finalize_logger_mock = mock.Mock()
     toolopts_cli_mock = mock.Mock()
     show_eula_mock = mock.Mock()
     print_data_collection_mock = mock.Mock()
@@ -242,6 +258,7 @@ def test_main(monkeypatch, tmp_path):
     monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
     monkeypatch.setattr(utils, "require_root", require_root_mock)
     monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
+    monkeypatch.setattr(main, "finalize_logger", finalize_logger_mock)
     monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
     monkeypatch.setattr(main, "show_eula", show_eula_mock)
     monkeypatch.setattr(breadcrumbs, "print_data_collection", print_data_collection_mock)
@@ -294,6 +311,7 @@ class TestRollbackFromMain:
     def test_main_rollback_post_cli_phase(self, monkeypatch, caplog, tmp_path):
         require_root_mock = mock.Mock()
         initialize_logger_mock = mock.Mock()
+        finalize_logger_mock = mock.Mock()
         toolopts_cli_mock = mock.Mock()
         show_eula_mock = mock.Mock(side_effect=Exception)
 
@@ -303,6 +321,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
         monkeypatch.setattr(utils, "require_root", require_root_mock)
         monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
+        monkeypatch.setattr(main, "finalize_logger", finalize_logger_mock)
         monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
         monkeypatch.setattr(main, "show_eula", show_eula_mock)
         monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
@@ -319,6 +338,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
         monkeypatch.setattr(utils, "require_root", RequireRootMocked())
         monkeypatch.setattr(main, "initialize_logger", InitializeLoggerMocked())
+        monkeypatch.setattr(main, "finalize_logger", FinalizeLoggerMocked())
         monkeypatch.setattr(toolopts, "CLI", CLIMocked())
         monkeypatch.setattr(main, "show_eula", ShowEulaMocked())
         monkeypatch.setattr(breadcrumbs, "print_data_collection", PrintDataCollectionMocked())
@@ -360,6 +380,7 @@ class TestRollbackFromMain:
     def test_main_traceback_before_action_completion(self, monkeypatch, caplog, tmp_path):
         require_root_mock = mock.Mock()
         initialize_logger_mock = mock.Mock()
+        finalize_logger_mock = mock.Mock()
         toolopts_cli_mock = mock.Mock()
         show_eula_mock = mock.Mock()
         print_data_collection_mock = mock.Mock()
@@ -379,6 +400,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
         monkeypatch.setattr(utils, "require_root", require_root_mock)
         monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
+        monkeypatch.setattr(main, "finalize_logger", finalize_logger_mock)
         monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
         monkeypatch.setattr(main, "show_eula", show_eula_mock)
         monkeypatch.setattr(breadcrumbs, "print_data_collection", print_data_collection_mock)
@@ -394,8 +416,9 @@ class TestRollbackFromMain:
         monkeypatch.setattr(report, "summary_as_txt", summary_as_txt_mock)
 
         assert main.main() == 1
-        assert require_root_mock.call_count == 1
         assert initialize_logger_mock.call_count == 1
+        assert require_root_mock.call_count == 1
+        assert finalize_logger_mock.call_count == 1
         assert toolopts_cli_mock.call_count == 1
         assert show_eula_mock.call_count == 1
         assert print_data_collection_mock.call_count == 1
@@ -417,6 +440,7 @@ class TestRollbackFromMain:
     def test_main_rollback_pre_ponr_changes_phase(self, monkeypatch, caplog, tmp_path):
         require_root_mock = mock.Mock()
         initialize_logger_mock = mock.Mock()
+        finalize_logger_mock = mock.Mock()
         toolopts_cli_mock = mock.Mock()
         show_eula_mock = mock.Mock()
         print_data_collection_mock = mock.Mock()
@@ -438,6 +462,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
         monkeypatch.setattr(utils, "require_root", require_root_mock)
         monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
+        monkeypatch.setattr(main, "finalize_logger", finalize_logger_mock)
         monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
         monkeypatch.setattr(main, "show_eula", show_eula_mock)
         monkeypatch.setattr(breadcrumbs, "print_data_collection", print_data_collection_mock)
@@ -455,8 +480,9 @@ class TestRollbackFromMain:
         monkeypatch.setattr(report, "summary_as_txt", summary_as_txt_mock)
 
         assert main.main() == 1
-        assert require_root_mock.call_count == 1
         assert initialize_logger_mock.call_count == 1
+        assert require_root_mock.call_count == 1
+        assert finalize_logger_mock.call_count == 1
         assert toolopts_cli_mock.call_count == 1
         assert show_eula_mock.call_count == 1
         assert print_data_collection_mock.call_count == 1
@@ -477,6 +503,7 @@ class TestRollbackFromMain:
     def test_main_rollback_analyze_exit_phase(self, global_tool_opts, monkeypatch, tmp_path):
         require_root_mock = mock.Mock()
         initialize_logger_mock = mock.Mock()
+        finalize_logger_mock = mock.Mock()
         toolopts_cli_mock = mock.Mock()
         show_eula_mock = mock.Mock()
         print_data_collection_mock = mock.Mock()
@@ -497,6 +524,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
         monkeypatch.setattr(utils, "require_root", require_root_mock)
         monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
+        monkeypatch.setattr(main, "finalize_logger", finalize_logger_mock)
         monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
         monkeypatch.setattr(main, "show_eula", show_eula_mock)
         monkeypatch.setattr(breadcrumbs, "print_data_collection", print_data_collection_mock)
@@ -517,6 +545,7 @@ class TestRollbackFromMain:
         assert main.main() == 0
         assert require_root_mock.call_count == 1
         assert initialize_logger_mock.call_count == 1
+        assert finalize_logger_mock.call_count == 1
         assert toolopts_cli_mock.call_count == 1
         assert show_eula_mock.call_count == 1
         assert print_data_collection_mock.call_count == 1
@@ -534,6 +563,7 @@ class TestRollbackFromMain:
     def test_main_rollback_post_ponr_changes_phase(self, monkeypatch, caplog, tmp_path):
         require_root_mock = mock.Mock()
         initialize_logger_mock = mock.Mock()
+        finalize_logger_mock = mock.Mock()
         toolopts_cli_mock = mock.Mock()
         show_eula_mock = mock.Mock()
         print_data_collection_mock = mock.Mock()
@@ -557,6 +587,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
         monkeypatch.setattr(utils, "require_root", require_root_mock)
         monkeypatch.setattr(main, "initialize_logger", initialize_logger_mock)
+        monkeypatch.setattr(main, "finalize_logger", finalize_logger_mock)
         monkeypatch.setattr(toolopts, "CLI", toolopts_cli_mock)
         monkeypatch.setattr(main, "show_eula", show_eula_mock)
         monkeypatch.setattr(breadcrumbs, "print_data_collection", print_data_collection_mock)
@@ -578,6 +609,7 @@ class TestRollbackFromMain:
         assert main.main() == 1
         assert require_root_mock.call_count == 1
         assert initialize_logger_mock.call_count == 1
+        assert finalize_logger_mock.call_count == 1
         assert toolopts_cli_mock.call_count == 1
         assert show_eula_mock.call_count == 1
         assert print_data_collection_mock.call_count == 1

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -905,12 +905,12 @@ class TestRunSubprocess:
         assert 0 == rc
 
 
-def test_require_root_is_not_root(monkeypatch, capsys):
+def test_require_root_is_not_root(monkeypatch, caplog):
     monkeypatch.setattr(os, "geteuid", GetEUIDMocked(1000))
     with pytest.raises(SystemExit):
         utils.require_root()
 
-    assert "The tool needs to be run under the root user." in capsys.readouterr().out
+    assert "The tool needs to be run under the root user." in caplog.text
 
 
 def test_require_root_is_root(monkeypatch):

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -287,12 +287,8 @@ def get_executable_name():
     return os.path.basename(inspect.stack()[-1][1])
 
 
-def is_root():
-    return os.geteuid() == 0
-
-
 def require_root():
-    if not is_root():
+    if os.geteuid() != 0:
         loggerinst.critical("The tool needs to be run under the root user.\nNo changes were made to the system.")
 
 

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -287,11 +287,13 @@ def get_executable_name():
     return os.path.basename(inspect.stack()[-1][1])
 
 
+def is_root():
+    return os.geteuid() == 0
+
+
 def require_root():
-    if os.geteuid() != 0:
-        print("The tool needs to be run under the root user.")
-        print("\nNo changes were made to the system.")
-        sys.exit(1)
+    if not is_root():
+        loggerinst.critical("The tool needs to be run under the root user.\nNo changes were made to the system.")
 
 
 def get_file_content(filename, as_list=False):

--- a/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
@@ -23,7 +23,7 @@ def test_check_user_privileges(shell):
     # Check the program exits as it is required to be run by root
     assert result.returncode != 0
     # Check the program exits for the correct reason
-    assert "The tool needs to be run under the root user.\n" "\n" "No changes were made to the system." in result.output
+    assert "The tool needs to be run under the root user.\nNo changes were made to the system." in result.output
     # Delete testuser (if present)
     assert shell(f"userdel -r '{user}'").returncode == 0
 

--- a/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
@@ -23,9 +23,7 @@ def test_check_user_privileges(shell):
     # Check the program exits as it is required to be run by root
     assert result.returncode != 0
     # Check the program exits for the correct reason
-    assert (
-        result.output == "The tool needs to be run under the root user.\n" "\n" "No changes were made to the system.\n"
-    )
+    assert "The tool needs to be run under the root user.\n" "\n" "No changes were made to the system." in result.output
     # Delete testuser (if present)
     assert shell(f"userdel -r '{user}'").returncode == 0
 


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

To do

- [x] Potentially changing integration tests
- [x] Testing locally
- [x] Fix buffer going to the log file on init


In short of the changes:

- Split the log handlers into an initialize and finalize function, where FileHandler is added later
- Logging when not being root no longer causes logs to not work or function correctly (as FileHandler isn't added)
- Also fixes the issue of clearing the log files if a duplicate process is found, we just initialize the FileHandler later
- Custom memory buffer is added to keep the last 100 logs, and once FileHandler is added we instantly log the buffer to it


<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: 
- [RHELC-1131](https://issues.redhat.com/browse/RHELC-1131)
- [RHELC-1234](https://issues.redhat.com/browse/RHELC-1234)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
