### PR TITLE
[RHELC-1397] Always save conversion facts.

### DIFF
--- a/convert2rhel/breadcrumbs.py
+++ b/convert2rhel/breadcrumbs.py
@@ -101,8 +101,7 @@ class Breadcrumbs:
         self._set_ended()
 
         self._save_migration_results()
-        if self._inform_telemetry and "CONVERT2RHEL_DISABLE_TELEMETRY" not in os.environ:
-            self._save_rhsm_facts()
+        self._save_rhsm_facts()
 
     def _set_activity(self):
         """Set the activity that convert2rhel is going to perform"""
@@ -225,7 +224,6 @@ class Breadcrumbs:
                 "- Source OS vendor and version\n"
                 "- Target RHEL version\n"
                 "- Convert2RHEL related environment variables\n\n"
-                "To disable the data collection, use the 'CONVERT2RHEL_DISABLE_TELEMETRY=1' environment variable."
             )
 
             utils.ask_to_continue()


### PR DESCRIPTION
Always create the conversion facts file.

This change removes the `CONVERT2RHEL_DISABLE_TELEMETRY` environment variable.

Jira Issues: [RHELC-1397](https://issues.redhat.com/browse/RHELC-1397)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [X] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [X] PR title explains the change from the user's point of view
- [X] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
