### PR TITLE
Fix: pylance extension can't connect to server

### DIFF
--- a/.devcontainer/alma9/devcontainer.json
+++ b/.devcontainer/alma9/devcontainer.json
@@ -36,7 +36,7 @@
 				"python.languageServer": "Pylance"
 			},
 			"extensions": [
-				"ms-python.vscode-pylance",
+				"ms-python.vscode-pylance@2023.11.10",
 				"eamodio.gitlens",
 				"GitHub.vscode-pull-request-github",
 				"Cameron.vscode-pytest",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,13 @@ Versions newer than `2022.8.1` of extension `ms-python.python` will not work whe
 
 To work around this, go to extensions tab and select Ignore Updates on the extension, thereafter select install a new version and install `2022.8.1`. It will prompt to reload the window, make sure the right version is installed after reload. Now debugging should work
 
+##### Pylance couldn't create connection to server
+In different version of `ms-python.vscode-pylance` than `2023.11.10` pylance can't connect to server
+which results in missing language support. We have pinned the version but VS Code might auto-update the extension.
+
+To work around this, go to extensions tab and select Ignore Updates on the extension, thereafter select install a new version and install `2023.11.10`. It will prompt to reload the window, make sure the right version is installed after reload.
+Now language support should work.
+
 ### Dependencies for local development
 
 We have some required dependencies you should have installed on your system


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
When using Dev container I had issues with Pylance extension - can't connect to the server. I found that downgrading Pylance to version `2023.11.10` works. Version `2023.10.40` (and older?) also works, but the `2023.11.10` is the newest working version.

Also updated the known issues part under Dev container in `CONTRIBUTING.md`

<!-- Link to relevant Jira issue, add multiple if necessary -->


Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
