### PR TITLE
Remove python version lock in dev container

### DIFF
--- a/.devcontainer/alma9/devcontainer.json
+++ b/.devcontainer/alma9/devcontainer.json
@@ -31,8 +31,8 @@
 	"customizations": {
 		"vscode": {
 			"settings": {
-				"extensions.autoUpdate": false,
-				"extensions.autoCheckUpdates": false,
+				"extensions.autoUpdate": true,
+				"extensions.autoCheckUpdates": true,
 				"python.languageServer": "Pylance"
 			},
 			"extensions": [
@@ -41,7 +41,7 @@
 				"GitHub.vscode-pull-request-github",
 				"Cameron.vscode-pytest",
 				"njpwerner.autodocstring",
-				"ms-python.python@2022.8.1"
+				"ms-python.python"
 			]
 		}
 	}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,12 +76,6 @@ Dev Containers: Open Folder in Container
 You are now inside a container as indicated by the bottom left box. There is an extension for tests in the left
 navigation that auto-discovers tests that you can run. This will be much faster than developing using `make tests`
 
-#### Known issues
-##### Debugging just loads and does nothing
-Versions newer than `2022.8.1` of extension `ms-python.python` will not work when debugging code. We have pinned the version but VS Code might auto-update the extension.
-
-To work around this, go to extensions tab and select Ignore Updates on the extension, thereafter select install a new version and install `2022.8.1`. It will prompt to reload the window, make sure the right version is installed after reload. Now debugging should work
-
 ### Dependencies for local development
 
 We have some required dependencies you should have installed on your system


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
When having the version locked, it causes issues with the pylance extension. Since everything works in up-to-date state, removing the lock.

The issues with pylance are mentioned there: https://github.com/oamg/convert2rhel/pull/1128

<!-- Link to relevant Jira issue, add multiple if necessary -->


Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
