### PR TITLE
[RHELC-1328] Migrate post conversion transaction function

### DIFF
--- a/convert2rhel/actions/conversion/transaction.py
+++ b/convert2rhel/actions/conversion/transaction.py
@@ -1,0 +1,46 @@
+# Copyright(C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import logging
+
+from convert2rhel import actions, exceptions, pkgmanager
+
+
+logger = logging.getLogger(__name__)
+
+
+class ConvertSystemPackages(actions.Action):
+    id = "CONVERT_SYSTEM_PACKAGES"
+
+    def run(self):
+        """Convert the system packages using either yum/dnf."""
+        super(ConvertSystemPackages, self).run()
+
+        try:
+            logger.task("Convert: Replace system packages")
+            transaction_handler = pkgmanager.create_transaction_handler()
+            transaction_handler.run_transaction()
+        except exceptions.CriticalError as e:
+            self.set_result(
+                level="ERROR",
+                id=e.id,
+                title=e.title,
+                description=e.description,
+                diagnosis=e.diagnosis,
+                remediations=e.remediations,
+                variables=e.variables,
+            )

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -331,9 +331,6 @@ def post_ponr_changes():
 
 def post_ponr_conversion():
     """Perform main steps for system conversion."""
-    transaction_handler = pkgmanager.create_transaction_handler()
-    loggerinst.task("Convert: Replace system packages")
-    transaction_handler.run_transaction()
     loggerinst.task("Convert: Prepare kernel")
     pkghandler.preserve_only_rhel_kernel()
     loggerinst.task("Convert: List remaining non-Red Hat packages")

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -140,19 +140,18 @@ def main_locked():
         utils.ask_to_continue()
 
         process_phase = ConversionPhase.POST_PONR_CHANGES
-        # TODO(r0x0d): Just temporary, so we don't need to rush with migrating
-        # all the functions at once to the framework.
-        if "CONVERT2RHEL_EXPERIMENTAL_POST_PONR_ACTIONS" in os.environ:
-            post_conversion_results = actions.run_post_actions()
-            _raise_for_skipped_failures(post_conversion_results)
-            # Print the assessment just before we ask the user whether to continue past the PONR
-            report.summary(
-                results=post_conversion_results,
-                include_all_reports=False,
-                disable_colors=logger_module.should_disable_color_output(),
-            )
-        else:
-            post_ponr_changes()
+        post_conversion_results = actions.run_post_actions()
+
+        # TODO(r0x0d): Remove this after migrating all functions to Actions.
+        post_ponr_changes()
+
+        _raise_for_skipped_failures(post_conversion_results)
+        # Print the assessment just before we ask the user whether to continue past the PONR
+        report.summary(
+            results=post_conversion_results,
+            include_all_reports=False,
+            disable_colors=logger_module.should_disable_color_output(),
+        )
 
         loggerinst.info("\nConversion successful!\n")
 

--- a/convert2rhel/unit_tests/actions/conversion/transaction_test.py
+++ b/convert2rhel/unit_tests/actions/conversion/transaction_test.py
@@ -1,0 +1,74 @@
+# Copyright(C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+import pytest
+import six
+
+from convert2rhel import exceptions, pkgmanager, unit_tests
+from convert2rhel.actions import STATUS_CODE
+from convert2rhel.actions.conversion import transaction
+from convert2rhel.pkgmanager.handlers.base import TransactionHandlerBase
+from convert2rhel.unit_tests.conftest import all_systems
+
+
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
+
+
+@pytest.fixture
+def convert_system_packages():
+    return transaction.ConvertSystemPackages()
+
+
+@all_systems
+def test_convert_system_packages(pretend_os, convert_system_packages, monkeypatch):
+    transaction_handler_instance = mock.create_autospec(TransactionHandlerBase)
+    monkeypatch.setattr(
+        pkgmanager,
+        "create_transaction_handler",
+        mock.Mock(spec=pkgmanager.create_transaction_handler, return_value=transaction_handler_instance),
+    )
+
+    convert_system_packages.run()
+
+    assert transaction_handler_instance.run_transaction.call_count == 1
+    assert transaction_handler_instance.run_transaction.call_args == mock.call()
+    assert convert_system_packages.result.level == STATUS_CODE["SUCCESS"]
+
+
+@all_systems
+def test_convert_system_packages_unknown_error(pretend_os, convert_system_packages, monkeypatch):
+    # TODO(r0x0d): Update this test once we have better execeptions to change
+    # the SystemExit references.
+
+    monkeypatch.setattr(
+        pkgmanager,
+        "create_transaction_handler",
+        mock.Mock(
+            spec=pkgmanager.create_transaction_handler,
+            side_effect=exceptions.CriticalError(id_="ID", title="Title", description="Description"),
+        ),
+    )
+
+    convert_system_packages.run()
+
+    unit_tests.assert_actions_result(
+        convert_system_packages,
+        level="ERROR",
+        id="ID",
+        title="Title",
+        description="Description",
+    )

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -223,10 +223,9 @@ def test_main(monkeypatch, tmp_path):
     assert collect_early_data_mock.call_count == 1
     assert clean_yum_metadata_mock.call_count == 1
     assert run_pre_actions_mock.call_count == 1
-    # TODO(r0x0d): Turn this to 1 after we remove the env var.
-    assert run_post_actions_mock.call_count == 0
-    assert raise_for_skipped_failures_mock.call_count == 1
-    assert report_summary_mock.call_count == 1
+    assert run_post_actions_mock.call_count == 1
+    assert raise_for_skipped_failures_mock.call_count == 2
+    assert report_summary_mock.call_count == 2
     assert clear_versionlock_mock.call_count == 1
     assert ask_to_continue_mock.call_count == 1
     assert post_ponr_conversion_mock.call_count == 1

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -119,14 +119,12 @@ class TestShowEula:
 
 def test_post_ponr_conversion(monkeypatch):
     perserve_only_rhel_kernel_mock = mock.Mock()
-    create_transaction_handler_mock = mock.Mock()
     list_non_red_hat_pkgs_left_mock = mock.Mock()
     post_ponr_set_efi_configuration_mock = mock.Mock()
     yum_conf_patch_mock = mock.Mock()
     lock_releasever_in_rhel_repositories_mock = mock.Mock()
 
     monkeypatch.setattr(pkghandler, "preserve_only_rhel_kernel", perserve_only_rhel_kernel_mock)
-    monkeypatch.setattr(pkgmanager, "create_transaction_handler", create_transaction_handler_mock)
     monkeypatch.setattr(pkghandler, "list_non_red_hat_pkgs_left", list_non_red_hat_pkgs_left_mock)
     monkeypatch.setattr(grub, "post_ponr_set_efi_configuration", post_ponr_set_efi_configuration_mock)
     monkeypatch.setattr(redhatrelease.YumConf, "patch", yum_conf_patch_mock)
@@ -134,7 +132,6 @@ def test_post_ponr_conversion(monkeypatch):
     main.post_ponr_conversion()
 
     assert perserve_only_rhel_kernel_mock.call_count == 1
-    assert create_transaction_handler_mock.call_count == 1
     assert list_non_red_hat_pkgs_left_mock.call_count == 1
     assert post_ponr_set_efi_configuration_mock.call_count == 1
     assert yum_conf_patch_mock.call_count == 1


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
First function to be converted to the actions is done in this commit.
This function is responsible for converting system packages to rhel
packages, thus, being the first function to be executed, it was the
first one to be migrated as well.

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1328](https://issues.redhat.com/browse/RHELC-1328)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant

### Depends on 

- [x] https://github.com/oamg/convert2rhel/pull/1144

