### PR TITLE
Add a task log for update breadcrumbs

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -299,6 +299,7 @@ def post_ponr_changes():
     loggerinst.task("Final: Configure host-metering")
     hostmetering.configure_host_metering()
 
+    loggerinst.task("Final: Update breadcrumbs")
     breadcrumbs.breadcrumbs.finish_collection(success=True)
 
     loggerinst.task("Final: Update RHSM custom facts")


### PR DESCRIPTION
Without a log task, the breadcrumbs update part has its output very near to other logs from other tasks. This commit introduces a simple task log to separate what is the task running, and the breadcrumbs being updated.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
