### PR TITLE
[RHELC-1379] Port certs and restorable key to backup module

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/subscription.py
+++ b/convert2rhel/actions/pre_ponr_changes/subscription.py
@@ -18,7 +18,8 @@ __metaclass__ = type
 import logging
 import os.path
 
-from convert2rhel import actions, backup, cert, exceptions, pkghandler, repo, subscription, toolopts, utils
+from convert2rhel import actions, backup, exceptions, pkghandler, repo, subscription, toolopts, utils
+from convert2rhel.backup.certs import RestorablePEMCert
 
 
 logger = logging.getLogger(__name__)
@@ -48,7 +49,7 @@ class InstallRedHatCertForYumRepositories(actions.Action):
         # example on CentOS Linux 7 this package is missing the cert due to intentional
         # debranding. Thus we need to ensure the cert is in place even when the pkg is installed.
         logger.task("Convert: Install cdn.redhat.com SSL CA certificate")
-        repo_cert = cert.PEMCert(_REDHAT_CDN_CACERT_SOURCE_DIR, _REDHAT_CDN_CACERT_TARGET_DIR)
+        repo_cert = RestorablePEMCert(_REDHAT_CDN_CACERT_SOURCE_DIR, _REDHAT_CDN_CACERT_TARGET_DIR)
         backup.backup_control.push(repo_cert)
 
 
@@ -120,7 +121,7 @@ class PreSubscription(actions.Action):
             subscription.verify_rhsm_installed()
 
             logger.task("Convert: Install a RHEL product certificate for RHSM")
-            product_cert = cert.PEMCert(_RHSM_PRODUCT_CERT_SOURCE_DIR, _RHSM_PRODUCT_CERT_TARGET_DIR)
+            product_cert = RestorablePEMCert(_RHSM_PRODUCT_CERT_SOURCE_DIR, _RHSM_PRODUCT_CERT_TARGET_DIR)
             backup.backup_control.push(product_cert)
 
         except SystemExit as e:

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -29,6 +29,7 @@ import rpm
 
 from convert2rhel import backup, exceptions, pkgmanager, utils
 from convert2rhel.backup import RestorableChange, remove_pkgs
+from convert2rhel.backup.certs import RestorableRpmKey
 from convert2rhel.backup.files import RestorableFile
 from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts
@@ -921,7 +922,7 @@ def install_gpg_keys():
     gpg_keys = [os.path.join(gpg_path, key) for key in os.listdir(gpg_path)]
     for gpg_key in gpg_keys:
         try:
-            restorable_key = backup.RestorableRpmKey(gpg_key)
+            restorable_key = RestorableRpmKey(gpg_key)
             backup.backup_control.push(restorable_key)
         except utils.ImportGPGKeyError as e:
             loggerinst.critical("Importing the GPG key into rpm failed:\n %s" % str(e))

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/subscription_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/subscription_test.py
@@ -23,7 +23,7 @@ from functools import partial
 import pytest
 import six
 
-from convert2rhel import actions, backup, cert, pkghandler, repo, subscription, toolopts, unit_tests
+from convert2rhel import actions, backup, pkghandler, repo, subscription, toolopts, unit_tests
 from convert2rhel.actions import STATUS_CODE
 from convert2rhel.actions.pre_ponr_changes import subscription as appc_subscription
 from convert2rhel.actions.pre_ponr_changes.subscription import PreSubscription, SubscribeSystem
@@ -55,7 +55,7 @@ def install_gpg_key_instance():
 
 class TestInstallRedHatCertForYumRepositories:
     def test_run(self, monkeypatch, install_repo_cert_instance, restorable):
-        monkeypatch.setattr(cert, "PEMCert", lambda x, y: restorable)
+        monkeypatch.setattr(appc_subscription, "RestorablePEMCert", lambda x, y: restorable)
         install_repo_cert_instance.run()
 
         assert restorable.called["enable"] == 1

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/subscription_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/subscription_test.py
@@ -23,7 +23,7 @@ from functools import partial
 import pytest
 import six
 
-from convert2rhel import actions, backup, pkghandler, repo, subscription, toolopts, unit_tests
+from convert2rhel import actions, pkghandler, repo, subscription, toolopts, unit_tests
 from convert2rhel.actions import STATUS_CODE
 from convert2rhel.actions.pre_ponr_changes import subscription as appc_subscription
 from convert2rhel.actions.pre_ponr_changes.subscription import PreSubscription, SubscribeSystem

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -7,7 +7,8 @@ import sys
 import pytest
 import six
 
-from convert2rhel import backup, cert, pkgmanager, redhatrelease, systeminfo, toolopts, utils
+from convert2rhel import backup, pkgmanager, redhatrelease, systeminfo, toolopts, utils
+from convert2rhel.backup.certs import RestorablePEMCert
 from convert2rhel.logger import add_file_handler, setup_logger_handler
 from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts
@@ -118,15 +119,15 @@ def setup_logger(tmpdir, request):
 @pytest.fixture
 def system_cert_with_target_path(monkeypatch, tmpdir, request):
     """
-    Create a single PEMCert backed by a temp file.
+    Create a single RestorablePEMCert backed by a temp file.
 
-    Use it in unit tests when you need a PEMCert that has a real file backing it.
+    Use it in unit tests when you need a RestorablePEMCert that has a real file backing it.
 
     The cert to be copied is the RHEL8 cert, 479.pem.
     """
     pem_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), "../data/8/x86_64/rhel-certs"))
 
-    sys_cert = cert.PEMCert(pem_dir, str(tmpdir))
+    sys_cert = RestorablePEMCert(pem_dir, str(tmpdir))
     return sys_cert
 
 

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -28,6 +28,7 @@ import rpm
 import six
 
 from convert2rhel import backup, exceptions, pkghandler, pkgmanager, unit_tests, utils
+from convert2rhel.backup.certs import RestorableRpmKey
 from convert2rhel.backup.files import RestorableFile
 from convert2rhel.pkghandler import (
     PackageInformation,
@@ -1306,7 +1307,7 @@ class TestInstallGpgKeys:
 
         # Prevent RestorableRpmKey from actually performing any work
         enable_mock = mock.Mock()
-        monkeypatch.setattr(backup.RestorableRpmKey, "enable", enable_mock)
+        monkeypatch.setattr(RestorableRpmKey, "enable", enable_mock)
 
         pkghandler.install_gpg_keys()
 

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -27,8 +27,8 @@ import dbus.exceptions
 import pytest
 import six
 
-from convert2rhel import backup, exceptions, pkghandler, subscription, toolopts, unit_tests, utils
-from convert2rhel.systeminfo import EUS_MINOR_VERSIONS, Version, system_info
+from convert2rhel import exceptions, pkghandler, subscription, toolopts, unit_tests, utils
+from convert2rhel.systeminfo import Version, system_info
 from convert2rhel.unit_tests import (
     PromptUserMocked,
     RegisterSystemMocked,


### PR DESCRIPTION
Both the RestorableRpmKey and the PEMCert classes got migrated to their own module inside the backup folder.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1379](https://issues.redhat.com/browse/RHELC-1379)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
