### PR TITLE
Introduce new log levels

### DIFF
--- a/convert2rhel/actions/__init__.py
+++ b/convert2rhel/actions/__init__.py
@@ -520,7 +520,7 @@ class Stage:
             running is WARNING or better (WARNING or SUCCESS) and
             failure as worse than WARNING (OVERRIDABLE, ERROR)
         """
-        logger.task("Prepare: %s" % self.task_header)
+        logger.prepare(self.task_header)
 
         if self._has_run:
             raise ActionError("Stage %s has already run." % self.stage_name)

--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -49,7 +49,7 @@ class BackupRedhatRelease(actions.Action):
 
     def run(self):
         """Backup redhat release file before starting conversion process"""
-        loggerinst.task("Prepare: Backup Redhat Release Files")
+        loggerinst.prepare("Backup Redhat Release Files")
 
         super(BackupRedhatRelease, self).run()
 
@@ -76,7 +76,7 @@ class BackupRepository(actions.Action):
 
     def run(self):
         """Backup repository files before starting conversion process"""
-        loggerinst.task("Prepare: Backup Repository Files")
+        loggerinst.prepare("Backup Repository Files")
 
         super(BackupRepository, self).run()
 
@@ -104,7 +104,7 @@ class BackupYumVariables(actions.Action):
 
     def run(self):
         """Backup varsdir folder in /etc/{yum,dnf}/vars so the variables can be restored on rollback."""
-        loggerinst.task("Prepare: Backup variables")
+        loggerinst.prepare("Backup variables")
 
         super(BackupYumVariables, self).run()
 
@@ -145,7 +145,7 @@ class BackupPackageFiles(actions.Action):
         """Backup changed package files"""
         super(BackupPackageFiles, self).run()
 
-        loggerinst.task("Prepare: Backup package files")
+        loggerinst.prepare("Backup package files")
 
         package_files_changes = self._get_changed_package_files()
 

--- a/convert2rhel/actions/pre_ponr_changes/handle_packages.py
+++ b/convert2rhel/actions/pre_ponr_changes/handle_packages.py
@@ -39,7 +39,7 @@ class ListThirdPartyPackages(actions.Action):
         """
         super(ListThirdPartyPackages, self).run()
 
-        logger.task("Convert: List third-party packages")
+        logger.convert("List third-party packages")
         third_party_pkgs = pkghandler.get_third_party_pkgs()
         if third_party_pkgs:
             pkg_list = pkghandler.format_pkg_info(sorted(third_party_pkgs, key=self.extract_packages))
@@ -94,7 +94,7 @@ class RemoveSpecialPackages(actions.Action):
         all_pkgs = []
         pkgs_removed = []
         try:
-            logger.task("Convert: Searching for the following excluded packages")
+            logger.convert("Searching for the following excluded packages")
             excluded_pkgs = sorted(pkghandler.get_packages_to_remove(system_info.excluded_pkgs))
 
             logger.task(

--- a/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
+++ b/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
@@ -238,7 +238,7 @@ class EnsureKernelModulesCompatibility(actions.Action):
         """Ensure that the host kernel modules are compatible with RHEL."""
         super(EnsureKernelModulesCompatibility, self).run()
 
-        logger.task("Prepare: Ensure kernel modules compatibility with RHEL")
+        logger.prepare("Ensure kernel modules compatibility with RHEL")
 
         try:
             host_kmods = self._get_loaded_kmods()

--- a/convert2rhel/actions/pre_ponr_changes/special_cases.py
+++ b/convert2rhel/actions/pre_ponr_changes/special_cases.py
@@ -47,7 +47,7 @@ class RemoveIwlax2xxFirmware(actions.Action):
         """
         super(RemoveIwlax2xxFirmware, self).run()
 
-        logger.task("Convert: Resolve possible edge case")
+        logger.convert("Resolve possible edge case")
         iwl7260_firmware = system_info.is_rpm_installed(name="iwl7260-firmware")
         iwlax2xx_firmware = system_info.is_rpm_installed(name="iwlax2xx-firmware")
 

--- a/convert2rhel/actions/pre_ponr_changes/subscription.py
+++ b/convert2rhel/actions/pre_ponr_changes/subscription.py
@@ -48,7 +48,7 @@ class InstallRedHatCertForYumRepositories(actions.Action):
         # The subscription-manager-rhsm-certificates package contains this cert but for
         # example on CentOS Linux 7 this package is missing the cert due to intentional
         # debranding. Thus we need to ensure the cert is in place even when the pkg is installed.
-        logger.task("Convert: Install cdn.redhat.com SSL CA certificate")
+        logger.convert("Install cdn.redhat.com SSL CA certificate")
         repo_cert = RestorablePEMCert(_REDHAT_CDN_CACERT_SOURCE_DIR, _REDHAT_CDN_CACERT_TARGET_DIR)
         backup.backup_control.push(repo_cert)
 
@@ -61,7 +61,7 @@ class InstallRedHatGpgKeyForRpm(actions.Action):
 
         # Import the Red Hat GPG Keys for installing Subscription-manager
         # and for later.
-        logger.task("Convert: Import Red Hat GPG keys")
+        logger.convert("Import Red Hat GPG keys")
         pkghandler.install_gpg_keys()
 
 
@@ -93,12 +93,12 @@ class PreSubscription(actions.Action):
             return
 
         try:
-            logger.task("Convert: Subscription Manager - Check for installed packages")
+            logger.convert("Subscription Manager - Check for installed packages")
             subscription_manager_pkgs = subscription.needed_subscription_manager_pkgs()
             if not subscription_manager_pkgs:
                 logger.info("Subscription Manager is already present")
             else:
-                logger.task("Convert: Subscription Manager - Install packages")
+                logger.convert("Subscription Manager - Install packages")
                 # Hack for 1.4: if we install subscription-manager from the UBI repo, it
                 # may require newer versions of packages than provided by the vendor.
                 # (Note: the function is marked private because this is a hack
@@ -107,10 +107,10 @@ class PreSubscription(actions.Action):
                 update_pkgs = subscription._dependencies_to_update(subscription_manager_pkgs)
                 subscription.install_rhel_subscription_manager(subscription_manager_pkgs, update_pkgs)
 
-            logger.task("Convert: Subscription Manager - Verify installation")
+            logger.convert("Subscription Manager - Verify installation")
             subscription.verify_rhsm_installed()
 
-            logger.task("Convert: Install a RHEL product certificate for RHSM")
+            logger.convert("Install a RHEL product certificate for RHSM")
             product_cert = RestorablePEMCert(_RHSM_PRODUCT_CERT_SOURCE_DIR, _RHSM_PRODUCT_CERT_TARGET_DIR)
             backup.backup_control.push(product_cert)
 
@@ -167,7 +167,7 @@ class SubscribeSystem(actions.Action):
                 )
                 return
 
-            logger.task("Convert: Subscription Manager - Reload configuration")
+            logger.convert("Subscription Manager - Reload configuration")
             # We will use subscription-manager later to enable the RHEL repos so we need to make
             # sure subscription-manager knows about the product certificate. Refreshing
             # subscription info will do that.
@@ -192,19 +192,19 @@ class SubscribeSystem(actions.Action):
             # condition or a separate Action.  Not doing it now because we
             # have to disentangle the exception handling when we do that.
             if subscription.should_subscribe():
-                logger.task("Convert: Subscription Manager - Subscribe system")
+                logger.convert("Subscription Manager - Subscribe system")
                 restorable_subscription = subscription.RestorableSystemSubscription()
                 backup.backup_control.push(restorable_subscription)
 
-            logger.task("Convert: Get RHEL repository IDs")
+            logger.convert("Get RHEL repository IDs")
             rhel_repoids = repo.get_rhel_repoids()
 
-            logger.task("Convert: Subscription Manager - Disable all repositories")
+            logger.convert("Subscription Manager - Disable all repositories")
             subscription.disable_repos()
 
             # we need to enable repos after removing repofile pkgs, otherwise
             # we don't get backups to restore from on a rollback
-            logger.task("Convert: Subscription Manager - Enable RHEL repositories")
+            logger.convert("Subscription Manager - Enable RHEL repositories")
             subscription.enable_repos(rhel_repoids)
         except OSError as e:
             # This should not occur anymore as all the relevant OSError has been changed to a CriticalError

--- a/convert2rhel/actions/pre_ponr_changes/transaction.py
+++ b/convert2rhel/actions/pre_ponr_changes/transaction.py
@@ -42,7 +42,7 @@ class ValidatePackageManagerTransaction(actions.Action):
         super(ValidatePackageManagerTransaction, self).run()
 
         try:
-            logger.task("Prepare: Validate the %s transaction", pkgmanager.TYPE)
+            logger.prepare("Validate the %s transaction", pkgmanager.TYPE)
             transaction_handler = pkgmanager.create_transaction_handler()
             transaction_handler.run_transaction(
                 validate_transaction=True,

--- a/convert2rhel/actions/system_checks/check_firewalld_availability.py
+++ b/convert2rhel/actions/system_checks/check_firewalld_availability.py
@@ -85,7 +85,7 @@ class CheckFirewalldAvailability(actions.Action):
     def run(self):
         """Error out if the firewalld service is running on the system."""
         super(CheckFirewalldAvailability, self).run()
-        logger.task("Prepare: Check that firewalld is running")
+        logger.prepare("Check that firewalld is running")
 
         if system_info.id == "oracle" and system_info.version.major == 8 and system_info.version.minor >= 8:
             # If firewalld is not present on the system, we can just skip skip.

--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -55,7 +55,7 @@ class Convert2rhelLatest(actions.Action):
 
     def run(self):
         """Make sure that we are running the latest downstream version of convert2rhel"""
-        logger.task("Prepare: Check if this is the latest version of Convert2RHEL")
+        logger.prepare("Check if this is the latest version of Convert2RHEL")
 
         super(Convert2rhelLatest, self).run()
 

--- a/convert2rhel/actions/system_checks/custom_repos_are_valid.py
+++ b/convert2rhel/actions/system_checks/custom_repos_are_valid.py
@@ -35,7 +35,7 @@ class CustomReposAreValid(actions.Action):
         - the repository "baseurl" is accessible and contains repository metadata
         """
         super(CustomReposAreValid, self).run()
-        logger.task("Prepare: Check if --enablerepo repositories are accessible")
+        logger.prepare("Check if --enablerepo repositories are accessible")
 
         if not tool_opts.no_rhsm:
             logger.info("Did not perform the check of repositories due to the use of RHSM for the conversion.")

--- a/convert2rhel/actions/system_checks/dbus.py
+++ b/convert2rhel/actions/system_checks/dbus.py
@@ -30,7 +30,7 @@ class DbusIsRunning(actions.Action):
     def run(self):
         """Error out if we need to register with rhsm and the dbus daemon is not running."""
         super(DbusIsRunning, self).run()
-        logger.task("Prepare: Check that DBus Daemon is running")
+        logger.prepare("Check that DBus Daemon is running")
 
         if not subscription.should_subscribe():
             logger.info("Did not perform the check because we have been asked not to subscribe this system to RHSM.")

--- a/convert2rhel/actions/system_checks/duplicate_packages.py
+++ b/convert2rhel/actions/system_checks/duplicate_packages.py
@@ -30,7 +30,7 @@ class DuplicatePackages(actions.Action):
         """Ensure that there are no duplicate system packages installed."""
         super(DuplicatePackages, self).run()
 
-        logger.task("Prepare: Check if there are any duplicate installed packages on the system")
+        logger.prepare("Check if there are any duplicate installed packages on the system")
         output, _ = utils.run_subprocess(["/usr/bin/package-cleanup", "--dupes", "--quiet"], print_output=False)
         if not output:
             return

--- a/convert2rhel/actions/system_checks/efi.py
+++ b/convert2rhel/actions/system_checks/efi.py
@@ -32,7 +32,7 @@ class Efi(actions.Action):
         """Inhibit the conversion when we are not able to handle UEFI."""
         super(Efi, self).run()
 
-        logger.task("Prepare: Check the firmware interface type (BIOS/UEFI)")
+        logger.prepare("Check the firmware interface type (BIOS/UEFI)")
         if not grub.is_efi():
             logger.info("BIOS detected.")
             return

--- a/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
+++ b/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
@@ -35,7 +35,7 @@ class IsLoadedKernelLatest(actions.Action):
     def run(self):  # pylint: disable= too-many-return-statements
         """Check if the loaded kernel is behind or of the same version as in yum repos."""
         super(IsLoadedKernelLatest, self).run()
-        logger.task("Prepare: Check if the loaded kernel version is the most recent")
+        logger.prepare("Check if the loaded kernel version is the most recent")
 
         if system_info.id == "oracle" and system_info.eus_system:
             logger.info(

--- a/convert2rhel/actions/system_checks/package_updates.py
+++ b/convert2rhel/actions/system_checks/package_updates.py
@@ -33,7 +33,7 @@ class PackageUpdates(actions.Action):
     def run(self):
         """Ensure that the system packages installed are up-to-date."""
         super(PackageUpdates, self).run()
-        logger.task("Prepare: Check if the installed packages are up-to-date")
+        logger.prepare("Check if the installed packages are up-to-date")
 
         if system_info.id == "oracle" and system_info.eus_system:
             logger.info(

--- a/convert2rhel/actions/system_checks/readonly_mounts.py
+++ b/convert2rhel/actions/system_checks/readonly_mounts.py
@@ -48,7 +48,7 @@ class ReadonlyMountMnt(actions.Action):
 
     def run(self):
         super(ReadonlyMountMnt, self).run()
-        logger.task("Prepare: Check if /mnt is read-write")
+        logger.prepare("Check if /mnt is read-write")
 
         if readonly_mount_detection("/mnt"):
             self.set_result(
@@ -67,7 +67,7 @@ class ReadonlyMountSys(actions.Action):
 
     def run(self):
         super(ReadonlyMountSys, self).run()
-        logger.task("Prepare: Check if /sys is read-write")
+        logger.prepare("Check if /sys is read-write")
 
         if readonly_mount_detection("/sys"):
             self.set_result(

--- a/convert2rhel/actions/system_checks/rhel_compatible_kernel.py
+++ b/convert2rhel/actions/system_checks/rhel_compatible_kernel.py
@@ -58,7 +58,7 @@ class RhelCompatibleKernel(actions.Action):
         original system.
         """
         super(RhelCompatibleKernel, self).run()
-        logger.task("Prepare: Check kernel compatibility with RHEL")
+        logger.prepare("Check kernel compatibility with RHEL")
         for check_function in (_bad_kernel_version, _bad_kernel_package_signature, _bad_kernel_substring):
             try:
                 check_function(system_info.booted_kernel)

--- a/convert2rhel/actions/system_checks/tainted_kmods.py
+++ b/convert2rhel/actions/system_checks/tainted_kmods.py
@@ -42,7 +42,7 @@ class TaintedKmods(actions.Action):
         """
         super(TaintedKmods, self).run()
 
-        logger.task("Prepare: Check if loaded kernel modules are not tainted")
+        logger.prepare("Check if loaded kernel modules are not tainted")
         unsigned_modules, _ = run_subprocess(["grep", "(", "/proc/modules"])
         module_names = "\n  ".join([mod.split(" ")[0] for mod in unsigned_modules.splitlines()])
         tainted_kmods_skip = os.environ.get("CONVERT2RHEL_TAINTED_KERNEL_MODULE_CHECK_SKIP", None)

--- a/convert2rhel/backup/certs.py
+++ b/convert2rhel/backup/certs.py
@@ -133,7 +133,7 @@ class RestorablePEMCert(RestorableChange):
 
     def restore(self):
         """Remove certificate (.pem), which was copied to system's cert dir."""
-        loggerinst.task("Rollback: Remove installed certificate")
+        loggerinst.rollback("Remove installed certificate")
 
         if self.enabled and not self.previously_installed:
             self._restore()

--- a/convert2rhel/backup/files.py
+++ b/convert2rhel/backup/files.py
@@ -109,7 +109,7 @@ class RestorableFile(RestorableChange):
     def restore(self, rollback=True):
         """Restore a previously backed up file"""
         if rollback:
-            loggerinst.task("Rollback: Restore %s from backup" % self.filepath)
+            loggerinst.rollback("Restore %s from backup" % self.filepath)
         else:
             loggerinst.info("Restoring %s from backup" % self.filepath)
 
@@ -174,7 +174,7 @@ class MissingFile(RestorableChange):
         if not self.enabled:
             return
 
-        loggerinst.task("Rollback: remove file created during conversion {filepath}".format(filepath=self.filepath))
+        loggerinst.rollback("remove file created during conversion {filepath}".format(filepath=self.filepath))
 
         if not os.path.isfile(self.filepath):
             loggerinst.info("File {filepath} wasn't created during conversion".format(filepath=self.filepath))

--- a/convert2rhel/backup/packages.py
+++ b/convert2rhel/backup/packages.py
@@ -178,7 +178,7 @@ class RestorablePackage(RestorableChange):
 
         utils.remove_orphan_folders()
 
-        loggerinst.task("Rollback: Install removed packages")
+        loggerinst.rollback("Install removed packages")
         if not self._backedup_pkgs_paths:
             loggerinst.warning("Couldn't find a backup for %s package." % ",".join(self.pkgs))
             return
@@ -379,7 +379,7 @@ class RestorablePackageSet(RestorableChange):
         if not self.enabled:
             return
 
-        loggerinst.task("Rollback: Remove installed RHSM packages")
+        loggerinst.rollback("Remove installed RHSM packages")
         loggerinst.info("Removing set of installed pkgs: %s" % utils.format_sequence_as_message(self.installed_pkgs))
         utils.remove_pkgs(self.installed_pkgs, critical=False)
 

--- a/convert2rhel/logger.py
+++ b/convert2rhel/logger.py
@@ -25,6 +25,10 @@ CRITICAL            (50)    Calls critical() function and sys.exit(1)
 ERROR               (40)    Prints error message using date/time
 WARNING             (30)    Prints warning message using date/time
 INFO                (20)    Prints info message (no date/time, just plain message)
+PREPARE             (15)    Prints prepare header message for pre-conversion tasks
+CONVERT             (15)    Prints convert header message for post-conversion tasks
+FINAL               (15)    Prints final header message for post-conversion tasks
+ROLLBACK            (15)    Prints rollback header message
 TASK                (15)    CUSTOM LABEL - Prints a task header message (using asterisks)
 DEBUG               (10)    Prints debug message (using date/time)
 FILE                (5)     CUSTOM LABEL - Outputs with the DEBUG label but only to a file
@@ -53,6 +57,26 @@ class LogLevelCriticalNoExit:
 class LogLevelTask:
     level = 15
     label = "TASK"
+
+
+class LogLevelPrepare:
+    level = 15
+    label = "PREPARE"
+
+
+class LogLevelConvert:
+    level = 15
+    label = "CONVERT"
+
+
+class LogLevelFinal:
+    level = 15
+    label = "FINAL"
+
+
+class LogLevelRollback:
+    level = 15
+    label = "ROLLBACK"
 
 
 class LogLevelFile:
@@ -122,9 +146,17 @@ def setup_logger_handler():
     from your application's main start point.
     """
     # set custom labels
+    logging.addLevelName(LogLevelPrepare.level, LogLevelPrepare.label)
+    logging.addLevelName(LogLevelConvert.level, LogLevelConvert.label)
+    logging.addLevelName(LogLevelFinal.level, LogLevelFinal.label)
+    logging.addLevelName(LogLevelRollback.level, LogLevelRollback.label)
     logging.addLevelName(LogLevelTask.level, LogLevelTask.label)
     logging.addLevelName(LogLevelFile.level, LogLevelFile.label)
     logging.addLevelName(LogLevelCriticalNoExit.level, LogLevelCriticalNoExit.label)
+    logging.Logger.prepare = _prepare
+    logging.Logger.convert = _convert
+    logging.Logger.final = _final
+    logging.Logger.rollback = _rollback
     logging.Logger.task = _task
     logging.Logger.file = _file
     logging.Logger.debug = _debug
@@ -231,6 +263,30 @@ def archive_old_logger_files(log_name, log_dir):
     file_name, suffix = tuple(log_name.rsplit(".", 1))
     archive_log_file = "%s/%s-%s.%s" % (archive_log_dir, file_name, formatted_time, suffix)
     shutil.move(current_log_file, archive_log_file)
+
+
+def _prepare(self, msg, *args, **kwargs):
+    if self.isEnabledFor(LogLevelPrepare.level):
+        message = "Prepare: %s" % msg
+        self._log(LogLevelPrepare.level, message, args, **kwargs)
+
+
+def _convert(self, msg, *args, **kwargs):
+    if self.isEnabledFor(LogLevelConvert.level):
+        message = "Convert: %s" % msg
+        self._log(LogLevelConvert.level, message, args, **kwargs)
+
+
+def _final(self, msg, *args, **kwargs):
+    if self.isEnabledFor(LogLevelFinal.level):
+        message = "Final: %s" % msg
+        self._log(LogLevelFinal.level, message, args, **kwargs)
+
+
+def _rollback(self, msg, *args, **kwargs):
+    if self.isEnabledFor(LogLevelRollback.level):
+        message = "Rollback: %s" % msg
+        self._log(LogLevelRollback.level, message, args, **kwargs)
 
 
 def _task(self, msg, *args, **kwargs):

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -232,10 +232,10 @@ def _handle_main_exceptions(process_phase, pre_conversion_results=None):
 def perform_boilerplate():
     """Standard interactions with the user prior to doing any conversion work."""
     # license agreement
-    loggerinst.task("Prepare: Show Red Hat software EULA")
+    loggerinst.prepare("Show Red Hat software EULA")
     show_eula()
 
-    loggerinst.task("Prepare: Inform about data collection")
+    loggerinst.prepare("Inform about data collection")
     breadcrumbs.breadcrumbs.print_data_collection()
 
 
@@ -259,7 +259,7 @@ def show_eula():
 def gather_system_info():
     """Retrieve information about the system to be converted"""
     # gather system information
-    loggerinst.task("Prepare: Gather system information")
+    loggerinst.prepare("Gather system information")
     systeminfo.system_info.resolve_system_info()
     systeminfo.system_info.print_system_information()
     breadcrumbs.breadcrumbs.collect_early_data()
@@ -267,10 +267,10 @@ def gather_system_info():
 
 def prepare_system():
     """Setup the environment to do the conversion within"""
-    loggerinst.task("Prepare: Clear YUM/DNF version locks")
+    loggerinst.prepare("Clear YUM/DNF version locks")
     pkghandler.clear_versionlock()
 
-    loggerinst.task("Prepare: Clean yum cache metadata")
+    loggerinst.prepare("Clean yum cache metadata")
     pkgmanager.clean_yum_metadata()
 
 
@@ -284,42 +284,42 @@ def post_ponr_changes():
     loggerinst.info("Starting Conversion")
     post_ponr_conversion()
 
-    loggerinst.task("Final: Show RPM files modified by the conversion")
+    loggerinst.final("Show RPM files modified by the conversion")
     systeminfo.system_info.modified_rpm_files_diff()
 
-    loggerinst.task("Final: Update GRUB2 configuration")
+    loggerinst.final("Update GRUB2 configuration")
     grub.update_grub_after_conversion()
 
-    loggerinst.task("Final: Remove temporary folder %s" % utils.TMP_DIR)
+    loggerinst.final("Remove temporary folder %s" % utils.TMP_DIR)
     utils.remove_tmp_dir()
 
-    loggerinst.task("Final: Check kernel boot files")
+    loggerinst.final("Check kernel boot files")
     checks.check_kernel_boot_files()
 
-    loggerinst.task("Final: Configure host-metering")
+    loggerinst.final("Configure host-metering")
     hostmetering.configure_host_metering()
 
-    loggerinst.task("Final: Update breadcrumbs")
+    loggerinst.final("Update breadcrumbs")
     breadcrumbs.breadcrumbs.finish_collection(success=True)
 
-    loggerinst.task("Final: Update RHSM custom facts")
+    loggerinst.final("Update RHSM custom facts")
     subscription.update_rhsm_custom_facts()
 
 
 def post_ponr_conversion():
     """Perform main steps for system conversion."""
     transaction_handler = pkgmanager.create_transaction_handler()
-    loggerinst.task("Convert: Replace system packages")
+    loggerinst.convert("Replace system packages")
     transaction_handler.run_transaction()
-    loggerinst.task("Convert: Prepare kernel")
+    loggerinst.convert("Prepare kernel")
     pkghandler.preserve_only_rhel_kernel()
-    loggerinst.task("Convert: List remaining non-Red Hat packages")
+    loggerinst.convert("List remaining non-Red Hat packages")
     pkghandler.list_non_red_hat_pkgs_left()
-    loggerinst.task("Convert: Configure the bootloader")
+    loggerinst.convert("Configure the bootloader")
     grub.post_ponr_set_efi_configuration()
-    loggerinst.task("Convert: Patch yum configuration file")
+    loggerinst.convert("Patch yum configuration file")
     redhatrelease.YumConf().patch()
-    loggerinst.task("Convert: Lock releasever in RHEL repositories")
+    loggerinst.convert("Lock releasever in RHEL repositories")
     subscription.lock_releasever_in_rhel_repositories()
 
 

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -92,7 +92,7 @@ class RestorableSystemSubscription(backup.RestorableChange):
 
     def restore(self):
         """Rollback subscription related changes"""
-        loggerinst.task("Rollback: RHSM-related actions")
+        loggerinst.rollback("RHSM-related actions")
 
         if self.enabled:
             try:


### PR DESCRIPTION
Intorucing four new logging levels, `prepare`, `convert`, `final` and `rollback`. Essentially, this commit introduces the task headers as log levels to leave the responsability for the text of what will be printed to the logging class instead of the string in the `task` log level.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
