### PR TITLE
[RHELC-1393] Move logger initialization to initialize module

### DIFF
--- a/convert2rhel/backup/files.py
+++ b/convert2rhel/backup/files.py
@@ -33,7 +33,6 @@ loggerinst = logging.getLogger(__name__)
 class RestorableFile(RestorableChange):
     def __init__(self, filepath):
         super(RestorableFile, self).__init__()
-
         # The filepath we want to back up needs to start with at least a `/`,
         # otherwise, let's error out and warn the developer/user that the
         # filepath is not what we expect. This is mostly intended to be an

--- a/convert2rhel/initialize.py
+++ b/convert2rhel/initialize.py
@@ -21,6 +21,10 @@ import logging
 import os
 
 from convert2rhel import i18n
+from convert2rhel import logger as logger_module
+
+
+loggerinst = logging.getLogger(__name__)
 
 
 def disable_root_logger():
@@ -34,6 +38,40 @@ def disable_root_logger():
     and other credentials.
     """
     logging.getLogger().addHandler(logging.NullHandler())
+
+
+def initialize_logger():
+    """
+    Entrypoint function that aggregates other calls for initialization logic
+    and setup for logger handlers that do not require root.
+    """
+
+    return logger_module.setup_logger_handler()
+
+
+def initialize_file_logging(log_name, log_dir):
+    """
+    Archive existing file logs and setup all logging handlers that require
+    root, like FileHandlers.
+
+    This function should be called after
+    :func:`~convert2rhel.main.initialize_logger`.
+
+    .. warning::
+        Setting log_dir underneath a world-writable directory (including
+        letting it be user settable) is insecure.  We will need to write
+        some checks for all calls to `os.makedirs()` if we allow changing
+        log_dir.
+
+    :param str log_name: Name of the logfile to archive and log to
+    :param str log_dir: Directory where logfiles are stored
+    """
+    try:
+        logger_module.archive_old_logger_files(log_name, log_dir)
+    except (IOError, OSError) as e:
+        loggerinst.warning("Unable to archive previous log: %s" % e)
+
+    logger_module.add_file_handler(log_name, log_dir)
 
 
 def set_locale():
@@ -76,6 +114,13 @@ def run():
 
     # Initialize logging to stop duplicate messages.
     disable_root_logger()
+
+    # initialize logging
+    initialize_logger()
+
+    # since we now have root, we can add the FileLogging
+    # and also archive previous logs
+    initialize_file_logging("convert2rhel.log", logger_module.LOG_DIR)
 
     from convert2rhel import main
 

--- a/convert2rhel/initialize.py
+++ b/convert2rhel/initialize.py
@@ -49,31 +49,6 @@ def initialize_logger():
     return logger_module.setup_logger_handler()
 
 
-def initialize_file_logging(log_name, log_dir):
-    """
-    Archive existing file logs and setup all logging handlers that require
-    root, like FileHandlers.
-
-    This function should be called after
-    :func:`~convert2rhel.main.initialize_logger`.
-
-    .. warning::
-        Setting log_dir underneath a world-writable directory (including
-        letting it be user settable) is insecure.  We will need to write
-        some checks for all calls to `os.makedirs()` if we allow changing
-        log_dir.
-
-    :param str log_name: Name of the logfile to archive and log to
-    :param str log_dir: Directory where logfiles are stored
-    """
-    try:
-        logger_module.archive_old_logger_files(log_name, log_dir)
-    except (IOError, OSError) as e:
-        loggerinst.warning("Unable to archive previous log: %s" % e)
-
-    logger_module.add_file_handler(log_name, log_dir)
-
-
 def set_locale():
     """
     Set the C locale, also known as the POSIX locale, for the main process as well as the child processes.
@@ -117,10 +92,6 @@ def run():
 
     # initialize logging
     initialize_logger()
-
-    # since we now have root, we can add the FileLogging
-    # and also archive previous logs
-    initialize_file_logging("convert2rhel.log", logger_module.LOG_DIR)
 
     from convert2rhel import main
 

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -43,6 +43,31 @@ class ConversionPhase:
     POST_PONR_CHANGES = 4
 
 
+def initialize_file_logging(log_name, log_dir):
+    """
+    Archive existing file logs and setup all logging handlers that require
+    root, like FileHandlers.
+
+    This function should be called after
+    :func:`~convert2rhel.main.initialize_logger`.
+
+    .. warning::
+        Setting log_dir underneath a world-writable directory (including
+        letting it be user settable) is insecure.  We will need to write
+        some checks for all calls to `os.makedirs()` if we allow changing
+        log_dir.
+
+    :param str log_name: Name of the logfile to archive and log to
+    :param str log_dir: Directory where logfiles are stored
+    """
+    try:
+        logger_module.archive_old_logger_files(log_name, log_dir)
+    except (IOError, OSError) as e:
+        loggerinst.warning("Unable to archive previous log: %s" % e)
+
+    logger_module.add_file_handler(log_name, log_dir)
+
+
 def main():
     """
     Wrapper around the main entrypoint.
@@ -72,6 +97,10 @@ def main_locked():
 
     pre_conversion_results = None
     process_phase = ConversionPhase.POST_CLI
+
+    # since we now have root, we can add the FileLogging
+    # and also archive previous logs
+    initialize_file_logging("convert2rhel.log", logger_module.LOG_DIR)
 
     try:
         perform_boilerplate()

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -19,7 +19,6 @@ __metaclass__ = type
 
 import logging
 import os
-import sys
 
 from convert2rhel import actions, applock, backup, breadcrumbs, checks, exceptions, grub
 from convert2rhel import logger as logger_module
@@ -44,40 +43,6 @@ class ConversionPhase:
     POST_PONR_CHANGES = 4
 
 
-def initialize_logger():
-    """
-    Entrypoint function that aggregates other calls for initialization logic
-    and setup for logger handlers that do not require root.
-    """
-
-    return logger_module.setup_logger_handler()
-
-
-def initialize_file_logging(log_name, log_dir):
-    """
-    Archive existing file logs and setup all logging handlers that require
-    root, like FileHandlers.
-
-    This function should be called after
-    :func:`~convert2rhel.main.initialize_logger`.
-
-    .. warning::
-        Setting log_dir underneath a world-writable directory (including
-        letting it be user settable) is insecure.  We will need to write
-        some checks for all calls to `os.makedirs()` if we allow changing
-        log_dir.
-
-    :param str log_name: Name of the logfile to archive and log to
-    :param str log_dir: Directory where logfiles are stored
-    """
-    try:
-        logger_module.archive_old_logger_files(log_name, log_dir)
-    except (IOError, OSError) as e:
-        loggerinst.warning("Unable to archive previous log: %s" % e)
-
-    logger_module.add_file_handler(log_name, log_dir)
-
-
 def main():
     """
     Wrapper around the main entrypoint.
@@ -86,9 +51,6 @@ def main():
     conversion process itself, then calls main_locked(), protected by
     the application lock, to do the conversion process.
     """
-
-    # initialize logging
-    initialize_logger()
 
     # handle command line arguments
     toolopts.CLI()
@@ -110,10 +72,6 @@ def main_locked():
 
     pre_conversion_results = None
     process_phase = ConversionPhase.POST_CLI
-
-    # since we now have root, we can add the FileLogging
-    # and also archive previous logs
-    initialize_file_logging("convert2rhel.log", logger_module.LOG_DIR)
 
     try:
         perform_boilerplate()

--- a/convert2rhel/unit_tests/__init__.py
+++ b/convert2rhel/unit_tests/__init__.py
@@ -360,7 +360,7 @@ class InitializeLoggerMocked(MockFunctionObject):
 
 
 class InitializeFileLoggingMocked(MockFunctionObject):
-    spec = initialize.initialize_file_logging
+    spec = main.initialize_file_logging
 
 
 class MainLockedMocked(MockFunctionObject):

--- a/convert2rhel/unit_tests/__init__.py
+++ b/convert2rhel/unit_tests/__init__.py
@@ -30,6 +30,7 @@ from convert2rhel import (
     breadcrumbs,
     exceptions,
     grub,
+    initialize,
     main,
     pkghandler,
     subscription,
@@ -355,11 +356,11 @@ class PrintDataCollectionMocked(MockFunctionObject):
 
 
 class InitializeLoggerMocked(MockFunctionObject):
-    spec = main.initialize_logger
+    spec = initialize.initialize_logger
 
 
 class InitializeFileLoggingMocked(MockFunctionObject):
-    spec = main.initialize_file_logging
+    spec = initialize.initialize_file_logging
 
 
 class MainLockedMocked(MockFunctionObject):

--- a/convert2rhel/unit_tests/initialize_test.py
+++ b/convert2rhel/unit_tests/initialize_test.py
@@ -54,32 +54,3 @@ def test_initialize_logger(monkeypatch):
 
     initialize.initialize_logger()
     setup_logger_handler_mock.assert_called_once()
-
-
-@pytest.mark.parametrize(("exception_type", "exception"), ((IOError, True), (OSError, True), (None, False)))
-def test_initialize_file_logging(exception_type, exception, monkeypatch, caplog):
-    add_file_handler_mock = mock.Mock()
-    archive_old_logger_files_mock = mock.Mock()
-
-    if exception:
-        archive_old_logger_files_mock.side_effect = exception_type
-
-    monkeypatch.setattr(
-        logger_module,
-        "add_file_handler",
-        value=add_file_handler_mock,
-    )
-    monkeypatch.setattr(
-        logger_module,
-        "archive_old_logger_files",
-        value=archive_old_logger_files_mock,
-    )
-
-    initialize.initialize_file_logging("convert2rhel.log", "/tmp")
-
-    if exception:
-        assert caplog.records[-1].levelname == "WARNING"
-        assert "Unable to archive previous log:" in caplog.records[-1].message
-
-    add_file_handler_mock.assert_called_once()
-    archive_old_logger_files_mock.assert_called_once()


### PR DESCRIPTION
Initializing the logger module earlier makes the tool work correctly when trying to find the /etc/system-release file, and if it is not there, throw a critical error to the user before anything else happens.

If we don't move the module to this point, the first /etc/system-releaes check will silently fail and only the next call will throw the exception, because at this point, we already have the logger initialized.

To prevent further executions in the system, it is more reliable to initialize the logger module earlier.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1393](https://issues.redhat.com/browse/RHELC-1393)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
