### PR TITLE
[RHELC-1465] Set consistent task prefix for pre-conversion

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/handle_packages.py
+++ b/convert2rhel/actions/pre_ponr_changes/handle_packages.py
@@ -39,7 +39,7 @@ class ListThirdPartyPackages(actions.Action):
         """
         super(ListThirdPartyPackages, self).run()
 
-        logger.task("Convert: List third-party packages")
+        logger.task("Prepare: List third-party packages")
         third_party_pkgs = pkghandler.get_third_party_pkgs()
         if third_party_pkgs:
             pkg_list = pkghandler.format_pkg_info(sorted(third_party_pkgs, key=self.extract_packages))
@@ -94,11 +94,11 @@ class RemoveSpecialPackages(actions.Action):
         all_pkgs = []
         pkgs_removed = []
         try:
-            logger.task("Convert: Searching for the following excluded packages")
+            logger.task("Prepare: Searching for the following excluded packages")
             excluded_pkgs = sorted(pkghandler.get_packages_to_remove(system_info.excluded_pkgs))
 
             logger.task(
-                "Convert: Searching for packages containing .repo files or affecting variables in the .repo files"
+                "Prepare: Searching for packages containing .repo files or affecting variables in the .repo files"
             )
             repofile_pkgs = sorted(pkghandler.get_packages_to_remove(system_info.repofile_pkgs))
 

--- a/convert2rhel/actions/pre_ponr_changes/special_cases.py
+++ b/convert2rhel/actions/pre_ponr_changes/special_cases.py
@@ -47,7 +47,7 @@ class RemoveIwlax2xxFirmware(actions.Action):
         """
         super(RemoveIwlax2xxFirmware, self).run()
 
-        logger.task("Convert: Resolve possible edge case")
+        logger.task("Prepare: Resolve possible edge case")
         iwl7260_firmware = system_info.is_rpm_installed(name="iwl7260-firmware")
         iwlax2xx_firmware = system_info.is_rpm_installed(name="iwlax2xx-firmware")
 

--- a/convert2rhel/actions/pre_ponr_changes/subscription.py
+++ b/convert2rhel/actions/pre_ponr_changes/subscription.py
@@ -48,7 +48,7 @@ class InstallRedHatCertForYumRepositories(actions.Action):
         # The subscription-manager-rhsm-certificates package contains this cert but for
         # example on CentOS Linux 7 this package is missing the cert due to intentional
         # debranding. Thus we need to ensure the cert is in place even when the pkg is installed.
-        logger.task("Convert: Install cdn.redhat.com SSL CA certificate")
+        logger.task("Prepare: Install cdn.redhat.com SSL CA certificate")
         repo_cert = RestorablePEMCert(_REDHAT_CDN_CACERT_SOURCE_DIR, _REDHAT_CDN_CACERT_TARGET_DIR)
         backup.backup_control.push(repo_cert)
 
@@ -61,7 +61,7 @@ class InstallRedHatGpgKeyForRpm(actions.Action):
 
         # Import the Red Hat GPG Keys for installing Subscription-manager
         # and for later.
-        logger.task("Convert: Import Red Hat GPG keys")
+        logger.task("Prepare: Import Red Hat GPG keys")
         pkghandler.install_gpg_keys()
 
 
@@ -93,12 +93,12 @@ class PreSubscription(actions.Action):
             return
 
         try:
-            logger.task("Convert: Subscription Manager - Check for installed packages")
+            logger.task("Prepare: Subscription Manager - Check for installed packages")
             subscription_manager_pkgs = subscription.needed_subscription_manager_pkgs()
             if not subscription_manager_pkgs:
                 logger.info("Subscription Manager is already present")
             else:
-                logger.task("Convert: Subscription Manager - Install packages")
+                logger.task("Prepare: Subscription Manager - Install packages")
                 # Hack for 1.4: if we install subscription-manager from the UBI repo, it
                 # may require newer versions of packages than provided by the vendor.
                 # (Note: the function is marked private because this is a hack
@@ -107,10 +107,10 @@ class PreSubscription(actions.Action):
                 update_pkgs = subscription._dependencies_to_update(subscription_manager_pkgs)
                 subscription.install_rhel_subscription_manager(subscription_manager_pkgs, update_pkgs)
 
-            logger.task("Convert: Subscription Manager - Verify installation")
+            logger.task("Prepare: Subscription Manager - Verify installation")
             subscription.verify_rhsm_installed()
 
-            logger.task("Convert: Install a RHEL product certificate for RHSM")
+            logger.task("Prepare: Install a RHEL product certificate for RHSM")
             product_cert = RestorablePEMCert(_RHSM_PRODUCT_CERT_SOURCE_DIR, _RHSM_PRODUCT_CERT_TARGET_DIR)
             backup.backup_control.push(product_cert)
 
@@ -167,7 +167,7 @@ class SubscribeSystem(actions.Action):
                 )
                 return
 
-            logger.task("Convert: Subscription Manager - Reload configuration")
+            logger.task("Prepare: Subscription Manager - Reload configuration")
             # We will use subscription-manager later to enable the RHEL repos so we need to make
             # sure subscription-manager knows about the product certificate. Refreshing
             # subscription info will do that.
@@ -192,19 +192,19 @@ class SubscribeSystem(actions.Action):
             # condition or a separate Action.  Not doing it now because we
             # have to disentangle the exception handling when we do that.
             if subscription.should_subscribe():
-                logger.task("Convert: Subscription Manager - Subscribe system")
+                logger.task("Prepare: Subscription Manager - Subscribe system")
                 restorable_subscription = subscription.RestorableSystemSubscription()
                 backup.backup_control.push(restorable_subscription)
 
-            logger.task("Convert: Get RHEL repository IDs")
+            logger.task("Prepare: Get RHEL repository IDs")
             rhel_repoids = repo.get_rhel_repoids()
 
-            logger.task("Convert: Subscription Manager - Disable all repositories")
+            logger.task("Prepare: Subscription Manager - Disable all repositories")
             subscription.disable_repos()
 
             # we need to enable repos after removing repofile pkgs, otherwise
             # we don't get backups to restore from on a rollback
-            logger.task("Convert: Subscription Manager - Enable RHEL repositories")
+            logger.task("Prepare: Subscription Manager - Enable RHEL repositories")
             subscription.enable_repos(rhel_repoids)
         except OSError as e:
             # This should not occur anymore as all the relevant OSError has been changed to a CriticalError

--- a/tests/integration/tier0/non-destructive/problematic-third-party-pkgs/main.fmf
+++ b/tests/integration/tier0/non-destructive/problematic-third-party-pkgs/main.fmf
@@ -9,7 +9,7 @@ description+: |
     summary+: |
         List third party packages check
     description+: |
-        This test verifies, that the  TASK - [Convert: List third-party packages]
+        This test verifies, that the  TASK - [Prepare: List third-party packages]
         won't fail listing packages if previously problematic third party packages are installed.
         Installed package(s):
         v8-devel from the epel repository

--- a/tests/integration/tier0/non-destructive/problematic-third-party-pkgs/test_problematic_third_party_pkgs.py
+++ b/tests/integration/tier0/non-destructive/problematic-third-party-pkgs/test_problematic_third_party_pkgs.py
@@ -6,7 +6,7 @@ from envparse import env
 @pytest.fixture
 def problematic_third_party_package(shell):
     """
-    Install problematic package which previously caused the TASK - [Convert: List third-party packages]
+    Install problematic package which previously caused the TASK - [Prepare: List third-party packages]
     to fail.
     Installed package(s):
     v8-devel from the epel repository
@@ -29,7 +29,7 @@ def problematic_third_party_package(shell):
 @pytest.mark.test_list_third_party_pkgs_error
 def test_list_third_party_pkgs_error(convert2rhel, problematic_third_party_package):
     """
-    This test verifies, that the  TASK - [Convert: List third-party packages]
+    This test verifies, that the  TASK - [Prepare: List third-party packages]
     won't fail listing packages if previously problematic third party packages are installed.
     Installed package(s):
     v8-devel from the epel repository

--- a/tests/integration/tier0/non-destructive/rollback-handling/test_rollback_handling.py
+++ b/tests/integration/tier0/non-destructive/rollback-handling/test_rollback_handling.py
@@ -169,7 +169,7 @@ def test_proper_rhsm_clean_up(shell, convert2rhel):
 
         # Wait till the system is properly registered and subscribed, then
         # send the interrupt signal to the c2r process.
-        c2r.expect("Convert: Get RHEL repository IDs")
+        c2r.expect("Prepare: Get RHEL repository IDs")
         c2r.sendcontrol("c")
 
         c2r.expect("Calling command 'subscription-manager unregister'", timeout=120)
@@ -256,9 +256,5 @@ def test_terminate_registration_success(convert2rhel):
         c2r.expect("Auto-attaching compatible subscriptions to the system ...", timeout=180)
         c2r.expect("DEBUG - Calling command 'subscription-manager attach --auto'", timeout=180)
         c2r.expect("Status:       Subscribed", timeout=180)
-        # TODO [mlitwora]: If the SIGINT is sent right after the Status: Subscribed, then the system ends up in broken stat
-        # that makes another c2r unsuccessful. Waiting little bit longer fixes the problem but probably makes the
-        # test "useless".
-        # c2r.expect("Convert: Get RHEL repository IDs")
         terminate_and_assert_good_rollback(c2r)
     assert c2r.exitstatus != 0


### PR DESCRIPTION
Some task headers for pre-conversion were using "Convert" instead of "Prepare". Since we are dealing with actions that are present before we start the conversion, all of those log tasks were changed to contain the word "Prepare" instead to not sound confusing to the user as what is happening.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1465](https://issues.redhat.com/browse/RHELC-1465)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
