### PR TITLE
[RHELC-1307] Collect environment variables in breadcrumbs

### DIFF
--- a/convert2rhel/breadcrumbs.py
+++ b/convert2rhel/breadcrumbs.py
@@ -84,6 +84,7 @@ class Breadcrumbs:
         self._set_signature()
         self._set_source_os()
         self._set_started()
+        self._set_env()
 
     def finish_collection(self, success=False):
         """Set the final data for breadcrumbs after the conversion ends.

--- a/convert2rhel/unit_tests/breadcrumbs_test.py
+++ b/convert2rhel/unit_tests/breadcrumbs_test.py
@@ -18,7 +18,6 @@
 __metaclass__ = type
 
 import json
-import os
 
 import pytest
 import six

--- a/convert2rhel/unit_tests/breadcrumbs_test.py
+++ b/convert2rhel/unit_tests/breadcrumbs_test.py
@@ -18,6 +18,7 @@
 __metaclass__ = type
 
 import json
+import os
 
 import pytest
 import six
@@ -54,13 +55,14 @@ def breadcrumbs_instance(_mock_pkg_obj, _mock_pkg_information, monkeypatch):
     monkeypatch.setattr(breadcrumbs.breadcrumbs, "_pkg_object", _mock_pkg_obj)
     monkeypatch.setattr(pkghandler, "get_installed_pkg_objects", lambda name: [_mock_pkg_obj])
     monkeypatch.setattr(pkghandler, "get_installed_pkg_information", lambda name: [_mock_pkg_information])
+    monkeypatch.setenv("CONVERT2RHEL_FOO_BAR", "1")
     breadcrumbs.breadcrumbs.collect_early_data()
 
     yield breadcrumbs.Breadcrumbs()
 
 
 @pytest.fixture
-def finish_collection_mocks(monkeypatch):
+def finish_collection_mocks():
     save_migration_results_mock = mock.Mock()
     save_rhsm_facts_mock = mock.Mock()
 
@@ -68,7 +70,7 @@ def finish_collection_mocks(monkeypatch):
 
 
 @centos7
-def test_collect_early_data(pretend_os, breadcrumbs_instance, global_tool_opts, monkeypatch):
+def test_collect_early_data(pretend_os, breadcrumbs_instance, global_tool_opts):
     global_tool_opts.activity = "analysis"
 
     breadcrumbs_instance.collect_early_data()
@@ -82,6 +84,7 @@ def test_collect_early_data(pretend_os, breadcrumbs_instance, global_tool_opts, 
     assert breadcrumbs_instance.executed != "null"
     assert breadcrumbs_instance.activity_started != "null"
     assert breadcrumbs_instance._pkg_object is not None
+    assert "CONVERT2RHEL_FOO_BAR" in breadcrumbs_instance.env
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The _set_env() method was missing in the breadcrumbs early data collection. This commit introduces the function in the early collection again.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1307](https://issues.redhat.com/browse/RHELC-1307)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
