### PR TITLE
[RHELC-1164] Update RHSM custom facts during analysis

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -152,7 +152,7 @@ def main_locked():
 
     except _AnalyzeExit:
         breadcrumbs.breadcrumbs.finish_collection(success=True)
-        # Update RHSM custom facts only when thi returns False. Otherwise,
+        # Update RHSM custom facts only when this returns False. Otherwise,
         # sub-man get uninstalled and the data is removed from the server.
         if not subscription.should_subscribe():
             subscription.update_rhsm_custom_facts()
@@ -193,7 +193,7 @@ def _handle_main_exceptions(process_phase, pre_conversion_results=None):
     if process_phase == ConversionPhase.POST_CLI:
         loggerinst.info(no_changes_msg)
     elif process_phase == ConversionPhase.PRE_PONR_CHANGES:
-        # Update RHSM custom facts only when thi returns False. Otherwise,
+        # Update RHSM custom facts only when this returns False. Otherwise,
         # sub-man get uninstalled and the data is removed from the server.
         if not subscription.should_subscribe():
             subscription.update_rhsm_custom_facts()

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -152,6 +152,10 @@ def main_locked():
 
     except _AnalyzeExit:
         breadcrumbs.breadcrumbs.finish_collection(success=True)
+        # Update RHSM custom facts only when thi returns False. Otherwise,
+        # sub-man get uninstalled and the data is removed from the server.
+        if not subscription.should_subscribe():
+            subscription.update_rhsm_custom_facts()
 
         rollback_changes()
 
@@ -189,6 +193,11 @@ def _handle_main_exceptions(process_phase, pre_conversion_results=None):
     if process_phase == ConversionPhase.POST_CLI:
         loggerinst.info(no_changes_msg)
     elif process_phase == ConversionPhase.PRE_PONR_CHANGES:
+        # Update RHSM custom facts only when thi returns False. Otherwise,
+        # sub-man get uninstalled and the data is removed from the server.
+        if not subscription.should_subscribe():
+            subscription.update_rhsm_custom_facts()
+
         rollback_changes()
         if pre_conversion_results is None:
             loggerinst.info("\nConversion interrupted before analysis of system completed. Report not generated.\n")

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -153,7 +153,7 @@ def main_locked():
     except _AnalyzeExit:
         breadcrumbs.breadcrumbs.finish_collection(success=True)
         # Update RHSM custom facts only when this returns False. Otherwise,
-        # sub-man get uninstalled and the data is removed from the server.
+        # sub-man get uninstalled and the data is removed from the RHSM server.
         if not subscription.should_subscribe():
             subscription.update_rhsm_custom_facts()
 
@@ -194,7 +194,7 @@ def _handle_main_exceptions(process_phase, pre_conversion_results=None):
         loggerinst.info(no_changes_msg)
     elif process_phase == ConversionPhase.PRE_PONR_CHANGES:
         # Update RHSM custom facts only when this returns False. Otherwise,
-        # sub-man get uninstalled and the data is removed from the server.
+        # sub-man get uninstalled and the data is removed from the RHSM server.
         if not subscription.should_subscribe():
             subscription.update_rhsm_custom_facts()
 

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -494,6 +494,7 @@ class TestRollbackFromMain:
             (applock, "_DEFAULT_LOCK_DIR", str(tmp_path)),
             (utils, "require_root", mock.Mock()),
             (main, "initialize_logger", mock.Mock()),
+            (main, "initialize_file_logging", mock.Mock()),
             (toolopts, "CLI", mock.Mock()),
             (main, "show_eula", mock.Mock()),
             (breadcrumbs, "print_data_collection", mock.Mock()),

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -493,7 +493,6 @@ class TestRollbackFromMain:
         mocks = (
             (applock, "_DEFAULT_LOCK_DIR", str(tmp_path)),
             (utils, "require_root", mock.Mock()),
-            (main, "initialize_logger", mock.Mock()),
             (main, "initialize_file_logging", mock.Mock()),
             (toolopts, "CLI", mock.Mock()),
             (main, "show_eula", mock.Mock()),
@@ -519,7 +518,6 @@ class TestRollbackFromMain:
 
         assert main.main() == 0
         assert utils.require_root.call_count == 1
-        assert main.initialize_logger.call_count == 1
         assert toolopts.CLI.call_count == 1
         assert main.show_eula.call_count == 1
         assert breadcrumbs.print_data_collection.call_count == 1

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -368,6 +368,8 @@ class TestRollbackFromMain:
 
         # Mock the rollback calls
         finish_collection_mock = mock.Mock()
+        should_subscribe_mock = mock.Mock(side_effect=lambda: False)
+        update_rhsm_custom_facts_mock = mock.Mock()
         rollback_changes_mock = mock.Mock()
         summary_as_json_mock = mock.Mock()
 
@@ -384,6 +386,8 @@ class TestRollbackFromMain:
         monkeypatch.setattr(pkgmanager, "clean_yum_metadata", clean_yum_metadata_mock)
         monkeypatch.setattr(actions, "run_actions", run_actions_mock)
         monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
+        monkeypatch.setattr(subscription, "should_subscribe", should_subscribe_mock)
+        monkeypatch.setattr(subscription, "update_rhsm_custom_facts", update_rhsm_custom_facts_mock)
         monkeypatch.setattr(main, "rollback_changes", rollback_changes_mock)
         monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
         monkeypatch.setattr(report, "summary_as_txt", summary_as_txt_mock)
@@ -400,6 +404,8 @@ class TestRollbackFromMain:
         assert run_actions_mock.call_count == 1
         assert clear_versionlock_mock.call_count == 1
         assert finish_collection_mock.call_count == 1
+        assert should_subscribe_mock.call_count == 1
+        assert update_rhsm_custom_facts_mock.call_count == 1
         assert rollback_changes_mock.call_count == 1
         assert summary_as_json_mock.call_count == 0
         assert summary_as_txt_mock.call_count == 0
@@ -427,6 +433,8 @@ class TestRollbackFromMain:
 
         # Mock the rollback calls
         finish_collection_mock = mock.Mock()
+        should_subscribe_mock = mock.Mock(side_effect=lambda: False)
+        update_rhsm_custom_facts_mock = mock.Mock()
         rollback_changes_mock = mock.Mock()
         summary_as_json_mock = mock.Mock()
 
@@ -445,6 +453,8 @@ class TestRollbackFromMain:
         monkeypatch.setattr(report, "summary", report_summary_mock)
         monkeypatch.setattr(actions, "find_actions_of_severity", find_actions_of_severity_mock)
         monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
+        monkeypatch.setattr(subscription, "should_subscribe", should_subscribe_mock)
+        monkeypatch.setattr(subscription, "update_rhsm_custom_facts", update_rhsm_custom_facts_mock)
         monkeypatch.setattr(main, "rollback_changes", rollback_changes_mock)
         monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
         monkeypatch.setattr(report, "summary_as_txt", summary_as_txt_mock)
@@ -463,11 +473,68 @@ class TestRollbackFromMain:
         assert find_actions_of_severity_mock.call_count == 1
         assert clear_versionlock_mock.call_count == 1
         assert finish_collection_mock.call_count == 1
+        assert should_subscribe_mock.call_count == 1
+        assert update_rhsm_custom_facts_mock.call_count == 1
         assert rollback_changes_mock.call_count == 1
         assert summary_as_json_mock.call_count == 1
         assert summary_as_txt_mock.call_count == 1
         assert caplog.records[-3].message == "Conversion failed."
         assert caplog.records[-3].levelname == "CRITICAL"
+
+    def test_main_rollback_analyze_exit_phase_without_subman(self, global_tool_opts, monkeypatch, tmp_path):
+        """
+        This test is the opposite of
+        `py:test_main_rollback_analyze_exit_phase`, where we are checking the
+        case that the system needs to be registered during the analyze.
+
+        If that's the case, we don't want to call the update_rhsm_custom_facts
+        as the system will be unregistered in the end.
+        """
+        mocks = (
+            (applock, "_DEFAULT_LOCK_DIR", str(tmp_path)),
+            (utils, "require_root", mock.Mock()),
+            (main, "initialize_logger", mock.Mock()),
+            (toolopts, "CLI", mock.Mock()),
+            (main, "show_eula", mock.Mock()),
+            (breadcrumbs, "print_data_collection", mock.Mock()),
+            (system_info, "resolve_system_info", mock.Mock()),
+            (system_info, "print_system_information", mock.Mock()),
+            (breadcrumbs, "collect_early_data", mock.Mock()),
+            (pkghandler, "clear_versionlock", mock.Mock()),
+            (pkgmanager, "clean_yum_metadata", mock.Mock()),
+            (actions, "run_actions", mock.Mock()),
+            (report, "summary", mock.Mock()),
+            (breadcrumbs, "finish_collection", mock.Mock()),
+            (subscription, "should_subscribe", mock.Mock(side_effect=lambda: True)),
+            (subscription, "update_rhsm_custom_facts", mock.Mock()),
+            (main, "rollback_changes", mock.Mock()),
+            (os, "environ", {"CONVERT2RHEL_EXPERIMENTAL_ANALYSIS": 1}),
+            (report, "summary_as_json", mock.Mock()),
+            (report, "summary_as_txt", mock.Mock()),
+        )
+        global_tool_opts.activity = "analysis"
+        for module, function, value in mocks:
+            monkeypatch.setattr(module, function, value)
+
+        assert main.main() == 0
+        assert utils.require_root.call_count == 1
+        assert main.initialize_logger.call_count == 1
+        assert toolopts.CLI.call_count == 1
+        assert main.show_eula.call_count == 1
+        assert breadcrumbs.print_data_collection.call_count == 1
+        assert system_info.resolve_system_info.call_count == 1
+        assert system_info.print_system_information.call_count == 1
+        assert breadcrumbs.collect_early_data.call_count == 1
+        assert pkghandler.clear_versionlock.call_count == 1
+        assert pkgmanager.clean_yum_metadata.call_count == 1
+        assert actions.run_actions.call_count == 1
+        assert report.summary.call_count == 1
+        assert breadcrumbs.finish_collection.call_count == 1
+        assert subscription.should_subscribe.call_count == 1
+        assert subscription.update_rhsm_custom_facts.call_count == 0
+        assert main.rollback_changes.call_count == 1
+        assert report.summary_as_json.call_count == 1
+        assert report.summary_as_txt.call_count == 1
 
     def test_main_rollback_analyze_exit_phase(self, global_tool_opts, monkeypatch, tmp_path):
         require_root_mock = mock.Mock()
@@ -487,6 +554,8 @@ class TestRollbackFromMain:
 
         # Mock the rollback calls
         finish_collection_mock = mock.Mock()
+        should_subscribe_mock = mock.Mock(side_effect=lambda: False)
+        update_rhsm_custom_facts_mock = mock.Mock()
         rollback_changes_mock = mock.Mock()
 
         monkeypatch.setattr(applock, "_DEFAULT_LOCK_DIR", str(tmp_path))
@@ -503,6 +572,8 @@ class TestRollbackFromMain:
         monkeypatch.setattr(actions, "run_actions", run_actions_mock)
         monkeypatch.setattr(report, "summary", report_summary_mock)
         monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
+        monkeypatch.setattr(subscription, "should_subscribe", should_subscribe_mock)
+        monkeypatch.setattr(subscription, "update_rhsm_custom_facts", update_rhsm_custom_facts_mock)
         monkeypatch.setattr(main, "rollback_changes", rollback_changes_mock)
         monkeypatch.setattr(os, "environ", {"CONVERT2RHEL_EXPERIMENTAL_ANALYSIS": 1})
         monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
@@ -522,6 +593,8 @@ class TestRollbackFromMain:
         assert report_summary_mock.call_count == 1
         assert clear_versionlock_mock.call_count == 1
         assert finish_collection_mock.call_count == 1
+        assert should_subscribe_mock.call_count == 1
+        assert update_rhsm_custom_facts_mock.call_count == 1
         assert rollback_changes_mock.call_count == 1
         assert summary_as_json_mock.call_count == 1
         assert summary_as_txt_mock.call_count == 1

--- a/tests/integration/tier0/non-destructive/rhsm-facts/main.fmf
+++ b/tests/integration/tier0/non-destructive/rhsm-facts/main.fmf
@@ -1,0 +1,21 @@
+summary+: |
+    RHSM facts update when in analysis mode
+description+: |
+    Verify that the subscription-manager facts command is called after the
+    analysis is done (either succeeding or failling).
+
+/rhsm_facts_update_in_analysis:
+    summary+: |
+        RHSM facts update after analysis
+    description+: |
+        TODO(r0x0d): ...
+
+        This test verifies, that the  TASK - [Convert: List third-party packages]
+        won't fail listing packages if previously problematic third party packages are installed.
+        Installed package(s):
+        v8-devel from the epel repository
+        nodejs from the epel repository
+    tag+:
+        - test-rhsm-facts-called-in-analysis
+    test: |
+        pytest -svv -m test_rhsm_facts_called_in_analysis

--- a/tests/integration/tier0/non-destructive/rhsm-facts/main.fmf
+++ b/tests/integration/tier0/non-destructive/rhsm-facts/main.fmf
@@ -14,3 +14,7 @@ description+: |
         - test-rhsm-facts-called-in-analysis
     test: |
         pytest -svv -m test_rhsm_facts_called_in_analysis
+    adjust+:
+        - enabled: false
+          when: distro == oracle-7, oracle-8
+          because: RHSM package not available in oracle repos

--- a/tests/integration/tier0/non-destructive/rhsm-facts/main.fmf
+++ b/tests/integration/tier0/non-destructive/rhsm-facts/main.fmf
@@ -8,13 +8,8 @@ description+: |
     summary+: |
         RHSM facts update after analysis
     description+: |
-        TODO(r0x0d): ...
-
-        This test verifies, that the  TASK - [Convert: List third-party packages]
-        won't fail listing packages if previously problematic third party packages are installed.
-        Installed package(s):
-        v8-devel from the epel repository
-        nodejs from the epel repository
+        This test verifies that the RHSM facts are uploaded when running
+        convert2rhel with analysis option.
     tag+:
         - test-rhsm-facts-called-in-analysis
     test: |

--- a/tests/integration/tier0/non-destructive/rhsm-facts/test_rhsm_facts_update_analysis.py
+++ b/tests/integration/tier0/non-destructive/rhsm-facts/test_rhsm_facts_update_analysis.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+@pytest.mark.test_rhsm_facts_called_in_analysis
+def test_rhsm_facts_called_after_analysis(convert2rhel, pre_registered):
+    """
+    ...
+    """
+    with convert2rhel("analyze -y --debug") as c2r:
+        # Verify that the analysis report is printed
+        c2r.expect("Updating RHSM custom facts collected during the conversion.", timeout=600)
+        c2r.expect("RHSM custom facts uploaded successfully.", timeout=600)
+
+    # The analysis should exit with 0, if it finishes successfully
+    assert c2r.exitstatus == 0

--- a/tests/integration/tier0/non-destructive/rhsm-facts/test_rhsm_facts_update_analysis.py
+++ b/tests/integration/tier0/non-destructive/rhsm-facts/test_rhsm_facts_update_analysis.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.mark.test_rhsm_facts_called_in_analysis
 def test_rhsm_facts_called_after_analysis(convert2rhel, pre_registered):
     """
-    ...
+    Verify that the RHSM custom facts are uploaded after the analysis is done.
     """
     with convert2rhel("analyze -y --debug") as c2r:
         # Verify that the analysis report is printed


### PR DESCRIPTION
Enable the RHSM custom facts update during analysis mode.

The update will only happen if the system was registered before, otherwise, we won't do nothing

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1164](https://issues.redhat.com/browse/RHELC-1164)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
