### PR TITLE
[RHELC-1361] Fix file clash in NewRestorableFile

### DIFF
--- a/convert2rhel/unit_tests/backup/backup_test.py
+++ b/convert2rhel/unit_tests/backup/backup_test.py
@@ -1,5 +1,6 @@
 __metaclass__ = type
 
+import hashlib
 import os
 
 import pytest

--- a/convert2rhel/unit_tests/backup/files_test.py
+++ b/convert2rhel/unit_tests/backup/files_test.py
@@ -1,5 +1,6 @@
 __metaclass__ = type
 
+import hashlib
 import os
 import shutil
 
@@ -9,7 +10,6 @@ import six
 from convert2rhel import exceptions
 from convert2rhel.backup import files
 from convert2rhel.backup.files import MissingFile, RestorableFile
-from convert2rhel.unit_tests.conftest import centos7, centos8
 
 
 six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
@@ -26,11 +26,28 @@ class TestRestorableFile:
         return file_for_backup, backup_dir
 
     @pytest.mark.parametrize(
+        ("filepath", "isdir", "exception", "match"),
+        (
+            (
+                "test.txt",
+                False,
+                TypeError,
+                "Filepath needs to be an absolute path.",
+            ),
+            ("/test", True, TypeError, "Path must be a file not a directory."),
+        ),
+    )
+    def test_restorable_file_type_error(self, filepath, isdir, exception, match, monkeypatch):
+        monkeypatch.setattr(os.path, "isdir", lambda path: isdir)
+        with pytest.raises(exception, match=match):
+            RestorableFile(filepath)
+
+    @pytest.mark.parametrize(
         ("filename", "message_backup", "message_remove", "message_restore", "backup_exists"),
         (
             (
                 "filename",
-                "Copied {file_for_backup} to {backup_dir}.",
+                "Copied {file_for_backup} to {backedup_file}.",
                 "File {file_for_backup} removed.",
                 "File {file_for_backup} restored.",
                 True,
@@ -60,20 +77,23 @@ class TestRestorableFile:
         Can be used as an example how to work with BackupController"""
         # Prepare file and folder for backup
         file_for_backup, backup_dir = get_backup_file_dir
+        backup_dir = str(backup_dir)
+        file_for_backup = str(file_for_backup)
 
         if filename:
             # location, where the file should be after backup
-            backedup_file = os.path.join(str(backup_dir), filename)
+            dirname = os.path.dirname(backup_dir)
+            backedup_file = os.path.join(backup_dir, hashlib.md5(dirname.encode()).hexdigest(), filename)
         else:
             file_for_backup = "/invalid/path/invalid_name"
             backedup_file = os.path.join(str(backup_dir), "invalid_name")
 
         # Format the messages which should be in output
-        message_backup = message_backup.format(file_for_backup=str(file_for_backup), backup_dir=str(backup_dir))
-        message_restore = message_restore.format(file_for_backup=str(file_for_backup))
-        message_remove = message_remove.format(file_for_backup=str(file_for_backup))
+        message_backup = message_backup.format(file_for_backup=file_for_backup, backedup_file=backedup_file)
+        message_restore = message_restore.format(file_for_backup=file_for_backup)
+        message_remove = message_remove.format(file_for_backup=file_for_backup)
 
-        monkeypatch.setattr(files, "BACKUP_DIR", str(backup_dir))
+        monkeypatch.setattr(files, "BACKUP_DIR", backup_dir)
 
         file_backup = RestorableFile(str(file_for_backup))
 
@@ -87,18 +107,18 @@ class TestRestorableFile:
         assert message_remove in caplog.records[-1].message
         assert os.path.isfile(backedup_file) == backup_exists
         if filename:
-            assert not os.path.isfile(str(file_for_backup))
+            assert not os.path.isfile(file_for_backup)
 
         # Restore the file
         global_backup_control.pop()
         assert message_restore in caplog.records[-1].message
         if filename:
-            assert os.path.isfile(str(file_for_backup))
+            assert os.path.isfile(file_for_backup)
 
     @pytest.mark.parametrize(
         ("filename", "enabled_preset", "enabled_value", "message", "backed_up"),
         (
-            ("filename", False, True, "Copied {file_for_backup} to {backup_dir}.", True),
+            ("filename", False, True, "Copied {file_for_backup} to {backedup_file}.", True),
             (None, False, False, "Can't find {file_for_backup}.", False),
             ("filename", True, True, "", False),
         ),
@@ -116,18 +136,24 @@ class TestRestorableFile:
     ):
         # Prepare file and folder for backup
         file_for_backup, backup_dir = get_backup_file_dir
+        backup_dir = str(backup_dir)
+
         # Prepare path where the file should be backed up
         if filename:
-            backedup_file = os.path.join(str(backup_dir), filename)
+            dirname = os.path.dirname(backup_dir)
+            backedup_file = os.path.join(backup_dir, hashlib.md5(dirname.encode()).hexdigest(), filename)
         else:
             file_for_backup = "/invalid/path/invalid_name"
-            backedup_file = os.path.join(str(backup_dir), "invalid_name")
+            backedup_file = os.path.join(backup_dir, "invalid_name")
+
+        file_for_backup = str(file_for_backup)
 
         # Prepare message
-        message = message.format(file_for_backup=file_for_backup, backup_dir=backup_dir)
+        message = message.format(file_for_backup=file_for_backup, backedup_file=backedup_file)
 
-        monkeypatch.setattr(files, "BACKUP_DIR", str(backup_dir))
-        file_backup = RestorableFile(str(file_for_backup))
+        monkeypatch.setattr(files, "BACKUP_DIR", backup_dir)
+        file_backup = RestorableFile(file_for_backup)
+
         # Set the enabled value if needed, default is False
         file_backup.enabled = enabled_preset
 
@@ -142,71 +168,73 @@ class TestRestorableFile:
             assert not caplog.records
 
     @pytest.mark.parametrize(
-        ("filename", "messages", "enabled", "rollback"),
+        ("filename", "messages", "enabled", "rollback", "isfile"),
         (
-            ("filename", ["Rollback: Restore {orig_path} from backup", "File {orig_path} restored."], True, True),
-            (None, ["Rollback: Restore {orig_path} from backup", "{orig_path} hasn't been backed up."], True, True),
+            (
+                "filename",
+                ["Rollback: Restore {orig_path} from backup", "File {orig_path} restored."],
+                True,
+                True,
+                True,
+            ),
+            (
+                None,
+                ["Rollback: Restore {orig_path} from backup", "{orig_path} hasn't been backed up."],
+                True,
+                True,
+                False,
+            ),
             (
                 "filename",
                 ["Rollback: Restore {orig_path} from backup", "{orig_path} hasn't been backed up."],
                 False,
                 True,
+                False,
             ),
-            ("filename", ["Restoring {orig_path} from backup", "File {orig_path} restored."], True, False),
+            ("filename", ["Restoring {orig_path} from backup", "File {orig_path} restored."], True, False, True),
         ),
     )
-    def test_restorable_file_restore(self, tmpdir, monkeypatch, caplog, filename, messages, enabled, rollback):
+    def test_restorable_file_restore(self, tmpdir, monkeypatch, caplog, filename, messages, enabled, rollback, isfile):
         backup_dir = tmpdir.mkdir("backup")
-        orig_path = os.path.join(str(tmpdir), "filename")
+        backup_file = backup_dir.join("test")
+        backup_file.write("content")
+        backup_file = str(backup_file)
 
         if filename:
             file_for_restore = tmpdir.join("backup/filename")
             file_for_restore.write("content")
 
         for i, _ in enumerate(messages):
-            messages[i] = messages[i].format(orig_path=orig_path)
+            messages[i] = messages[i].format(orig_path=backup_file)
 
+        monkeypatch.setattr(os.path, "isfile", lambda file: isfile)
+        monkeypatch.setattr(shutil, "copy2", mock.Mock())
         monkeypatch.setattr(files, "BACKUP_DIR", str(backup_dir))
 
-        file_backup = RestorableFile(str(orig_path))
+        file_backup = RestorableFile(backup_file)
         file_backup.enabled = enabled
         file_backup.restore(rollback=rollback)
 
         for i, message in enumerate(messages):
             assert message in caplog.records[i].message
+
         if filename and enabled:
-            assert os.path.isfile(orig_path)
+            assert os.path.isfile(backup_file)
 
-    @centos7
-    def test_restorable_file_backup_ioerror(self, tmpdir, caplog, monkeypatch, pretend_os):
+    def test_restorable_file_backup_oserror(self, tmpdir, caplog, monkeypatch):
         backup_dir = tmpdir.mkdir("backup")
-        orig_path = os.path.join(str(tmpdir), "filename")
-        file_for_restore = tmpdir.join("backup/filename")
-        file_for_restore.write("content")
+        backup_file = backup_dir.join("filename")
+        backup_file.write("content")
 
-        copy2 = mock.Mock(side_effect=OSError(2, "No such file or directory"))
-
-        monkeypatch.setattr(shutil, "copy2", copy2)
+        monkeypatch.setattr(
+            shutil,
+            "copy2",
+            mock.Mock(side_effect=[None, OSError(2, "No such file or directory")]),
+        )
+        monkeypatch.setattr(os.path, "isfile", lambda file: True)
         monkeypatch.setattr(files, "BACKUP_DIR", str(backup_dir))
-        file_backup = RestorableFile(str(orig_path))
-        file_backup.enabled = True
-        file_backup.restore()
-
-        assert "Error(2): No such file or directory" in caplog.records[-1].message
-
-    @centos8
-    def test_restorable_file_backup_oserror(self, tmpdir, caplog, monkeypatch, pretend_os):
-        backup_dir = tmpdir.mkdir("backup")
-        orig_path = os.path.join(str(tmpdir), "filename")
-        file_for_restore = tmpdir.join("backup/filename")
-        file_for_restore.write("content")
-
-        copy2 = mock.Mock(side_effect=OSError(2, "No such file or directory"))
-
-        monkeypatch.setattr(shutil, "copy2", copy2)
-        monkeypatch.setattr(files, "BACKUP_DIR", str(backup_dir))
-        file_backup = RestorableFile(str(orig_path))
-        file_backup.enabled = True
+        file_backup = RestorableFile(str(backup_file))
+        file_backup.enable()
         file_backup.restore()
 
         assert "Error(2): No such file or directory" in caplog.records[-1].message
@@ -240,7 +268,25 @@ class TestRestorableFile:
         with pytest.raises(exceptions.CriticalError):
             global_backup_control.push(rf)
 
-        assert "Error(2): No such file or directory" in caplog.records[-1].message
+        assert "Error(13): Permission denied" in caplog.records[-1].message
+
+    @pytest.mark.parametrize(
+        ("filepath",),
+        (
+            ("/test.txt",),
+            ("/another/directory/file.txt",),
+        ),
+    )
+    def test_hash_backup_path(self, filepath, tmpdir, monkeypatch):
+        backup_dir = str(tmpdir)
+        monkeypatch.setattr(files, "BACKUP_DIR", backup_dir)
+        path, name = os.path.split(filepath)
+        expected = "%s/%s/%s" % (backup_dir, hashlib.md5(path.encode()).hexdigest(), name)
+        file = RestorableFile(filepath)
+
+        result = file._hash_backup_path()
+        assert os.path.exists(os.path.dirname(result))
+        assert result == expected
 
 
 class TestMissingFile:


### PR DESCRIPTION
There was a clash happening in the way we backup files, as if there is a file to backup that has the same name as one directory or another file already created, an error will be thrown to the user.

This commit fixes that clash by generating an hash directory based on the dirname of the absolute path.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1361](https://issues.redhat.com/browse/RHELC-1361)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
