### PR TITLE
Add debug logs to host-metering

### DIFF
--- a/convert2rhel/hostmetering.py
+++ b/convert2rhel/hostmetering.py
@@ -67,6 +67,7 @@ def configure_host_metering():
     """
     env_var = os.environ.get("CONVERT2RHEL_CONFIGURE_HOST_METERING", None)
     if env_var not in ("force", "auto"):
+        logger.debug("Value for environment variable not recognized: %s" % env_var)
         return False
 
     if system_info.version.major != 7 and env_var != "force":
@@ -82,6 +83,7 @@ def configure_host_metering():
         )
     elif env_var == "auto":
         should_configure_metering = True
+        logger.debug("Automatic detection of host hyperscaler and configuration.")
     else:
         should_configure_metering = False
 


### PR DESCRIPTION
Added a couple of debug logs to host-metering to help identify what is happening in case of a environment variable not being set, or what option the user specified in the env var.

```
[2024-03-13T15:49:55+0000] TASK - [Final: Configure host-metering] ***********************************
Writing breadcrumbs to '/etc/migration-results'.
Writing RHSM custom facts to '/etc/rhsm/facts/convert2rhel.facts'.
```

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
