### PR TITLE
[RHELC-1370] Fix Alma Linux 8 packages being seen as third-party 

### DIFF
--- a/convert2rhel/actions/system_checks/rhel_compatible_kernel.py
+++ b/convert2rhel/actions/system_checks/rhel_compatible_kernel.py
@@ -138,7 +138,7 @@ def _bad_kernel_package_signature(kernel_release):
         )
 
     kernel_pkg_obj = get_installed_pkg_information(pkg_name=kernel_pkg)
-    bad_signature = system_info.cfg_content["gpg_fingerprints"] != kernel_pkg_obj[0].fingerprint
+    bad_signature = kernel_pkg_obj[0].fingerprint not in system_info.fingerprints_orig_os
     if bad_signature:
         raise KernelIncompatibleError(
             "INVALID_KERNEL_PACKAGE_SIGNATURE",

--- a/convert2rhel/data/8/x86_64/configs/almalinux-8-x86_64.cfg
+++ b/convert2rhel/data/8/x86_64/configs/almalinux-8-x86_64.cfg
@@ -3,7 +3,9 @@
 # Fingerprints of GPG keys used for signing packages of the OS to be converted.
 # The GPG key is available at https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux
 # Delimited by whitespace(s).
-gpg_fingerprints = 51d6647ec21ad6ea
+gpg_fingerprints =
+  51d6647ec21ad6ea
+  2ae81e8aced7258b
 
 # List of packages to be removed before the system conversion starts.
 # Delimited by any whitespace(s).


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
With the latest packages signed with a new GPG key, said packages were recognized as third-party.
Add the GPG fingerprint to recognized in the config.

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1370](https://issues.redhat.com/browse/RHELC-1370)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
