### PR TITLE
Quiet an environment variable type warning in toolopts unit tests.

### DIFF
--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -741,7 +741,7 @@ def test_should_subscribe(username, password, organization, activation_key, no_r
 def test_setting_no_rpm_va(argv, env_var, expected, message, monkeypatch, global_tool_opts, caplog):
     monkeypatch.setattr(sys, "argv", mock_cli_arguments(argv))
     if env_var:
-        monkeypatch.setenv("CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK", 1)
+        monkeypatch.setenv("CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK", "1")
 
     try:
         convert2rhel.toolopts.CLI()


### PR DESCRIPTION
We patch an environment variable in the toolopts unit tests with an integer value when it should be a string. This change quiets the warning.

Jira Issues: none

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x]] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
