### PR TITLE
[RHELC-1347] Update report to include post conversion actions

### DIFF
--- a/convert2rhel/actions/report.py
+++ b/convert2rhel/actions/report.py
@@ -35,8 +35,11 @@ from convert2rhel.logger import colorize
 logger = logging.getLogger(__name__)
 
 #: The filename to store the results of running preassessment
-CONVERT2RHEL_JSON_RESULTS = "/var/log/convert2rhel/convert2rhel-pre-conversion.json"
-CONVERT2RHEL_TXT_RESULTS = "/var/log/convert2rhel/convert2rhel-pre-conversion.txt"
+CONVERT2RHEL_PRE_CONVERSION_JSON_RESULTS = "/var/log/convert2rhel/convert2rhel-pre-conversion.json"
+CONVERT2RHEL_PRE_CONVERSION_TXT_RESULTS = "/var/log/convert2rhel/convert2rhel-pre-conversion.txt"
+#: The filename to store the results of the post conversion report
+CONVERT2RHEL_POST_CONVERSION_JSON_RESULTS = "/var/log/convert2rhel/convert2rhel-post-conversion.json"
+CONVERT2RHEL_POST_CONVERSION_TXT_RESULTS = "/var/log/convert2rhel/convert2rhel-post-conversion.txt"
 
 #: Map Status codes (from convert2rhel.actions.STATUS_CODE) to color name (from
 #: convert2rhel.logger.bcolor)
@@ -57,7 +60,7 @@ _STATUS_TO_COLOR = {
 }
 
 
-def summary_as_json(results, json_file=CONVERT2RHEL_JSON_RESULTS):
+def summary_as_json(results, json_file):
     """
     Output the results as a json_file.
 
@@ -149,7 +152,37 @@ def get_combined_results_and_message(results):
     return combined_results_and_message
 
 
-def summary(results, include_all_reports=False, disable_colors=False):
+def pre_conversion_report(results, include_all_reports=False, disable_colors=False):
+    """Wrapper around summary to output pre-conversion report.
+
+    :param results: Results dictionary as returned by :func:`run_actions`
+    :type results: Mapping
+    :keyword disable_colors: Whether to color the messages according to their status
+    :type disable_colors: bool
+    :keyword include_all_reports: If all reports should be logged instead of the
+        highest ones.
+    :type include_all_reports: bool
+    """
+    logger.task("Pre-conversion analysis report")
+    _summary(results, include_all_reports, disable_colors)
+
+
+def post_conversion_report(results, include_all_reports=False, disable_colors=False):
+    """Wrapper around summary to output post-conversion report.
+
+    :param results: Results dictionary as returned by :func:`run_actions`
+    :type results: Mapping
+    :keyword disable_colors: Whether to color the messages according to their status
+    :type disable_colors: bool
+    :keyword include_all_reports: If all reports should be logged instead of the
+        highest ones.
+    :type include_all_reports: bool
+    """
+    logger.task("Post-conversion report")
+    _summary(results, include_all_reports, disable_colors)
+
+
+def _summary(results, include_all_reports, disable_colors):
     """Output a summary regarding the actions execution.
 
     This summary is intended to be used to inform the user about the results
@@ -213,7 +246,6 @@ def summary(results, include_all_reports=False, disable_colors=False):
         highest ones.
     :type include_all_reports: bool
     """
-    logger.task("Pre-conversion analysis report")
     report = []
 
     combined_results_and_message = get_combined_results_and_message(results)
@@ -247,7 +279,7 @@ def summary(results, include_all_reports=False, disable_colors=False):
     # If there is no other message sent to the user, then we just give a
     # happy message to them.
     if not combined_results_and_message:
-        report.append("No problems detected during the analysis!")
+        report.append("No problems detected!")
 
     logger.info("%s\n" % "\n".join(report))
 
@@ -291,7 +323,7 @@ def find_highest_report_level(results):
     return highest_action_level
 
 
-def summary_as_txt(results):
+def summary_as_txt(results, txt_file):
     """
     Print the report to txt file. Used mainly by Satellite.
     Accepts the data preformatted by summary function.
@@ -317,5 +349,5 @@ def summary_as_txt(results):
     txt_result = txt_result.strip()
 
     # We need info from the last run, any old results are discarded
-    with open(CONVERT2RHEL_TXT_RESULTS, "w") as file:
+    with open(txt_file, "w") as file:
         file.write(txt_result)

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -43,6 +43,22 @@ class ConversionPhase:
     POST_PONR_CHANGES = 4
 
 
+_REPORT_MAPPING = {
+    ConversionPhase.ANALYZE_EXIT: (
+        report.CONVERT2RHEL_PRE_CONVERSION_JSON_RESULTS,
+        report.CONVERT2RHEL_PRE_CONVERSION_TXT_RESULTS,
+    ),
+    ConversionPhase.PRE_PONR_CHANGES: (
+        report.CONVERT2RHEL_PRE_CONVERSION_JSON_RESULTS,
+        report.CONVERT2RHEL_PRE_CONVERSION_TXT_RESULTS,
+    ),
+    ConversionPhase.POST_PONR_CHANGES: (
+        report.CONVERT2RHEL_POST_CONVERSION_JSON_RESULTS,
+        report.CONVERT2RHEL_POST_CONVERSION_TXT_RESULTS,
+    ),
+}
+
+
 def initialize_file_logging(log_name, log_dir):
     """
     Archive existing file logs and setup all logging handlers that require
@@ -182,16 +198,12 @@ def main_locked():
         # Write the assessment to a file as json data so that other tools can
         # parse and act upon it.
         results = _pick_conversion_results(process_phase, pre_conversion_results, post_conversion_results)
-        json_filepath = report.CONVERT2RHEL_PRE_CONVERSION_JSON_RESULTS
-        txt_filepath = report.CONVERT2RHEL_PRE_CONVERSION_TXT_RESULTS
 
-        if process_phase == ConversionPhase.POST_PONR_CHANGES:
-            json_filepath = report.CONVERT2RHEL_POST_CONVERSION_JSON_RESULTS
-            txt_filepath = report.CONVERT2RHEL_POST_CONVERSION_TXT_RESULTS
+        if results and process_phase in _REPORT_MAPPING:
+            json_report, txt_report = _REPORT_MAPPING[process_phase]
 
-        if results:
-            report.summary_as_json(results, json_filepath)
-            report.summary_as_txt(results, txt_filepath)
+            report.summary_as_json(results, json_report)
+            report.summary_as_txt(results, txt_report)
 
     return 0
 

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -166,7 +166,7 @@ def main_locked():
         rollback_changes()
 
         report.pre_conversion_report(
-            pre_conversion_results,
+            results=pre_conversion_results,
             include_all_reports=True,
             disable_colors=logger_module.should_disable_color_output(),
         )

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -170,6 +170,7 @@ def test_main(monkeypatch, tmp_path):
     raise_for_skipped_failures_mock = mock.Mock()
     report_summary_mock = mock.Mock()
     run_pre_actions_mock = mock.Mock()
+    run_pre_actions_mock = mock.Mock()
     run_post_actions_mock = mock.Mock()
     clear_versionlock_mock = mock.Mock()
     ask_to_continue_mock = mock.Mock()

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -129,6 +129,7 @@ def test_post_ponr_conversion(monkeypatch):
     monkeypatch.setattr(grub, "post_ponr_set_efi_configuration", post_ponr_set_efi_configuration_mock)
     monkeypatch.setattr(redhatrelease.YumConf, "patch", yum_conf_patch_mock)
     monkeypatch.setattr(subscription, "lock_releasever_in_rhel_repositories", lock_releasever_in_rhel_repositories_mock)
+
     main.post_ponr_conversion()
 
     assert perserve_only_rhel_kernel_mock.call_count == 1
@@ -170,7 +171,6 @@ def test_main(monkeypatch, tmp_path):
     raise_for_skipped_failures_mock = mock.Mock()
     report_summary_mock = mock.Mock()
     run_pre_actions_mock = mock.Mock()
-    run_pre_actions_mock = mock.Mock()
     run_post_actions_mock = mock.Mock()
     clear_versionlock_mock = mock.Mock()
     ask_to_continue_mock = mock.Mock()
@@ -200,7 +200,7 @@ def test_main(monkeypatch, tmp_path):
     monkeypatch.setattr(actions, "run_pre_actions", run_pre_actions_mock)
     monkeypatch.setattr(actions, "run_post_actions", run_post_actions_mock)
     monkeypatch.setattr(main, "_raise_for_skipped_failures", raise_for_skipped_failures_mock)
-    monkeypatch.setattr(report, "summary", report_summary_mock)
+    monkeypatch.setattr(report, "_summary", report_summary_mock)
     monkeypatch.setattr(utils, "ask_to_continue", ask_to_continue_mock)
     monkeypatch.setattr(main, "post_ponr_conversion", post_ponr_conversion_mock)
     monkeypatch.setattr(system_info, "modified_rpm_files_diff", rpm_files_diff_mock)
@@ -404,7 +404,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(pkghandler, "clear_versionlock", clear_versionlock_mock)
         monkeypatch.setattr(pkgmanager, "clean_yum_metadata", clean_yum_metadata_mock)
         monkeypatch.setattr(actions, "run_pre_actions", run_pre_actions_mock)
-        monkeypatch.setattr(report, "summary", report_summary_mock)
+        monkeypatch.setattr(report, "_summary", report_summary_mock)
         monkeypatch.setattr(actions, "find_actions_of_severity", find_actions_of_severity_mock)
         monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
         monkeypatch.setattr(subscription, "should_subscribe", should_subscribe_mock)
@@ -432,8 +432,8 @@ class TestRollbackFromMain:
         assert rollback_changes_mock.call_count == 1
         assert summary_as_json_mock.call_count == 1
         assert summary_as_txt_mock.call_count == 1
-        assert caplog.records[-3].message == "Conversion failed."
-        assert caplog.records[-3].levelname == "CRITICAL"
+        assert caplog.records[-4].message == "Conversion failed."
+        assert caplog.records[-4].levelname == "CRITICAL"
 
     def test_main_rollback_analyze_exit_phase_without_subman(self, global_tool_opts, monkeypatch, tmp_path):
         """
@@ -457,7 +457,7 @@ class TestRollbackFromMain:
             (pkghandler, "clear_versionlock", mock.Mock()),
             (pkgmanager, "clean_yum_metadata", mock.Mock()),
             (actions, "run_pre_actions", mock.Mock()),
-            (report, "summary", mock.Mock()),
+            (report, "_summary", mock.Mock()),
             (breadcrumbs, "finish_collection", mock.Mock()),
             (subscription, "should_subscribe", mock.Mock(side_effect=lambda: True)),
             (subscription, "update_rhsm_custom_facts", mock.Mock()),
@@ -481,7 +481,7 @@ class TestRollbackFromMain:
         assert pkghandler.clear_versionlock.call_count == 1
         assert pkgmanager.clean_yum_metadata.call_count == 1
         assert actions.run_pre_actions.call_count == 1
-        assert report.summary.call_count == 1
+        assert report._summary.call_count == 1
         assert breadcrumbs.finish_collection.call_count == 1
         assert subscription.should_subscribe.call_count == 1
         assert subscription.update_rhsm_custom_facts.call_count == 0
@@ -523,7 +523,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(pkghandler, "clear_versionlock", clear_versionlock_mock)
         monkeypatch.setattr(pkgmanager, "clean_yum_metadata", clean_yum_metadata_mock)
         monkeypatch.setattr(actions, "run_pre_actions", run_pre_actions_mock)
-        monkeypatch.setattr(report, "summary", report_summary_mock)
+        monkeypatch.setattr(report, "_summary", report_summary_mock)
         monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
         monkeypatch.setattr(subscription, "should_subscribe", should_subscribe_mock)
         monkeypatch.setattr(subscription, "update_rhsm_custom_facts", update_rhsm_custom_facts_mock)
@@ -563,6 +563,7 @@ class TestRollbackFromMain:
         collect_early_data_mock = mock.Mock()
         clean_yum_metadata_mock = mock.Mock()
         run_pre_actions_mock = mock.Mock()
+        run_post_actions_mock = mock.Mock()
         find_actions_of_severity_mock = mock.Mock(return_value=[])
         report_summary_mock = mock.Mock()
         clear_versionlock_mock = mock.Mock()
@@ -587,8 +588,9 @@ class TestRollbackFromMain:
         monkeypatch.setattr(pkghandler, "clear_versionlock", clear_versionlock_mock)
         monkeypatch.setattr(pkgmanager, "clean_yum_metadata", clean_yum_metadata_mock)
         monkeypatch.setattr(actions, "run_pre_actions", run_pre_actions_mock)
+        monkeypatch.setattr(actions, "run_post_actions", run_post_actions_mock)
         monkeypatch.setattr(actions, "find_actions_of_severity", find_actions_of_severity_mock)
-        monkeypatch.setattr(report, "summary", report_summary_mock)
+        monkeypatch.setattr(report, "_summary", report_summary_mock)
         monkeypatch.setattr(utils, "ask_to_continue", ask_to_continue_mock)
         monkeypatch.setattr(main, "post_ponr_conversion", post_ponr_conversion_mock)
         monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
@@ -606,15 +608,16 @@ class TestRollbackFromMain:
         assert collect_early_data_mock.call_count == 1
         assert clean_yum_metadata_mock.call_count == 1
         assert run_pre_actions_mock.call_count == 1
+        assert run_pre_actions_mock.call_count == 1
         assert find_actions_of_severity_mock.call_count == 1
         assert clear_versionlock_mock.call_count == 1
-        assert report_summary_mock.call_count == 1
+        assert report_summary_mock.call_count == 2
         assert ask_to_continue_mock.call_count == 1
         assert post_ponr_conversion_mock.call_count == 1
         assert finish_collection_mock.call_count == 1
         assert summary_as_json_mock.call_count == 1
         assert summary_as_txt_mock.call_count == 1
-        assert "The system is left in an undetermined state that Convert2RHEL cannot fix." in caplog.records[-2].message
+        assert "The system is left in an undetermined state that Convert2RHEL cannot fix." in caplog.records[-3].message
         assert update_rhsm_custom_facts_mock.call_count == 1
 
 


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
The report had to be updated to include the post conversion results from
the actions, since we are extending the framework and migrating the
functions to become actions, we need to make a few modifications to
adapt the reporting to work with both pre and post conversion actions.

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1347](https://issues.redhat.com/browse/RHELC-1347)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant

### Depends on 

- [x] https://github.com/oamg/convert2rhel/pull/1144
- [x] https://github.com/oamg/convert2rhel/pull/1152
