### PR TITLE
[RHELC-1288] Add integration test verifying duplicate pkgs installed

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -107,3 +107,4 @@ markers =
     test_host_metering_conversion
     test_active_host_metering
     test_traceback_not_present
+    test_duplicate_pkgs

--- a/tests/integration/tier0/non-destructive/duplicate-pkgs/main.fmf
+++ b/tests/integration/tier0/non-destructive/duplicate-pkgs/main.fmf
@@ -1,0 +1,20 @@
+summary+: |
+    Duplicate pkgs installed on the system
+description+: |
+    Verify that the conversion does not crash when the same
+    package (of different version) is installed on the system.
+    Verify that the proper inhibitor is raised.
+
+
+/duplicate-pkgs:
+    link: https://issues.redhat.com/browse/RHELC-1070
+    adjust+:
+        - enabled: false
+          when: distro == centos-8, alma-8, rocky-8, oracle-8
+          because: |
+            The bug is reproducible only on EL7 distros.
+            On EL8 the issue is handled by the DNF itself.
+    tag+:
+        - test-duplicate-pkgs
+    test: |
+        pytest -svv -m test_duplicate_pkgs

--- a/tests/integration/tier0/non-destructive/duplicate-pkgs/test_duplicate_pkgs.py
+++ b/tests/integration/tier0/non-destructive/duplicate-pkgs/test_duplicate_pkgs.py
@@ -1,0 +1,68 @@
+import pytest
+
+from conftest import SYSTEM_RELEASE_ENV
+from envparse import env
+
+
+DUPLICATE_PKG_URL_MAPPING = {
+    "centos-7": "https://vault.centos.org/7.4.1708/os/x86_64/Packages/python2-cryptography-1.7.2-1.el7.x86_64.rpm",
+    "oracle-7": "https://yum.oracle.com/repo/OracleLinux/OL7/latest/x86_64/getPackage/abrt-2.1.11-50.0.1.el7.x86_64.rpm",
+}
+
+DUPLICATE_PKG_URL = DUPLICATE_PKG_URL_MAPPING[SYSTEM_RELEASE_ENV]
+
+
+@pytest.fixture(scope="function")
+def install_duplicate_pkg(shell):
+    """
+    Install duplicate package on the system.
+    """
+    pkg = ""
+    pkg_was_installed = True
+
+    if SYSTEM_RELEASE_ENV == "centos-7":
+        pkg = "python2-cryptography"
+    elif SYSTEM_RELEASE_ENV == "oracle-7":
+        pkg = "abrt"
+
+    # Install `pkg` from the latest repository
+    if shell(f"rpm -q {pkg}").returncode == 1:
+        shell(f"yum install -y {pkg}")
+        pkg_was_installed = False
+
+    # Download and install duplicate package with different version
+    shell(f"curl -o duplicate-{pkg}.rpm {DUPLICATE_PKG_URL}")
+    shell(f"rpm -i --noscripts --justdb --nodeps --force duplicate-{pkg}.rpm")
+
+    assert int(shell(f"rpm -q {pkg} | wc -l ").output) >= 2
+
+    yield
+
+    # This should remove both the packages
+    shell(f"yum remove -y {pkg}")
+
+    # If the package was originally installed on the system, install it back
+    if pkg_was_installed:
+        shell(f"yum install -y {pkg}")
+
+
+@pytest.mark.test_duplicate_pkgs
+def test_duplicate_pkgs(convert2rhel, install_duplicate_pkg):
+    """
+    Verify that the conversion does not crash when the same
+    package (of different version) is installed on the system.
+    Verify that the proper inhibitor is raised.
+    """
+    with convert2rhel(
+        "analyze -y --serverurl {} --username {} --password {} --debug".format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+        )
+    ) as c2r:
+        # The error about duplicate packages should be included at the end of the pre-conversion analysis report
+        c2r.expect("Pre-conversion analysis report", timeout=600)
+        c2r.expect_exact("(ERROR) DUPLICATE_PACKAGES::DUPLICATE_PACKAGES_FOUND")
+
+    # The analysis should exit with 0, if it finishes successfully
+    assert c2r.exitstatus == 0


### PR DESCRIPTION
Verify that the conversion does not crash when the same package (of different version) is installed on the system.
Verify that the proper inhibitor is raised. The bug is reproducible only on EL7 distros. On EL8 the issue is handled by the DNF itself.

Address the https://issues.redhat.com/browse/RHELC-1070

Jira Issues: [RHELC-1070](https://issues.redhat.com/browse/RHELC-1070),  [RHELC-1288](https://issues.redhat.com/browse/RHELC-1288)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
