### PR TITLE
Fix leftover remediation from #684

### DIFF
--- a/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
@@ -471,7 +471,7 @@ class TestIsLoadedKernelLatest:
                     title=title,
                     description=description,
                     diagnosis=diagnosis,
-                    remediation=remediation,
+                    remediations=remediations,
                 ),
             )
         )
@@ -493,7 +493,7 @@ class TestIsLoadedKernelLatest:
             "description",
             "unsupported_message",
             "diagnosis",
-            "remediation",
+            "remediations",
         ),
         (
             pytest.param(
@@ -529,7 +529,7 @@ class TestIsLoadedKernelLatest:
         description,
         unsupported_message,
         diagnosis,
-        remediation,
+        remediations,
         monkeypatch,
         caplog,
         is_loaded_kernel_latest_action,
@@ -572,7 +572,7 @@ class TestIsLoadedKernelLatest:
                     title=title,
                     description=description,
                     diagnosis=diagnosis,
-                    remediation=remediation,
+                    remediations=remediations,
                 ),
             )
         )
@@ -591,7 +591,7 @@ class TestIsLoadedKernelLatest:
             "title",
             "description",
             "diagnosis",
-            "remediation",
+            "remediations",
         ),
         (
             pytest.param(
@@ -620,7 +620,7 @@ class TestIsLoadedKernelLatest:
         title,
         description,
         diagnosis,
-        remediation,
+        remediations,
         monkeypatch,
         caplog,
         is_loaded_kernel_latest_action,


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
There were leftover `remediation` usage in #684 that needs to be changed to the new `remediations`

After the fix:
![image](https://github.com/oamg/convert2rhel/assets/6598829/7be9ec59-5bc8-4b80-9cf9-e9026c7ebf19)

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
