### PR TITLE
[RHELC-1430] Breaking change: Rename incomplete rollback envvar

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -183,7 +183,7 @@ class BackupPackageFiles(actions.Action):
                 output = f.read()
         # Catch the IOError due Python 2 compatibility
         except IOError as err:
-            if os.environ.get("CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK", None):
+            if os.environ.get("CONVERT2RHEL_INCOMPLETE_ROLLBACK", None):
                 loggerinst.debug("Skipping backup of the package files. CONVERT2RHEL_INCOMPLETE_ROLLBACK detected.")
                 # Return empty list results in no backup of the files
                 return data

--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -185,7 +185,7 @@ class CLI:
             " stored in log files %s and %s. At the end of the conversion, these logs are compared"
             " to show you what rpm files have been affected by the conversion."
             " Cannot be used with analyze subcommand."
-            " The environment variable CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK"
+            " The environment variable CONVERT2RHEL_INCOMPLETE_ROLLBACK"
             " needs to be set to 1 to use this argument." % (PRE_RPM_VA_LOG_FILENAME, POST_RPM_VA_LOG_FILENAME),
         )
         self._shared_options_parser.add_argument(
@@ -374,13 +374,13 @@ class CLI:
                     " in the analysis mode is essential for a complete rollback to the original"
                     " system state at the end of the analysis."
                 )
-            elif os.getenv("CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK", None):
+            elif os.getenv("CONVERT2RHEL_INCOMPLETE_ROLLBACK", None):
                 tool_opts.no_rpm_va = True
             else:
                 message = (
                     "We need to run the 'rpm -Va' command to be able to perform a complete rollback of changes"
                     " done to the system during the pre-conversion analysis. If you accept the risk of an"
-                    " incomplete rollback, set the CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK=1 environment"
+                    " incomplete rollback, set the CONVERT2RHEL_INCOMPLETE_ROLLBACK=1 environment"
                     " variable. Otherwise, remove the --no-rpm-va option."
                 )
                 loggerinst.critical(message)

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
@@ -231,10 +231,10 @@ class TestBackupSystem:
         monkeypatch.setattr(backup_system, "LOG_DIR", str(tmpdir))
 
         if env_var:
-            os.environ["CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK"] = "1"
+            os.environ["CONVERT2RHEL_INCOMPLETE_ROLLBACK"] = "1"
         else:
             # Unset the variable
-            os.environ.pop("CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK", None)
+            os.environ.pop("CONVERT2RHEL_INCOMPLETE_ROLLBACK", None)
 
         backup_package_file = backup_system.BackupPackageFiles()
 

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -679,7 +679,7 @@ def test_should_subscribe(username, password, organization, activation_key, no_r
             ["--no-rpm-va"],
             False,
             False,
-            "We need to run the 'rpm -Va' command to be able to perform a complete rollback of changes done to the system during the pre-conversion analysis. If you accept the risk of an incomplete rollback, set the CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK=1 environment variable. Otherwise, remove the --no-rpm-va option.",
+            "We need to run the 'rpm -Va' command to be able to perform a complete rollback of changes done to the system during the pre-conversion analysis. If you accept the risk of an incomplete rollback, set the CONVERT2RHEL_INCOMPLETE_ROLLBACK=1 environment variable. Otherwise, remove the --no-rpm-va option.",
         ),
         (["--no-rpm-va"], True, True, ""),
     ),
@@ -687,7 +687,7 @@ def test_should_subscribe(username, password, organization, activation_key, no_r
 def test_setting_no_rpm_va(argv, env_var, expected, message, monkeypatch, global_tool_opts, caplog):
     monkeypatch.setattr(sys, "argv", mock_cli_arguments(argv))
     if env_var:
-        monkeypatch.setenv("CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK", "1")
+        monkeypatch.setenv("CONVERT2RHEL_INCOMPLETE_ROLLBACK", "1")
 
     try:
         convert2rhel.toolopts.CLI()

--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -523,7 +523,7 @@ class TestDownload_pkg:
         monkeypatch.setattr(system_info, "releasever", "7Server")
         monkeypatch.setattr(system_info, "version", systeminfo.Version(7, 0))
         monkeypatch.setattr(utils, "run_cmd_in_pty", RunCmdInPtyMocked(return_code=1))
-        monkeypatch.setattr(os, "environ", {"CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK": "1"})
+        monkeypatch.setattr(os, "environ", {"CONVERT2RHEL_INCOMPLETE_ROLLBACK": "1"})
         monkeypatch.setattr(toolopts.tool_opts, "activity", "analysis")
 
         with pytest.raises(SystemExit):
@@ -533,7 +533,7 @@ class TestDownload_pkg:
         monkeypatch.setattr(system_info, "releasever", "7Server")
         monkeypatch.setattr(system_info, "version", systeminfo.Version(7, 0))
         monkeypatch.setattr(utils, "run_cmd_in_pty", RunCmdInPtyMocked(return_code=1))
-        monkeypatch.setattr(os, "environ", {"CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK": "1"})
+        monkeypatch.setattr(os, "environ", {"CONVERT2RHEL_INCOMPLETE_ROLLBACK": "1"})
         monkeypatch.setattr(toolopts.tool_opts, "activity", "conversion")
 
         path = utils.download_pkg("kernel")
@@ -567,9 +567,9 @@ def test_get_rpm_path_from_yumdownloader_output(output):
     ("envvar", "activity", "should_raise", "message"),
     (
         (None, "conversion", True, "If you would rather disregard this check"),
-        ("CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK", "conversion", False, "environment variable detected"),
+        ("CONVERT2RHEL_INCOMPLETE_ROLLBACK", "conversion", False, "environment variable detected"),
         (None, "analysis", True, "you can choose to disregard this check"),
-        ("CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK", "analysis", True, "you can choose to disregard this check"),
+        ("CONVERT2RHEL_INCOMPLETE_ROLLBACK", "analysis", True, "you can choose to disregard this check"),
     ),
 )
 def test_report_on_a_download_error(envvar, activity, should_raise, message, monkeypatch, caplog):

--- a/convert2rhel/utils.py
+++ b/convert2rhel/utils.py
@@ -804,20 +804,20 @@ def report_on_a_download_error(output, pkg):
     from convert2rhel.systeminfo import system_info
 
     if toolopts.tool_opts.activity == "conversion":
-        if "CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK" not in os.environ:
+        if "CONVERT2RHEL_INCOMPLETE_ROLLBACK" not in os.environ:
             loggerinst.critical(
                 "Couldn't download the %s package. This means we will not be able to do a"
                 " complete rollback and may put the system in a broken state.\n"
                 "Check to make sure that the %s repositories are enabled"
                 " and the package is updated to its latest version.\n"
                 "If you would rather disregard this check set the environment variable"
-                " 'CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK=1'." % (pkg, system_info.name)
+                " 'CONVERT2RHEL_INCOMPLETE_ROLLBACK=1'." % (pkg, system_info.name)
             )
         else:
             loggerinst.warning(
                 "Couldn't download the %s package. This means we will not be able to do a"
                 " complete rollback and may put the system in a broken state.\n"
-                "'CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK' environment variable detected, continuing"
+                "'CONVERT2RHEL_INCOMPLETE_ROLLBACK' environment variable detected, continuing"
                 " conversion." % pkg
             )
     else:
@@ -826,7 +826,7 @@ def report_on_a_download_error(output, pkg):
             " Check to make sure that the %s repositories are enabled and the package is"
             " updated to its latest version.\n"
             "Note that you can choose to disregard this check when running a conversion by"
-            " setting the environment variable 'CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK=1'"
+            " setting the environment variable 'CONVERT2RHEL_INCOMPLETE_ROLLBACK=1'"
             " but not during a pre-conversion analysis." % (pkg, system_info.name)
         )
 

--- a/man/convert2rhel.8
+++ b/man/convert2rhel.8
@@ -53,7 +53,7 @@ before and after the conversion with the output stored in log files rpm_va.log
 and rpm_va_after_conversion.log. At the end of the conversion, these logs are
 compared to show you what rpm files have been affected by the conversion.
 Cannot be used with analyze subcommand. The environment variable
-CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK needs to be set to 1 to use this
+CONVERT2RHEL_INCOMPLETE_ROLLBACK needs to be set to 1 to use this
 argument.
 
 .TP
@@ -199,7 +199,7 @@ before and after the conversion with the output stored in log files rpm_va.log
 and rpm_va_after_conversion.log. At the end of the conversion, these logs are
 compared to show you what rpm files have been affected by the conversion.
 Cannot be used with analyze subcommand. The environment variable
-CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK needs to be set to 1 to use this
+CONVERT2RHEL_INCOMPLETE_ROLLBACK needs to be set to 1 to use this
 argument.
 
 .TP

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -123,9 +123,9 @@ description+: |
             environment+:
                 CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK: 1
                 # Since we are removing all the repositories other than rhel-7-server-rpms
-                # we need pass CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK due to the inability
+                # we need pass CONVERT2RHEL_INCOMPLETE_ROLLBACK due to the inability
                 # to download and backup packages
-                CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK: 1
+                CONVERT2RHEL_INCOMPLETE_ROLLBACK: 1
                 # Unavailable kmods may be present on the system due to the kernel package
                 # not being updated. Mitigate the issues by exporting CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS.
                 CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS: 1

--- a/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
@@ -299,11 +299,11 @@ def test_data_collection_acknowledgement(shell, convert2rhel):
 
 @pytest.fixture
 def analyze_incomplete_rollback_envar():
-    os.environ["CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK"] = "1"
+    os.environ["CONVERT2RHEL_INCOMPLETE_ROLLBACK"] = "1"
 
     yield
 
-    del os.environ["CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK"]
+    del os.environ["CONVERT2RHEL_INCOMPLETE_ROLLBACK"]
 
 
 @pytest.mark.test_analyze_incomplete_rollback
@@ -325,7 +325,7 @@ def test_analyze_incomplete_rollback(repositories, convert2rhel, analyze_incompl
         # Verify the user is informed to not use the envar during the analysis
         assert (
             c2r.expect(
-                "setting the environment variable 'CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK=1' but not during a pre-conversion analysis",
+                "setting the environment variable 'CONVERT2RHEL_INCOMPLETE_ROLLBACK=1' but not during a pre-conversion analysis",
                 timeout=300,
             )
             == 0
@@ -338,7 +338,7 @@ def test_analyze_incomplete_rollback(repositories, convert2rhel, analyze_incompl
         c2r.sendline("y")
         assert (
             c2r.expect(
-                "'CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK' environment variable detected, continuing conversion.",
+                "'CONVERT2RHEL_INCOMPLETE_ROLLBACK' environment variable detected, continuing conversion.",
                 timeout=300,
             )
             == 0

--- a/tests/integration/tier0/non-destructive/system-release-backup/main.fmf
+++ b/tests/integration/tier0/non-destructive/system-release-backup/main.fmf
@@ -20,7 +20,7 @@ tag+:
             Verify that the /etc/os-release file is restored after the rollback.
         /backup_os_release_no_envar:
             summary+: |
-                Restore os-release without CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK
+                Restore os-release without CONVERT2RHEL_INCOMPLETE_ROLLBACK
             description+: |
                 This case runs the conversion with no repositories available.
                 Verify that this condition disables the package backup,
@@ -33,10 +33,10 @@ tag+:
 
         /backup_os_release_with_envar:
             summary+: |
-                Restore os-release with CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK
+                Restore os-release with CONVERT2RHEL_INCOMPLETE_ROLLBACK
             description+: |
                 This case runs the conversion with no repositories available
-                and "CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK" envar set.
+                and "CONVERT2RHEL_INCOMPLETE_ROLLBACK" envar set.
                 Verify that this condition disables the package backup,
                 convert2rhel warns the user, but continues the conversion.
             tag+:

--- a/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
+++ b/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
@@ -127,7 +127,7 @@ def test_backup_os_release_no_envar(
     """
     This test case removes all the repos on the system which prevents the backup of some files.
     Satellite is being used in all of test cases.
-    In this scenario there is no variable `CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK` set.
+    In this scenario there is no variable `CONVERT2RHEL_INCOMPLETE_ROLLBACK` set.
     This means the conversion is inhibited in early stage.
     """
 
@@ -139,7 +139,7 @@ def test_backup_os_release_no_envar(
         ),
         unregister=True,
     ) as c2r:
-        c2r.expect("set the environment variable 'CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK")
+        c2r.expect("set the environment variable 'CONVERT2RHEL_INCOMPLETE_ROLLBACK")
         assert c2r.exitstatus != 0
 
     assert shell("find /etc/os-release").returncode == 0
@@ -147,11 +147,11 @@ def test_backup_os_release_no_envar(
 
 @pytest.fixture(scope="function")
 def unsupported_rollback_envar(shell):
-    os.environ["CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK"] = "1"
+    os.environ["CONVERT2RHEL_INCOMPLETE_ROLLBACK"] = "1"
 
     yield
 
-    del os.environ["CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK"]
+    del os.environ["CONVERT2RHEL_INCOMPLETE_ROLLBACK"]
 
 
 @pytest.mark.test_backup_os_release_with_envar
@@ -159,7 +159,7 @@ def test_backup_os_release_with_envar(
     shell, convert2rhel, custom_subman, katello_package, repositories, unsupported_rollback_envar, kernel_check_envar
 ):
     """
-    In this scenario the variable `CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK` is set.
+    In this scenario the variable `CONVERT2RHEL_INCOMPLETE_ROLLBACK` is set.
     This test case removes all the repos on the system and validates that
     the /etc/os-release package is being backed up and restored during rollback.
     Ref ticket: OAMG-5457. Note that after the test, the $releasever
@@ -175,9 +175,7 @@ def test_backup_os_release_with_envar(
         ),
         unregister=True,
     ) as c2r:
-        c2r.expect(
-            "'CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK' environment variable detected, continuing conversion."
-        )
+        c2r.expect("'CONVERT2RHEL_INCOMPLETE_ROLLBACK' environment variable detected, continuing conversion.")
         c2r.sendcontrol("c")
 
     assert c2r.exitstatus != 0

--- a/tests/integration/tier1/destructive/one-kernel-scenario/test_one_kernel_scenario.py
+++ b/tests/integration/tier1/destructive/one-kernel-scenario/test_one_kernel_scenario.py
@@ -72,7 +72,7 @@ def test_one_kernel_scenario(shell, convert2rhel, one_kernel):
             # from Testing Farm
             shell("rm /etc/yum.repos.d/copr_build-convert2rhel-1.repo")
 
-        os.environ["CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK"] = "1"
+        os.environ["CONVERT2RHEL_INCOMPLETE_ROLLBACK"] = "1"
         os.environ["CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK"] = "1"
         # Unavailable kmods may be present on the system due to the kernel package
         # not being updated. Mitigate the issues by exporting CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS.


### PR DESCRIPTION
We are moving away from using the word UNSUPPORTED in environment
variables as it is confusing and not very descriptive of what is
unsupported. Since this relates to the tool itself not supporting it in
a predictable way, we are renaming mentions of the word unsupported.

This change has to do with renaming
``CONVERT2RHEL_UNSUPPORTED_INCOMPLETE_ROLLBACK``
to
`CONVERT2RHEL_INCOMPLETE_ROLLBACK`

`CONVERT2RHEL_INCOMPLETE_ROLLBACK` means that we can garantee a rollback
will be successful on a potential failure and user would have to specify
the environment variable themselves to understand this to not blame the
tool.

This change does not do anything else and no backwards compatibility is
considered as it is intended to be changed in a major version change.
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1430](https://issues.redhat.com/browse/RHELC-1430)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
