### PR TITLE
[RHELC-1396] fix: errors in utils.py after full test suite

### DIFF
--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -74,8 +74,6 @@ class LogfileBufferHandler(BufferingHandler):
     which will keep a buffer of the logs and flush it to the FileHandler
     """
 
-    name = "logfile_buffer_handler"
-
     def __init__(self, capacity, handler_name="file_handler"):
         """
         Initialize the handler with the buffer size.
@@ -86,6 +84,7 @@ class LogfileBufferHandler(BufferingHandler):
         super(LogfileBufferHandler, self).__init__(capacity)
         # the FileLogger handler that we are logging to
         self._handler_name = handler_name
+        self.set_name("logfile_buffer_handler")
 
     @property
     def target(self):
@@ -97,7 +96,7 @@ class LogfileBufferHandler(BufferingHandler):
         :return logging.Handler: Either the found FileHandler setup or temporary NullHandler
         """
         for handler in logger.handlers:
-            if handler.name == self._handler_name:
+            if hasattr(handler, "name") and handler.name == self._handler_name:
                 return handler
         return logging.NullHandler()
 
@@ -175,8 +174,8 @@ def add_file_handler(log_name, log_dir):
     # We now have a FileHandler added, but we still need the logs from before
     # this point. Luckily we have the memory buffer that we can flush logs from
     for handler in logger.handlers:
-        if handler.name == "logfile_buffer_handler":
-            handler.flush()
+        if hasattr(handler, "name") and handler.name == "logfile_buffer_handler":
+            handler.close()
             # after we've flushed to the file we don't need the handler anymore
             logger.removeHandler(handler)
             break

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -1,5 +1,6 @@
 __metaclass__ = type
 
+import logging
 import os
 import sys
 
@@ -73,12 +74,15 @@ def pkg_root():
 
 
 @pytest.fixture(autouse=True)
-def setup_logger(tmpdir, request):
+def setup_logger(request):
     # This makes it so we can skip this using @pytest.mark.noautofixtures
     if "noautofixtures" in request.keywords:
         return
     setup_logger_handler()
-    add_file_handler(log_name="convert2rhel", log_dir=str(tmpdir))
+    # get root logger
+    logger = logging.getLogger("convert2rhel")
+    for handler in logger.handlers:
+        logger.removeHandler(handler)
 
 
 @pytest.fixture

--- a/convert2rhel/unit_tests/logger_test.py
+++ b/convert2rhel/unit_tests/logger_test.py
@@ -26,12 +26,13 @@ import pytest
 from convert2rhel import logger as logger_module
 
 
+@pytest.mark.noautofixtures
 def test_logger_handlers(monkeypatch, tmpdir, read_std, global_tool_opts):
     """Test if the logger handlers emits the events to the file and stdout."""
     monkeypatch.setattr("convert2rhel.toolopts.tool_opts", global_tool_opts)
 
     # initializing the logger first
-    log_fname = "convert2rhel.log"
+    log_fname = "customlogfile.log"
     global_tool_opts.debug = True  # debug entries > stdout if True
     logger_module.setup_logger_handler()
     logger_module.add_file_handler(log_name=log_fname, log_dir=str(tmpdir))
@@ -41,15 +42,15 @@ def test_logger_handlers(monkeypatch, tmpdir, read_std, global_tool_opts):
     logger.info("Test info: %s", "data")
     logger.debug("Test debug: %s", "other data")
 
-    # Test if logs were emmited to the file
-    with open(str(tmpdir.join(log_fname))) as log_f:
-        assert "Test info: data" in log_f.readline().rstrip()
-        assert "Test debug: other data" in log_f.readline().rstrip()
-
     # Test if logs were emmited to the stdout
     stdouterr_out, stdouterr_err = read_std()
     assert "Test info: data" in stdouterr_out
     assert "Test debug: other data" in stdouterr_out
+
+    # Test if logs were emmited to the file
+    with open(str(tmpdir.join(log_fname))) as log_f:
+        assert "Test info: data" in log_f.readline().rstrip()
+        assert "Test debug: other data" in log_f.readline().rstrip()
 
 
 def test_tools_opts_debug(monkeypatch, read_std, is_py2, global_tool_opts):


### PR DESCRIPTION
Since of merging #1029 we get an issue with unit tests that causes a lot
of strange errors to occur. Likely due to a stream not being closed
correctly.

This aims to either fix or mitigate this from occuring during test runs
as it should not appear in convert2rhel by itself.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1396](https://issues.redhat.com/browse/RHELC-1396)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
