### PR TITLE
chore: update autotag naming

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -14,13 +14,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create tag
-        id: create_tag
-        run: echo "tag=$(git describe --tags --abbrev=0)-${{ github.run_number }}" >> $GITHUB_OUTPUT
+      - name: Determine tag
+        id: determine_tag
+        run: |
+          current_tag=$(git describe --tags --abbrev=0)
+          echo "tag=${current_tag:0:6}-$(date +%s)" >> $GITHUB_OUTPUT
 
       - name: Push tag
         run: |
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
-          git tag ${{ steps.create_tag.outputs.tag  }}
-          git push origin ${{ steps.create_tag.outputs.tag }}
+          git tag ${{ steps.determine_tag.outputs.tag  }}
+          git push origin ${{ steps.determine_tag.outputs.tag }}


### PR DESCRIPTION
As it was before, it would create a new tag with
the run number, so if no tags were created by us
it would look something like

- `v1.2.3-1`
- `v1.2.3-1-2`
- `v1.2.3-1-2-3`
- and so on.

To fix this we'll do a substring and
add epoch. Which will look like

- `v1.2.3-1707318660`
- `v1.2.3-1707318661`
- and so on.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
