### PR TITLE
[RHELC-1425] Breaking change: Remove `--disable-submgr` arg

### DIFF
--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -236,11 +236,6 @@ class CLI:
             description="The following options are required if you do not intend on using subscription-manager.",
         )
         group.add_argument(
-            "--disable-submgr",
-            action="store_true",
-            help="Replaced by --no-rhsm. Both options have the same effect.",
-        )
-        group.add_argument(
             "--no-rhsm",
             action="store_true",
             help="Do not use the subscription-manager, use custom repositories instead. See --enablerepo/--disablerepo"
@@ -406,10 +401,10 @@ class CLI:
                 message += "\nThis ambiguity may have unintended consequences."
                 loggerinst.warning(message)
 
-        if parsed_opts.no_rhsm or parsed_opts.disable_submgr:
+        if parsed_opts.no_rhsm:
             tool_opts.no_rhsm = True
             if not tool_opts.enablerepo:
-                loggerinst.critical("The --enablerepo option is required when --disable-submgr or --no-rhsm is used.")
+                loggerinst.critical("The --enablerepo option is required when --no-rhsm is used.")
 
         if parsed_opts.eus:
             tool_opts.eus = True
@@ -431,9 +426,7 @@ class CLI:
 
         if parsed_opts.serverurl:
             if tool_opts.no_rhsm:
-                loggerinst.warning(
-                    "Ignoring the --serverurl option. It has no effect when --disable-submgr or --no-rhsm is used."
-                )
+                loggerinst.warning("Ignoring the --serverurl option. It has no effect when --no-rhsm is used.")
             # WARNING: We cannot use the following helper until after no_rhsm,
             # username, password, activation_key, and organization have been set.
             elif not _should_subscribe(tool_opts):

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -124,7 +124,7 @@ class TestTooloptsParseFromCLI:
 
         convert2rhel.toolopts.CLI()
 
-        message = "Ignoring the --serverurl option. It has no effect when" " --disable-submgr or --no-rhsm is used."
+        message = "Ignoring the --serverurl option. It has no effect when --no-rhsm is used."
         assert message in caplog.text
 
     def test_serverurl_with_no_rhsm_credentials(self, caplog, monkeypatch, global_tool_opts):
@@ -167,23 +167,19 @@ def test_cmdline_obsolete_variant_option(argv, warn, ask_to_continue, monkeypatc
 @pytest.mark.parametrize(
     ("argv", "raise_exception", "no_rhsm_value"),
     (
-        (mock_cli_arguments(["--disable-submgr"]), True, True),
         (mock_cli_arguments(["--no-rhsm"]), True, True),
-        (mock_cli_arguments(["--disable-submgr", "--enablerepo", "test_repo"]), False, True),
-        (mock_cli_arguments(["--no-rhsm", "--disable-submgr", "--enablerepo", "test_repo"]), False, True),
+        (mock_cli_arguments(["--no-rhsm", "--enablerepo", "test_repo"]), False, True),
     ),
 )
 @mock.patch("convert2rhel.toolopts.tool_opts.no_rhsm", False)
 @mock.patch("convert2rhel.toolopts.tool_opts.enablerepo", [])
-def test_both_disable_submgr_and_no_rhsm_options_work(
-    argv, raise_exception, no_rhsm_value, monkeypatch, caplog, global_tool_opts
-):
+def test_no_rhsm_option_work(argv, raise_exception, no_rhsm_value, monkeypatch, caplog, global_tool_opts):
     monkeypatch.setattr(sys, "argv", argv)
 
     if raise_exception:
         with pytest.raises(SystemExit):
             convert2rhel.toolopts.CLI()
-            assert "The --enablerepo option is required when --disable-submgr or --no-rhsm is used." in caplog.text
+        assert "The --enablerepo option is required when --no-rhsm is used." in caplog.text
     else:
         convert2rhel.toolopts.CLI()
 

--- a/tests/integration/tier1/destructive/one-kernel-scenario/test_one_kernel_scenario.py
+++ b/tests/integration/tier1/destructive/one-kernel-scenario/test_one_kernel_scenario.py
@@ -78,7 +78,7 @@ def test_one_kernel_scenario(shell, convert2rhel, one_kernel):
         # not being updated. Mitigate the issues by exporting CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS.
         os.environ["CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS"] = "1"
 
-        with convert2rhel("-y --disable-submgr {} --debug".format(enable_repo_opt)) as c2r:
+        with convert2rhel("-y --no-rhsm {} --debug".format(enable_repo_opt)) as c2r:
             c2r.expect("Conversion successful!")
 
         assert c2r.exitstatus == 0


### PR DESCRIPTION
As we are going to do a major version change we want to remove all
deprecated and unused client-facing things, such as the unsupported
naming and deprecated arguments.

This change has to do with removing `--disable-submgr` as we have the
equivalent and newer `--no-rhsm` argument.
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1425](https://issues.redhat.com/browse/RHELC-1425)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
