### PR TITLE
Improve UX for release Jira auto-linking

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,16 @@
 <!-- Write a description of what the PR solves and how -->
 
-<!-- Link to relevant Jira issue, add multiple if necessary -->
+<!-- Link to relevant Red Hat Jira issues -->
+Jira Issues:
 
-Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)
+-
 
 Checklist
 
 - [ ] PR has been tested manually in a VM (either author or reviewer)
 - [ ] Jira issue has been made public if possible
 - [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
-- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
+- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
 - [ ] PR title explains the change from the user's point of view
 - [ ] Code and tests are documented properly
 - [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,7 @@
 <!-- Link to relevant Red Hat Jira issues -->
 Jira Issues:
 
+<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
 -
 
 Checklist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,26 @@ jobs:
         run: gh release view ${{github.ref_name}} --json body --jq '.body' > releaseBody.txt
 
       - name: Add Jira links
+        shell: python
         run: |
-          sed -i -e 's/\[\(RHEL.*\)\]/[[\1](https:\/\/issues.redhat.com\/browse\/\1)]/' releaseBody.txt
+          import re
+
+          #  RegEx explained
+          # (?<!\/) Negative lookbehind of / to avoid grabbing URLs
+          # (RHELC?-\d+) Get RHEL or RHELC keys, add to a group
+          # \b Word boundary to indicate this should be the end of the match
+          # (?!\]\() Negative lookahead of ]( to prevent Jira keys in markdown links
+          regex=re.compile(r"(?<!\/)(RHELC?-\d+)\b(?!\]\()", re.MULTILINE)
+          with open("releaseBody.txt", 'r+') as f:
+            data = f.read()
+            f.seek(0)
+            # RegEx explained
+            # Replace the grabbed Jira key with a Markdown link [key](i.r.c/browse/key)
+            # [\g<0>] Add the Jira key group 0, equivalent of \1
+            # (https://issues.redhat.com/browse/\g<0>) Add the Jira key group 0, equivalent of \1, to end of URL
+            body = regex.sub(r"[\g<0>](https://issues.redhat.com/browse/\g<0>)", data)
+            f.write(body)
+            f.truncate()
 
       - name: Update release body with Jira links
         run: gh release edit ${{github.ref_name}} --notes-file releaseBody.txt


### PR DESCRIPTION
Currently we do not add the Jira links correctly as was observed for the
v1.7.0 release as one PR title contained two RHELC Jira issues in the
title. E.g. `[RHELC-1, RHELC-2] Test title`. This change should now
be more flexible and also handles more edge-cases that could occur.

We now use python to do RegEx replace rather than sed or awk as they
were too limiting. Opted for not using perl as python shell is already
present for GitHub actions.

This is how we want it to be:
https://github.com/oamg/convert2rhel/releases/tag/v1.7.0

Tested on my repo
https://github.com/SpyTec/convert2rhel/releases/tag/v24.03.04.3

What changed
```diff
-- RHELC-1 test
-- RHEL-1, RHEL-2 testtest
-- [RHELC-1, RHEL-1234] Title test stuff here
-- [RHELC-12] Test title
+- [RHELC-1](https://issues.redhat.com/browse/RHELC-1) test
+- [RHEL-1](https://issues.redhat.com/browse/RHEL-1), [RHEL-2](https://issues.redhat.com/browse/RHEL-2) testtest
+- [[RHELC-1](https://issues.redhat.com/browse/RHELC-1), [RHEL-1234](https://issues.redhat.com/browse/RHEL-1234)] Title test stuff here
+- [[RHELC-12](https://issues.redhat.com/browse/RHELC-12)] Test title
 - [[RHELC-1234](https://issues.redhat.com/browse/RHELC-1361)] Test title
 - [RHELC-1234](https://issues.redhat.com/browse/RHELC-1361) Test title
```
 ---

This also updates the pull_request_template to be a bit nicer

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
