### PR TITLE
[RHELC-1243] Add int test to verify the httpd package error

### DIFF
--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -6,10 +6,7 @@ description+: |
     tier1 is run when the PR gets merged to the main branch.
 
 
-
 /non-destructive:
-    enabled: false
-    because: No non-destructive tests assigned to tier1.
     discover+:
         filter+:
             ['tier: 1', 'tag: non-destructive']
@@ -68,7 +65,7 @@ description+: |
                 - enabled: true
                   when: distro == oracle-7, centos-7
             environment+:
-                PACKAGES: gnome-documents-libs shim-x64
+                PACKAGES: gnome-documents-libs shim-x64 libreport-plugin-mantisbt
 
 
     /one_kernel_scenario:
@@ -177,8 +174,7 @@ description+: |
         enabled: false
         adjust+:
             - enabled: true
-              when: initiator == human
-              because: There are no UEFI images available on the Testing Farm yet.
+              when: boot_method == uefi
         discover+:
             test+<:
                 - detect-bootloader-partition/detect_correct_boot_partition

--- a/pytest.ini
+++ b/pytest.ini
@@ -108,3 +108,4 @@ markers =
     test_active_host_metering
     test_traceback_not_present
     test_duplicate_pkgs
+    test_httpd_package_transaction_error

--- a/tests/integration/tier1/non-destructive/httpd-package-transaction-error/main.fmf
+++ b/tests/integration/tier1/non-destructive/httpd-package-transaction-error/main.fmf
@@ -1,0 +1,22 @@
+summary: |
+    Test that verifies that having httpd installed is not causing transaction error.
+description: |
+    The yum transaction error happened when some packages depends on each
+    other. When a package had dependency on some excluded package (like centos-logos)
+    which was removed during the conversion then the package had missing dependency.
+    If reinstall of some package happens that brings those dependencies into the transaction
+    the error was raised. The problem was mostly caused by the httpd package installed on the
+    system.
+
+tag+:
+    - httpd-package-transaction-error
+
+/httpd_package_transaction_error:
+    enabled: false
+    link: https://issues.redhat.com/browse/RHELC-1130
+    adjust+:
+        enabled: true
+        when: distro == centos-7
+        because: The bug is reproducible only on centos-7
+    test: |
+        pytest -svv -m test_httpd_package_transaction_error

--- a/tests/integration/tier1/non-destructive/httpd-package-transaction-error/test_httpd_package_transaction_error.py
+++ b/tests/integration/tier1/non-destructive/httpd-package-transaction-error/test_httpd_package_transaction_error.py
@@ -1,0 +1,81 @@
+import pytest
+
+from envparse import env
+
+
+@pytest.fixture(scope="function")
+def handle_packages(shell):
+    """
+    Handle the installation and removal of the packages required for the test.
+    Ensure that system stays in the same state before and after the test.
+    """
+    # Packages that need to be installed on the system before running the analysis.
+    package_to_be_present_before = "httpd"
+
+    # Packages that need to be removed from the system before running the analysis.
+    packages_to_be_missing_before = [
+        "plymouth",
+        "plymouth-core-libs",
+        "plymouth-scripts",
+    ]
+
+    # Packages that needs to be installed back on the system after the analysis
+    # to ensure that the system stays in the same state as before.
+    packages_to_be_reinstalled_after = []
+
+    # Packages that needs to be removed from the system after the analysis
+    # to ensure that the system stays in the same state as before.
+    package_to_be_removed_after = None
+
+    # Install packages
+    if shell(f"rpm -q {package_to_be_present_before}").returncode == 1:
+        assert shell(f"yum install -y {package_to_be_present_before}").returncode == 0
+        package_to_be_removed_after = package_to_be_present_before
+
+    # Remove packages
+    for pkg in packages_to_be_missing_before:
+        if shell(f"rpm -q {pkg}").returncode == 0:
+            packages_to_be_reinstalled_after.append(pkg)
+        assert shell(f"yum remove -y {pkg}").returncode == 0
+
+    # Return back to the test
+    yield
+
+    if package_to_be_removed_after:
+        assert shell(f"yum remove -y {package_to_be_removed_after}").returncode == 0
+
+    for pkg in packages_to_be_reinstalled_after:
+        assert shell(f"yum install -y {pkg}").returncode == 0
+
+
+@pytest.mark.test_httpd_package_transaction_error
+def test_httpd_package_transaction_error(shell, convert2rhel, handle_packages):
+    """
+    This test verifies the https://issues.redhat.com/browse/RHELC-1130.
+    The yum transaction error happened when some packages depends on each
+    other. When a package had dependency on some excluded package (like centos-logos)
+    which was removed during the conversion then the package had missing dependency.
+    If reinstall of some package happens that brings those dependencies into the transaction
+    the error was raised. The problem was mostly caused by the httpd package installed on the
+    system.
+    """
+    # run c2r analyze to verify the yum transaction
+    with convert2rhel(
+        "analyze -y --serverurl {} --username {} --password {} --pool {} --debug".format(
+            env.str("RHSM_SERVER_URL"),
+            env.str("RHSM_USERNAME"),
+            env.str("RHSM_PASSWORD"),
+            env.str("RHSM_POOL"),
+        )
+    ) as c2r:
+        index = c2r.expect_exact(
+            [
+                "Package centos-logos will be swapped to redhat-logos during conversion",
+                "Error (Must fix before conversion)",
+            ],
+            timeout=600,
+        )
+        assert index == 0, "The analysis found an error. Probably related to the transaction check."
+        assert c2r.expect_exact("VALIDATE_PACKAGE_MANAGER_TRANSACTION has succeeded") == 0
+
+    assert c2r.exitstatus == 0

--- a/tests/integration/tier1/non-destructive/main.fmf
+++ b/tests/integration/tier1/non-destructive/main.fmf
@@ -1,5 +1,5 @@
 summary+: |
-    Set of non-destructive tests
+    Set of non-destructive tests tier 1
 
 description+: |
     All tests are non-destructive, meaning there is not a full conversion being done.


### PR DESCRIPTION
The test is added as a tier1 as it is a corner
case scenario.
The bug to verify: https://issues.redhat.com/browse/RHELC-1130

Jira Issues: [RHELC-1243](https://issues.redhat.com/browse/RHELC-1243)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
