### PR TITLE
Fix root_privileges test string checking

### DIFF
--- a/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
@@ -23,7 +23,9 @@ def test_check_user_privileges(shell):
     # Check the program exits as it is required to be run by root
     assert result.returncode != 0
     # Check the program exits for the correct reason
-    assert "The tool needs to be run under the root user.\nNo changes were made to the system." in result.output
+    assert "The tool needs to be run under the root user." in result.output
+    assert "No changes were made to the system." in result.output
+
     # Delete testuser (if present)
     assert shell(f"userdel -r '{user}'").returncode == 0
 


### PR DESCRIPTION
Splitting the string checking in the root_privileges test to assert that the needed messages are contained in the result output.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
