### PR TITLE
[RHELC-1239] Add integration test for correct logging

### DIFF
--- a/tests/integration/tier0/non-destructive/application-lock/main.fmf
+++ b/tests/integration/tier0/non-destructive/application-lock/main.fmf
@@ -14,9 +14,14 @@ tag+:
     summary+: |
         Simultaneous runs
     description+: |
-        Verify that convert2rhel locks out other instances while it
-        is running and notifies the user of the second instance that
-        it cannot be run.
+        Verify that running convert2rhel locks out other instances.
+        Additionally validate that the logfile did not get overwritten by the second invocation's output.
+        1/ Invoke convert2rhel, wait on data collection acknowledgement prompt.
+        2/ Invoke second instance of convert2rhel, observe warning and the utility exit.
+        3/ Exit the first run of convert2rhel.
+        4/ Validate that the logfile did not get overwritten by the second invocation's output.
+        5/ Invoke third instance of convert2rhel; with the previous instances dead, the third instance should be allowed to run.
+        6/ Exit the utility on the first prompt.
     tag+:
         - simultaneous-runs
     test: |


### PR DESCRIPTION
* validate that second invocation of convert2rhel honors the already running process' logging
* validate the log does not get overwritten by the second invocation

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1239](https://issues.redhat.com/browse/RHELC-1239)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [x] When merged: Jira issue has been updated to `Release Pending` if relevant
