### PR TITLE
[RHELC-1425] breaking change: Remove deprecated CLI arguments

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -36,7 +36,6 @@ markers =
     test_config_custom_path_custom_filename
     test_config_custom_path_standard_filename
     test_config_cli_priority
-    test_config_password_file_priority
     test_config_standard_paths_priority_diff_methods
     test_config_standard_paths_priority
     test_custom_valid_repo_provided

--- a/tests/integration/tier0/destructive/offline-system-conversion/test_offline_system_conversion.py
+++ b/tests/integration/tier0/destructive/offline-system-conversion/test_offline_system_conversion.py
@@ -8,7 +8,7 @@ def test_offline_system_conversion(convert2rhel):
     """Test converting systems not connected to the Internet but requiring sub-mgr (e.g. managed by Satellite)."""
 
     with convert2rhel(
-        "-y -k {} -o {} --keep-rhsm --debug".format(
+        "-y -k {} -o {} --debug".format(
             env.str("SATELLITE_KEY"),
             env.str("SATELLITE_ORG"),
         )

--- a/tests/integration/tier0/non-destructive/config-file/main.fmf
+++ b/tests/integration/tier0/non-destructive/config-file/main.fmf
@@ -49,18 +49,6 @@ tag+:
     test: |
         pytest -svv -m test_config_cli_priority
 
-/config_password_file_priority:
-    summary+: |
-        Password file preferred
-    description+: |
-        Verify that passing the password through the password file
-        is preferred to the config file.
-    tag+:
-        - config-password-file-priority
-        - sanity
-    test: |
-        pytest -svv -m test_config_password_file_priority
-
 /config_standard_paths_priority_diff_methods:
     summary+: |
         Activation key preferred to password

--- a/tests/integration/tier0/non-destructive/config-file/test_config_file.py
+++ b/tests/integration/tier0/non-destructive/config-file/test_config_file.py
@@ -76,28 +76,6 @@ def test_user_path_cli_priority(convert2rhel):
     remove_files(config)
 
 
-@pytest.mark.test_config_password_file_priority
-def test_user_path_pswd_file_priority(convert2rhel):
-    config = [
-        Config("~/.convert2rhel.ini", "[subscription_manager]\npassword = config_password"),
-        Config("~/password_file", "file_password"),
-    ]
-    create_files(config)
-
-    with convert2rhel('-f "~/password_file" --debug') as c2r:
-        c2r.expect("DEBUG - Found password in /root/.convert2rhel.ini")
-        c2r.expect("WARNING - Deprecated. Use -c | --config-file instead.")
-        c2r.expect(
-            "WARNING - You have passed the RHSM credentials both through a config file and through a password file."
-            " We're going to use the password file."
-        )
-        c2r.sendcontrol("c")
-
-    assert c2r.exitstatus != 0
-
-    remove_files(config)
-
-
 @pytest.mark.test_config_standard_paths_priority_diff_methods
 def test_std_paths_priority_diff_methods(convert2rhel):
     config = [

--- a/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
+++ b/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
@@ -95,7 +95,7 @@ def test_backup_os_release_wrong_registration(shell, convert2rhel, custom_subman
     """
     assert shell("find /etc/os-release").returncode == 0
 
-    with convert2rhel("-y -k wrong_key -o rUbBiSh_pWd --debug --keep-rhsm") as c2r:
+    with convert2rhel("-y -k wrong_key -o rUbBiSh_pWd --debug") as c2r:
         c2r.expect("Unable to register the system through subscription-manager.")
         c2r.expect("Restore /etc/os-release from backup")
 
@@ -149,7 +149,7 @@ def test_backup_os_release_no_envar(
 
     assert shell("find /etc/os-release").returncode == 0
     with convert2rhel(
-        "-y -k {} -o {} --debug --keep-rhsm".format(
+        "-y -k {} -o {} --debug".format(
             env.str("SATELLITE_KEY"),
             env.str("SATELLITE_ORG"),
         ),
@@ -185,7 +185,7 @@ def test_backup_os_release_with_envar(
     assert shell("find /etc/os-release").returncode == 0
 
     with convert2rhel(
-        "-y -k {} -o {} --debug --keep-rhsm".format(
+        "-y -k {} -o {} --debug".format(
             env.str("SATELLITE_KEY"),
             env.str("SATELLITE_ORG"),
         ),


### PR DESCRIPTION
This removes a few deprecated CLI arguments, they will no longer work
or give a warning about its deprecation.

This includes
- Removal of `convert2rhel -f|--password-from-file`
- Removal of unused `convert2rhel --keep-rhsm`

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1425](https://issues.redhat.com/browse/RHELC-1425)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
