### PR TITLE
Set downgrade to strict mode to not miss deps

### DIFF
--- a/convert2rhel/pkgmanager/handlers/dnf/__init__.py
+++ b/convert2rhel/pkgmanager/handlers/dnf/__init__.py
@@ -162,7 +162,7 @@ class DnfTransactionHandler(TransactionHandlerBase):
                 self._base.reinstall(pkg_spec=pkg)
             except pkgmanager.exceptions.PackagesNotAvailableError:
                 try:
-                    self._base.downgrade(pkg_spec=pkg)
+                    self._base.downgrade_to(pkg_spec=pkg, strict=True)
                 except pkgmanager.exceptions.PackagesNotInstalledError:
                     loggerinst.warning("Package %s not available in RHEL repositories.", pkg)
 

--- a/convert2rhel/unit_tests/pkgmanager/handlers/dnf/dnf_test.py
+++ b/convert2rhel/unit_tests/pkgmanager/handlers/dnf/dnf_test.py
@@ -119,7 +119,7 @@ class TestDnfTransactionHandler:
         monkeypatch.setattr(pkgmanager.Base, "fill_sack", value=mock.Mock())
         monkeypatch.setattr(pkgmanager.Base, "upgrade", value=mock.Mock())
         monkeypatch.setattr(pkgmanager.Base, "reinstall", value=mock.Mock())
-        monkeypatch.setattr(pkgmanager.Base, "downgrade", value=mock.Mock())
+        monkeypatch.setattr(pkgmanager.Base, "downgrade_to", value=mock.Mock())
         monkeypatch.setattr(pkgmanager.Base, "resolve", value=mock.Mock())
         monkeypatch.setattr(pkgmanager.Base, "download_packages", value=mock.Mock())
         monkeypatch.setattr(pkgmanager.Base, "do_transaction", value=mock.Mock())
@@ -230,8 +230,8 @@ class TestDnfTransactionHandler:
         instance._perform_operations()
 
         assert pkgmanager.Base.reinstall.call_count == len(SYSTEM_PACKAGES)
-        assert pkgmanager.Base.downgrade.call_count == 0
         assert swap_base_os_specific_packages.call_count == 1
+        assert pkgmanager.Base.downgrade_to.call_count == 0
 
     @centos8
     def test_package_marked_for_update(self, pretend_os, monkeypatch):
@@ -249,7 +249,7 @@ class TestDnfTransactionHandler:
 
         assert pkgmanager.Base.upgrade.call_count == len(SYSTEM_PACKAGES)
         assert pkgmanager.Base.reinstall.call_count == 0
-        assert pkgmanager.Base.downgrade.call_count == 0
+        assert pkgmanager.Base.downgrade_to.call_count == 0
 
     @centos8
     def test_perform_operations_reinstall_exception(self, pretend_os, caplog, monkeypatch):
@@ -264,7 +264,7 @@ class TestDnfTransactionHandler:
         instance._perform_operations()
 
         assert pkgmanager.Base.reinstall.call_count == len(SYSTEM_PACKAGES)
-        assert pkgmanager.Base.downgrade.call_count == len(SYSTEM_PACKAGES)
+        assert pkgmanager.Base.downgrade_to.call_count == len(SYSTEM_PACKAGES)
         assert "not available in RHEL repositories" not in caplog.records[-1].message
 
     @centos8
@@ -275,14 +275,14 @@ class TestDnfTransactionHandler:
             value=lambda: SYSTEM_PACKAGES,
         )
         pkgmanager.Base.reinstall.side_effect = pkgmanager.exceptions.PackagesNotAvailableError
-        pkgmanager.Base.downgrade.side_effect = pkgmanager.exceptions.PackagesNotInstalledError
+        pkgmanager.Base.downgrade_to.side_effect = pkgmanager.exceptions.PackagesNotInstalledError
 
         instance = DnfTransactionHandler()
         instance._set_up_base()
         instance._perform_operations()
 
         assert pkgmanager.Base.reinstall.call_count == len(SYSTEM_PACKAGES)
-        assert pkgmanager.Base.downgrade.call_count == len(SYSTEM_PACKAGES)
+        assert pkgmanager.Base.downgrade_to.call_count == len(SYSTEM_PACKAGES)
         assert "not available in RHEL repositories" in caplog.text
 
     @centos8


### PR DESCRIPTION
Without strict mode, dnf will not tell us if there is a dependency problem with a downgrade. This is necessary so we can make sure to fail during the analysis phase.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
