### PR TITLE
[RHELC-1425] Breaking change: Remove `-v|--variant` arg

### DIFF
--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -312,15 +312,6 @@ class CLI:
             " If no pool ID is provided, the --auto option is used",
         )
         group.add_argument(
-            "-v",
-            "--variant",
-            help="This option is not supported anymore and has no effect. When"
-            " converting a system to RHEL 7 using subscription-manager,"
-            " the system is now always converted to the Server variant. In case"
-            " of using custom repositories, the system is converted to the variant"
-            " provided by these repositories.",
-        )
-        group.add_argument(
             "--serverurl",
             help="Hostname of the subscription service to be used when registering the system with"
             " subscription-manager. The default is the Customer Portal Subscription Management service"
@@ -331,8 +322,6 @@ class CLI:
     def _process_cli_options(self):
         """Process command line options used with the tool."""
         _log_command_used()
-
-        warn_on_unsupported_options()
 
         # algorithm function to properly organize all CLI args
         argv = _add_default_command(sys.argv[1:])
@@ -510,15 +499,6 @@ class CLI:
             loggerinst.critical(
                 "Either the --organization or the --activationkey option is missing. You can't use one without the other."
             )
-
-
-def warn_on_unsupported_options():
-    if any(x in sys.argv[1:] for x in ["--variant", "-v"]):
-        loggerinst.warning(
-            "The -v|--variant option is not supported anymore and has no effect.\n"
-            "See help (convert2rhel -h) for more information."
-        )
-        utils.ask_to_continue()
 
 
 def _log_command_used():

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -140,31 +140,6 @@ class TestTooloptsParseFromCLI:
 
 
 @pytest.mark.parametrize(
-    ("argv", "warn", "ask_to_continue"),
-    (
-        (mock_cli_arguments(["-v", "Server"]), True, True),
-        (mock_cli_arguments(["--variant", "Client"]), True, True),
-        (mock_cli_arguments(["-v"]), True, True),
-        (mock_cli_arguments(["--variant"]), True, True),
-        (mock_cli_arguments(["--version"]), False, False),
-        (mock_cli_arguments([]), False, False),
-    ),
-)
-def test_cmdline_obsolete_variant_option(argv, warn, ask_to_continue, monkeypatch, caplog):
-    monkeypatch.setattr(sys, "argv", argv)
-    monkeypatch.setattr(convert2rhel.utils, "ask_to_continue", mock.Mock())
-    convert2rhel.toolopts.warn_on_unsupported_options()
-    if warn:
-        assert "variant option is not supported" in caplog.text
-    else:
-        assert "variant option is not supported" not in caplog.text
-    if ask_to_continue:
-        convert2rhel.utils.ask_to_continue.assert_called_once()
-    else:
-        convert2rhel.utils.ask_to_continue.assert_not_called()
-
-
-@pytest.mark.parametrize(
     ("argv", "raise_exception", "no_rhsm_value"),
     (
         (mock_cli_arguments(["--no-rhsm"]), True, True),

--- a/man/convert2rhel.8
+++ b/man/convert2rhel.8
@@ -142,13 +142,6 @@ obtain by running 'subscription\-manager list \-\-available'. If no pool ID is
 provided, the \-\-auto option is used
 
 .TP
-\fB\-v\fR \fI\,VARIANT\/\fR, \fB\-\-variant\fR \fI\,VARIANT\/\fR
-This option is not supported anymore and has no effect. When converting a
-system to RHEL 7 using subscription\-manager, the system is now always
-converted to the Server variant. In case of using custom repositories, the
-system is converted to the variant provided by these repositories.
-
-.TP
 \fB\-\-serverurl\fR \fI\,SERVERURL\/\fR
 Hostname of the subscription service to be used when registering the system
 with subscription\-manager. The default is the Customer Portal Subscription
@@ -286,13 +279,6 @@ Automatically attach compatible subscriptions to the system.
 Subscription pool ID. A list of the available subscriptions is possible to
 obtain by running 'subscription\-manager list \-\-available'. If no pool ID is
 provided, the \-\-auto option is used
-
-.TP
-\fB\-v\fR \fI\,VARIANT\/\fR, \fB\-\-variant\fR \fI\,VARIANT\/\fR
-This option is not supported anymore and has no effect. When converting a
-system to RHEL 7 using subscription\-manager, the system is now always
-converted to the Server variant. In case of using custom repositories, the
-system is converted to the variant provided by these repositories.
 
 .TP
 \fB\-\-serverurl\fR \fI\,SERVERURL\/\fR

--- a/pytest.ini
+++ b/pytest.ini
@@ -29,7 +29,6 @@ markers =
     test_version_older_with_envar
     test_clean_cache
     test_log_rhsm_error
-    test_variant_message
     test_data_collection_acknowledgement
     test_disable_data_collection
     test_analyze_incomplete_rollback

--- a/tests/integration/tier0/non-destructive/basic-sanity-checks/main.fmf
+++ b/tests/integration/tier0/non-destructive/basic-sanity-checks/main.fmf
@@ -6,7 +6,6 @@ description: |
         - Only last version of Convert2RHEL supported
         - Yum cache cleaned before any other check
         - Missing RHSM certificates logged properly
-        - Deprecated --variant message displayed
 
 tier: 0
 
@@ -120,17 +119,6 @@ tag+:
         - log-rhsm-error
     test: |
       pytest -svv -m test_log_rhsm_error
-
-
-/variant_message:
-    summary+: |
-        Deprecated variant message
-    description+: |
-        Verify that the message about deprecated --variant option is printed.
-    tag+:
-        - variant-message
-    test: |
-      pytest -svv -m test_variant_message
 
 
 /data_collection:

--- a/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
@@ -239,36 +239,6 @@ def test_rhsm_error_logged(convert2rhel):
             assert "ERROR - OSError(2): No such file or directory" not in line
 
 
-@pytest.mark.test_variant_message
-def test_check_variant_message(convert2rhel):
-    """
-    Run Convert2RHEL with deprecated -v/--variant option and verify that the warning message is shown.
-    """
-    # Run c2r with --variant option
-    with convert2rhel("--debug --variant Server") as c2r:
-        c2r.expect("WARNING - The -v|--variant option is not supported anymore and has no effect")
-        c2r.sendcontrol("c")
-    assert c2r.exitstatus != 0
-
-    # Run c2r with --variant option empty
-    with convert2rhel("--debug --variant") as c2r:
-        c2r.expect("WARNING - The -v|--variant option is not supported anymore and has no effect")
-        c2r.sendcontrol("c")
-    assert c2r.exitstatus != 0
-
-    # Run c2r with -v option
-    with convert2rhel("--debug -v Client") as c2r:
-        c2r.expect("WARNING - The -v|--variant option is not supported anymore and has no effect")
-        c2r.sendcontrol("c")
-    assert c2r.exitstatus != 0
-
-    # Run c2r with -v option empty
-    with convert2rhel("--debug -v") as c2r:
-        c2r.expect("WARNING - The -v|--variant option is not supported anymore and has no effect")
-        c2r.sendcontrol("c")
-    assert c2r.exitstatus != 0
-
-
 @pytest.mark.test_data_collection_acknowledgement
 def test_data_collection_acknowledgement(shell, convert2rhel):
     """


### PR DESCRIPTION
As we are going to do a major version change we want to remove all
deprecated and unused client-facing things, such as the unsupported
naming and deprecated arguments.

This change has to do with removing `--variant` as it is no longer used
and serves no purpose.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1425
](https://issues.redhat.com/browse/RHELC-1425
)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
