### PR TITLE
[RHELC-1190] Add shim-x64 to the exclude list for Alma 8

### DIFF
--- a/convert2rhel/data/8/x86_64/configs/almalinux-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/almalinux-8-x86_64.cfg
@@ -11,6 +11,7 @@ gpg_fingerprints =
 # Delimited by any whitespace(s).
 excluded_pkgs =
   almalinux-gpg-keys
+  shim-x64
 
 # Mapping of packages that need to be swapped during the transaction
 swap_pkgs =

--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -90,13 +90,6 @@ description+: |
 
     /single_yum_transaction:
         /packages_upgraded_after_conversion:
-            #TODO(danmyway) Enable again when RHELC-1190 gets fixed
-            adjust+:
-                - enabled: false
-                  when:
-                    distro == alma-8.8
-                  because: There is a known issue causing the shim-x64 package not being reinstalled.
-
             discover+:
                 test+<:
                     - single-yum-transaction/packages_upgraded_after_conversion


### PR DESCRIPTION
The package is causing dependency problem with the kernel-core package, as both of them are marked for downgrade. The dependencies does not match.

This solution is used for Oracle Linux 7 as well, as we simply add the package to the exclude list as well.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1190](https://issues.redhat.com/browse/RHELC-1190)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
