### PR TITLE
Add auto retry for coverage analysis

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,7 +42,27 @@ jobs:
           make tests${{ matrix.el.ver }} PYTEST_ARGS="--cov --cov-report xml --cov-report term" KEEP_TEST_CONTAINER=1 BUILD_IMAGES=0
           podman cp pytest-container:/data/coverage.xml .
 
-      - name: Upload coverage to Codecov
+      - name: Upload coverage to Codecov - First Attempt
+        id: UploadFirstAttempt
+        continue-on-error: true
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          env_vars: OS,PYTHON
+          flags: ${{ matrix.el.distro }}-linux-${{ matrix.el.ver }}
+          name: coverage-${{ matrix.el.distro }}
+          fail_ci_if_error: true
+          files: ./coverage.xml
+          verbose: true # optional (default = false)
+
+      - name: Wait before retrying
+        if: steps.UploadFirstAttempt.outcome == 'failure'
+        run: sleep 1m
+
+      - name: Upload coverage to Codecov - Second Attempt
+        id: UploadSecondAttempt
+        if: steps.UploadFirstAttempt.outcome == 'failure'
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Add auto retry for coverage analysis

The "Upload coverage to Codecov" step of the coverage analysis often
fails due to network issues with an error like:

```
Commit creating failed: {"error": "Server Error (500)"}
```

GitHub coverage action doesn't have a retry parameter, thus we use a
trick:

we add one more upload step exactly as the previous one, but we would
trigger it only in case the previous step failed.

Additionally, as retrying one upload too close to the other still gets a
failure we add a sleep step to wait for a minute before retrying.

Checklist

- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
