### PR TITLE
refactor: move `utils.py` to a module

### DIFF
--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -27,6 +27,7 @@ from convert2rhel import __version__ as running_convert2rhel_version
 from convert2rhel import actions, utils
 from convert2rhel.pkghandler import parse_pkg_string
 from convert2rhel.systeminfo import system_info
+from convert2rhel.utils import files
 
 
 logger = logging.getLogger(__name__)
@@ -87,7 +88,7 @@ class Convert2rhelLatest(actions.Action):
 
         # Note: This is safe because we're creating in utils.TMP_DIR which is hardcoded to
         # /var/lib/convert2rhel which does not have any world-writable directory components.
-        utils.mkdir_p(repo_dir)
+        files.mkdir_p(repo_dir)
 
         try:
             raw_output_convert2rhel_versions, return_code = utils.run_subprocess(cmd, print_output=False)

--- a/convert2rhel/backup/certs.py
+++ b/convert2rhel/backup/certs.py
@@ -24,6 +24,7 @@ import shutil
 
 from convert2rhel import exceptions, utils
 from convert2rhel.backup import RestorableChange
+from convert2rhel.utils import files
 
 
 loggerinst = logging.getLogger(__name__)
@@ -115,7 +116,7 @@ class RestorablePEMCert(RestorableChange):
             self.previously_installed = True
         else:
             try:
-                utils.mkdir_p(self._target_cert_dir)
+                files.mkdir_p(self._target_cert_dir)
                 shutil.copy2(self._source_cert_path, self._target_cert_dir)
             except OSError as err:
                 loggerinst.critical_no_exit("OSError({0}): {1}".format(err.errno, err.strerror))

--- a/convert2rhel/backup/packages.py
+++ b/convert2rhel/backup/packages.py
@@ -28,6 +28,7 @@ from convert2rhel.pkgmanager import call_yum_cmd
 # split this out.
 from convert2rhel.repo import get_hardcoded_repofiles_dir
 from convert2rhel.systeminfo import system_info
+from convert2rhel.utils import files
 
 
 loggerinst = logging.getLogger(__name__)
@@ -308,8 +309,8 @@ class RestorablePackageSet(RestorableChange):
         # Note, this use of mkdir_p is secure because SUBMGR_RPMS_DIR and
         # _RHSM_TMP_DIR do not contain any path components writable by
         # a different user.
-        utils.mkdir_p(_SUBMGR_RPMS_DIR)
-        utils.mkdir_p(_RHSM_TMP_DIR)
+        files.mkdir_p(_SUBMGR_RPMS_DIR)
+        files.mkdir_p(_RHSM_TMP_DIR)
 
         loggerinst.info("Downloading requested packages")
         all_pkgs_to_install = self.pkgs_to_install + self.pkgs_to_update

--- a/convert2rhel/breadcrumbs.py
+++ b/convert2rhel/breadcrumbs.py
@@ -27,6 +27,7 @@ from datetime import datetime
 
 from convert2rhel import pkghandler, toolopts, utils
 from convert2rhel.systeminfo import system_info
+from convert2rhel.utils import files
 
 
 # Path to the migration results of the old breadcrumbs.
@@ -200,7 +201,7 @@ class Breadcrumbs:
             # is provided.
             # This is safe as the RHSM_CUSTOM_FACTS_FOLDER, /etc/rhsm/facts, and its parents
             # are only writable by root
-            utils.mkdir_p(RHSM_CUSTOM_FACTS_FOLDER)
+            files.mkdir_p(RHSM_CUSTOM_FACTS_FOLDER)
 
         data = utils.flatten(dictionary=self.data, parent_key=RHSM_CUSTOM_FACTS_NAMESPACE)
         loggerinst.info("Writing RHSM custom facts to '%s'.", RHSM_CUSTOM_FACTS_FILE)

--- a/convert2rhel/unit_tests/backup/certs_test.py
+++ b/convert2rhel/unit_tests/backup/certs_test.py
@@ -29,6 +29,7 @@ from convert2rhel.backup import certs
 from convert2rhel.backup.certs import RestorablePEMCert, RestorableRpmKey
 from convert2rhel.systeminfo import system_info
 from convert2rhel.unit_tests import RunSubprocessMocked
+from convert2rhel.utils import files
 
 
 # Directory with all the tool data
@@ -70,7 +71,7 @@ def cert_dir(monkeypatch, request):
 
         # Create temporary directory that has no certificate
         cert_dir = os.path.join(rhel_cert_dir, request.param["arch"])
-        utils.mkdir_p(cert_dir)
+        files.mkdir_p(cert_dir)
 
     monkeypatch.setattr(utils, "DATA_DIR", data_dir)
     monkeypatch.setattr(system_info, "arch", request.param["arch"])
@@ -204,7 +205,7 @@ class TestPEMCert:
 
     def test_enable_certificate_error(self, caplog, monkeypatch, system_cert_with_target_path):
         fake_mkdir_p = mock.Mock(side_effect=OSError(13, "Permission denied"))
-        monkeypatch.setattr(utils, "mkdir_p", fake_mkdir_p)
+        monkeypatch.setattr(files, "mkdir_p", fake_mkdir_p)
 
         with pytest.raises(exceptions.CriticalError):
             system_cert_with_target_path.enable()

--- a/convert2rhel/utils/__init__.py
+++ b/convert2rhel/utils/__init__.py
@@ -17,7 +17,6 @@
 
 __metaclass__ = type
 
-import errno
 import fcntl
 import getpass
 import json
@@ -500,19 +499,6 @@ class PexpectSpawnWithDimensions(pexpect.spawn):
 
             # Restore the real setwinsize
             self.setwinsize = real_setwinsize
-
-
-def mkdir_p(path):
-    """Create all missing directories for the path and raise no exception
-    if the path exists.
-    """
-    try:
-        os.makedirs(path)
-    except OSError as err:
-        if err.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise
 
 
 def ask_to_continue():

--- a/convert2rhel/utils/files.py
+++ b/convert2rhel/utils/files.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+
+import errno
+import os
+
+
+def mkdir_p(path):
+    """Create all missing directories for the path.
+
+    :param str path: Absolute path to create directories for
+    :raises OSError: If it fails to create directories. Does not raise if the path already exists.
+    """
+    try:
+        os.makedirs(path)
+    except OSError as err:
+        if err.errno == errno.EEXIST and os.path.isdir(path):
+            return
+        raise


### PR DESCRIPTION
As we kept using `utils.py` file and adding more and more things it
became quite bloated. To solve this the best thing to do, while also
making it easy to test and reduce cyclic imports is to split it into
smaller parts.

This takes care of the initial move by putting everything on the module
level while still having backwards compatibility for the time being.

To make this easier for ourselves we should migrate the file into
more modules over time

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
