### PR TITLE
Modify pre-commit to use latest pylint version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,18 +9,14 @@ repos:
         language: python
         language_version: "python3"
         additional_dependencies: [click==7.1.2, black==21.12b0]
-  - repo: local
+  - repo: https://github.com/pylint-dev/pylint
+    rev: v3.1.0
     hooks:
       - id: pylint
-        name: pylint
-        entry: pylint
-        types: [python]
-        language: python
-        additional_dependencies: [pylint==2.15.10]
         args: [
-            "-sn", # Don't display the score
-            "--rcfile=.pylintrc", # Link to your config file
-          ]
+          "-sn", # Don't display the score
+          "--rcfile=.pylintrc", # Link to your config file
+        ]
   - repo: "https://github.com/timothycrosley/isort"
     rev: 5.13.2
     hooks:

--- a/.pylintrc
+++ b/.pylintrc
@@ -15,6 +15,7 @@ disable=
 # on the versions of python we support.
  redundant-u-string-prefix,  # Python 3.0+
  consider-using-f-string,  # Python 3.6+
+ use-yield-from, # Python 3+
 # These are our current failures 2023-01-11.  We can go through them and either
 # fix them or add a comment to say why we are leaving it disabled.
  anomalous-backslash-in-string,

--- a/convert2rhel/actions/system_checks/rhel_compatible_kernel.py
+++ b/convert2rhel/actions/system_checks/rhel_compatible_kernel.py
@@ -99,7 +99,7 @@ def _bad_kernel_version(kernel_release):
         raise KernelIncompatibleError(
             "UNEXPECTED_VERSION",
             "Unexpected OS major version. Expected: {compatible_version}",
-            dict(compatible_version=COMPATIBLE_KERNELS_VERS.keys()),
+            {"compatible_version": COMPATIBLE_KERNELS_VERS.keys()},
         )
 
     if incompatible_version:
@@ -107,11 +107,11 @@ def _bad_kernel_version(kernel_release):
             "INCOMPATIBLE_VERSION",
             "Booted kernel version '{kernel_version}' does not correspond to the version "
             "'{compatible_version}' available in RHEL {rhel_major_version}",
-            dict(
-                kernel_version=kernel_version,
-                compatible_version=COMPATIBLE_KERNELS_VERS[system_info.version.major],
-                rhel_major_version=system_info.version.major,
-            ),
+            {
+                "kernel_version": kernel_version,
+                "compatible_version": COMPATIBLE_KERNELS_VERS[system_info.version.major],
+                "rhel_major_version": system_info.version.major,
+            },
         )
 
     logger.debug(
@@ -134,7 +134,7 @@ def _bad_kernel_package_signature(kernel_release):
             "UNSIGNED_PACKAGE",
             "The booted kernel {vmlinuz_path} is not owned by any installed package."
             " It needs to be owned by a package signed by {os_vendor}.",
-            dict(vmlinuz_path=vmlinuz_path, os_vendor=os_vendor),
+            {"vmlinuz_path": vmlinuz_path, "os_vendor": os_vendor},
         )
 
     kernel_pkg_obj = get_installed_pkg_information(pkg_name=kernel_pkg)
@@ -143,7 +143,7 @@ def _bad_kernel_package_signature(kernel_release):
         raise KernelIncompatibleError(
             "INVALID_KERNEL_PACKAGE_SIGNATURE",
             "Custom kernel detected. The booted kernel needs to be signed by {os_vendor}.",
-            dict(os_vendor=os_vendor),
+            {"os_vendor": os_vendor},
         )
 
     logger.debug("The booted kernel is signed by %s." % os_vendor)
@@ -158,6 +158,6 @@ def _bad_kernel_substring(kernel_release):
             "INVALID_PACKAGE_SUBSTRING",
             "The booted kernel '{kernel_release}' contains one of the disallowed "
             "substrings: {bad_kernel_release_substrings}",
-            dict(kernel_release=kernel_release, bad_kernel_release_substrings=BAD_KERNEL_RELEASE_SUBSTRINGS),
+            {"kernel_release": kernel_release, "bad_kernel_release_substrings": BAD_KERNEL_RELEASE_SUBSTRINGS},
         )
     return False

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -379,8 +379,9 @@ def format_pkg_info(pkgs):
         package_info[nevra] = {"packager": packager, "repoid": "N/A"}
 
     # Get packager length
-    packager_field_lengths = (len(package["packager"]) for package in package_info.values())
-    max_packager_length = max(max(packager_field_lengths), len("Vendor/Packager"))
+    packager_field_lengths = [len(package["packager"]) for package in package_info.values()]
+    max_packager_field_length = max(packager_field_lengths)
+    max_packager_length = max(max_packager_field_length, len("Vendor/Packager"))
 
     # Get nevra length
     max_nvra_length = max(len(nvra) for nvra in package_info)

--- a/convert2rhel/unit_tests/actions/actions_test.py
+++ b/convert2rhel/unit_tests/actions/actions_test.py
@@ -58,27 +58,34 @@ class TestAction:
         (
             # Set one result field
             (
-                dict(level="SUCCESS", id="SUCCESS"),
-                dict(level="SUCCESS", id="SUCCESS", title="", description="", diagnosis="", remediations=""),
+                {"level": "SUCCESS", "id": "SUCCESS"},
+                {
+                    "level": "SUCCESS",
+                    "id": "SUCCESS",
+                    "title": "",
+                    "description": "",
+                    "diagnosis": "",
+                    "remediations": "",
+                },
             ),
             # Set all result fields
             (
-                dict(
-                    level="ERROR",
-                    id="ERRORCASE",
-                    title="Problem detected",
-                    description="problem",
-                    diagnosis="detected",
-                    remediations="move on",
-                ),
-                dict(
-                    level="ERROR",
-                    id="ERRORCASE",
-                    title="Problem detected",
-                    description="problem",
-                    diagnosis="detected",
-                    remediations="move on",
-                ),
+                {
+                    "level": "ERROR",
+                    "id": "ERRORCASE",
+                    "title": "Problem detected",
+                    "description": "problem",
+                    "diagnosis": "detected",
+                    "remediations": "move on",
+                },
+                {
+                    "level": "ERROR",
+                    "id": "ERRORCASE",
+                    "title": "Problem detected",
+                    "description": "problem",
+                    "diagnosis": "detected",
+                    "remediations": "move on",
+                },
             ),
         ),
     )
@@ -738,18 +745,18 @@ class TestRunActions:
                     [],
                 ),
                 {
-                    "One": dict(
-                        messages=[],
-                        result=dict(
-                            level=STATUS_CODE["SUCCESS"],
-                            id="SUCCESS",
-                            title="",
-                            description="",
-                            diagnosis="",
-                            remediations="",
-                            variables={},
-                        ),
-                    )
+                    "One": {
+                        "messages": [],
+                        "result": {
+                            "level": STATUS_CODE["SUCCESS"],
+                            "id": "SUCCESS",
+                            "title": "",
+                            "description": "",
+                            "diagnosis": "",
+                            "remediations": "",
+                            "variables": {},
+                        },
+                    }
                 },
             ),
             (
@@ -775,30 +782,30 @@ class TestRunActions:
                     [],
                 ),
                 {
-                    "One": dict(
-                        messages=[],
-                        result=dict(
-                            level=STATUS_CODE["SUCCESS"],
-                            id="SUCCESS",
-                            title="",
-                            description="",
-                            diagnosis="",
-                            remediations="",
-                            variables={},
-                        ),
-                    ),
-                    "Two": dict(
-                        messages=[],
-                        result=dict(
-                            level=STATUS_CODE["SUCCESS"],
-                            id="SUCCESS",
-                            title="",
-                            description="",
-                            diagnosis="",
-                            remediations="",
-                            variables={},
-                        ),
-                    ),
+                    "One": {
+                        "messages": [],
+                        "result": {
+                            "level": STATUS_CODE["SUCCESS"],
+                            "id": "SUCCESS",
+                            "title": "",
+                            "description": "",
+                            "diagnosis": "",
+                            "remediations": "",
+                            "variables": {},
+                        },
+                    },
+                    "Two": {
+                        "messages": [],
+                        "result": {
+                            "level": STATUS_CODE["SUCCESS"],
+                            "id": "SUCCESS",
+                            "title": "",
+                            "description": "",
+                            "diagnosis": "",
+                            "remediations": "",
+                            "variables": {},
+                        },
+                    },
                 },
             ),
             # Single Failures
@@ -822,18 +829,18 @@ class TestRunActions:
                     [],
                 ),
                 {
-                    "One": dict(
-                        messages=[],
-                        result=dict(
-                            level=STATUS_CODE["ERROR"],
-                            id="SOME_ERROR",
-                            title="Error",
-                            description="Action error",
-                            diagnosis="User error",
-                            remediations="move on",
-                            variables={},
-                        ),
-                    ),
+                    "One": {
+                        "messages": [],
+                        "result": {
+                            "level": STATUS_CODE["ERROR"],
+                            "id": "SOME_ERROR",
+                            "title": "Error",
+                            "description": "Action error",
+                            "diagnosis": "User error",
+                            "remediations": "move on",
+                            "variables": {},
+                        },
+                    },
                 },
             ),
             (
@@ -856,18 +863,18 @@ class TestRunActions:
                     [],
                 ),
                 {
-                    "One": dict(
-                        messages=[],
-                        result=dict(
-                            level=STATUS_CODE["OVERRIDABLE"],
-                            id="SOME_ERROR",
-                            title="Overridable",
-                            description="Action overridable",
-                            diagnosis="User overridable",
-                            remediations="move on",
-                            variables={},
-                        ),
-                    ),
+                    "One": {
+                        "messages": [],
+                        "result": {
+                            "level": STATUS_CODE["OVERRIDABLE"],
+                            "id": "SOME_ERROR",
+                            "title": "Overridable",
+                            "description": "Action overridable",
+                            "diagnosis": "User overridable",
+                            "remediations": "move on",
+                            "variables": {},
+                        },
+                    },
                 },
             ),
             (
@@ -890,18 +897,18 @@ class TestRunActions:
                     ],
                 ),
                 {
-                    "One": dict(
-                        messages=[],
-                        result=dict(
-                            level=STATUS_CODE["SKIP"],
-                            id="SOME_ERROR",
-                            title="Skip",
-                            description="Action skip",
-                            diagnosis="User skip",
-                            remediations="move on",
-                            variables={},
-                        ),
-                    ),
+                    "One": {
+                        "messages": [],
+                        "result": {
+                            "level": STATUS_CODE["SKIP"],
+                            "id": "SOME_ERROR",
+                            "title": "Skip",
+                            "description": "Action skip",
+                            "diagnosis": "User skip",
+                            "remediations": "move on",
+                            "variables": {},
+                        },
+                    },
                 },
             ),
             # Mixture of failures and successes.
@@ -940,42 +947,42 @@ class TestRunActions:
                     ],
                 ),
                 {
-                    "One": dict(
-                        messages=[],
-                        result=dict(
-                            level=STATUS_CODE["ERROR"],
-                            id="ERROR_ID",
-                            title="Error",
-                            description="Action error",
-                            diagnosis="User error",
-                            remediations="move on",
-                            variables={},
-                        ),
-                    ),
-                    "Two": dict(
-                        messages=[],
-                        result=dict(
-                            level=STATUS_CODE["SKIP"],
-                            id="SKIP_ID",
-                            title="Skip",
-                            description="Action skip",
-                            diagnosis="User skip",
-                            remediations="move on",
-                            variables={},
-                        ),
-                    ),
-                    "Three": dict(
-                        messages=[],
-                        result=dict(
-                            level=STATUS_CODE["SUCCESS"],
-                            id="SUCCESS",
-                            title="",
-                            description="",
-                            diagnosis="",
-                            remediations="",
-                            variables={},
-                        ),
-                    ),
+                    "One": {
+                        "messages": [],
+                        "result": {
+                            "level": STATUS_CODE["ERROR"],
+                            "id": "ERROR_ID",
+                            "title": "Error",
+                            "description": "Action error",
+                            "diagnosis": "User error",
+                            "remediations": "move on",
+                            "variables": {},
+                        },
+                    },
+                    "Two": {
+                        "messages": [],
+                        "result": {
+                            "level": STATUS_CODE["SKIP"],
+                            "id": "SKIP_ID",
+                            "title": "Skip",
+                            "description": "Action skip",
+                            "diagnosis": "User skip",
+                            "remediations": "move on",
+                            "variables": {},
+                        },
+                    },
+                    "Three": {
+                        "messages": [],
+                        "result": {
+                            "level": STATUS_CODE["SUCCESS"],
+                            "id": "SUCCESS",
+                            "title": "",
+                            "description": "",
+                            "diagnosis": "",
+                            "remediations": "",
+                            "variables": {},
+                        },
+                    },
                 },
             ),
         ),
@@ -1015,28 +1022,28 @@ class TestRunActions:
                     [],
                 ),
                 {
-                    "One": dict(
-                        messages=[
-                            dict(
-                                level=STATUS_CODE["WARNING"],
-                                id="WARNING_ID",
-                                title="Warning",
-                                description="Action warning",
-                                diagnosis="User warning",
-                                remediations="move on",
-                                variables={},
-                            )
+                    "One": {
+                        "messages": [
+                            {
+                                "level": STATUS_CODE["WARNING"],
+                                "id": "WARNING_ID",
+                                "title": "Warning",
+                                "description": "Action warning",
+                                "diagnosis": "User warning",
+                                "remediations": "move on",
+                                "variables": {},
+                            }
                         ],
-                        result=dict(
-                            level=STATUS_CODE["SUCCESS"],
-                            id="SUCCESS",
-                            title="",
-                            description="",
-                            diagnosis="",
-                            remediations="",
-                            variables={},
-                        ),
-                    )
+                        "result": {
+                            "level": STATUS_CODE["SUCCESS"],
+                            "id": "SUCCESS",
+                            "title": "",
+                            "description": "",
+                            "diagnosis": "",
+                            "remediations": "",
+                            "variables": {},
+                        },
+                    }
                 },
             ),
             (
@@ -1080,50 +1087,50 @@ class TestRunActions:
                     [],
                 ),
                 {
-                    "One": dict(
-                        messages=[
-                            dict(
-                                level=STATUS_CODE["WARNING"],
-                                id="WARNING_ID",
-                                title="Warning",
-                                description="Action warning",
-                                diagnosis="User warning",
-                                remediations="move on",
-                                variables={},
-                            )
+                    "One": {
+                        "messages": [
+                            {
+                                "level": STATUS_CODE["WARNING"],
+                                "id": "WARNING_ID",
+                                "title": "Warning",
+                                "description": "Action warning",
+                                "diagnosis": "User warning",
+                                "remediations": "move on",
+                                "variables": {},
+                            }
                         ],
-                        result=dict(
-                            level=STATUS_CODE["SUCCESS"],
-                            id="SUCCESS",
-                            title="",
-                            description="",
-                            diagnosis="",
-                            remediations="",
-                            variables={},
-                        ),
-                    ),
-                    "Two": dict(
-                        messages=[
-                            dict(
-                                level=STATUS_CODE["WARNING"],
-                                id="WARNING_ID",
-                                title="Warning",
-                                description="Action warning",
-                                diagnosis="User warning",
-                                remediations="move on",
-                                variables={},
-                            )
+                        "result": {
+                            "level": STATUS_CODE["SUCCESS"],
+                            "id": "SUCCESS",
+                            "title": "",
+                            "description": "",
+                            "diagnosis": "",
+                            "remediations": "",
+                            "variables": {},
+                        },
+                    },
+                    "Two": {
+                        "messages": [
+                            {
+                                "level": STATUS_CODE["WARNING"],
+                                "id": "WARNING_ID",
+                                "title": "Warning",
+                                "description": "Action warning",
+                                "diagnosis": "User warning",
+                                "remediations": "move on",
+                                "variables": {},
+                            }
                         ],
-                        result=dict(
-                            level=STATUS_CODE["SUCCESS"],
-                            id="SUCCESS",
-                            title="",
-                            description="",
-                            diagnosis="",
-                            remediations="",
-                            variables={},
-                        ),
-                    ),
+                        "result": {
+                            "level": STATUS_CODE["SUCCESS"],
+                            "id": "SUCCESS",
+                            "title": "",
+                            "description": "",
+                            "diagnosis": "",
+                            "remediations": "",
+                            "variables": {},
+                        },
+                    },
                 },
             ),
             # Single Failures
@@ -1156,28 +1163,28 @@ class TestRunActions:
                     [],
                 ),
                 {
-                    "One": dict(
-                        messages=[
-                            dict(
-                                level=STATUS_CODE["WARNING"],
-                                id="WARNING_ID",
-                                title="Warning",
-                                description="Action warning",
-                                diagnosis="User warning",
-                                remediations="move on",
-                                variables={},
-                            )
+                    "One": {
+                        "messages": [
+                            {
+                                "level": STATUS_CODE["WARNING"],
+                                "id": "WARNING_ID",
+                                "title": "Warning",
+                                "description": "Action warning",
+                                "diagnosis": "User warning",
+                                "remediations": "move on",
+                                "variables": {},
+                            }
                         ],
-                        result=dict(
-                            level=STATUS_CODE["ERROR"],
-                            id="SOME_ERROR",
-                            title="Error",
-                            description="Action error",
-                            diagnosis="User error",
-                            remediations="move on",
-                            variables={},
-                        ),
-                    ),
+                        "result": {
+                            "level": STATUS_CODE["ERROR"],
+                            "id": "SOME_ERROR",
+                            "title": "Error",
+                            "description": "Action error",
+                            "diagnosis": "User error",
+                            "remediations": "move on",
+                            "variables": {},
+                        },
+                    },
                 },
             ),
             (
@@ -1209,28 +1216,28 @@ class TestRunActions:
                     [],
                 ),
                 {
-                    "One": dict(
-                        messages=[
-                            dict(
-                                level=STATUS_CODE["WARNING"],
-                                id="WARNING_ID",
-                                title="Warning",
-                                description="Action warning",
-                                diagnosis="User warning",
-                                remediations="move on",
-                                variables={},
-                            )
+                    "One": {
+                        "messages": [
+                            {
+                                "level": STATUS_CODE["WARNING"],
+                                "id": "WARNING_ID",
+                                "title": "Warning",
+                                "description": "Action warning",
+                                "diagnosis": "User warning",
+                                "remediations": "move on",
+                                "variables": {},
+                            }
                         ],
-                        result=dict(
-                            level=STATUS_CODE["OVERRIDABLE"],
-                            id="SOME_ERROR",
-                            title="Overridable",
-                            description="Action overridable",
-                            diagnosis="User overridable",
-                            remediations="move on",
-                            variables={},
-                        ),
-                    ),
+                        "result": {
+                            "level": STATUS_CODE["OVERRIDABLE"],
+                            "id": "SOME_ERROR",
+                            "title": "Overridable",
+                            "description": "Action overridable",
+                            "diagnosis": "User overridable",
+                            "remediations": "move on",
+                            "variables": {},
+                        },
+                    },
                 },
             ),
             (
@@ -1262,28 +1269,28 @@ class TestRunActions:
                     ],
                 ),
                 {
-                    "One": dict(
-                        messages=[
-                            dict(
-                                level=STATUS_CODE["WARNING"],
-                                id="WARNING_ID",
-                                title="Warning",
-                                description="Action warning",
-                                diagnosis="User warning",
-                                remediations="move on",
-                                variables={},
-                            )
+                    "One": {
+                        "messages": [
+                            {
+                                "level": STATUS_CODE["WARNING"],
+                                "id": "WARNING_ID",
+                                "title": "Warning",
+                                "description": "Action warning",
+                                "diagnosis": "User warning",
+                                "remediations": "move on",
+                                "variables": {},
+                            }
                         ],
-                        result=dict(
-                            level=STATUS_CODE["SKIP"],
-                            id="SOME_ERROR",
-                            title="Skip",
-                            description="Action skip",
-                            diagnosis="User skip",
-                            remediations="move on",
-                            variables={},
-                        ),
-                    ),
+                        "result": {
+                            "level": STATUS_CODE["SKIP"],
+                            "id": "SOME_ERROR",
+                            "title": "Skip",
+                            "description": "Action skip",
+                            "diagnosis": "User skip",
+                            "remediations": "move on",
+                            "variables": {},
+                        },
+                    },
                 },
             ),
             # Mixture of failures and successes.
@@ -1353,72 +1360,72 @@ class TestRunActions:
                     ],
                 ),
                 {
-                    "One": dict(
-                        messages=[
-                            dict(
-                                level=STATUS_CODE["WARNING"],
-                                id="WARNING_ID",
-                                title="Warning",
-                                description="Action warning",
-                                diagnosis="User warning",
-                                remediations="move on",
-                                variables={},
-                            )
+                    "One": {
+                        "messages": [
+                            {
+                                "level": STATUS_CODE["WARNING"],
+                                "id": "WARNING_ID",
+                                "title": "Warning",
+                                "description": "Action warning",
+                                "diagnosis": "User warning",
+                                "remediations": "move on",
+                                "variables": {},
+                            }
                         ],
-                        result=dict(
-                            level=STATUS_CODE["ERROR"],
-                            id="ERROR_ID",
-                            title="Error",
-                            description="Action error",
-                            diagnosis="User error",
-                            remediations="move on",
-                            variables={},
-                        ),
-                    ),
-                    "Two": dict(
-                        messages=[
-                            dict(
-                                level=STATUS_CODE["WARNING"],
-                                id="WARNING_ID",
-                                title="Warning",
-                                description="Action warning",
-                                diagnosis="User warning",
-                                remediations="move on",
-                                variables={},
-                            )
+                        "result": {
+                            "level": STATUS_CODE["ERROR"],
+                            "id": "ERROR_ID",
+                            "title": "Error",
+                            "description": "Action error",
+                            "diagnosis": "User error",
+                            "remediations": "move on",
+                            "variables": {},
+                        },
+                    },
+                    "Two": {
+                        "messages": [
+                            {
+                                "level": STATUS_CODE["WARNING"],
+                                "id": "WARNING_ID",
+                                "title": "Warning",
+                                "description": "Action warning",
+                                "diagnosis": "User warning",
+                                "remediations": "move on",
+                                "variables": {},
+                            }
                         ],
-                        result=dict(
-                            level=STATUS_CODE["SKIP"],
-                            id="SKIP_ID",
-                            title="Skip",
-                            description="Action skip",
-                            diagnosis="User skip",
-                            remediations="move on",
-                            variables={},
-                        ),
-                    ),
-                    "Three": dict(
-                        messages=[
-                            dict(
-                                level=STATUS_CODE["WARNING"],
-                                id="WARNING_ID",
-                                title="Warning",
-                                description="Action warning",
-                                diagnosis="User warning",
-                                remediations="move on",
-                                variables={},
-                            )
+                        "result": {
+                            "level": STATUS_CODE["SKIP"],
+                            "id": "SKIP_ID",
+                            "title": "Skip",
+                            "description": "Action skip",
+                            "diagnosis": "User skip",
+                            "remediations": "move on",
+                            "variables": {},
+                        },
+                    },
+                    "Three": {
+                        "messages": [
+                            {
+                                "level": STATUS_CODE["WARNING"],
+                                "id": "WARNING_ID",
+                                "title": "Warning",
+                                "description": "Action warning",
+                                "diagnosis": "User warning",
+                                "remediations": "move on",
+                                "variables": {},
+                            }
                         ],
-                        result=dict(
-                            level=STATUS_CODE["SUCCESS"],
-                            id="SUCCESS",
-                            title="",
-                            description="",
-                            diagnosis="",
-                            remediations="",
-                            variables={},
-                        ),
-                    ),
+                        "result": {
+                            "level": STATUS_CODE["SUCCESS"],
+                            "id": "SUCCESS",
+                            "title": "",
+                            "description": "",
+                            "diagnosis": "",
+                            "remediations": "",
+                            "variables": {},
+                        },
+                    },
                 },
             ),
         ),
@@ -1448,10 +1455,10 @@ class TestRunActions:
 
 class TestFindFailedActions:
     test_results = {
-        "BAD": dict(result=dict(level=STATUS_CODE["ERROR"], id="ERROR", message="Explosion")),
-        "BAD2": dict(result=dict(level=STATUS_CODE["OVERRIDABLE"], id="OVERRIDABLE", message="Explosion")),
-        "BAD3": dict(result=dict(level=STATUS_CODE["SKIP"], id="SKIP", message="Explosion")),
-        "GOOD": dict(result=dict(level=STATUS_CODE["SUCCESS"], id="SUCCESS", message="No Error here")),
+        "BAD": {"result": {"level": STATUS_CODE["ERROR"], "id": "ERROR", "message": "Explosion"}},
+        "BAD2": {"result": {"level": STATUS_CODE["OVERRIDABLE"], "id": "OVERRIDABLE", "message": "Explosion"}},
+        "BAD3": {"result": {"level": STATUS_CODE["SKIP"], "id": "SKIP", "message": "Explosion"}},
+        "GOOD": {"result": {"level": STATUS_CODE["SUCCESS"], "id": "SUCCESS", "message": "No Error here"}},
     }
 
     @pytest.mark.parametrize(
@@ -1479,15 +1486,15 @@ class TestActionClasses:
                 None,
                 None,
                 None,
-                dict(
-                    id="SUCCESS",
-                    level=STATUS_CODE["SUCCESS"],
-                    title="",
-                    description="",
-                    diagnosis="",
-                    remediations="",
-                    variables={},
-                ),
+                {
+                    "id": "SUCCESS",
+                    "level": STATUS_CODE["SUCCESS"],
+                    "title": "",
+                    "description": "",
+                    "diagnosis": "",
+                    "remediations": "",
+                    "variables": {},
+                },
             ),
             (
                 "SKIP_ID",
@@ -1496,15 +1503,15 @@ class TestActionClasses:
                 "skip description",
                 "skip diagnosis",
                 "skip remediations",
-                dict(
-                    id="SKIP_ID",
-                    level=STATUS_CODE["SKIP"],
-                    title="Skip message",
-                    description="skip description",
-                    diagnosis="skip diagnosis",
-                    remediations="skip remediations",
-                    variables={},
-                ),
+                {
+                    "id": "SKIP_ID",
+                    "level": STATUS_CODE["SKIP"],
+                    "title": "Skip message",
+                    "description": "skip description",
+                    "diagnosis": "skip diagnosis",
+                    "remediations": "skip remediations",
+                    "variables": {},
+                },
             ),
             (
                 "OVERRIDABLE_ID",
@@ -1513,15 +1520,15 @@ class TestActionClasses:
                 "overridable description",
                 "overridable diagnosis",
                 "overridable remediations",
-                dict(
-                    id="OVERRIDABLE_ID",
-                    level=STATUS_CODE["OVERRIDABLE"],
-                    title="Overridable message",
-                    description="overridable description",
-                    diagnosis="overridable diagnosis",
-                    remediations="overridable remediations",
-                    variables={},
-                ),
+                {
+                    "id": "OVERRIDABLE_ID",
+                    "level": STATUS_CODE["OVERRIDABLE"],
+                    "title": "Overridable message",
+                    "description": "overridable description",
+                    "diagnosis": "overridable diagnosis",
+                    "remediations": "overridable remediations",
+                    "variables": {},
+                },
             ),
             (
                 "ERROR_ID",
@@ -1530,15 +1537,15 @@ class TestActionClasses:
                 "error description",
                 "error diagnosis",
                 "error remediations",
-                dict(
-                    id="ERROR_ID",
-                    level=STATUS_CODE["ERROR"],
-                    title="Error message",
-                    description="error description",
-                    diagnosis="error diagnosis",
-                    remediations="error remediations",
-                    variables={},
-                ),
+                {
+                    "id": "ERROR_ID",
+                    "level": STATUS_CODE["ERROR"],
+                    "title": "Error message",
+                    "description": "error description",
+                    "diagnosis": "error diagnosis",
+                    "remediations": "error remediations",
+                    "variables": {},
+                },
             ),
         ),
     )
@@ -1626,15 +1633,15 @@ class TestActionClasses:
                 "warning description",
                 "warning diagnosis",
                 "warning remediations",
-                dict(
-                    id="WARNING_ID",
-                    level=STATUS_CODE["WARNING"],
-                    title="Warning message",
-                    description="warning description",
-                    diagnosis="warning diagnosis",
-                    remediations="warning remediations",
-                    variables={},
-                ),
+                {
+                    "id": "WARNING_ID",
+                    "level": STATUS_CODE["WARNING"],
+                    "title": "Warning message",
+                    "description": "warning description",
+                    "diagnosis": "warning diagnosis",
+                    "remediations": "warning remediations",
+                    "variables": {},
+                },
             ),
             (
                 "INFO_ID",
@@ -1643,15 +1650,15 @@ class TestActionClasses:
                 "info description",
                 "info diagnosis",
                 "info remediations",
-                dict(
-                    id="INFO_ID",
-                    level=STATUS_CODE["INFO"],
-                    title="Info message",
-                    description="info description",
-                    diagnosis="info diagnosis",
-                    remediations="info remediations",
-                    variables={},
-                ),
+                {
+                    "id": "INFO_ID",
+                    "level": STATUS_CODE["INFO"],
+                    "title": "Info message",
+                    "description": "info description",
+                    "diagnosis": "info diagnosis",
+                    "remediations": "info remediations",
+                    "variables": {},
+                },
             ),
             (
                 "INFO_ID",
@@ -1660,15 +1667,15 @@ class TestActionClasses:
                 "info description",
                 "info diagnosis",
                 "info remediations",
-                dict(
-                    id="INFO_ID",
-                    level=STATUS_CODE["INFO"],
-                    title="Info message",
-                    description="info description",
-                    diagnosis="info diagnosis",
-                    remediations="info remediations",
-                    variables={},
-                ),
+                {
+                    "id": "INFO_ID",
+                    "level": STATUS_CODE["INFO"],
+                    "title": "Info message",
+                    "description": "info description",
+                    "diagnosis": "info diagnosis",
+                    "remediations": "info remediations",
+                    "variables": {},
+                },
             ),
         ),
     )
@@ -1778,15 +1785,15 @@ class TestActionClasses:
                 None,
                 None,
                 {},
-                dict(
-                    id="SUCCESS_ID",
-                    level=STATUS_CODE["SUCCESS"],
-                    title="",
-                    description="",
-                    diagnosis="",
-                    remediations="",
-                    variables={},
-                ),
+                {
+                    "id": "SUCCESS_ID",
+                    "level": STATUS_CODE["SUCCESS"],
+                    "title": "",
+                    "description": "",
+                    "diagnosis": "",
+                    "remediations": "",
+                    "variables": {},
+                },
             ),
             (
                 "SKIP_ID",
@@ -1796,15 +1803,15 @@ class TestActionClasses:
                 "skip diagnosis",
                 "skip remediations",
                 {},
-                dict(
-                    id="SKIP_ID",
-                    level=STATUS_CODE["SKIP"],
-                    title="Skip",
-                    description="skip description",
-                    diagnosis="skip diagnosis",
-                    remediations="skip remediations",
-                    variables={},
-                ),
+                {
+                    "id": "SKIP_ID",
+                    "level": STATUS_CODE["SKIP"],
+                    "title": "Skip",
+                    "description": "skip description",
+                    "diagnosis": "skip diagnosis",
+                    "remediations": "skip remediations",
+                    "variables": {},
+                },
             ),
             (
                 "OVERRIDABLE_ID",
@@ -1814,15 +1821,15 @@ class TestActionClasses:
                 "overridable diagnosis",
                 "overridable remediations",
                 {},
-                dict(
-                    id="OVERRIDABLE_ID",
-                    level=STATUS_CODE["OVERRIDABLE"],
-                    title="Overridable",
-                    description="overridable description",
-                    diagnosis="overridable diagnosis",
-                    remediations="overridable remediations",
-                    variables={},
-                ),
+                {
+                    "id": "OVERRIDABLE_ID",
+                    "level": STATUS_CODE["OVERRIDABLE"],
+                    "title": "Overridable",
+                    "description": "overridable description",
+                    "diagnosis": "overridable diagnosis",
+                    "remediations": "overridable remediations",
+                    "variables": {},
+                },
             ),
             (
                 "ERROR_ID",
@@ -1832,15 +1839,15 @@ class TestActionClasses:
                 "error diagnosis",
                 "error remediations",
                 {},
-                dict(
-                    id="ERROR_ID",
-                    level=STATUS_CODE["ERROR"],
-                    title="Error",
-                    description="error description",
-                    diagnosis="error diagnosis",
-                    remediations="error remediations",
-                    variables={},
-                ),
+                {
+                    "id": "ERROR_ID",
+                    "level": STATUS_CODE["ERROR"],
+                    "title": "Error",
+                    "description": "error description",
+                    "diagnosis": "error diagnosis",
+                    "remediations": "error remediations",
+                    "variables": {},
+                },
             ),
         ),
     )

--- a/convert2rhel/unit_tests/actions/report_test.py
+++ b/convert2rhel/unit_tests/actions/report_test.py
@@ -41,16 +41,16 @@ _LONG_MESSAGE = {
         (
             {
                 "CONVERT2RHEL_LATEST_VERSION": {
-                    "result": dict(level=STATUS_CODE["SUCCESS"], id="SUCCESS"),
+                    "result": {"level": STATUS_CODE["SUCCESS"], "id": "SUCCESS"},
                     "messages": [
-                        dict(
-                            level=STATUS_CODE["WARNING"],
-                            id="WARNING_ONE",
-                            title="A warning message",
-                            description="",
-                            diagnosis="",
-                            remediations="",
-                        ),
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ONE",
+                            "title": "A warning message",
+                            "description": "",
+                            "diagnosis": "",
+                            "remediations": "",
+                        },
                     ],
                 },
             },
@@ -59,16 +59,16 @@ _LONG_MESSAGE = {
                 "status": "WARNING",
                 "actions": {
                     "CONVERT2RHEL_LATEST_VERSION": {
-                        "result": dict(level="SUCCESS", id="SUCCESS"),
+                        "result": {"level": "SUCCESS", "id": "SUCCESS"},
                         "messages": [
-                            dict(
-                                level="WARNING",
-                                id="WARNING_ONE",
-                                title="A warning message",
-                                description="",
-                                diagnosis="",
-                                remediations="",
-                            ),
+                            {
+                                "level": "WARNING",
+                                "id": "WARNING_ONE",
+                                "title": "A warning message",
+                                "description": "",
+                                "diagnosis": "",
+                                "remediations": "",
+                            },
                         ],
                     },
                 },
@@ -77,16 +77,16 @@ _LONG_MESSAGE = {
         (
             {
                 "CONVERT2RHEL_LATEST_VERSION": {
-                    "result": dict(level=STATUS_CODE["SUCCESS"], id="SUCCESS"),
+                    "result": {"level": STATUS_CODE["SUCCESS"], "id": "SUCCESS"},
                     "messages": [
-                        dict(
-                            level=STATUS_CODE["WARNING"],
-                            id="WARNING_ONE",
-                            title="A warning message",
-                            description="A description",
-                            diagnosis="A diagnosis",
-                            remediations="A remediations",
-                        ),
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ONE",
+                            "title": "A warning message",
+                            "description": "A description",
+                            "diagnosis": "A diagnosis",
+                            "remediations": "A remediations",
+                        },
                     ],
                 },
             },
@@ -95,16 +95,16 @@ _LONG_MESSAGE = {
                 "status": "WARNING",
                 "actions": {
                     "CONVERT2RHEL_LATEST_VERSION": {
-                        "result": dict(level="SUCCESS", id="SUCCESS"),
+                        "result": {"level": "SUCCESS", "id": "SUCCESS"},
                         "messages": [
-                            dict(
-                                level="WARNING",
-                                id="WARNING_ONE",
-                                title="A warning message",
-                                description="A description",
-                                diagnosis="A diagnosis",
-                                remediations="A remediations",
-                            ),
+                            {
+                                "level": "WARNING",
+                                "id": "WARNING_ONE",
+                                "title": "A warning message",
+                                "description": "A description",
+                                "diagnosis": "A diagnosis",
+                                "remediations": "A remediations",
+                            },
                         ],
                     },
                 },
@@ -131,8 +131,8 @@ def test_summary_as_json(results, expected, tmpdir):
         # parameter.
         (
             {
-                "PreSubscription": dict(
-                    messages=[
+                "PreSubscription": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -143,7 +143,7 @@ def test_summary_as_json(results, expected, tmpdir):
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["SUCCESS"],
                         "id": "SUCCESS",
                         "title": "",
@@ -152,7 +152,7 @@ def test_summary_as_json(results, expected, tmpdir):
                         "remediations": "",
                         "variables": {},
                     },
-                )
+                }
             },
             True,
             [
@@ -162,9 +162,9 @@ def test_summary_as_json(results, expected, tmpdir):
         ),
         (
             {
-                "PreSubscription": dict(
-                    messages=[],
-                    result={
+                "PreSubscription": {
+                    "messages": [],
+                    "result": {
                         "level": STATUS_CODE["SUCCESS"],
                         "id": "SUCCESS",
                         "title": "",
@@ -173,9 +173,9 @@ def test_summary_as_json(results, expected, tmpdir):
                         "remediations": "",
                         "variables": {},
                     },
-                ),
-                "PreSubscription2": dict(
-                    messages=[
+                },
+                "PreSubscription2": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -186,7 +186,7 @@ def test_summary_as_json(results, expected, tmpdir):
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["SKIP"],
                         "id": "SKIPPED",
                         "title": "Skip",
@@ -195,7 +195,7 @@ def test_summary_as_json(results, expected, tmpdir):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
+                },
             },
             True,
             [
@@ -208,9 +208,9 @@ def test_summary_as_json(results, expected, tmpdir):
         # the logs.
         (
             {
-                "PreSubscription": dict(
-                    messages=[],
-                    result={
+                "PreSubscription": {
+                    "messages": [],
+                    "result": {
                         "level": STATUS_CODE["SUCCESS"],
                         "id": "SUCCESS",
                         "title": "",
@@ -219,15 +219,15 @@ def test_summary_as_json(results, expected, tmpdir):
                         "remediations": "",
                         "variables": {},
                     },
-                )
+                }
             },
             False,
             ["No problems detected during the analysis!"],
         ),
         (
             {
-                "PreSubscription": dict(
-                    messages=[
+                "PreSubscription": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -238,7 +238,7 @@ def test_summary_as_json(results, expected, tmpdir):
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["SUCCESS"],
                         "id": "SUCCESS",
                         "title": "",
@@ -247,7 +247,7 @@ def test_summary_as_json(results, expected, tmpdir):
                         "remediations": "",
                         "variables": {},
                     },
-                )
+                }
             },
             False,
             [
@@ -256,8 +256,8 @@ def test_summary_as_json(results, expected, tmpdir):
         ),
         (
             {
-                "PreSubscription": dict(
-                    messages=[
+                "PreSubscription": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -268,7 +268,7 @@ def test_summary_as_json(results, expected, tmpdir):
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["SUCCESS"],
                         "id": "SUCCESS",
                         "title": "",
@@ -277,9 +277,9 @@ def test_summary_as_json(results, expected, tmpdir):
                         "remediations": "",
                         "variables": {},
                     },
-                ),
-                "PreSubscription2": dict(
-                    messages=[
+                },
+                "PreSubscription2": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -290,7 +290,7 @@ def test_summary_as_json(results, expected, tmpdir):
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["SKIP"],
                         "id": "SKIPPED",
                         "title": "Skip",
@@ -299,7 +299,7 @@ def test_summary_as_json(results, expected, tmpdir):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
+                },
             },
             False,
             [
@@ -311,8 +311,8 @@ def test_summary_as_json(results, expected, tmpdir):
         # Test all messages are displayed, SKIP and higher
         (
             {
-                "PreSubscription1": dict(
-                    messages=[
+                "PreSubscription1": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -323,7 +323,7 @@ def test_summary_as_json(results, expected, tmpdir):
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["SKIP"],
                         "id": "SKIPPED",
                         "title": "Skip",
@@ -332,9 +332,9 @@ def test_summary_as_json(results, expected, tmpdir):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "PreSubscription2": dict(
-                    messages=[
+                },
+                "PreSubscription2": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -345,7 +345,7 @@ def test_summary_as_json(results, expected, tmpdir):
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["OVERRIDABLE"],
                         "id": "OVERRIDABLE_ID",
                         "title": "Overridable",
@@ -354,7 +354,7 @@ def test_summary_as_json(results, expected, tmpdir):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
+                },
             },
             False,
             [
@@ -366,8 +366,8 @@ def test_summary_as_json(results, expected, tmpdir):
         ),
         (
             {
-                "SkipAction": dict(
-                    messages=[
+                "SkipAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -378,7 +378,7 @@ def test_summary_as_json(results, expected, tmpdir):
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["SKIP"],
                         "id": "SKIP",
                         "title": "Skip",
@@ -387,9 +387,9 @@ def test_summary_as_json(results, expected, tmpdir):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "OverridableAction": dict(
-                    messages=[
+                },
+                "OverridableAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -400,7 +400,7 @@ def test_summary_as_json(results, expected, tmpdir):
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["OVERRIDABLE"],
                         "id": "OVERRIDABLE",
                         "title": "Overridable",
@@ -409,9 +409,9 @@ def test_summary_as_json(results, expected, tmpdir):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "ErrorAction": dict(
-                    messages=[
+                },
+                "ErrorAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -422,7 +422,7 @@ def test_summary_as_json(results, expected, tmpdir):
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["ERROR"],
                         "id": "ERROR",
                         "title": "Error",
@@ -431,9 +431,9 @@ def test_summary_as_json(results, expected, tmpdir):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "TestAction": dict(
-                    messages=[
+                },
+                "TestAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -444,7 +444,7 @@ def test_summary_as_json(results, expected, tmpdir):
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["ERROR"],
                         "id": "SECONDERROR",
                         "title": "Error",
@@ -453,7 +453,7 @@ def test_summary_as_json(results, expected, tmpdir):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
+                },
             },
             False,
             [
@@ -497,10 +497,10 @@ def test_results_summary_with_long_message(long_message, caplog):
     result.update(long_message)
     report.summary(
         {
-            "ErrorAction": dict(
-                messages=[],
-                result=result,
-            )
+            "ErrorAction": {
+                "messages": [],
+                "result": result,
+            }
         },
         disable_colors=True,
     )
@@ -541,9 +541,9 @@ def test_messages_summary_with_long_message(long_message, caplog):
     messages.update(long_message)
     report.summary(
         {
-            "ErrorAction": dict(
-                messages=[messages],
-                result={
+            "ErrorAction": {
+                "messages": [messages],
+                "result": {
                     "level": STATUS_CODE["SUCCESS"],
                     "id": "",
                     "title": "",
@@ -552,7 +552,7 @@ def test_messages_summary_with_long_message(long_message, caplog):
                     "remediations": "",
                     "variables": {},
                 },
-            )
+            }
         },
         disable_colors=True,
     )
@@ -578,9 +578,9 @@ def test_messages_summary_with_long_message(long_message, caplog):
         # Test all messages are displayed, SKIP and higher
         (
             {
-                "PreSubscription2": dict(
-                    messages=[],
-                    result={
+                "PreSubscription2": {
+                    "messages": [],
+                    "result": {
                         "level": STATUS_CODE["SKIP"],
                         "id": "SKIPPED",
                         "title": "Skipped",
@@ -589,10 +589,10 @@ def test_messages_summary_with_long_message(long_message, caplog):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "PreSubscription1": dict(
-                    messages=[],
-                    result={
+                },
+                "PreSubscription1": {
+                    "messages": [],
+                    "result": {
                         "level": STATUS_CODE["OVERRIDABLE"],
                         "id": "SOME_OVERRIDABLE",
                         "title": "Overridable",
@@ -601,7 +601,7 @@ def test_messages_summary_with_long_message(long_message, caplog):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
+                },
             },
             False,
             [
@@ -611,9 +611,9 @@ def test_messages_summary_with_long_message(long_message, caplog):
         ),
         (
             {
-                "SkipAction": dict(
-                    messages=[],
-                    result={
+                "SkipAction": {
+                    "messages": [],
+                    "result": {
                         "level": STATUS_CODE["SKIP"],
                         "id": "SKIP",
                         "title": "Skip",
@@ -622,10 +622,10 @@ def test_messages_summary_with_long_message(long_message, caplog):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "OverridableAction": dict(
-                    messages=[],
-                    result={
+                },
+                "OverridableAction": {
+                    "messages": [],
+                    "result": {
                         "level": STATUS_CODE["OVERRIDABLE"],
                         "id": "OVERRIDABLE",
                         "title": "Overridable",
@@ -634,10 +634,10 @@ def test_messages_summary_with_long_message(long_message, caplog):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "ErrorAction": dict(
-                    messages=[],
-                    result={
+                },
+                "ErrorAction": {
+                    "messages": [],
+                    "result": {
                         "level": STATUS_CODE["ERROR"],
                         "id": "ERROR",
                         "title": "Error",
@@ -646,7 +646,7 @@ def test_messages_summary_with_long_message(long_message, caplog):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
+                },
             },
             False,
             [
@@ -658,9 +658,9 @@ def test_messages_summary_with_long_message(long_message, caplog):
         # Message order with `include_all_reports` set to True.
         (
             {
-                "PreSubscription": dict(
-                    messages=[],
-                    result={
+                "PreSubscription": {
+                    "messages": [],
+                    "result": {
                         "level": STATUS_CODE["SUCCESS"],
                         "id": "SUCCESS",
                         "title": "",
@@ -669,10 +669,10 @@ def test_messages_summary_with_long_message(long_message, caplog):
                         "remediations": "",
                         "variables": {},
                     },
-                ),
-                "SkipAction": dict(
-                    messages=[],
-                    result={
+                },
+                "SkipAction": {
+                    "messages": [],
+                    "result": {
                         "level": STATUS_CODE["SKIP"],
                         "id": "SKIP",
                         "title": "Skip",
@@ -681,10 +681,10 @@ def test_messages_summary_with_long_message(long_message, caplog):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "OverridableAction": dict(
-                    messages=[],
-                    result={
+                },
+                "OverridableAction": {
+                    "messages": [],
+                    "result": {
                         "level": STATUS_CODE["OVERRIDABLE"],
                         "id": "OVERRIDABLE",
                         "title": "Overridable",
@@ -693,10 +693,10 @@ def test_messages_summary_with_long_message(long_message, caplog):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "ErrorAction": dict(
-                    messages=[],
-                    result={
+                },
+                "ErrorAction": {
+                    "messages": [],
+                    "result": {
                         "level": STATUS_CODE["ERROR"],
                         "id": "ERROR",
                         "title": "Error",
@@ -705,7 +705,7 @@ def test_messages_summary_with_long_message(long_message, caplog):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
+                },
             },
             True,
             [
@@ -737,8 +737,8 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
         # Test all messages are displayed, SKIP and higher
         (
             {
-                "PreSubscription2": dict(
-                    messages=[
+                "PreSubscription2": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -749,7 +749,7 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["SKIP"],
                         "id": "SKIPPED",
                         "title": "Skip",
@@ -758,10 +758,10 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "PreSubscription1": dict(
-                    messages=[],
-                    result={
+                },
+                "PreSubscription1": {
+                    "messages": [],
+                    "result": {
                         "level": STATUS_CODE["OVERRIDABLE"],
                         "id": "SOME_OVERRIDABLE",
                         "title": "Override",
@@ -770,7 +770,7 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
+                },
             },
             False,
             [
@@ -781,8 +781,8 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
         ),
         (
             {
-                "SkipAction": dict(
-                    messages=[
+                "SkipAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -793,7 +793,7 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["SKIP"],
                         "id": "SKIP",
                         "title": "Skip",
@@ -802,9 +802,9 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "OverridableAction": dict(
-                    messages=[
+                },
+                "OverridableAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -815,7 +815,7 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["OVERRIDABLE"],
                         "id": "OVERRIDABLE",
                         "title": "Overridable",
@@ -824,10 +824,10 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "ErrorAction": dict(
-                    messages=[],
-                    result={
+                },
+                "ErrorAction": {
+                    "messages": [],
+                    "result": {
                         "level": STATUS_CODE["ERROR"],
                         "id": "ERROR",
                         "title": "Error",
@@ -836,7 +836,7 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
+                },
             },
             False,
             [
@@ -850,8 +850,8 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
         # Message order with `include_all_reports` set to True.
         (
             {
-                "PreSubscription": dict(
-                    messages=[
+                "PreSubscription": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -862,7 +862,7 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["SUCCESS"],
                         "id": "SUCCESS",
                         "title": "",
@@ -871,9 +871,9 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
                         "remediations": "",
                         "variables": {},
                     },
-                ),
-                "SkipAction": dict(
-                    messages=[
+                },
+                "SkipAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -884,7 +884,7 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["SKIP"],
                         "id": "SKIP",
                         "title": "Skip",
@@ -893,9 +893,9 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "OverridableAction": dict(
-                    messages=[
+                },
+                "OverridableAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -906,7 +906,7 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["OVERRIDABLE"],
                         "id": "OVERRIDABLE",
                         "title": "Overridable",
@@ -915,9 +915,9 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "ErrorAction": dict(
-                    messages=[
+                },
+                "ErrorAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -928,7 +928,7 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["ERROR"],
                         "id": "ERROR",
                         "title": "Error",
@@ -937,7 +937,7 @@ def test_results_summary_ordering(results, include_all_reports, expected_results
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
+                },
             },
             True,
             [
@@ -973,8 +973,8 @@ def test_messages_summary_ordering(results, include_all_reports, expected_result
     (
         (
             {
-                "ErrorAction": dict(
-                    messages=[
+                "ErrorAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -985,7 +985,7 @@ def test_messages_summary_ordering(results, include_all_reports, expected_result
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["ERROR"],
                         "id": "ERROR",
                         "title": "Error",
@@ -994,7 +994,7 @@ def test_messages_summary_ordering(results, include_all_reports, expected_result
                         "remediations": "move on",
                         "variables": {},
                     },
-                )
+                }
             },
             "{begin}(ERROR) ErrorAction::ERROR - Error\n     Description: Action error\n     Diagnosis: User error\n     Remediations: move on{end}".format(
                 begin=bcolors.FAIL, end=bcolors.ENDC
@@ -1005,8 +1005,8 @@ def test_messages_summary_ordering(results, include_all_reports, expected_result
         ),
         (
             {
-                "OverridableAction": dict(
-                    messages=[
+                "OverridableAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -1017,7 +1017,7 @@ def test_messages_summary_ordering(results, include_all_reports, expected_result
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["OVERRIDABLE"],
                         "id": "OVERRIDABLE",
                         "title": "Overridable",
@@ -1026,7 +1026,7 @@ def test_messages_summary_ordering(results, include_all_reports, expected_result
                         "remediations": "move on",
                         "variables": {},
                     },
-                )
+                }
             },
             "{begin}(OVERRIDABLE) OverridableAction::OVERRIDABLE - Overridable\n     Description: Action overridable\n     Diagnosis: User overridable\n     Remediations: move on{end}".format(
                 begin=bcolors.FAIL, end=bcolors.ENDC
@@ -1037,8 +1037,8 @@ def test_messages_summary_ordering(results, include_all_reports, expected_result
         ),
         (
             {
-                "SkipAction": dict(
-                    messages=[
+                "SkipAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -1049,7 +1049,7 @@ def test_messages_summary_ordering(results, include_all_reports, expected_result
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["SKIP"],
                         "id": "SKIP",
                         "title": "Skip",
@@ -1058,7 +1058,7 @@ def test_messages_summary_ordering(results, include_all_reports, expected_result
                         "remediations": "move on",
                         "variables": {},
                     },
-                )
+                }
             },
             "{begin}(SKIP) SkipAction::SKIP - Skip\n     Description: Action skip\n     Diagnosis: User skip\n     Remediations: move on{end}".format(
                 begin=bcolors.FAIL, end=bcolors.ENDC
@@ -1069,8 +1069,8 @@ def test_messages_summary_ordering(results, include_all_reports, expected_result
         ),
         (
             {
-                "SuccessfulAction": dict(
-                    messages=[
+                "SuccessfulAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -1081,7 +1081,7 @@ def test_messages_summary_ordering(results, include_all_reports, expected_result
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["SUCCESS"],
                         "id": "SUCCESS",
                         "title": "",
@@ -1090,7 +1090,7 @@ def test_messages_summary_ordering(results, include_all_reports, expected_result
                         "remediations": "",
                         "variables": {},
                     },
-                )
+                }
             },
             "{begin}(SUCCESS) SuccessfulAction::SUCCESS - N/A{end}".format(begin=bcolors.OKGREEN, end=bcolors.ENDC),
             "{begin}(WARNING) SuccessfulAction::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediations: move on{end}".format(
@@ -1110,8 +1110,8 @@ def test_summary_colors(results, expected_result, expected_message, caplog):
     (
         (
             {
-                "SkipAction": dict(
-                    messages=[
+                "SkipAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -1122,7 +1122,7 @@ def test_summary_colors(results, expected_result, expected_message, caplog):
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["SKIP"],
                         "id": "SKIP",
                         "title": "Skip",
@@ -1131,9 +1131,9 @@ def test_summary_colors(results, expected_result, expected_message, caplog):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "OverridableAction": dict(
-                    messages=[
+                },
+                "OverridableAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -1144,7 +1144,7 @@ def test_summary_colors(results, expected_result, expected_message, caplog):
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["OVERRIDABLE"],
                         "id": "OVERRIDABLE",
                         "title": "Overridable",
@@ -1153,9 +1153,9 @@ def test_summary_colors(results, expected_result, expected_message, caplog):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "ErrorAction": dict(
-                    messages=[
+                },
+                "ErrorAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -1166,7 +1166,7 @@ def test_summary_colors(results, expected_result, expected_message, caplog):
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["ERROR"],
                         "id": "ERROR",
                         "title": "Error",
@@ -1175,9 +1175,9 @@ def test_summary_colors(results, expected_result, expected_message, caplog):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "TestAction": dict(
-                    messages=[
+                },
+                "TestAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -1188,7 +1188,7 @@ def test_summary_colors(results, expected_result, expected_message, caplog):
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["ERROR"],
                         "id": "SECONDERROR",
                         "title": "Error",
@@ -1197,7 +1197,7 @@ def test_summary_colors(results, expected_result, expected_message, caplog):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
+                },
             },
             [
                 "{begin_fail}(ERROR) ErrorAction::ERROR - Error\n Description: Action error\n Diagnosis: User error\n Remediations: move on\n{end}",
@@ -1232,8 +1232,8 @@ def test_summary_as_txt(results, text_lines, tmpdir, monkeypatch):
     (
         (
             {
-                "SkipAction": dict(
-                    messages=[
+                "SkipAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -1244,7 +1244,7 @@ def test_summary_as_txt(results, text_lines, tmpdir, monkeypatch):
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["SKIP"],
                         "id": "SKIP",
                         "title": "Skip",
@@ -1253,9 +1253,9 @@ def test_summary_as_txt(results, text_lines, tmpdir, monkeypatch):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "OverridableAction": dict(
-                    messages=[
+                },
+                "OverridableAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -1266,7 +1266,7 @@ def test_summary_as_txt(results, text_lines, tmpdir, monkeypatch):
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["OVERRIDABLE"],
                         "id": "OVERRIDABLE",
                         "title": "Overridable",
@@ -1275,9 +1275,9 @@ def test_summary_as_txt(results, text_lines, tmpdir, monkeypatch):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "ErrorAction": dict(
-                    messages=[
+                },
+                "ErrorAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -1288,7 +1288,7 @@ def test_summary_as_txt(results, text_lines, tmpdir, monkeypatch):
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["ERROR"],
                         "id": "ERROR",
                         "title": "Error",
@@ -1297,9 +1297,9 @@ def test_summary_as_txt(results, text_lines, tmpdir, monkeypatch):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
-                "TestAction": dict(
-                    messages=[
+                },
+                "TestAction": {
+                    "messages": [
                         {
                             "level": STATUS_CODE["WARNING"],
                             "id": "WARNING_ID",
@@ -1310,7 +1310,7 @@ def test_summary_as_txt(results, text_lines, tmpdir, monkeypatch):
                             "variables": {},
                         }
                     ],
-                    result={
+                    "result": {
                         "level": STATUS_CODE["ERROR"],
                         "id": "SECONDERROR",
                         "title": "Error",
@@ -1319,7 +1319,7 @@ def test_summary_as_txt(results, text_lines, tmpdir, monkeypatch):
                         "remediations": "move on",
                         "variables": {},
                     },
-                ),
+                },
             },
             [
                 "{begin_fail}(ERROR) ErrorAction::ERROR - Error\n Description: Action error\n Diagnosis: User error\n Remediations: move on\n{end}",

--- a/convert2rhel/unit_tests/actions/system_checks/rhel_compatible_kernel_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/rhel_compatible_kernel_test.py
@@ -50,7 +50,7 @@ def test_check_rhel_compatible_kernel_failure(
         rhel_compatible_kernel,
         "_bad_kernel_version",
         value=mock.Mock(
-            side_effect=KernelIncompatibleError("UNEXPECTED_VERSION", "Bad kernel version", dict(fake_data="fake"))
+            side_effect=KernelIncompatibleError("UNEXPECTED_VERSION", "Bad kernel version", {"fake_data": "fake"})
         ),
     )
     monkeypatch.setattr(
@@ -154,7 +154,7 @@ def test_bad_kernel_version_success(kernel_release, major_ver, exp_return, monke
             None,
             "UNEXPECTED_VERSION",
             "Unexpected OS major version. Expected: {compatible_version}",
-            dict(compatible_version=COMPATIBLE_KERNELS_VERS.keys()),
+            {"compatible_version": COMPATIBLE_KERNELS_VERS.keys()},
         ),
         (
             "5.4.17-2102.200.13.el8uek.x86_64",
@@ -162,7 +162,7 @@ def test_bad_kernel_version_success(kernel_release, major_ver, exp_return, monke
             "INCOMPATIBLE_VERSION",
             "Booted kernel version '{kernel_version}' does not correspond to the version "
             "'{compatible_version}' available in RHEL {rhel_major_version}",
-            dict(kernel_version="5.4.17", compatible_version=COMPATIBLE_KERNELS_VERS[8], rhel_major_version=8),
+            {"kernel_version": "5.4.17", "compatible_version": COMPATIBLE_KERNELS_VERS[8], "rhel_major_version": 8},
         ),
     ),
 )
@@ -199,20 +199,20 @@ def test_bad_kernel_substring_success(kernel_release, exp_return):
             "INVALID_PACKAGE_SUBSTRING",
             "The booted kernel '{kernel_release}' contains one of the disallowed "
             "substrings: {bad_kernel_release_substrings}",
-            dict(
-                kernel_release="5.4.17-2102.200.13.el8uek.x86_64",
-                bad_kernel_release_substrings=BAD_KERNEL_RELEASE_SUBSTRINGS,
-            ),
+            {
+                "kernel_release": "5.4.17-2102.200.13.el8uek.x86_64",
+                "bad_kernel_release_substrings": BAD_KERNEL_RELEASE_SUBSTRINGS,
+            },
         ),
         (
             "3.10.0-514.2.2.rt56.424.el7.x86_64",
             "INVALID_PACKAGE_SUBSTRING",
             "The booted kernel '{kernel_release}' contains one of the disallowed "
             "substrings: {bad_kernel_release_substrings}",
-            dict(
-                kernel_release="3.10.0-514.2.2.rt56.424.el7.x86_64",
-                bad_kernel_release_substrings=BAD_KERNEL_RELEASE_SUBSTRINGS,
-            ),
+            {
+                "kernel_release": "3.10.0-514.2.2.rt56.424.el7.x86_64",
+                "bad_kernel_release_substrings": BAD_KERNEL_RELEASE_SUBSTRINGS,
+            },
         ),
     ),
 )
@@ -285,7 +285,7 @@ def test_bad_kernel_package_signature_success(
             ),
             "INVALID_KERNEL_PACKAGE_SIGNATURE",
             "Custom kernel detected. The booted kernel needs to be signed by {os_vendor}.",
-            dict(os_vendor="CentOS"),
+            {"os_vendor": "CentOS"},
         ),
     ),
 )
@@ -323,7 +323,7 @@ def test_bad_kernel_package_signature_invalid_signature(
             "UNSIGNED_PACKAGE",
             "The booted kernel {vmlinuz_path} is not owned by any installed package."
             " It needs to be owned by a package signed by {os_vendor}.",
-            dict(vmlinuz_path="/boot/vmlinuz-4.18.0-240.22.1.el8_3.x86_64", os_vendor="CentOS"),
+            {"vmlinuz_path": "/boot/vmlinuz-4.18.0-240.22.1.el8_3.x86_64", "os_vendor": "CentOS"},
         ),
     ),
 )

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -675,7 +675,7 @@ class TestRegistrationCommand:
         def prompt_user(prompt, password=False):
             if prompt in prompt_input:
                 return prompt_input[prompt]
-            raise Exception("Should not have been called with that prompt for the input")
+            raise TypeError("Should not have been called with that prompt for the input")
 
         monkeypatch.setattr(utils, "prompt_user", PromptUserMocked(side_effect=prompt_user))
 


### PR DESCRIPTION
Update pre-commit config to use the latest version of pylint. Previously, we pinned the version of pylint as we still had to support older python versions because of RHEL 6.

Since we don't have this requirement anymore, we can update pylint and only ignore the flags that we know that won't be available for Python 2.7.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
