### PR TITLE
[RHELC-1457] Remove duplicate pop_all from rollback

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -332,19 +332,10 @@ def rollback_changes():
 
     loggerinst.warning("Abnormal exit! Performing rollback ...")
 
-    backup_control_was_empty = False
-    try:
-        backup.backup_control.pop_all()
-    except IndexError:
-        backup_control_was_empty = True
-
     try:
         backup.backup_control.pop_all()
     except IndexError as e:
         if e.args[0] == "No backups to restore":
-            # We have to check if we were able to pop some backups at the top
-            # of this function
-            if backup_control_was_empty:
-                loggerinst.info("During rollback there were no backups to restore")
+            loggerinst.info("During rollback there were no backups to restore")
         else:
             raise

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -60,13 +60,13 @@ class TestRollbackChanges:
 
         # Note: when we remove the BackupController partition hack, the first
         # of these calls will go away
-        assert global_backup_control.pop_all.call_args_list == [mock.call(), mock.call()]
+        assert global_backup_control.pop_all.call_args_list == mock.call()
 
     def test_backup_control_unknown_exception(self, monkeypatch, global_backup_control):
         monkeypatch.setattr(
             global_backup_control,
             "pop_all",
-            mock.Mock(side_effect=([], IndexError("Raised because of a bug in the code"))),
+            mock.Mock(side_effect=IndexError("Raised because of a bug in the code")),
         )
 
         with pytest.raises(IndexError, match="Raised because of a bug in the code"):


### PR DESCRIPTION
There was a leftover in the rollback process that was triggering the pop_all function from the backup_controller twice. Calling the pop_all twice does not cause problems with the rollback, but there is no necessity to double call it.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1457](https://issues.redhat.com/browse/RHELC-1457)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
