### PR TITLE
[RHELC-1434] Use public CDN instead of paywalled CDN and FTP

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/subscription.py
+++ b/convert2rhel/actions/pre_ponr_changes/subscription.py
@@ -47,9 +47,7 @@ class InstallRedHatCertForYumRepositories(actions.Action):
     def run(self):
         super(InstallRedHatCertForYumRepositories, self).run()
 
-        # We need to make sure the redhat-uep.pem file exists since the
-        # various Red Hat yum repositories (including the convert2rhel
-        # repo) use it.
+        # We need to make sure the redhat-uep.pem file exists since RHEL yum repositories use it.
         # The subscription-manager-rhsm-certificates package contains this cert but for
         # example on CentOS Linux 7 this package is missing the cert due to intentional
         # debranding. Thus we need to ensure the cert is in place even when the pkg is installed.

--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -32,22 +32,19 @@ from convert2rhel.utils import files
 
 logger = logging.getLogger(__name__)
 
-# The SSL certificate of the https://cdn.redhat.com/ server
-SSL_CERT_PATH = os.path.join(utils.DATA_DIR, "redhat-uep.pem")
-CDN_URL = "https://cdn.redhat.com/content/public/convert2rhel/$releasever/$basearch/os/"
+CDN_URL_7 = "https://cdn-public.redhat.com/content/public/addon/dist/convert2rhel/server/7/7Server/x86_64/os/"
+CDN_URL_8 = "https://cdn-public.redhat.com/content/public/addon/dist/convert2rhel8/8/x86_64/os/"
 RPM_GPG_KEY_PATH = os.path.join(utils.DATA_DIR, "gpg-keys", "RPM-GPG-KEY-redhat-release")
 
-CONVERT2RHEL_REPO_CONTENT = """\
+CONVERT2RHEL_REPO_CONTENT = (
+    """\
 [convert2rhel]
 name=Convert2RHEL Repository
-baseurl=%s
+baseurl={}
 gpgcheck=1
 enabled=1
-sslcacert=%s
-gpgkey=file://%s""" % (
-    CDN_URL,
-    SSL_CERT_PATH,
-    RPM_GPG_KEY_PATH,
+gpgkey=file://%s"""
+    % RPM_GPG_KEY_PATH
 )
 
 
@@ -62,7 +59,8 @@ class Convert2rhelLatest(actions.Action):
 
         repo_dir = tempfile.mkdtemp(prefix="convert2rhel_repo.", dir=utils.TMP_DIR)
         repo_path = os.path.join(repo_dir, "convert2rhel.repo")
-        utils.store_content_to_file(filename=repo_path, content=CONVERT2RHEL_REPO_CONTENT)
+        repo_content = CONVERT2RHEL_REPO_CONTENT.format(CDN_URL_7 if system_info.version.major == 7 else CDN_URL_8)
+        utils.store_content_to_file(filename=repo_path, content=repo_content)
 
         cmd = [
             "repoquery",

--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -50,8 +50,6 @@ class Convert2rhelLatest(actions.Action):
 
         cmd = [
             "repoquery",
-            "--disablerepo=*",
-            "--enablerepo=convert2rhel",
             "--releasever=%s" % system_info.version.major,
             "--setopt=reposdir=%s" % os.path.dirname(repofile_path),
             "--qf",

--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -232,7 +232,7 @@ class Convert2rhelLatest(actions.Action):
                 id="CONVERT2RHEL_LATEST_CHECK_UNEXPECTED_SYS_VERSION",
                 title="Did not perform convert2rhel latest version check",
                 description="Checking whether the installed convert2rhel package is of the latest available version was"
-                " skipped due to an unexpected system version",
+                " skipped due to an unexpected system version.",
                 diagnosis="Expected system versions: %s. Detected major version: %s"
                 % (", ".join(str(x) for x in C2R_REPOFILE_URLS), system_info.version.major),
             )
@@ -248,7 +248,7 @@ class Convert2rhelLatest(actions.Action):
                 id="CONVERT2RHEL_LATEST_CHECK_REPO_DOWNLOAD_FAILED",
                 title="Did not perform convert2rhel latest version check",
                 description="Checking whether the installed convert2rhel package is of the latest available version was"
-                " skipped due to not being able to download the convert2rhel repository file",
+                " skipped due to not being able to download the convert2rhel repository file.",
                 diagnosis=err.description,
             )
             return None

--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -44,7 +44,7 @@ class Convert2rhelLatest(actions.Action):
 
         super(Convert2rhelLatest, self).run()
 
-        repofile_path = self._get_convert2rhel_repofile_path()
+        repofile_path = self._download_convert2rhel_repofile()
         if not repofile_path:
             return
 
@@ -218,7 +218,7 @@ class Convert2rhelLatest(actions.Action):
 
         logger.info("Latest available convert2rhel version is installed.")
 
-    def _get_convert2rhel_repofile_path(self):
+    def _download_convert2rhel_repofile(self):
         """Download the official downstream convert2rhel repofile to a temporary directory.
 
         :return: Path of the downloaded downstream convert2rhel repofile

--- a/convert2rhel/repo.py
+++ b/convert2rhel/repo.py
@@ -110,14 +110,13 @@ def download_repofile(repofile_url):
                     description=description,
                 )
 
-            loggerinst.info("Successfully downloaded the requested repofile from %s." % repofile_url)
+            loggerinst.info("Successfully downloaded a repository file from %s." % repofile_url)
             return contents.decode()
     except urllib.error.URLError as err:
         raise exceptions.CriticalError(
             id_="DOWNLOAD_REPOSITORY_FILE_FAILED",
-            title="Failed to download repository file",
-            description="Failed to download the requested repository file from %s.\n"
-            "Reason: %s" % (repofile_url, err.reason),
+            title="Failed to download a repository file",
+            description="Failed to download a repository file from %s.\n" "Reason: %s" % (repofile_url, err.reason),
         )
 
 
@@ -132,12 +131,12 @@ def write_temporary_repofile(contents):
         repository contents to a file.
     """
     try:
-        repofile_dir = tempfile.mkdtemp(prefix="convert2rhel_repo.", dir=TMP_DIR)
+        repofile_dir = tempfile.mkdtemp(prefix="downloaded_repofiles.", dir=TMP_DIR)
     except (OSError, IOError) as err:
         raise exceptions.CriticalError(
-            id_="CREATE_TMP_DIR_FOR_C2R_REPO_FAILED",
+            id_="CREATE_TMP_DIR_FOR_REPOFILES_FAILED",
             title="Failed to create a temporary directory",
-            description="Failed to create a temporary directory for the convert2rhel repository under %s.\n"
+            description="Failed to create a temporary directory for storing a repository file under %s.\n"
             "Reason: %s" % (TMP_DIR, str(err)),
         )
     with tempfile.NamedTemporaryFile(mode="w", suffix=".repo", delete=False, dir=repofile_dir) as f:
@@ -146,8 +145,7 @@ def write_temporary_repofile(contents):
             return f.name
         except (OSError, IOError) as err:
             raise exceptions.CriticalError(
-                id_="STORE_REPOSITORY_FILE_FAILED",
+                id_="STORE_REPOFILE_FAILED",
                 title="Failed to store a repository file",
-                description="Failed to write the requested repository file contents to %s.\n"
-                "Reason: %s" % (f.name, str(err)),
+                description="Failed to write a repository file contents to %s.\n" "Reason: %s" % (f.name, str(err)),
             )

--- a/convert2rhel/repo.py
+++ b/convert2rhel/repo.py
@@ -131,7 +131,15 @@ def write_temporary_repofile(contents):
     :raises exceptions.CriticalError: In case of not being able to write the
         repository contents to a file.
     """
-    repofile_dir = tempfile.mkdtemp(prefix="convert2rhel_repo.", dir=TMP_DIR)
+    try:
+        repofile_dir = tempfile.mkdtemp(prefix="convert2rhel_repo.", dir=TMP_DIR)
+    except (OSError, IOError) as err:
+        raise exceptions.CriticalError(
+            id_="CREATE_TMP_DIR_FOR_C2R_REPO_FAILED",
+            title="Failed to create a temporary directory",
+            description="Failed to create a temporary directory for the convert2rhel repository under %s.\n"
+            "Reason: %s" % (TMP_DIR, str(err)),
+        )
     with tempfile.NamedTemporaryFile(mode="w", suffix=".repo", delete=False, dir=repofile_dir) as f:
         try:
             store_content_to_file(filename=f.name, content=contents)

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -48,7 +48,7 @@ def prepare_convert2rhel_latest_action(monkeypatch, tmpdir, request, global_syst
     marker = request.param
     monkeypatch.setattr(
         convert2rhel_latest.Convert2rhelLatest,
-        "_get_convert2rhel_repofile_path",
+        "_download_convert2rhel_repofile",
         mock.Mock(return_value="/test/path.py"),
     )
     monkeypatch.setattr(convert2rhel_latest, "running_convert2rhel_version", marker["local_version"])
@@ -770,7 +770,7 @@ class TestCheckConvert2rhelLatest:
         self, global_system_info, monkeypatch, convert2rhel_latest_action_instance
     ):
         monkeypatch.setattr(convert2rhel_latest, "system_info", global_system_info)
-        # Setting the major version to 0 will make _get_convert2rhel_repofile_path() generate
+        # Setting the major version to 0 will make _download_convert2rhel_repofile() generate
         # a WARNING-level report message and return None
         monkeypatch.setattr(global_system_info, "version", systeminfo.Version(0, 0))
 
@@ -791,7 +791,7 @@ class TestCheckConvert2rhelLatest:
             (8, False, True, None, "store failed"),
         ),
     )
-    def test_get_convert2rhel_repofile_path(
+    def test_download_convert2rhel_repofile(
         self,
         monkeypatch,
         global_system_info,
@@ -821,7 +821,7 @@ class TestCheckConvert2rhelLatest:
             monkeypatch.setattr(repo, "write_temporary_repofile", mock.Mock(return_value="/test/path.py"))
 
         convert2rhel_latest_action_instance = convert2rhel_latest.Convert2rhelLatest()
-        returned = convert2rhel_latest_action_instance._get_convert2rhel_repofile_path()
+        returned = convert2rhel_latest_action_instance._download_convert2rhel_repofile()
 
         assert returned == expected_return
         if msg_diag:

--- a/convert2rhel/unit_tests/repo_test.py
+++ b/convert2rhel/unit_tests/repo_test.py
@@ -162,7 +162,18 @@ def test_write_temporary_repofile(tmpdir, monkeypatch):
         assert f.read() == "test\n"
 
 
-def test_write_temporary_repofile_oserror(tmpdir, monkeypatch):
+def test_write_temporary_repofile_mkdir_failure(monkeypatch):
+    monkeypatch.setattr(repo.tempfile, "mkdtemp", mock.Mock(side_effect=OSError("unable")))
+
+    with pytest.raises(exceptions.CriticalError) as execinfo:
+        repo.write_temporary_repofile("test")
+
+    assert "CREATE_TMP_DIR_FOR_C2R_REPO_FAILED" in execinfo._excinfo[1].id
+    assert "Failed to create a temporary directory" in execinfo._excinfo[1].title
+    assert "unable" in execinfo._excinfo[1].description
+
+
+def test_write_temporary_repofile_store_failure(tmpdir, monkeypatch):
     monkeypatch.setattr(repo, "TMP_DIR", str(tmpdir))
     monkeypatch.setattr(repo, "store_content_to_file", mock.Mock(side_effect=OSError("test")))
 

--- a/convert2rhel/unit_tests/repo_test.py
+++ b/convert2rhel/unit_tests/repo_test.py
@@ -127,7 +127,7 @@ class TestDownloadRepofile:
 
         contents = repo.download_repofile("https://test")
         assert contents == "test_file"
-        assert "Successfully downloaded the requested repofile from https://test" in caplog.records[-1].message
+        assert "Successfully downloaded a repository file from https://test" in caplog.records[-1].message
 
     def test_failed_to_open_url(self, monkeypatch):
         monkeypatch.setattr(repo.urllib.request, "urlopen", mock.Mock(side_effect=urllib.error.URLError(reason="test")))
@@ -136,7 +136,7 @@ class TestDownloadRepofile:
             repo.download_repofile("https://test")
 
         assert "DOWNLOAD_REPOSITORY_FILE_FAILED" in execinfo._excinfo[1].id
-        assert "Failed to download repository file" in execinfo._excinfo[1].title
+        assert "Failed to download a repository file" in execinfo._excinfo[1].title
         assert "test" in execinfo._excinfo[1].description
 
     def test_no_contents_in_request_url(self, monkeypatch):
@@ -168,7 +168,7 @@ def test_write_temporary_repofile_mkdir_failure(monkeypatch):
     with pytest.raises(exceptions.CriticalError) as execinfo:
         repo.write_temporary_repofile("test")
 
-    assert "CREATE_TMP_DIR_FOR_C2R_REPO_FAILED" in execinfo._excinfo[1].id
+    assert "CREATE_TMP_DIR_FOR_REPOFILES_FAILED" in execinfo._excinfo[1].id
     assert "Failed to create a temporary directory" in execinfo._excinfo[1].title
     assert "unable" in execinfo._excinfo[1].description
 
@@ -180,6 +180,6 @@ def test_write_temporary_repofile_store_failure(tmpdir, monkeypatch):
     with pytest.raises(exceptions.CriticalError) as execinfo:
         repo.write_temporary_repofile("test")
 
-    assert "STORE_REPOSITORY_FILE_FAILED" in execinfo._excinfo[1].id
+    assert "STORE_REPOFILE_FAILED" in execinfo._excinfo[1].id
     assert "Failed to store a repository file" in execinfo._excinfo[1].title
     assert "test" in execinfo._excinfo[1].description

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -498,7 +498,8 @@ def pre_registered(shell, request, yum_conf_exclude):
         _add_client_tools_repo(shell)
 
     assert shell("yum install -y subscription-manager").returncode == 0
-    # Download the certificate using insecure connection
+    # The SSL certificate for accessing cdn.redhat.com is intentionally missing from
+    # the subscription-manager-rhsm-certificates package on CentOS Linux 7
     shell(
         "curl --create-dirs -ko /etc/rhsm/ca/redhat-uep.pem https://cdn-public.redhat.com/content/public/repofiles/redhat-uep.pem"
     )

--- a/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_rollback.py
+++ b/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_rollback.py
@@ -14,10 +14,10 @@ def test_sub_man_rollback(convert2rhel, shell, required_packages):
     Not removing and backing up the python3-syspurpose and python3-cloud-what packages on CentOS Linux 8.5 was causing
     a rollback failure when an older version of these two packages was installed.
 
-    The rollback failure caused the following issue during the subsequent second run of convert2rhel:
-      When the rollback happened before removing the centos-linux-release package, this package was not re-installed
-      back during the rollback and that lead to the $releasever variable being undefined, ultimately causing a traceback
-      when using the DNF python API (https://issues.redhat.com/browse/RHELC-762)
+    When a reinstallation of removed packages failed during the rollback due to not having the right versions of updated
+    dependencies backed up, the system was left without the centos-linux-release package installed, leading to the
+    $releasever variable being undefined, and ultimately causing a traceback during a subsequent execution of
+    convert2rhel (https://issues.redhat.com/browse/RHELC-762).
     """
     # By running convert2rhel twice we make sure that the rollback of the first run
     # correctly reinstalled centos-linux-release and subscription-manager* and the second run then does not fail


### PR DESCRIPTION
The convert2rhel repos moved from https://cdn.redhat.com/ to https://cdn-public.redhat.com/.
The convert2rhel repofiles moved from https://ftp.redhat.com/ to https://cdn-public.redhat.com/.

The https://cdn-public.redhat.com/ does not use a self-signed SSL cert as the https://cdn.redhat.com/ does. So we can drop handling the `redhat-uep.pem` certificate.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1434](https://issues.redhat.com/browse/RHELC-1434)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant

----

# Depends on 
- [x] https://github.com/oamg/convert2rhel/pull/1164