### PR TITLE
[RHELC-1275, RHELC-1516] Exit with 1 when rollback fails

### DIFF
--- a/convert2rhel/backup/certs.py
+++ b/convert2rhel/backup/certs.py
@@ -146,6 +146,11 @@ class RestorablePEMCert(RestorableChange):
     def _restore(self):
         """The actual code to remove the certificate.  Done in a helper method so we can handle all
         the cases where we do not want to remove and still run the base class's restore().
+
+            .. warning::
+                Exceptions are not handled and left for handling by the calling code.
+
+        :raises OSError: Can be raised when the file is not found.
         """
         # Check whether any package owns the certificate file.  It is
         # possible that a new rpm package was installed after we copied the
@@ -187,8 +192,10 @@ class RestorablePEMCert(RestorableChange):
             if err.errno == errno.ENOENT:
                 # Resolves RHSM error when removing certs, as the system might not have installed any certs yet
                 loggerinst.info("No certificates found to be removed.")
-            else:
-                loggerinst.error("OSError({0}): {1}".format(err.errno, err.strerror))
+                return
+
+            # Will be handled in BackupController
+            raise
 
 
 def _get_cert(cert_dir):

--- a/convert2rhel/backup/files.py
+++ b/convert2rhel/backup/files.py
@@ -179,8 +179,8 @@ class MissingFile(RestorableChange):
     def restore(self):
         """Remove the file if it was created during conversion.
 
-            .. warning::
-                Exceptions are not handled and left for handling by the calling code.
+        .. warning::
+            Exceptions are not handled and left for handling by the calling code.
 
         :raises OSError: When the removal of the file fails.
         :raises IOError: When the removal of the file fails.

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -198,7 +198,7 @@ def main_locked():
         provide_status_after_rollback(pre_conversion_results, include_all_reports=True)
 
         if backup.backup_control.rollback_failed:
-            return 1
+            return ConversionExitCodes.FAILURE
 
         report.pre_conversion_report(
             results=pre_conversion_results,

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -195,6 +195,10 @@ def main_locked():
             subscription.update_rhsm_custom_facts()
 
         rollback_changes()
+        provide_status_after_rollback(pre_conversion_results, include_all_reports=True)
+
+        if backup.backup_control.rollback_failed:
+            return 1
 
         report.pre_conversion_report(
             results=pre_conversion_results,
@@ -202,7 +206,6 @@ def main_locked():
             disable_colors=logger_module.should_disable_color_output(),
         )
         return ConversionExitCodes.SUCCESSFUL
-
     except _InhibitorsFound as err:
         loggerinst.critical_no_exit(str(err))
         _handle_main_exceptions(process_phase, pre_conversion_results)
@@ -215,15 +218,16 @@ def main_locked():
         results = _pick_conversion_results(process_phase, pre_conversion_results, post_conversion_results)
         return _handle_main_exceptions(process_phase, results)
     finally:
-        # Write the assessment to a file as json data so that other tools can
-        # parse and act upon it.
-        results = _pick_conversion_results(process_phase, pre_conversion_results, post_conversion_results)
+        if not backup.backup_control.rollback_failed:
+            # Write the assessment to a file as json data so that other tools can
+            # parse and act upon it.
+            results = _pick_conversion_results(process_phase, pre_conversion_results, post_conversion_results)
 
-        if results and process_phase in _REPORT_MAPPING:
-            json_report, txt_report = _REPORT_MAPPING[process_phase]
+            if results and process_phase in _REPORT_MAPPING:
+                json_report, txt_report = _REPORT_MAPPING[process_phase]
 
-            report.summary_as_json(results, json_report)
-            report.summary_as_txt(results, txt_report)
+                report.summary_as_json(results, json_report)
+                report.summary_as_txt(results, txt_report)
 
     return ConversionExitCodes.SUCCESSFUL
 
@@ -277,14 +281,10 @@ def _handle_main_exceptions(process_phase, results=None):
             subscription.update_rhsm_custom_facts()
 
         rollback_changes()
-        if results is None:
-            loggerinst.info("\nConversion interrupted before analysis of system completed. Report not generated.\n")
-        else:
-            report.pre_conversion_report(
-                results=results,
-                include_all_reports=True,
-                disable_colors=logger_module.should_disable_color_output(),
-            )
+        provide_status_after_rollback(
+            pre_conversion_results=results,
+            include_all_reports=True,
+        )
     elif process_phase == ConversionPhase.POST_PONR_CHANGES:
         # After the process of subscription is done and the mass update of
         # packages is started convert2rhel will not be able to guarantee a
@@ -421,3 +421,32 @@ def rollback_changes():
             loggerinst.info("During rollback there were no backups to restore")
         else:
             raise
+
+    return
+
+
+def provide_status_after_rollback(pre_conversion_results, include_all_reports):
+    """Print after-rollback messages and determine if there is a report to print or
+    if report shouldn't be printed after failure in rollback."""
+    if backup.backup_control.rollback_failed:
+        loggerinst.critical_no_exit(
+            "Rollback of system wasn't completed successfully.\n"
+            "The system is left in an undetermined state that Convert2RHEL cannot fix.\n"
+            "It is strongly recommended to store the Convert2RHEL logs for later investigation, and restore"
+            " the system from a backup.\n"
+            "Following errors were captured during rollback:\n"
+            "%s" % "\n".join(backup.backup_control.rollback_failures)
+        )
+
+        return
+
+    if not pre_conversion_results:
+        loggerinst.info("\nConversion interrupted before analysis of system completed. Report not generated.\n")
+
+        return
+
+    report.pre_conversion_report(
+        results=pre_conversion_results,
+        include_all_reports=include_all_reports,
+        disable_colors=logger_module.should_disable_color_output(),
+    )

--- a/convert2rhel/unit_tests/__init__.py
+++ b/convert2rhel/unit_tests/__init__.py
@@ -379,6 +379,10 @@ class RollbackChangesMocked(MockFunctionObject):
     spec = main.rollback_changes
 
 
+class PrintInfoAfterRollbackMocked(MockFunctionObject):
+    spec = main.provide_status_after_rollback
+
+
 class ShowEulaMocked(MockFunctionObject):
     spec = main.show_eula
 

--- a/convert2rhel/unit_tests/backup/certs_test.py
+++ b/convert2rhel/unit_tests/backup/certs_test.py
@@ -246,10 +246,6 @@ class TestPEMCert:
                 OSError(2, "No such file or directory"),
                 "No such file or directory",
             ),
-            (
-                OSError(13, "[Errno 13] Permission denied: '/tmpdir/certfile'"),
-                "OSError(13): Permission denied: '/tmpdir/certfile'",
-            ),
         ),
     )
     def test_restore_cert_error_conditions(
@@ -265,6 +261,16 @@ class TestPEMCert:
 
         for message in caplog.messages:
             assert text_not_expected_in_logs not in message
+
+    def test_restore_cert_error_raised(self, system_cert_with_target_path, monkeypatch, caplog):
+        monkeypatch.setattr(os, "remove", mock.Mock(side_effect=OSError(1, "Operation not permitted")))
+
+        system_cert_with_target_path.enable()
+
+        with pytest.raises(OSError):
+            system_cert_with_target_path.restore()
+
+        assert "No certificates found to be removed." not in caplog.text
 
     @pytest.mark.parametrize(
         ("rpm_exit_code", "rpm_stdout", "expected"),

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -571,7 +571,7 @@ class TestRollbackFromMain:
         assert pkghandler.clear_versionlock.call_count == 1
         assert pkgmanager.clean_yum_metadata.call_count == 1
         assert actions.run_pre_actions.call_count == 1
-        assert report._summary.call_count == 1
+        assert report._summary.call_count == 2
         assert breadcrumbs.finish_collection.call_count == 1
         assert subscription.should_subscribe.call_count == 1
         assert subscription.update_rhsm_custom_facts.call_count == 0
@@ -633,7 +633,7 @@ class TestRollbackFromMain:
         assert collect_early_data_mock.call_count == 1
         assert clean_yum_metadata_mock.call_count == 1
         assert run_pre_actions_mock.call_count == 1
-        assert report_summary_mock.call_count == 1
+        assert report_summary_mock.call_count == 2
         assert clear_versionlock_mock.call_count == 1
         assert finish_collection_mock.call_count == 1
         assert should_subscribe_mock.call_count == 1


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
There is a need to exit with exit code 1 when rollback fails to provide the ability to better recognize those types of failures for Insights. This situation can mainly happen when user uses analyze command or during the conversion answers "No" and user doesn't want to continue over point of no return. In those situations, rollback is processed and when it fails, the system is in an unknown state.

**Expected behavior:**
When rollback fails, c2r exits with 1, warning about unknown state and system should be restored from backup is printed. Any summaries of the report aren't printed or saved - because there is any big value of the report when the rollback failed.

**How it was solved:**
The new property `backup_failed` of BackupController was added. This property is based on instance variable `_rollback_failed` which is set when restore method of some restorable fails. 

I chose this solution because it keeps the code simple. Other solution with returning some value required a lot of code changed and added complexity to the codebase.

I also added a new function in `main.py` for printing info after rollback, which we do in two places. The goal was to reduce duplicity in this part of code.

To have captured exceptions during the rollback, I've also removed handling of exceptions in each restorable and let it up to `BackupController`. By this change I found a bug in the code, when the restorable file was removed from the backup folder when doing the restore for conversion purposes.  The file should stay in the backup folder, if we would remove it, then we won't have anything when processing the rollback.


<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1275](https://issues.redhat.com/browse/RHELC-1275), [RHELC-1516](https://issues.redhat.com/browse/RHELC-1516)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
