### PR TITLE
chore:Bump Oracle Linux to 8.9 target in .packit.yaml

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -160,7 +160,7 @@ jobs:
     tf_post_install_script: '#!/bin/bash\nsudo sed -i "s/^.*ssh-rsa/ssh-rsa/" /root/.ssh/authorized_keys'
     targets:
       epel-8-x86_64:
-        distros: ["OL8.8-x86_64-HVM-2023-06-21"]
+        distros: ["OL8.9-x86_64-HVM-2024-02-02"]
     tf_extra_params:
       environments:
         - tmt:


### PR DESCRIPTION
* OL8.9 finally available on AWS, bump the target


