### PR TITLE
[RHELC-1432] Copy instead of move when restoring a file

### DIFF
--- a/convert2rhel/backup/files.py
+++ b/convert2rhel/backup/files.py
@@ -120,7 +120,8 @@ class RestorableFile(RestorableChange):
             return
 
         try:
-            shutil.move(self._backup_path, self.filepath)
+            shutil.copy2(self._backup_path, self.filepath)
+            os.remove(self._backup_path)
         except (OSError, IOError) as err:
             # Do not call 'critical' which would halt the program. We are in
             # a rollback phase now and we want to rollback as much as possible.

--- a/convert2rhel/unit_tests/backup/files_test.py
+++ b/convert2rhel/unit_tests/backup/files_test.py
@@ -208,7 +208,8 @@ class TestRestorableFile:
             messages[i] = messages[i].format(orig_path=backup_file)
 
         monkeypatch.setattr(os.path, "isfile", lambda file: isfile)
-        monkeypatch.setattr(shutil, "move", mock.Mock())
+        monkeypatch.setattr(shutil, "copy2", mock.Mock())
+        monkeypatch.setattr(os, "remove", mock.Mock())
         monkeypatch.setattr(files, "BACKUP_DIR", str(backup_dir))
 
         file_backup = RestorableFile(backup_file)
@@ -220,6 +221,8 @@ class TestRestorableFile:
 
         if filename and enabled:
             assert os.path.isfile(backup_file)
+            assert shutil.copy2.call_count == 1
+            assert os.remove.call_count == 1
 
     def test_restorable_file_backup_oserror(self, tmpdir, caplog, monkeypatch):
         backup_dir = tmpdir.mkdir("backup")


### PR DESCRIPTION
Moving a file back to its own directory is causing the file to lose the metadata and not letting the user enter in their system with SSH after the analysis is done.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1432](https://issues.redhat.com/browse/RHELC-1432)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
