### PR TITLE
Fix is_loaded_kernel_latest env var test

### DIFF
--- a/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
@@ -693,7 +693,11 @@ class TestIsLoadedKernelLatest:
                 "Kernel currency check failed",
                 "Please refer to the diagnosis for further information",
                 "Could not find any {0} from repositories to compare against the loaded kernel.",
-                "Please, check if you have any vendor repositories enabled to proceed with the conversion.\nIf you wish to disregard this message, set the environment variable 'CONVERT2RHEL_UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK' to 1.",
+                (
+                    "Please, check if you have any vendor repositories enabled to proceed with the conversion.\n"
+                    "If you wish to disregard this message, set the environment variable "
+                    "'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' to 1."
+                ),
                 id="Repoquery failure without environment var",
             ),
         ),


### PR DESCRIPTION
The remediation message is different in the test and in the action, thus causing the failure.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
