### PR TITLE
[RHELC-1381] Port RestorablePackageSet to packages module

### DIFF
--- a/convert2rhel/backup/packages.py
+++ b/convert2rhel/backup/packages.py
@@ -1,0 +1,285 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import logging
+import os
+
+from convert2rhel import exceptions, utils
+from convert2rhel.backup import RestorableChange, remove_pkgs
+
+# Fine to import call_yum_cmd for now, but we really should figure out a way to
+# split this out.
+from convert2rhel.pkghandler import call_yum_cmd
+from convert2rhel.systeminfo import system_info
+
+
+loggerinst = logging.getLogger(__name__)
+
+# Dirctory to temporarily store yum repo configuration to download rhs packages
+# from
+_RHSM_TMP_DIR = os.path.join(utils.TMP_DIR, "rhsm")
+
+# Directory to temporarily store rpms to be installed
+_SUBMGR_RPMS_DIR = os.path.join(utils.DATA_DIR, "subscription-manager")
+
+# Configuration of the repository to get Red Hat created packages for RHEL7
+# from before we have access to all of RHEL.
+_UBI_7_REPO_CONTENT = (
+    "[ubi-7-convert2rhel]\n"
+    "name=Red Hat Universal Base Image 7 - added by Convert2RHEL\n"
+    "baseurl=https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/os/\n"
+    "gpgcheck=1\n"
+    "enabled=1\n"
+)
+# Path to the repository file that we store the RHEL7-compatible repo file.
+_UBI_7_REPO_PATH = os.path.join(_RHSM_TMP_DIR, "ubi_7.repo")
+
+# Configuration of the repository to get Red Hat created packages for RHEL8
+# from before we have access to all of RHEL
+# We are using UBI 8 instead of CentOS Linux 8 because there's a bug in subscription-manager-rhsm-certificates on CentOS Linux 8
+# https://bugs.centos.org/view.php?id=17907
+_UBI_8_REPO_CONTENT = (
+    "[ubi-8-baseos-convert2rhel]\n"
+    "name=Red Hat Universal Base Image 8 - BaseOS added by Convert2RHEL\n"
+    "baseurl=https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/os/\n"
+    "gpgcheck=1\n"
+    "enabled=1\n"
+)
+# Path to the repository file that we store the RHEL8-compatible repo file.
+_UBI_8_REPO_PATH = os.path.join(_RHSM_TMP_DIR, "ubi_8.repo")
+
+_UBI_9_REPO_CONTENT = (
+    "[ubi-9-baseos-convert2rhel]\n"
+    "name=Red Hat Universal Base Image 9 - BaseOS added by Convert2RHEL\n"
+    "baseurl=https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/os/\n"
+    "gpgcheck=1\n"
+    "enabled=1\n"
+)
+_UBI_9_REPO_PATH = os.path.join(_RHSM_TMP_DIR, "ubi_9.repo")
+
+
+class RestorablePackageSet(RestorableChange):
+    """Install a set of packages in a way that they can be uninstalled later.
+
+    .. warn:: This functionality is incomplete (These are things that need cleanup)
+        Installing and restoring packagesets are very complex. This class needs work before it is
+        generic for any set of packages. It currently hardcodes values that are specific to
+        downloading subscription-manager and how we do that.
+
+        Implementing it in a half-ready state because we need it to install and remove
+        subscription-manager rpms at the right time relative to unregistering the system. As such,
+        this class relies heavily on the implementation of downloading and installing
+        subscription-manager. To make this generic, some pieces of that will need to move into
+        this class:
+
+        * Need a generic way to specify the UBI_X_REPO_PATH and UBI_X_REPO_CONTENT vars. Parameters
+          to __init__?  Parameter to install pkgs from "symbolic name" (vendor, pre-rhel, rhel,
+          enablerepos)? which we map to specific repo configurations?
+        * Backup and restore the vendor versions of packages which are in update_pkgs.
+        * Rename the global variables for SUBMGR_RPS_DIR, _RHSM_TMP_DIR, _UBI_7_REPO_CONTENT,
+          _UBI_7_REPO_PATH, _UBI_8_REPO_CONTENT, _UBI_8_REPO_PATH to more generic names
+        * Rename the helper functions: _download_rhsm_pkgs, _log_rhsm_download_directory_contents,
+          exit_on_failed_download
+        * Is the "We're using distro-sync" comment wrong?  We are using install, not distro-sync and
+          git log never shows us using distro-sync.
+        * This class is useful for package installation but not package removal. To replace backup.ChangedRPMPackagesController and back.RestorablePackage, we need to implement removal as well.  Should we do that here or in a second class?
+          * Note: ChangedRPMPackagesController might still have code that deals with package replacement.  AFAIK, that can be removed entirely.  As of 1.4, there's never a time where we replace rpms and can restore them.  (Installing might upgrade dependencies from the vendor to other vendor packages).
+        * Do we need to deal with dependency version issues?  With this code, if an installed dependency is an older version than the subscription-manager package we're installing needs to upgrade and the upgraded version is not present in the vendor's repo, then we will fail.
+        * Do we want to filter already installed packages from the package_list in this function
+          or leave it to the caller? If we leave it to the caller, then we need to backup vendor supplied previous files here and restore them on rollback. (Currently the
+          caller handles this via subscription.needed_subscription_manager_pkgs().  This could cause problems if we need to do extra handling in enable/restore for packages which already exist on the system.)
+        * Do we always want to pre-download the rpms and install from a directory of package files
+          or do we sometimes want yum to download and install as one step? (Current caller
+          doesn't care in subscription.install_rhel_subscription_manager().)
+        * Why is system_info.is_rpm_installed() implemented in syste_info? Evaluate if it should be
+          moved here.
+
+    .. warn:: Some things that are not handled by this class:
+        * Packages installed as a dependency on packages listed here will not be rolled back to the
+          system default if we rollback the changes.
+    """
+
+    def __init__(self, pkgs_to_install, pkgs_to_update=None):
+        self.pkgs_to_install = pkgs_to_install
+        self.pkgs_to_update = pkgs_to_update or []
+        self.installed_pkgs = []
+        self.updated_pkgs = []
+
+        super(RestorablePackageSet, self).__init__()
+
+    def enable(self):
+        if self.enabled:
+            return
+
+        self._enable()
+
+        super(RestorablePackageSet, self).enable()
+
+    def _enable(self):
+        """
+        Actually install packages.  Do it in a helper so that we always call super() even if we
+        exit early.
+        """
+        if not self.pkgs_to_install:
+            loggerinst.info("All packages were already installed")
+            return
+
+        # Note, this use of mkdir_p is secure because SUBMGR_RPMS_DIR and
+        # _RHSM_TMP_DIR do not contain any path components writable by
+        # a different user.
+        utils.mkdir_p(_SUBMGR_RPMS_DIR)
+        utils.mkdir_p(_RHSM_TMP_DIR)
+
+        loggerinst.info("Downloading requested packages")
+        all_pkgs_to_install = self.pkgs_to_install + self.pkgs_to_update
+
+        if system_info.version.major == 7:
+            _download_rhsm_pkgs(all_pkgs_to_install, _UBI_7_REPO_PATH, _UBI_7_REPO_CONTENT)
+        elif system_info.version.major == 8:
+            _download_rhsm_pkgs(all_pkgs_to_install, _UBI_8_REPO_PATH, _UBI_8_REPO_CONTENT)
+        elif system_info.version.major == 9:
+            _download_rhsm_pkgs(all_pkgs_to_install, _UBI_9_REPO_PATH, _UBI_9_REPO_CONTENT)
+
+        # installing the packages
+        rpms_to_install = [os.path.join(_SUBMGR_RPMS_DIR, filename) for filename in os.listdir(_SUBMGR_RPMS_DIR)]
+
+        loggerinst.info("Installing subscription-manager RPMs.")
+        loggerinst.debug("RPMs scheduled for installation: %s" % utils.format_sequence_as_message(rpms_to_install))
+
+        output, ret_code = call_yum_cmd(
+            # We're using distro-sync as there might be various versions of the subscription-manager pkgs installed
+            # and we need these packages to be replaced with the provided RPMs from RHEL.
+            command="install",
+            args=rpms_to_install,
+            print_output=False,
+            # When installing subscription-manager packages, the RHEL repos are
+            # not available yet for getting dependencies so we need to use the repos that are
+            # available on the system
+            enable_repos=[],
+            disable_repos=[],
+            # When using the original system repos, we need YUM/DNF to expand the $releasever by itself
+            set_releasever=False,
+        )
+        if ret_code:
+            loggerinst.critical_no_exit(
+                "Failed to install subscription-manager packages. Check the yum output below for details:\n\n %s"
+                % output
+            )
+            raise exceptions.CriticalError(
+                id_="FAILED_TO_INSTALL_SUBSCRIPTION_MANAGER_PACKAGES",
+                title="Failed to install subscription-manager packages.",
+                description="convert2rhel was unable to install subscription-manager packages. These packages are required to subscribe the system and install RHEL packages.",
+                diagnosis="Failed to install packages %s. Output: %s, Status: %s"
+                % (utils.format_sequence_as_message(rpms_to_install), output, ret_code),
+            )
+
+        # Need to do this here instead of in pkghandler.call_yum_cmd() to avoid
+        # double printing the output if an error occurred.
+        loggerinst.info(output.rstrip("\n"))
+
+        installed_pkg_names = _get_pkg_names_from_rpm_paths(rpms_to_install)
+        loggerinst.info(
+            "\nPackages we installed or updated:\n%s" % utils.format_sequence_as_message(installed_pkg_names)
+        )
+
+        # We could rely on these always being installed/updated when
+        # self.enabled is True but putting the values into separate attributes
+        # is more friendly if outside code needs to inspect the values.
+        # It is tempting to use the rpms we actually installed to populate these
+        # but we would have to extract both name and arch information from the
+        # rpms if we do that. (for the cornercases where a pkg for one arch is
+        # already installed and we have to install a different one.
+        self.installed_pkgs = self.pkgs_to_install[:]
+        self.updated_pkgs = self.pkgs_to_update[:]
+
+        super(RestorablePackageSet, self).enable()
+
+    def restore(self):
+        if not self.enabled:
+            return
+
+        loggerinst.task("Convert: Remove installed RHSM packages")
+        loggerinst.info("Removing set of installed pkgs: %s" % utils.format_sequence_as_message(self.installed_pkgs))
+        remove_pkgs(self.installed_pkgs, backup=False, critical=False)
+
+        super(RestorablePackageSet, self).restore()
+
+
+def _download_rhsm_pkgs(pkgs_to_download, repo_path, repo_content):
+    paths = None
+    try:
+        _log_rhsm_download_directory_contents(_SUBMGR_RPMS_DIR, "before RHEL rhsm packages download")
+        utils.store_content_to_file(filename=repo_path, content=repo_content)
+        paths = utils.download_pkgs(pkgs_to_download, dest=_SUBMGR_RPMS_DIR, reposdir=_RHSM_TMP_DIR)
+        _log_rhsm_download_directory_contents(_SUBMGR_RPMS_DIR, "after RHEL rhsm packages download")
+    except (OSError, IOError) as err:
+        loggerinst.warning("OSError({0}): {1}".format(err.errno, err.strerror))
+    except SystemExit as e:
+        loggerinst.critical_no_exit(
+            "Unable to download the subscription-manager package and its dependencies. See details of"
+            " the failed yumdownloader call above. These packages are necessary for the conversion"
+            " unless you use the --no-rhsm option."
+        )
+        raise exceptions.CriticalError(
+            id_="FAILED_TO_DOWNLOAD_SUBSCRIPTION_MANAGER_PACKAGES",
+            title="Failed to download subscription-manager package and its dependencies.",
+            description="To be able to subscribe the system to Red Hat we need the subscription-manager package and its dependencies to do so. Without these packages we cannot subscribe the system and we cannot install Red Hat Enterprise Linux packages.",
+            diagnosis="Failed to download subscription-manager package %s." % (str(e)),
+        )
+
+    # TODO(r0x0d): Probably we need to check if paths is not empty before
+    # reaching this point. There are a couple of cases where this could happen
+    # and it would be ideal if we took care of that before reaching the point
+    # where we try this if statement.
+    if None in paths:
+        loggerinst.critical_no_exit(
+            "Unable to download the subscription-manager package or its dependencies. See details of"
+            " the failed yumdownloader call above. These packages are necessary for the conversion"
+            " unless you use the --no-rhsm option."
+        )
+        raise exceptions.CriticalError(
+            id_="FAILED_TO_DOWNLOAD_SUBSCRIPTION_MANAGER_PACKAGES",
+            title="Failed to download subscription-manager package and its dependencies.",
+            description="To be able to subscribe the system to Red Hat we need the subscription-manager package and its dependencies to do so. Without these packages we cannot subscribe the system and we cannot install Red Hat Enterprise Linux packages.",
+        )
+
+
+def _log_rhsm_download_directory_contents(directory, when_message):
+    pkgs = ["<download directory does not exist>"]
+    if os.path.isdir(directory):
+        pkgs = os.listdir(directory)
+    loggerinst.debug(
+        "Contents of %s directory %s:\n%s",
+        directory,
+        when_message,
+        "\n".join(pkgs),
+    )
+
+
+def _get_pkg_names_from_rpm_paths(rpm_paths):
+    """Return names of packages represented by locally stored rpm packages.
+    :param rpm_paths: List of rpm with filepaths.
+    :type rpm_paths: list[str]
+    :return: A list of package names extracted from the rpm filepath.
+    :rtype: list
+    """
+    pkg_names = []
+    for rpm_path in rpm_paths:
+        pkg_names.append(utils.get_package_name_from_rpm(rpm_path))
+    return pkg_names

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -27,8 +27,8 @@ from collections import namedtuple
 
 import rpm
 
-from convert2rhel import backup, exceptions, pkgmanager, utils
-from convert2rhel.backup import RestorableChange, remove_pkgs
+from convert2rhel import backup, pkgmanager, utils
+from convert2rhel.backup import remove_pkgs
 from convert2rhel.backup.certs import RestorableRpmKey
 from convert2rhel.backup.files import RestorableFile
 from convert2rhel.systeminfo import system_info
@@ -40,47 +40,6 @@ loggerinst = logging.getLogger(__name__)
 # Limit the number of loops over yum command calls for the case there was
 # an error.
 MAX_YUM_CMD_CALLS = 3
-
-# Directory to temporarily store rpms to be installed
-SUBMGR_RPMS_DIR = os.path.join(utils.DATA_DIR, "subscription-manager")
-# Dirctory to temporarily store yum repo configuration to download rhs packages
-# from
-_RHSM_TMP_DIR = os.path.join(utils.TMP_DIR, "rhsm")
-
-# Configuration of the repository to get Red Hat created packages for RHEL7
-# from before we have access to all of RHEL.
-_UBI_7_REPO_CONTENT = (
-    "[ubi-7-convert2rhel]\n"
-    "name=Red Hat Universal Base Image 7 - added by Convert2RHEL\n"
-    "baseurl=https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/os/\n"
-    "gpgcheck=1\n"
-    "enabled=1\n"
-)
-# Path to the repository file that we store the RHEL7-compatible repo file.
-_UBI_7_REPO_PATH = os.path.join(_RHSM_TMP_DIR, "ubi_7.repo")
-
-# Configuration of the repository to get Red Hat created packages for RHEL8
-# from before we have access to all of RHEL
-# We are using UBI 8 instead of CentOS Linux 8 because there's a bug in subscription-manager-rhsm-certificates on CentOS Linux 8
-# https://bugs.centos.org/view.php?id=17907
-_UBI_8_REPO_CONTENT = (
-    "[ubi-8-baseos-convert2rhel]\n"
-    "name=Red Hat Universal Base Image 8 - BaseOS added by Convert2RHEL\n"
-    "baseurl=https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/os/\n"
-    "gpgcheck=1\n"
-    "enabled=1\n"
-)
-# Path to the repository file that we store the RHEL8-compatible repo file.
-_UBI_8_REPO_PATH = os.path.join(_RHSM_TMP_DIR, "ubi_8.repo")
-
-_UBI_9_REPO_CONTENT = (
-    "[ubi-9-baseos-convert2rhel]\n"
-    "name=Red Hat Universal Base Image 9 - BaseOS added by Convert2RHEL\n"
-    "baseurl=https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/os/\n"
-    "gpgcheck=1\n"
-    "enabled=1\n"
-)
-_UBI_9_REPO_PATH = os.path.join(_RHSM_TMP_DIR, "ubi_9.repo")
 
 _VERSIONLOCK_FILE_PATH = "/etc/yum/pluginconf.d/versionlock.list"  # This file is used by the dnf plugin as well
 
@@ -132,200 +91,6 @@ PackageInformation = namedtuple(
         "signature",
     ),
 )
-
-
-class RestorablePackageSet(RestorableChange):
-    """Install a set of packages in a way that they can be uninstalled later.
-
-    .. warn:: This functionality is incomplete (These are things that need cleanup)
-        Installing and restoring packagesets are very complex. This class needs work before it is
-        generic for any set of packages. It currently hardcodes values that are specific to
-        downloading subscription-manager and how we do that.
-
-        Implementing it in a half-ready state because we need it to install and remove
-        subscription-manager rpms at the right time relative to unregistering the system. As such,
-        this class relies heavily on the implementation of downloading and installing
-        subscription-manager. To make this generic, some pieces of that will need to move into
-        this class:
-
-        * Need a generic way to specify the UBI_X_REPO_PATH and UBI_X_REPO_CONTENT vars. Parameters
-          to __init__?  Parameter to install pkgs from "symbolic name" (vendor, pre-rhel, rhel,
-          enablerepos)? which we map to specific repo configurations?
-        * Backup and restore the vendor versions of packages which are in update_pkgs.
-        * Rename the global variables for SUBMGR_RPS_DIR, _RHSM_TMP_DIR, _UBI_7_REPO_CONTENT,
-          _UBI_7_REPO_PATH, _UBI_8_REPO_CONTENT, _UBI_8_REPO_PATH to more generic names
-        * Rename the helper functions: download_rhsm_pkgs, _log_rhsm_download_directory_contents,
-          exit_on_failed_download
-        * Is the "We're using distro-sync" comment wrong?  We are using install, not distro-sync and
-          git log never shows us using distro-sync.
-        * This class is useful for package installation but not package removal. To replace backup.ChangedRPMPackagesController and back.RestorablePackage, we need to implement removal as well.  Should we do that here or in a second class?
-          * Note: ChangedRPMPackagesController might still have code that deals with package replacement.  AFAIK, that can be removed entirely.  As of 1.4, there's never a time where we replace rpms and can restore them.  (Installing might upgrade dependencies from the vendor to other vendor packages).
-        * Do we need to deal with dependency version issues?  With this code, if an installed dependency is an older version than the subscription-manager package we're installing needs to upgrade and the upgraded version is not present in the vendor's repo, then we will fail.
-        * Do we want to filter already installed packages from the package_list in this function
-          or leave it to the caller? If we leave it to the caller, then we need to backup vendor supplied previous files here and restore them on rollback. (Currently the
-          caller handles this via subscription.needed_subscription_manager_pkgs().  This could cause problems if we need to do extra handling in enable/restore for packages which already exist on the system.)
-        * Do we always want to pre-download the rpms and install from a directory of package files
-          or do we sometimes want yum to download and install as one step? (Current caller
-          doesn't care in subscription.install_rhel_subscription_manager().)
-        * Why is system_info.is_rpm_installed() implemented in syste_info? Evaluate if it should be
-          moved here.
-
-    .. warn:: Some things that are not handled by this class:
-        * Packages installed as a dependency on packages listed here will not be rolled back to the
-          system default if we rollback the changes.
-    """
-
-    def __init__(self, pkgs_to_install, pkgs_to_update=None):
-        self.pkgs_to_install = pkgs_to_install
-        self.pkgs_to_update = pkgs_to_update or []
-        self.installed_pkgs = []
-        self.updated_pkgs = []
-
-        super(RestorablePackageSet, self).__init__()
-
-    def enable(self):
-        if self.enabled:
-            return
-
-        self._enable()
-
-        super(RestorablePackageSet, self).enable()
-
-    def _enable(self):
-        """
-        Actually install packages.  Do it in a helper so that we always call super() even if we
-        exit early.
-        """
-        if not self.pkgs_to_install:
-            loggerinst.info("All packages were already installed")
-            return
-
-        # Note, this use of mkdir_p is secure because SUBMGR_RPMS_DIR and
-        # _RHSM_TMP_DIR do not contain any path components writable by
-        # a different user.
-        utils.mkdir_p(SUBMGR_RPMS_DIR)
-        utils.mkdir_p(_RHSM_TMP_DIR)
-
-        loggerinst.info("Downloading requested packages")
-        all_pkgs_to_install = self.pkgs_to_install + self.pkgs_to_update
-
-        if system_info.version.major == 7:
-            download_rhsm_pkgs(all_pkgs_to_install, _UBI_7_REPO_PATH, _UBI_7_REPO_CONTENT)
-        elif system_info.version.major == 8:
-            download_rhsm_pkgs(all_pkgs_to_install, _UBI_8_REPO_PATH, _UBI_8_REPO_CONTENT)
-        elif system_info.version.major == 9:
-            download_rhsm_pkgs(all_pkgs_to_install, _UBI_9_REPO_PATH, _UBI_9_REPO_CONTENT)
-
-        # installing the packages
-        rpms_to_install = [os.path.join(SUBMGR_RPMS_DIR, filename) for filename in os.listdir(SUBMGR_RPMS_DIR)]
-
-        loggerinst.info("Installing subscription-manager RPMs.")
-        loggerinst.debug("RPMs scheduled for installation: %s" % utils.format_sequence_as_message(rpms_to_install))
-
-        output, ret_code = call_yum_cmd(
-            # We're using distro-sync as there might be various versions of the subscription-manager pkgs installed
-            # and we need these packages to be replaced with the provided RPMs from RHEL.
-            command="install",
-            args=rpms_to_install,
-            print_output=False,
-            # When installing subscription-manager packages, the RHEL repos are
-            # not available yet for getting dependencies so we need to use the repos that are
-            # available on the system
-            enable_repos=[],
-            disable_repos=[],
-            # When using the original system repos, we need YUM/DNF to expand the $releasever by itself
-            set_releasever=False,
-        )
-        if ret_code:
-            loggerinst.critical_no_exit(
-                "Failed to install subscription-manager packages. Check the yum output below for details:\n\n %s"
-                % output
-            )
-            raise exceptions.CriticalError(
-                id_="FAILED_TO_INSTALL_SUBSCRIPTION_MANAGER_PACKAGES",
-                title="Failed to install subscription-manager packages.",
-                description="convert2rhel was unable to install subscription-manager packages. These packages are required to subscribe the system and install RHEL packages.",
-                diagnosis="Failed to install packages %s. Output: %s, Status: %s"
-                % (utils.format_sequence_as_message(rpms_to_install), output, ret_code),
-            )
-
-        # Need to do this here instead of in pkghandler.call_yum_cmd() to avoid
-        # double printing the output if an error occurred.
-        loggerinst.info(output.rstrip("\n"))
-
-        installed_pkg_names = get_pkg_names_from_rpm_paths(rpms_to_install)
-        loggerinst.info(
-            "\nPackages we installed or updated:\n%s" % utils.format_sequence_as_message(installed_pkg_names)
-        )
-
-        # We could rely on these always being installed/updated when
-        # self.enabled is True but putting the values into separate attributes
-        # is more friendly if outside code needs to inspect the values.
-        # It is tempting to use the rpms we actually installed to populate these
-        # but we would have to extract both name and arch information from the
-        # rpms if we do that. (for the cornercases where a pkg for one arch is
-        # already installed and we have to install a different one.
-        self.installed_pkgs = self.pkgs_to_install[:]
-        self.updated_pkgs = self.pkgs_to_update[:]
-
-        super(RestorablePackageSet, self).enable()
-
-    def restore(self):
-        if not self.enabled:
-            return
-
-        loggerinst.task("Convert: Remove installed RHSM packages")
-        loggerinst.info("Removing set of installed pkgs: %s" % utils.format_sequence_as_message(self.installed_pkgs))
-        backup.remove_pkgs(self.installed_pkgs, backup=False, critical=False)
-
-        super(RestorablePackageSet, self).restore()
-
-
-def download_rhsm_pkgs(pkgs_to_download, repo_path, repo_content):
-    paths = None
-    try:
-        _log_rhsm_download_directory_contents(SUBMGR_RPMS_DIR, "before RHEL rhsm packages download")
-        utils.store_content_to_file(filename=repo_path, content=repo_content)
-        paths = utils.download_pkgs(pkgs_to_download, dest=SUBMGR_RPMS_DIR, reposdir=_RHSM_TMP_DIR)
-        _log_rhsm_download_directory_contents(SUBMGR_RPMS_DIR, "after RHEL rhsm packages download")
-    except (OSError, IOError) as err:
-        loggerinst.warning("OSError({0}): {1}".format(err.errno, err.strerror))
-    except SystemExit as e:
-        loggerinst.critical_no_exit(
-            "Unable to download the subscription-manager package and its dependencies. See details of"
-            " the failed yumdownloader call above. These packages are necessary for the conversion"
-            " unless you use the --no-rhsm option."
-        )
-        raise exceptions.CriticalError(
-            id_="FAILED_TO_DOWNLOAD_SUBSCRIPTION_MANAGER_PACKAGES",
-            title="Failed to download subscription-manager package and its dependencies.",
-            description="To be able to subscribe the system to Red Hat we need the subscription-manager package and its dependencies to do so. Without these packages we cannot subscribe the system and we cannot install Red Hat Enterprise Linux packages.",
-            diagnosis="Failed to download subscription-manager package %s." % (str(e)),
-        )
-
-    if None in paths:
-        loggerinst.critical_no_exit(
-            "Unable to download the subscription-manager package or its dependencies. See details of"
-            " the failed yumdownloader call above. These packages are necessary for the conversion"
-            " unless you use the --no-rhsm option."
-        )
-        raise exceptions.CriticalError(
-            id_="FAILED_TO_DOWNLOAD_SUBSCRIPTION_MANAGER_PACKAGES",
-            title="Failed to download subscription-manager package and its dependencies.",
-            description="To be able to subscribe the system to Red Hat we need the subscription-manager package and its dependencies to do so. Without these packages we cannot subscribe the system and we cannot install Red Hat Enterprise Linux packages.",
-        )
-
-
-def _log_rhsm_download_directory_contents(directory, when_message):
-    pkgs = ["<download directory does not exist>"]
-    if os.path.isdir(SUBMGR_RPMS_DIR):
-        pkgs = os.listdir(SUBMGR_RPMS_DIR)
-    loggerinst.debug(
-        "Contents of %s directory %s:\n%s",
-        SUBMGR_RPMS_DIR,
-        when_message,
-        "\n".join(pkgs),
-    )
 
 
 def call_yum_cmd(
@@ -1204,19 +969,6 @@ def clear_versionlock():
         call_yum_cmd("versionlock", args=["clear"], print_output=False)
     else:
         loggerinst.info("Usage of YUM/DNF versionlock plugin not detected.")
-
-
-def get_pkg_names_from_rpm_paths(rpm_paths):
-    """Return names of packages represented by locally stored rpm packages.
-    :param rpm_paths: List of rpm with filepaths.
-    :type rpm_paths: list[str]
-    :return: A list of package names extracted from the rpm filepath.
-    :rtype: list
-    """
-    pkg_names = []
-    for rpm_path in rpm_paths:
-        pkg_names.append(utils.get_package_name_from_rpm(rpm_path))
-    return pkg_names
 
 
 @utils.run_as_child_process

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -29,6 +29,7 @@ import dbus.connection
 import dbus.exceptions
 
 from convert2rhel import backup, exceptions, i18n, pkghandler, utils
+from convert2rhel.backup.packages import RestorablePackageSet
 from convert2rhel.redhatrelease import os_release_file
 from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import _should_subscribe, tool_opts
@@ -556,7 +557,7 @@ def install_rhel_subscription_manager(pkgs_to_install, pkgs_to_upgrade=None):
     """
 
     pkgs_to_upgrade = pkgs_to_upgrade or []
-    installed_pkg_set = pkghandler.RestorablePackageSet(pkgs_to_install, pkgs_to_upgrade)
+    installed_pkg_set = RestorablePackageSet(pkgs_to_install, pkgs_to_upgrade)
     backup.backup_control.push(installed_pkg_set)
 
 

--- a/convert2rhel/unit_tests/backup/packages_test.py
+++ b/convert2rhel/unit_tests/backup/packages_test.py
@@ -95,18 +95,20 @@ class TestRestorablePackageSet:
         yum_repo_dir = tmpdir.join("yum-repo.d")
         ubi7_repo_path = yum_repo_dir.join("ubi_7.repo")
         ubi8_repo_path = yum_repo_dir.join("ubi_8.repo")
+        ubi9_repo_path = yum_repo_dir.join("ubi_9.repo")
 
         monkeypatch.setattr(packages, "_SUBMGR_RPMS_DIR", str(pkg_download_dir))
         monkeypatch.setattr(packages, "_RHSM_TMP_DIR", str(yum_repo_dir))
         monkeypatch.setattr(packages, "_UBI_7_REPO_PATH", str(ubi7_repo_path))
         monkeypatch.setattr(packages, "_UBI_8_REPO_PATH", str(ubi8_repo_path))
+        monkeypatch.setattr(packages, "_UBI_9_REPO_PATH", str(ubi9_repo_path))
 
         return RestorablePackageSet(["subscription-manager", "python-syspurpose"])
 
     def test_smoketest_init(self):
         package_set = RestorablePackageSet(["pkg1"])
 
-        assert package_set.pkg_set == ["pkg1"]
+        assert package_set.pkgs_to_install == ["pkg1"]
         assert package_set.enabled is False
         # We actually care that this is an empty list and not just False-y
         assert package_set.installed_pkgs == []  # pylint: disable=use-implicit-booleaness-not-comparison
@@ -116,6 +118,7 @@ class TestRestorablePackageSet:
         (
             (7, 10),
             (8, 5),
+            (9, 3),
         ),
     )
     def test_enable_need_to_install(self, rhel_major_version, package_set, global_system_info, caplog, monkeypatch):

--- a/convert2rhel/unit_tests/backup/packages_test.py
+++ b/convert2rhel/unit_tests/backup/packages_test.py
@@ -1,0 +1,285 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import os
+
+import pytest
+import six
+
+from convert2rhel import exceptions, pkghandler, utils
+from convert2rhel.backup import packages
+from convert2rhel.backup.packages import RestorablePackageSet
+from convert2rhel.systeminfo import Version
+from convert2rhel.unit_tests import (
+    CallYumCmdMocked,
+    DownloadPkgMocked,
+    GetInstalledPkgInformationMocked,
+    MockFunctionObject,
+    RemovePkgsMocked,
+    StoreContentToFileMocked,
+)
+from convert2rhel.unit_tests.conftest import centos8
+
+
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
+
+
+class DownloadPkgsMocked(MockFunctionObject):
+    spec = utils.download_pkgs
+
+    def __init__(self, destdir=None, **kwargs):
+        self.destdir = destdir
+
+        self.pkgs = []
+        self.dest = None
+
+        if "return_value" not in kwargs:
+            kwargs["return_value"] = ["/path/to.rpm"]
+
+        super(DownloadPkgsMocked, self).__init__(**kwargs)
+
+    def __call__(self, pkgs, dest, *args, **kwargs):
+        self.pkgs = pkgs
+        self.dest = dest
+        self.reposdir = kwargs.get("reposdir", None)
+
+        if self.destdir and not os.path.exists(self.destdir):
+            os.mkdir(self.destdir, 0o700)
+
+        return super(DownloadPkgsMocked, self).__call__(pkgs, dest, *args, **kwargs)
+
+
+class TestRestorablePackageSet:
+    @staticmethod
+    def fake_download_pkg(pkg, *args, **kwargs):
+        pkg_to_filename = {
+            "subscription-manager": "subscription-manager-1.0-1.el7.noarch.rpm",
+            "python-syspurpose": "python-syspurpose-1.2-2.el7.noarch.rpm",
+            "json-c.x86_64": "json-c-0.14-1.el7.x86_64.rpm",
+            "json-c.i686": "json-c-0.14-1.el7.i686.rpm",
+            "json-c": "json-c-0.14-1.el7.x86_64.rpm",
+        }
+
+        rpm_path = os.path.join(packages._SUBMGR_RPMS_DIR, pkg_to_filename[pkg])
+        with open(rpm_path, "w"):
+            # We just need to create this file
+            pass
+
+        return rpm_path
+
+    @staticmethod
+    def fake_get_pkg_name_from_rpm(path):
+        path = path.rsplit("/", 1)[-1]
+        return path.rsplit("-", 2)[0]
+
+    @pytest.fixture
+    def package_set(self, monkeypatch, tmpdir):
+        pkg_download_dir = tmpdir.join("pkg-download-dir")
+        yum_repo_dir = tmpdir.join("yum-repo.d")
+        ubi7_repo_path = yum_repo_dir.join("ubi_7.repo")
+        ubi8_repo_path = yum_repo_dir.join("ubi_8.repo")
+
+        monkeypatch.setattr(packages, "_SUBMGR_RPMS_DIR", str(pkg_download_dir))
+        monkeypatch.setattr(packages, "_RHSM_TMP_DIR", str(yum_repo_dir))
+        monkeypatch.setattr(packages, "_UBI_7_REPO_PATH", str(ubi7_repo_path))
+        monkeypatch.setattr(packages, "_UBI_8_REPO_PATH", str(ubi8_repo_path))
+
+        return RestorablePackageSet(["subscription-manager", "python-syspurpose"])
+
+    def test_smoketest_init(self):
+        package_set = RestorablePackageSet(["pkg1"])
+
+        assert package_set.pkg_set == ["pkg1"]
+        assert package_set.enabled is False
+        # We actually care that this is an empty list and not just False-y
+        assert package_set.installed_pkgs == []  # pylint: disable=use-implicit-booleaness-not-comparison
+
+    @pytest.mark.parametrize(
+        ("rhel_major_version"),
+        (
+            (7, 10),
+            (8, 5),
+        ),
+    )
+    def test_enable_need_to_install(self, rhel_major_version, package_set, global_system_info, caplog, monkeypatch):
+        global_system_info.version = Version(*rhel_major_version)
+        monkeypatch.setattr(packages, "system_info", global_system_info)
+
+        monkeypatch.setattr(utils, "download_pkg", DownloadPkgMocked(side_effect=self.fake_download_pkg))
+        monkeypatch.setattr(packages, "call_yum_cmd", CallYumCmdMocked())
+        monkeypatch.setattr(utils, "get_package_name_from_rpm", self.fake_get_pkg_name_from_rpm)
+
+        package_set.pkgs_to_update = ["json-c.x86_64"]
+
+        package_set.enable()
+
+        assert package_set.enabled is True
+        assert frozenset(("python-syspurpose", "subscription-manager")) == frozenset(package_set.installed_pkgs)
+
+        assert "\nPackages we installed or updated:\n" in caplog.records[-1].message
+        assert "python-syspurpose" in caplog.records[-1].message
+        assert "subscription-manager" in caplog.records[-1].message
+        assert "json-c" in caplog.records[-1].message
+        assert "json-c" not in package_set.installed_pkgs
+        assert "json-c.x86_64" not in package_set.installed_pkgs
+
+    @centos8
+    def test_enable_call_yum_cmd_fail(self, pretend_os, package_set, global_system_info, caplog, monkeypatch):
+        global_system_info.version = Version(7, 0)
+        monkeypatch.setattr(packages, "system_info", global_system_info)
+        monkeypatch.setattr(
+            pkghandler,
+            "get_installed_pkg_information",
+            GetInstalledPkgInformationMocked(side_effect=(["subscription-manager"], [], [])),
+        )
+        monkeypatch.setattr(utils, "download_pkg", DownloadPkgMocked(side_effect=self.fake_download_pkg))
+
+        yum_cmd = CallYumCmdMocked(return_code=1)
+        monkeypatch.setattr(pkghandler, "call_yum_cmd", yum_cmd)
+        monkeypatch.setattr(utils, "get_package_name_from_rpm", self.fake_get_pkg_name_from_rpm)
+
+        with pytest.raises(exceptions.CriticalError):
+            package_set.enable()
+
+        assert (
+            "Failed to install subscription-manager packages. Check the yum output below for details"
+            in caplog.records[-1].message
+        )
+
+    def test_enable_already_enabled(self, package_set, monkeypatch):
+        enable_worker_mock = mock.Mock()
+        monkeypatch.setattr(packages.RestorablePackageSet, "_enable", enable_worker_mock)
+        package_set.enable()
+        previous_number_of_calls = enable_worker_mock.call_count
+        package_set.enable()
+
+        assert enable_worker_mock.call_count == previous_number_of_calls
+
+    def test_enable_no_packages(self, package_set, caplog, monkeypatch, global_system_info):
+        global_system_info.version = Version(8, 0)
+        monkeypatch.setattr(pkghandler, "system_info", global_system_info)
+
+        package_set.pkgs_to_install = []
+        package_set.pkgs_to_update = ["python-syspurpose", "json-c.x86_64"]
+
+        package_set.enable()
+
+        assert caplog.records[-1].levelname == "INFO"
+        assert "All packages were already installed" in caplog.records[-1].message
+
+    def test_restore(self, package_set, monkeypatch):
+        mock_remove_pkgs = RemovePkgsMocked()
+        monkeypatch.setattr(packages, "remove_pkgs", mock_remove_pkgs)
+        package_set.enabled = 1
+        package_set.installed_pkgs = ["one", "two"]
+
+        package_set.restore()
+
+        assert mock_remove_pkgs.call_count == 1
+        mock_remove_pkgs.assert_called_with(["one", "two"], backup=False, critical=False)
+
+    @pytest.mark.parametrize(
+        ("install", "update", "removed"),
+        (
+            (
+                ["subscription-manager", "python-syspurpose", "json-c.x86_64"],
+                ["json-c.i686"],
+                ["subscription-manager", "python-syspurpose", "json-c.x86_64"],
+            ),
+            (
+                ["subscription-manager", "python-syspurpose", "json-c.x86_64"],
+                ["python-syspurpose"],
+                ["subscription-manager", "python-syspurpose", "json-c.x86_64"],
+            ),
+            (
+                ["subscription-manager", "json-c.x86_64"],
+                ["python-syspurpose"],
+                ["subscription-manager", "json-c.x86_64"],
+            ),
+            (
+                ["subscription-manager", "python-syspurpose"],
+                ["json-c.x86_64", "json-c.i686"],
+                ["subscription-manager", "python-syspurpose"],
+            ),
+            (
+                ["subscription-manager", "python3-cloud-what"],
+                ["json-c.x86_64", "python3-syspurpose"],
+                ["subscription-manager", "python3-cloud-what"],
+            ),
+        ),
+    )
+    def test_restore_with_pkgs_in_updates(self, install, update, removed, package_set, monkeypatch):
+        remove_pkgs_mock = RemovePkgsMocked()
+        monkeypatch.setattr(packages, "remove_pkgs", remove_pkgs_mock)
+
+        package_set.enabled = 1
+        package_set.installed_pkgs = install
+        package_set.updated_pkgs = update
+
+        package_set.restore()
+
+        remove_pkgs_mock.assert_called_with(removed, backup=False, critical=False)
+
+    def test_restore_not_enabled(self, package_set, monkeypatch):
+        mock_remove_pkgs = RemovePkgsMocked()
+        monkeypatch.setattr(packages, "remove_pkgs", mock_remove_pkgs)
+
+        package_set.enabled = 1
+        package_set.restore()
+        previously_called = mock_remove_pkgs.call_count
+
+        package_set.restore()
+
+        assert previously_called >= 1
+        assert mock_remove_pkgs.call_count == previously_called
+
+
+class TestDownloadRHSMPkgs:
+    def test_download_rhsm_pkgs(self, monkeypatch, tmpdir):
+        """Smoketest that download_rhsm_pkgs works in the happy path"""
+        download_rpms_directory = tmpdir.join("submgr-downloads")
+        monkeypatch.setattr(packages, "_SUBMGR_RPMS_DIR", str(download_rpms_directory))
+
+        monkeypatch.setattr(utils, "store_content_to_file", StoreContentToFileMocked())
+        monkeypatch.setattr(utils, "download_pkgs", DownloadPkgsMocked(destdir=str(download_rpms_directory)))
+
+        packages._download_rhsm_pkgs(["testpkg"], "/path/to.repo", "content")
+
+        assert utils.store_content_to_file.call_args == mock.call("/path/to.repo", "content")
+        assert utils.download_pkgs.call_count == 1
+
+    def test_download_rhsm_pkgs_one_package_failed_to_download(self, monkeypatch):
+        """
+        Test that download_rhsm_pkgs() aborts when one of the subscription-manager packages fails to download.
+        """
+        monkeypatch.setattr(utils, "store_content_to_file", StoreContentToFileMocked())
+        monkeypatch.setattr(utils, "download_pkgs", DownloadPkgsMocked(return_value=["/path/to.rpm", None]))
+
+        with pytest.raises(exceptions.CriticalError):
+            packages._download_rhsm_pkgs(["testpkg"], "/path/to.repo", "content")
+
+
+@pytest.mark.parametrize(
+    ("rpm_paths", "expected"),
+    ((["pkg1", "pkg2"], ["pkg1", "pkg2"]),),
+)
+def test_get_pkg_names_from_rpm_paths(rpm_paths, expected, monkeypatch):
+    monkeypatch.setattr(utils, "get_package_name_from_rpm", lambda x: x)
+    assert packages._get_pkg_names_from_rpm_paths(rpm_paths) == expected

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -142,31 +142,6 @@ class ReturnPackagesObject(unit_tests.MockFunctionObject):
         return [pkg_obj]
 
 
-class DownloadPkgsMocked(unit_tests.MockFunctionObject):
-    spec = utils.download_pkgs
-
-    def __init__(self, destdir=None, **kwargs):
-        self.destdir = destdir
-
-        self.pkgs = []
-        self.dest = None
-
-        if "return_value" not in kwargs:
-            kwargs["return_value"] = ["/path/to.rpm"]
-
-        super(DownloadPkgsMocked, self).__init__(**kwargs)
-
-    def __call__(self, pkgs, dest, *args, **kwargs):
-        self.pkgs = pkgs
-        self.dest = dest
-        self.reposdir = kwargs.get("reposdir", None)
-
-        if self.destdir and not os.path.exists(self.destdir):
-            os.mkdir(self.destdir, 0o700)
-
-        return super(DownloadPkgsMocked, self).__call__(pkgs, dest, *args, **kwargs)
-
-
 class FakeTransactionSet:
     def dbMatch(self, key="name", value=""):
         db = [
@@ -645,216 +620,6 @@ class TestFixDefaultKernel:
             assert not re.search("Boot kernel [^ ]\\+ was changed to [^ ]\\+", record.message)
 
 
-class TestRestorablePackageSet:
-    @staticmethod
-    def fake_download_pkg(pkg, *args, **kwargs):
-        pkg_to_filename = {
-            "subscription-manager": "subscription-manager-1.0-1.el7.noarch.rpm",
-            "python-syspurpose": "python-syspurpose-1.2-2.el7.noarch.rpm",
-            "json-c.x86_64": "json-c-0.14-1.el7.x86_64.rpm",
-            "json-c.i686": "json-c-0.14-1.el7.i686.rpm",
-            "json-c": "json-c-0.14-1.el7.x86_64.rpm",
-        }
-
-        rpm_path = os.path.join(pkghandler.SUBMGR_RPMS_DIR, pkg_to_filename[pkg])
-        with open(rpm_path, "w"):
-            # We just need to create this file
-            pass
-
-        return rpm_path
-
-    @staticmethod
-    def fake_get_pkg_name_from_rpm(path):
-        path = path.rsplit("/", 1)[-1]
-        return path.rsplit("-", 2)[0]
-
-    @pytest.fixture
-    def package_set(self, monkeypatch, tmpdir):
-        pkg_download_dir = tmpdir / "pkg-download-dir"
-        yum_repo_dir = tmpdir / "yum-repo.d"
-        ubi7_repo_path = yum_repo_dir / "ubi_7.repo"
-        ubi8_repo_path = yum_repo_dir / "ubi_8.repo"
-
-        monkeypatch.setattr(pkghandler, "SUBMGR_RPMS_DIR", str(pkg_download_dir))
-        monkeypatch.setattr(pkghandler, "_RHSM_TMP_DIR", str(yum_repo_dir))
-        monkeypatch.setattr(pkghandler, "_UBI_7_REPO_PATH", str(ubi7_repo_path))
-        monkeypatch.setattr(pkghandler, "_UBI_8_REPO_PATH", str(ubi8_repo_path))
-
-        return pkghandler.RestorablePackageSet(["subscription-manager", "python-syspurpose"])
-
-    def test_smoketest_init(self):
-        package_set = pkghandler.RestorablePackageSet(["pkg1"])
-
-        assert package_set.pkgs_to_install == ["pkg1"]
-        assert package_set.enabled is False
-        # We actually care that this is an empty list and not just False-y
-        assert package_set.installed_pkgs == []  # pylint: disable=use-implicit-booleaness-not-comparison
-
-    @pytest.mark.parametrize(
-        ("rhel_major_version"),
-        (
-            (7, 10),
-            (8, 5),
-        ),
-    )
-    def test_enable_need_to_install(self, rhel_major_version, package_set, global_system_info, caplog, monkeypatch):
-        global_system_info.version = Version(*rhel_major_version)
-        monkeypatch.setattr(pkghandler, "system_info", global_system_info)
-
-        monkeypatch.setattr(utils, "download_pkg", DownloadPkgMocked(side_effect=self.fake_download_pkg))
-        monkeypatch.setattr(pkghandler, "call_yum_cmd", CallYumCmdMocked())
-        monkeypatch.setattr(utils, "get_package_name_from_rpm", self.fake_get_pkg_name_from_rpm)
-
-        package_set.pkgs_to_update = ["json-c.x86_64"]
-
-        package_set.enable()
-
-        assert package_set.enabled is True
-        assert frozenset(("python-syspurpose", "subscription-manager")) == frozenset(package_set.installed_pkgs)
-
-        assert "\nPackages we installed or updated:\n" in caplog.records[-1].message
-        assert "python-syspurpose" in caplog.records[-1].message
-        assert "subscription-manager" in caplog.records[-1].message
-        assert "json-c" in caplog.records[-1].message
-        assert "json-c" not in package_set.installed_pkgs
-        assert "json-c.x86_64" not in package_set.installed_pkgs
-
-    def test_enable_call_yum_cmd_fail(self, package_set, global_system_info, caplog, monkeypatch):
-        global_system_info.version = Version(7, 0)
-        monkeypatch.setattr(pkghandler, "system_info", global_system_info)
-
-        monkeypatch.setattr(
-            pkghandler,
-            "get_installed_pkg_information",
-            GetInstalledPkgInformationMocked(side_effect=(["subscription-manager"], [], [])),
-        )
-        monkeypatch.setattr(utils, "download_pkg", DownloadPkgMocked(side_effect=self.fake_download_pkg))
-
-        yum_cmd = CallYumCmdMocked(return_code=1)
-        monkeypatch.setattr(pkghandler, "call_yum_cmd", yum_cmd)
-        monkeypatch.setattr(utils, "get_package_name_from_rpm", self.fake_get_pkg_name_from_rpm)
-
-        with pytest.raises(exceptions.CriticalError):
-            package_set.enable()
-
-        assert (
-            "Failed to install subscription-manager packages. Check the yum output below for details"
-            in caplog.records[-1].message
-        )
-
-    def test_enable_already_enabled(self, package_set, monkeypatch):
-        enable_worker_mock = mock.Mock()
-        monkeypatch.setattr(pkghandler.RestorablePackageSet, "_enable", enable_worker_mock)
-        package_set.enable()
-        previous_number_of_calls = enable_worker_mock.call_count
-        package_set.enable()
-
-        assert enable_worker_mock.call_count == previous_number_of_calls
-
-    def test_enable_no_packages(self, package_set, caplog, monkeypatch, global_system_info):
-        global_system_info.version = Version(8, 0)
-        monkeypatch.setattr(pkghandler, "system_info", global_system_info)
-
-        package_set.pkgs_to_install = []
-        package_set.pkgs_to_update = ["python-syspurpose", "json-c.x86_64"]
-
-        package_set.enable()
-
-        assert caplog.records[-1].levelname == "INFO"
-        assert "All packages were already installed" in caplog.records[-1].message
-
-    def test_restore(self, package_set, monkeypatch):
-        mock_remove_pkgs = RemovePkgsMocked()
-        monkeypatch.setattr(backup, "remove_pkgs", mock_remove_pkgs)
-        package_set.enabled = 1
-        package_set.installed_pkgs = ["one", "two"]
-
-        package_set.restore()
-
-        assert mock_remove_pkgs.call_count == 1
-        mock_remove_pkgs.assert_called_with(["one", "two"], backup=False, critical=False)
-
-    @pytest.mark.parametrize(
-        ("install", "update", "removed"),
-        (
-            (
-                ["subscription-manager", "python-syspurpose", "json-c.x86_64"],
-                ["json-c.i686"],
-                ["subscription-manager", "python-syspurpose", "json-c.x86_64"],
-            ),
-            (
-                ["subscription-manager", "python-syspurpose", "json-c.x86_64"],
-                ["python-syspurpose"],
-                ["subscription-manager", "python-syspurpose", "json-c.x86_64"],
-            ),
-            (
-                ["subscription-manager", "json-c.x86_64"],
-                ["python-syspurpose"],
-                ["subscription-manager", "json-c.x86_64"],
-            ),
-            (
-                ["subscription-manager", "python-syspurpose"],
-                ["json-c.x86_64", "json-c.i686"],
-                ["subscription-manager", "python-syspurpose"],
-            ),
-            (
-                ["subscription-manager", "python3-cloud-what"],
-                ["json-c.x86_64", "python3-syspurpose"],
-                ["subscription-manager", "python3-cloud-what"],
-            ),
-        ),
-    )
-    def test_restore_with_pkgs_in_updates(self, install, update, removed, package_set, monkeypatch):
-        remove_pkgs_mock = RemovePkgsMocked()
-        monkeypatch.setattr(backup, "remove_pkgs", remove_pkgs_mock)
-
-        package_set.enabled = 1
-        package_set.installed_pkgs = install
-        package_set.updated_pkgs = update
-
-        package_set.restore()
-
-        remove_pkgs_mock.assert_called_with(removed, backup=False, critical=False)
-
-    def test_restore_not_enabled(self, package_set, monkeypatch):
-        mock_remove_pkgs = RemovePkgsMocked()
-        monkeypatch.setattr(backup, "remove_pkgs", mock_remove_pkgs)
-
-        package_set.enabled = 1
-        package_set.restore()
-        previously_called = mock_remove_pkgs.call_count
-
-        package_set.restore()
-
-        assert previously_called >= 1
-        assert mock_remove_pkgs.call_count == previously_called
-
-
-class TestDownloadRHSMPkgs:
-    def test_download_rhsm_pkgs(self, monkeypatch, tmpdir):
-        """Smoketest that download_rhsm_pkgs works in the happy path"""
-        download_rpms_directory = tmpdir.join("submgr-downloads")
-        monkeypatch.setattr(pkghandler, "SUBMGR_RPMS_DIR", str(download_rpms_directory))
-
-        monkeypatch.setattr(utils, "store_content_to_file", StoreContentToFileMocked())
-        monkeypatch.setattr(utils, "download_pkgs", DownloadPkgsMocked(destdir=str(download_rpms_directory)))
-
-        pkghandler.download_rhsm_pkgs(["testpkg"], "/path/to.repo", "content")
-
-        assert utils.store_content_to_file.call_args == mock.call("/path/to.repo", "content")
-        assert utils.download_pkgs.call_count == 1
-
-    def test_download_rhsm_pkgs_one_package_failed_to_download(self, monkeypatch):
-        """
-        Test that download_rhsm_pkgs() aborts when one of the subscription-manager packages fails to download.
-        """
-        monkeypatch.setattr(utils, "store_content_to_file", StoreContentToFileMocked())
-        monkeypatch.setattr(utils, "download_pkgs", DownloadPkgsMocked(return_value=["/path/to.rpm", None]))
-
-        with pytest.raises(exceptions.CriticalError):
-            pkghandler.download_rhsm_pkgs(["testpkg"], "/path/to.repo", "content")
-
-
 @pytest.mark.parametrize(
     ("version1", "version2", "expected"),
     (
@@ -1306,8 +1071,7 @@ class TestInstallGpgKeys:
         monkeypatch.setattr(utils, "DATA_DIR", self.data_dir)
 
         # Prevent RestorableRpmKey from actually performing any work
-        enable_mock = mock.Mock()
-        monkeypatch.setattr(RestorableRpmKey, "enable", enable_mock)
+        monkeypatch.setattr(RestorableRpmKey, "enable", mock.Mock())
 
         pkghandler.install_gpg_keys()
 
@@ -1339,15 +1103,6 @@ class TestInstallGpgKeys:
 
         with pytest.raises(SystemExit, match="Importing the GPG key into rpm failed:\n .*"):
             pkghandler.install_gpg_keys()
-
-
-@pytest.mark.parametrize(
-    ("rpm_paths", "expected"),
-    ((["pkg1", "pkg2"], ["pkg1", "pkg2"]),),
-)
-def test_get_pkg_names_from_rpm_paths(rpm_paths, expected, monkeypatch):
-    monkeypatch.setattr(utils, "get_package_name_from_rpm", lambda x: x)
-    assert pkghandler.get_pkg_names_from_rpm_paths(rpm_paths) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
RestorablePackageSet is moved to be under the packages module inside the backup folder. This is one part of the refactoring of the backup controller to make it more organized and easier to work with.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1381](https://issues.redhat.com/browse/RHELC-1381)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
