### PR TITLE
[RHELC-1425] breaking change: Remove deprecated unsupported version env variable

### DIFF
--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -203,24 +203,7 @@ class Convert2rhelLatest(actions.Action):
         formatted_available_version = _format_EVR(*precise_available_version)
 
         if ver_compare < 0:
-            # Current and deprecated env var names
-            allow_older_envvar_names = ("CONVERT2RHEL_ALLOW_OLDER_VERSION", "CONVERT2RHEL_UNSUPPORTED_VERSION")
-            if any(envvar in os.environ for envvar in allow_older_envvar_names):
-                if "CONVERT2RHEL_ALLOW_OLDER_VERSION" not in os.environ:
-                    logger.warning(
-                        "You are using the deprecated 'CONVERT2RHEL_UNSUPPORTED_VERSION'"
-                        " environment variable.  Please switch to 'CONVERT2RHEL_ALLOW_OLDER_VERSION'"
-                        " instead."
-                    )
-                    self.add_message(
-                        level="WARNING",
-                        id="DEPRECATED_ENVIRONMENT_VARIABLE",
-                        title="Deprecated environment variable",
-                        description="A deprecated environment variable has been detected",
-                        diagnosis="You are using the deprecated 'CONVERT2RHEL_UNSUPPORTED_VERSION'",
-                        remediations="Please switch to the 'CONVERT2RHEL_ALLOW_OLDER_VERSION' environment variable instead",
-                    )
-
+            if "CONVERT2RHEL_ALLOW_OLDER_VERSION" in os.environ:
                 diagnosis = (
                     "You are currently running %s and the latest version of convert2rhel is %s.\n"
                     "'CONVERT2RHEL_ALLOW_OLDER_VERSION' environment variable detected, continuing conversion"

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -394,9 +394,6 @@ class TestCheckConvert2rhelLatest:
         )
         assert log_msg in caplog.text
 
-        deprecated_var_name = "CONVERT2RHEL_UNSUPPORTED_VERSION"
-        assert deprecated_var_name not in caplog.text
-
     @pytest.mark.parametrize(
         ("convert2rhel_latest_version_test",),
         (
@@ -637,89 +634,6 @@ class TestCheckConvert2rhelLatest:
             ),
             remediations="If you want to disregard this check, then set the environment variable 'CONVERT2RHEL_ALLOW_OLDER_VERSION=1' to continue.",
         )
-
-    @pytest.mark.parametrize(
-        ("convert2rhel_latest_version_test",),
-        (
-            [
-                {
-                    "local_version": "0.17.0",
-                    "package_version": "C2R convert2rhel-0.18.0-1.el7.noarch",
-                    "package_version_repoquery": "C2R convert2rhel-0:0.18.0-1.el7.noarch",
-                    "package_version_qf": "C2R convert2rhel-0:0.17.0-1.el7.noarch",
-                    "package_version_V": 0,
-                    "pmajor": "8",
-                    "running_version": "0.17.0",
-                    "latest_version": "0.18.0",
-                }
-            ],
-            [
-                {
-                    "local_version": "0.17",
-                    "package_version": "C2R convert2rhel-0.18.0-1.el7.noarch",
-                    "package_version_repoquery": "C2R convert2rhel-0:0.18.0-1.el7.noarch",
-                    "package_version_qf": "C2R convert2rhel-0:0.17-1.el7.noarch",
-                    "package_version_V": 0,
-                    "pmajor": "8",
-                    "running_version": "0.17",
-                    "latest_version": "0.18.0",
-                }
-            ],
-            [
-                {
-                    "local_version": "0.17.0",
-                    "package_version": "C2R convert2rhel-0.18-1.el7.noarch",
-                    "package_version_repoquery": "C2R convert2rhel-0:0.18-1.el7.noarch",
-                    "package_version_qf": "C2R convert2rhel-0:0.17.0-1.el7.noarch",
-                    "package_version_V": 0,
-                    "pmajor": "8",
-                    "running_version": "0.17.0",
-                    "latest_version": "0.18",
-                }
-            ],
-        ),
-        indirect=True,
-    )
-    def test_c2r_up_to_date_deprecated_env_var(
-        self, caplog, monkeypatch, convert2rhel_latest_action, convert2rhel_latest_version_test
-    ):
-        running_version, latest_version = convert2rhel_latest_version_test
-        env = {"CONVERT2RHEL_UNSUPPORTED_VERSION": 1}
-        monkeypatch.setattr(os, "environ", env)
-        expected = set(
-            (
-                actions.ActionMessage(
-                    level="WARNING",
-                    id="DEPRECATED_ENVIRONMENT_VARIABLE",
-                    title="Deprecated environment variable",
-                    description="A deprecated environment variable has been detected",
-                    diagnosis="You are using the deprecated 'CONVERT2RHEL_UNSUPPORTED_VERSION'",
-                    remediations="Please switch to the 'CONVERT2RHEL_ALLOW_OLDER_VERSION' environment variable instead",
-                ),
-                actions.ActionMessage(
-                    level="WARNING",
-                    id="ALLOW_OLDER_VERSION_ENVIRONMENT_VARIABLE",
-                    title="Outdated convert2rhel version detected",
-                    description="An outdated convert2rhel version has been detected",
-                    diagnosis="You are currently running %s and the latest version of convert2rhel is %s.\n"
-                    "'CONVERT2RHEL_ALLOW_OLDER_VERSION' environment variable detected, continuing conversion"
-                    % (running_version, latest_version),
-                    remediations=None,
-                ),
-            )
-        )
-        convert2rhel_latest_action.run()
-
-        log_msg = (
-            "You are using the deprecated 'CONVERT2RHEL_UNSUPPORTED_VERSION'"
-            " environment variable.  Please switch to 'CONVERT2RHEL_ALLOW_OLDER_VERSION'"
-            " instead."
-        )
-        print(expected)
-        print(convert2rhel_latest_action.messages)
-        assert expected.issuperset(convert2rhel_latest_action.messages)
-        assert expected.issubset(convert2rhel_latest_action.messages)
-        assert log_msg in caplog.text
 
     @pytest.mark.parametrize(
         ("convert2rhel_latest_version_test",),


### PR DESCRIPTION
This removes `CONVERT2RHEL_UNSUPPORTED_VERSION`
as it is deprecated and to be removed in the next major version as a
breaking change.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1425](https://issues.redhat.com/browse/RHELC-1425)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
