### PR TITLE
[RHELC-1372] Change ignore to disregard in messages

### DIFF
--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -266,7 +266,7 @@ class Convert2rhelLatest(actions.Action):
                             "Only the latest version is supported for conversion."
                             % (formatted_convert2rhel_version, formatted_available_version)
                         ),
-                        remediations="If you want to ignore this check, then set the environment variable 'CONVERT2RHEL_ALLOW_OLDER_VERSION=1' to continue.",
+                        remediations="If you want to disregard this check, then set the environment variable 'CONVERT2RHEL_ALLOW_OLDER_VERSION=1' to continue.",
                     )
                     return
 

--- a/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
+++ b/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
@@ -167,7 +167,7 @@ class IsLoadedKernelLatest(actions.Action):
                 ),
                 remediations=(
                     "Please, check if you have any vendor repositories enabled to proceed with the conversion.\n"
-                    "If you wish to ignore this message, set the environment variable "
+                    "If you wish to disregard this message, set the environment variable "
                     "'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK' to 1."
                 ),
             )

--- a/convert2rhel/actions/system_checks/package_updates.py
+++ b/convert2rhel/actions/system_checks/package_updates.py
@@ -88,7 +88,7 @@ class PackageUpdates(actions.Action):
                     title="Package up to date check fail",
                     description="Please refer to the diagnosis for further information",
                     diagnosis=package_up_to_date_error_message,
-                    remediations="If you wish to ignore this message, set the environment variable "
+                    remediations="If you wish to disregard this message, set the environment variable "
                     "'CONVERT2RHEL_PACKAGE_UP_TO_DATE_CHECK_SKIP' to 1.",
                 )
                 return

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -214,7 +214,7 @@ class TestCheckConvert2rhelLatest:
                 "You are currently running %s and the latest version of convert2rhel is %s.\n"
                 "Only the latest version is supported for conversion." % (running_version, latest_version)
             ),
-            remediations="If you want to ignore this check, then set the environment variable 'CONVERT2RHEL_ALLOW_OLDER_VERSION=1' to continue.",
+            remediations="If you want to disregard this check, then set the environment variable 'CONVERT2RHEL_ALLOW_OLDER_VERSION=1' to continue.",
         )
 
     @pytest.mark.parametrize(
@@ -635,7 +635,7 @@ class TestCheckConvert2rhelLatest:
                 "You are currently running %s and the latest version of convert2rhel is %s.\n"
                 "Only the latest version is supported for conversion." % (running_version, latest_version)
             ),
-            remediations="If you want to ignore this check, then set the environment variable 'CONVERT2RHEL_ALLOW_OLDER_VERSION=1' to continue.",
+            remediations="If you want to disregard this check, then set the environment variable 'CONVERT2RHEL_ALLOW_OLDER_VERSION=1' to continue.",
         )
 
     @pytest.mark.parametrize(
@@ -903,7 +903,7 @@ class TestCheckConvert2rhelLatest:
                 "You are currently running %s and the latest version of convert2rhel is %s.\n"
                 "Only the latest version is supported for conversion." % (running_version, latest_version)
             ),
-            remediations="If you want to ignore this check, then set the environment variable 'CONVERT2RHEL_ALLOW_OLDER_VERSION=1' to continue.",
+            remediations="If you want to disregard this check, then set the environment variable 'CONVERT2RHEL_ALLOW_OLDER_VERSION=1' to continue.",
         )
 
 

--- a/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
@@ -686,7 +686,7 @@ class TestIsLoadedKernelLatest:
                 "Kernel currency check failed",
                 "Please refer to the diagnosis for further information",
                 "Could not find any {0} from repositories to compare against the loaded kernel.",
-                "Please, check if you have any vendor repositories enabled to proceed with the conversion.\nIf you wish to ignore this message, set the environment variable 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK' to 1.",
+                "Please, check if you have any vendor repositories enabled to proceed with the conversion.\nIf you wish to disregard this message, set the environment variable 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK' to 1.",
                 id="Repoquery failure without environment var",
             ),
         ),

--- a/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
@@ -158,7 +158,7 @@ def test_check_package_updates_with_repoerror(pretend_os, monkeypatch, caplog, p
         title="Package up to date check fail",
         description="Please refer to the diagnosis for further information",
         diagnosis=diagnosis,
-        remediations="If you wish to ignore this message, set the environment variable "
+        remediations="If you wish to disregard this message, set the environment variable "
         "'CONVERT2RHEL_PACKAGE_UP_TO_DATE_CHECK_SKIP' to 1.",
         variables={},
     )

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -567,10 +567,10 @@ def test_get_rpm_path_from_yumdownloader_output(output):
 @pytest.mark.parametrize(
     ("envvar", "activity", "should_raise", "message"),
     (
-        (None, "conversion", True, "If you would rather ignore this check"),
+        (None, "conversion", True, "If you would rather disregard this check"),
         ("CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK", "conversion", False, "environment variable detected"),
-        (None, "analysis", True, "you can choose to ignore this check"),
-        ("CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK", "analysis", True, "you can choose to ignore this check"),
+        (None, "analysis", True, "you can choose to disregard this check"),
+        ("CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK", "analysis", True, "you can choose to disregard this check"),
     ),
 )
 def test_report_on_a_download_error(envvar, activity, should_raise, message, monkeypatch, caplog):

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -754,7 +754,7 @@ def report_on_a_download_error(output, pkg):
                 " complete rollback and may put the system in a broken state.\n"
                 "Check to make sure that the %s repositories are enabled"
                 " and the package is updated to its latest version.\n"
-                "If you would rather ignore this check set the environment variable"
+                "If you would rather disregard this check set the environment variable"
                 " 'CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK=1'." % (pkg, system_info.name)
             )
         else:
@@ -769,7 +769,7 @@ def report_on_a_download_error(output, pkg):
             "Couldn't download the %s package which is needed to do a rollback of this action."
             " Check to make sure that the %s repositories are enabled and the package is"
             " updated to its latest version.\n"
-            "Note that you can choose to ignore this check when running a conversion by"
+            "Note that you can choose to disregard this check when running a conversion by"
             " setting the environment variable 'CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK=1'"
             " but not during a pre-conversion analysis." % (pkg, system_info.name)
         )


### PR DESCRIPTION
Some of our remediation messages have used 'ignore' to tell the user they can override certain checks, example - "If you wish to ignore this message, set the environment variable 'CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP' to 1". Using the word 'disregard' sounds better in this context so each instance of that has been changed.

Jira Issues: [RHELC-1372](https://issues.redhat.com/browse/RHELC-1372)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
