### PR TITLE
chore: Update Jira links in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 ---
-name: Build release RPMs
+name: Build release RPMs & Handle release
 
 on:
   release:
@@ -28,3 +28,20 @@ jobs:
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: .rpms/*el${{ matrix.el.ver }}*
+
+  update_jira_links:
+    name: Update Jira links
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Get release content
+        run: gh release view ${{github.ref_name}} --json body --jq '.body' > releaseBody.txt
+
+      - name: Add Jira links
+        run: |
+          sed -i -e 's/\[\(RHEL.*\)\]/[[\1](https:\/\/issues.redhat.com\/browse\/\1)]/' releaseBody.txt
+
+      - name: Update release body with Jira links
+        run: gh release edit ${{github.ref_name}} --notes-file releaseBody.txt


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
This updates the release workflow to also update the release once it has been published to include links to the Jira issues. Has tested and works as intended

https://github.com/SpyTec/convert2rhel/releases/tag/v24.02.07.7

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
