### PR TITLE
[RHELC-1425] breaking change: Remove deprecated latest kernel env variable

### DIFF
--- a/.devcontainer/alma9/alma9-development.Containerfile
+++ b/.devcontainer/alma9/alma9-development.Containerfile
@@ -12,7 +12,9 @@ ENV APP_MAIN_DEPS \
     python3-six \
     python3-dbus \
     python3-pexpect \
-    git
+    git \
+    man \
+    make
 
 ENV USERNAME=vscode
 ENV USER_UID=1000

--- a/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
+++ b/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
@@ -80,21 +80,7 @@ class IsLoadedKernelLatest(actions.Action):
         # Repoquery failed to detected any kernel or kernel-core packages in it's repositories
         # we allow the user to provide a environment variable to override the functionality and proceed
         # with the conversion, otherwise, we just throw a critical logging to them.
-        allow_older_envvar_names = (
-            "CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK",
-            "CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK",
-        )
-        # This check is to see which environment variable is set, To allow users in the next version
-        # to adjust their environmental variable names. This check will be removed in the future and
-        # will only have the 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' environment variable
-        if any(envvar in os.environ for envvar in allow_older_envvar_names):
-            if "CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK" in os.environ:
-                logger.warning(
-                    "You are using the deprecated 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK'"
-                    " environment variable. Please switch to 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK'"
-                    " instead."
-                )
-
+        if "CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK" in os.environ:
             logger.warning(
                 "Detected 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip "
                 "the %s comparison.\n"

--- a/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
@@ -394,7 +394,6 @@ class TestIsLoadedKernelLatest:
         (
             "repoquery_stdout",
             "return_code",
-            "unsupported_skip",
             "skip_check",
             "level",
             "id",
@@ -407,7 +406,6 @@ class TestIsLoadedKernelLatest:
             pytest.param(
                 "",
                 0,
-                "0",
                 "1",
                 "WARNING",
                 "UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK_DETECTED",
@@ -426,7 +424,6 @@ class TestIsLoadedKernelLatest:
         pretend_os,
         repoquery_stdout,
         return_code,
-        unsupported_skip,
         skip_check,
         level,
         id,
@@ -465,11 +462,6 @@ class TestIsLoadedKernelLatest:
         monkeypatch.setattr(
             os,
             "environ",
-            {"CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK": unsupported_skip},
-        )
-        monkeypatch.setattr(
-            os,
-            "environ",
             {"CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK": skip_check},
         )
 
@@ -487,104 +479,6 @@ class TestIsLoadedKernelLatest:
         )
         is_loaded_kernel_latest_action.run()
         assert description in caplog.records[-1].message
-        assert expected_set.issuperset(is_loaded_kernel_latest_action.messages)
-        assert expected_set.issubset(is_loaded_kernel_latest_action.messages)
-
-    @centos8
-    @pytest.mark.parametrize(
-        (
-            "repoquery_stdout",
-            "return_code",
-            "unsupported_skip",
-            "level",
-            "id",
-            "title",
-            "description",
-            "unsupported_message",
-            "diagnosis",
-            "remediations",
-        ),
-        (
-            pytest.param(
-                "",
-                0,
-                "1",
-                "WARNING",
-                "UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK_DETECTED",
-                "Did not perform the kernel currency check",
-                (
-                    "Detected 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip the kernel-core comparison.\nBeware, this could leave your system in a broken state."
-                ),
-                (
-                    "You are using the deprecated 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK' environment variable. Please switch to 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' instead."
-                ),
-                None,
-                None,
-                id="Unsupported skip with environment var set to 1",
-            ),
-        ),
-    )
-    def test_is_loaded_kernel_latest_unsupported_skip_warning(
-        self,
-        pretend_os,
-        repoquery_stdout,
-        return_code,
-        unsupported_skip,
-        level,
-        id,
-        title,
-        description,
-        unsupported_message,
-        diagnosis,
-        remediations,
-        monkeypatch,
-        caplog,
-        is_loaded_kernel_latest_action,
-    ):
-        run_subprocess_mocked = mock.Mock(
-            spec=run_subprocess,
-            side_effect=run_subprocess_side_effect(
-                (
-                    (
-                        "repoquery",
-                        "--setopt=exclude=",
-                        "--quiet",
-                        "--qf",
-                        "C2R\\t%{BUILDTIME}\\t%{VERSION}-%{RELEASE}\\t%{REPOID}",
-                        "kernel-core",
-                    ),
-                    (
-                        repoquery_stdout,
-                        return_code,
-                    ),
-                ),
-            ),
-        )
-        monkeypatch.setattr(
-            is_loaded_kernel_latest,
-            "run_subprocess",
-            value=run_subprocess_mocked,
-        )
-        monkeypatch.setattr(
-            os,
-            "environ",
-            {"CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK": unsupported_skip},
-        )
-
-        expected_set = set(
-            (
-                actions.ActionMessage(
-                    level=level,
-                    id=id,
-                    title=title,
-                    description=description,
-                    diagnosis=diagnosis,
-                    remediations=remediations,
-                ),
-            )
-        )
-        is_loaded_kernel_latest_action.run()
-        assert unsupported_message in caplog.records[-2].message
         assert expected_set.issuperset(is_loaded_kernel_latest_action.messages)
         assert expected_set.issubset(is_loaded_kernel_latest_action.messages)
 

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -121,7 +121,7 @@ description+: |
                 - enabled: true
                   when: distro == centos-7, oracle-7
             environment+:
-                CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK: 1
+                CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK: 1
                 # Since we are removing all the repositories other than rhel-7-server-rpms
                 # we need pass CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK due to the inability
                 # to download and backup packages

--- a/pytest.ini
+++ b/pytest.ini
@@ -109,3 +109,5 @@ markers =
     test_traceback_not_present
     test_duplicate_pkgs
     test_httpd_package_transaction_error
+# Unit test related
+    noautofixtures: disable all auto-use fixtures

--- a/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
+++ b/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
@@ -75,7 +75,7 @@ def katello_package(shell):
 def kernel_check_envar(shell):
     """
     Fixture.
-    Set CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK environment variable
+    Set CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK environment variable
     to skip the kernel currency check.
     """
     # Since we are moving all repos away, we need to bypass kernel check

--- a/tests/integration/tier1/destructive/kernel-check-skip/test_latest_kernel_check_skip.py
+++ b/tests/integration/tier1/destructive/kernel-check-skip/test_latest_kernel_check_skip.py
@@ -13,7 +13,7 @@ def test_skip_kernel_check(shell, convert2rhel):
     Verify that it's possible to run the full conversion with older kernel,
     than available in the RHEL repositories.
         1/ Install older kernel on the system
-        2/ Make sure the `CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK` is in place
+        2/ Make sure the `CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK` is in place
             * doing that we also verify, the deprecated envar is still allowed
         3/ Enable *just* the rhel-7-server-rpms repository prior to conversion
         4/ Run conversion verifying the conversion is not inhibited and completes successfully
@@ -30,7 +30,7 @@ def test_skip_kernel_check(shell, convert2rhel):
 
     # Verify the environment variable to bypass the check is in place
     # Intentionally use the deprecated variable to verify its compatibility
-    assert os.environ["CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK"] == "1"
+    assert os.environ["CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK"] == "1"
 
     # We need to set envar to override the out of date packages check
     # to perform the full conversion
@@ -55,8 +55,6 @@ def test_skip_kernel_check(shell, convert2rhel):
             env.str("RHSM_POOL"),
         )
     ) as c2r:
-        # Verify that using the deprecated environment variable is still allowed and continues the conversion
-        assert c2r.expect("You are using the deprecated 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK'") == 0
         # Make sure the kernel comparison is skipped
         c2r_expect_index = c2r.expect(
             [


### PR DESCRIPTION
This removes `CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK`
as it is deprecated and to be removed in the next major version as a
breaking change.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1425](https://issues.redhat.com/browse/RHELC-1425)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
