### PR TITLE
[RHELC-1187] Add preconversion analysis check for device PART_ENTRY_NUMBER

### DIFF
--- a/convert2rhel/actions/system_checks/efi.py
+++ b/convert2rhel/actions/system_checks/efi.py
@@ -71,6 +71,7 @@ class Efi(actions.Action):
         # good to check that we can obtain all the required data before the PONR.
         try:
             efiboot_info = grub.EFIBootInfo()
+            grub.get_device_number(grub.get_efi_partition())
         except grub.BootloaderError as e:
             self.set_result(
                 level="ERROR",

--- a/convert2rhel/grub.py
+++ b/convert2rhel/grub.py
@@ -152,7 +152,7 @@ def _get_blk_device(device):
     return output.strip().splitlines()[-1].strip()
 
 
-def _get_device_number(device):
+def get_device_number(device):
     """Get the partition number of a particular device.
 
     This method will use `blkid` to determinate what is the partition number
@@ -171,6 +171,8 @@ def _get_device_number(device):
         raise BootloaderError("Unable to get information about the '%s' device" % device)
     # We are spliting the partition entry number, and we are just taking that
     # output as our desired partition number
+    if not output:
+        raise BootloaderError("The '%s' device has no PART_ENTRY_NUMBER" % device)
     partition_number = output.split("PART_ENTRY_NUMBER=")[-1].replace('"', "")
     return int(partition_number)
 
@@ -396,7 +398,7 @@ def _add_rhel_boot_entry(efibootinfo_orig):
 
     Return the new bootloader info (EFIBootInfo).
     """
-    dev_number = _get_device_number(get_efi_partition())
+    dev_number = get_device_number(get_efi_partition())
     blk_dev = get_grub_device()
 
     logger.debug("Block device: %s" % str(blk_dev))

--- a/convert2rhel/unit_tests/actions/system_checks/efi_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/efi_test.py
@@ -23,6 +23,8 @@ from collections import namedtuple
 
 import pytest
 
+from six.moves import mock
+
 from convert2rhel import actions, grub, systeminfo, unit_tests
 from convert2rhel.actions.system_checks import efi
 from convert2rhel.unit_tests import EFIBootInfoMocked
@@ -160,6 +162,8 @@ class TestEFIChecks:
         monkeypatch.setattr(efi.system_info, "version", systeminfo.Version(7, 9))
         monkeypatch.setattr(os.path, "exists", lambda x: x == "/usr/sbin/efibootmgr")
         monkeypatch.setattr(grub, "EFIBootInfo", EFIBootInfoMocked(current_bootnum="0002"))
+        monkeypatch.setattr(grub, "get_device_number", mock.Mock(return_value=1))
+        monkeypatch.setattr(grub, "get_efi_partition", mock.Mock(return_value="/dev/sda"))
 
         efi_action.run()
 


### PR DESCRIPTION
This PR adds a conditional to check if there is no output received from a subprocess call to blkid querying for the devices PART_ENTRY_NUMBER. If there is no output we raise a custom BootloaderError exception telling the user their device has no PART_ENTRY_NUMBER. In addition we have a call made to the function calling blkid (_get_device_number)inside the preconversion analysis efi check so we can error out early in the execution of convert2rhel instead of in the conversion process in the event there is no PART_ENTRY_NUMBER. 
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1187](https://issues.redhat.com/browse/RHELC-1187)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
