### PR TITLE
[RHELC-1486] Drop envparse from tests

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -58,7 +58,3 @@ prepare+:
     - name: remove all copr repositories
       how: shell
       script: grep -l "copr:copr.fedorainfracloud.org:group_oamg:convert2rhel" /etc/yum.repos.d/* | xargs rm
-
-# Commenting this out in favour of using a github actions with tft
-environment-file:
-    - https://gitlab.cee.redhat.com/oamg/convert2rhel/convert2rhel-secrets/-/raw/main/.env

--- a/tests/ansible_collections/main.yml
+++ b/tests/ansible_collections/main.yml
@@ -20,4 +20,6 @@
 
     - role: install-testing-deps
 
+    - role: get-test-vars
+
     - role: update-ca-trust

--- a/tests/ansible_collections/roles/get-test-vars/tasks/get-test-vars.yml
+++ b/tests/ansible_collections/roles/get-test-vars/tasks/get-test-vars.yml
@@ -1,0 +1,7 @@
+---
+- name: Download the test vars file
+  get_url:
+    url: https://gitlab.cee.redhat.com/oamg/convert2rhel/convert2rhel-secrets/-/raw/main/.env
+    validate_certs: false
+    dest: /var/tmp/.env
+    mode: '0444'

--- a/tests/ansible_collections/roles/get-test-vars/tasks/main.yml
+++ b/tests/ansible_collections/roles/get-test-vars/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: get-test-vars.yml

--- a/tests/ansible_collections/roles/install-testing-deps/tasks/main.yml
+++ b/tests/ansible_collections/roles/install-testing-deps/tasks/main.yml
@@ -22,7 +22,7 @@
     name:
       - "pytest"
       - "pytest-cov"
-      - "envparse"
+      - "python-dotenv"
       - "click"
       - "pexpect"
       - "dataclasses"

--- a/tests/ansible_collections/roles/update-ca-trust/tasks/update-ca-trust.yml
+++ b/tests/ansible_collections/roles/update-ca-trust/tasks/update-ca-trust.yml
@@ -1,7 +1,11 @@
 ---
+- name: Get cacert_url
+  shell: "grep -o 'CACERT_URL=.*' /var/tmp/.env | cut -d'=' -f2"
+  register: CACERT_URL
+
 - name: Download the internal CA certificate
   get_url:
-    url: "{{ lookup('ansible.builtin.env', 'CACERT_URL') }}"
+    url: "{{ CACERT_URL.stdout }}"
     dest: /etc/pki/ca-trust/source/anchors/Current-IT-Root-CAs.pem
 
 - name: Add the certificate to trusted CA's

--- a/tests/integration/tier0/destructive/conversion-method/test_activation_key.py
+++ b/tests/integration/tier0/destructive/conversion-method/test_activation_key.py
@@ -1,6 +1,6 @@
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 @pytest.mark.test_activation_key_conversion
@@ -10,9 +10,9 @@ def test_activation_key_conversion(convert2rhel):
     """
     with convert2rhel(
         "-y --serverurl {} -k {} -o {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_KEY"),
-            env.str("RHSM_ORG"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_KEY"],
+            TEST_VARS["RHSM_ORG"],
         )
     ) as c2r:
         c2r.expect("Conversion successful!")

--- a/tests/integration/tier0/destructive/conversion-method/test_config_file.py
+++ b/tests/integration/tier0/destructive/conversion-method/test_config_file.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 Config = namedtuple("Config", "path content")
@@ -29,12 +29,12 @@ def test_conversion_with_config_file(convert2rhel):
     Use config file to feed the credentials for the registration and verify a successful conversion.
     """
     activation_key = "[subscription_manager]\nactivation_key = {}\norg = {}".format(
-        env.str("RHSM_KEY"), env.str("RHSM_ORG")
+        TEST_VARS["RHSM_KEY"], TEST_VARS["RHSM_ORG"]
     )
     config = [Config("~/.convert2rhel.ini", activation_key)]
     create_files(config)
 
-    with convert2rhel("-y --serverurl {} --debug".format(env.str("RHSM_SERVER_URL"))) as c2r:
+    with convert2rhel("-y --serverurl {} --debug".format(TEST_VARS["RHSM_SERVER_URL"])) as c2r:
         c2r.expect("DEBUG - Found activation_key in /root/.convert2rhel.ini")
         c2r.expect("DEBUG - Found org in /root/.convert2rhel.ini")
         c2r.expect("Conversion successful!")

--- a/tests/integration/tier0/destructive/conversion-method/test_rhsm.py
+++ b/tests/integration/tier0/destructive/conversion-method/test_rhsm.py
@@ -1,16 +1,16 @@
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 @pytest.mark.test_rhsm_conversion
 def test_run_conversion(convert2rhel):
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         c2r.expect("Conversion successful!")

--- a/tests/integration/tier0/destructive/conversion-method/test_rhsm_non_eus.py
+++ b/tests/integration/tier0/destructive/conversion-method/test_rhsm_non_eus.py
@@ -1,6 +1,6 @@
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 @pytest.mark.test_rhsm_non_eus_account_conversion
@@ -17,10 +17,10 @@ def test_rhsm_non_eus_account(convert2rhel):
 
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug --eus".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_NON_EUS_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_NON_EUS_POOL"],
         )
     ) as c2r:
         c2r.expect_exact("Error: 'rhel-8-for-x86_64-baseos-eus-rpms' does not match a valid repository ID.")

--- a/tests/integration/tier0/destructive/conversion-method/test_satellite.py
+++ b/tests/integration/tier0/destructive/conversion-method/test_satellite.py
@@ -1,7 +1,6 @@
 import pytest
 
-from conftest import SATELLITE_PKG_DST, SATELLITE_PKG_URL
-from envparse import env
+from conftest import SATELLITE_PKG_DST, SATELLITE_PKG_URL, TEST_VARS
 
 
 @pytest.mark.test_satellite_conversion
@@ -25,8 +24,8 @@ def test_satellite_conversion(shell, convert2rhel):
 
     with convert2rhel(
         "-y -k {} -o {} --debug".format(
-            env.str("SATELLITE_KEY"),
-            env.str("SATELLITE_ORG"),
+            TEST_VARS["SATELLITE_KEY"],
+            TEST_VARS["SATELLITE_ORG"],
         )
     ) as c2r:
         pass

--- a/tests/integration/tier0/destructive/offline-system-conversion/prepare_system.py
+++ b/tests/integration/tier0/destructive/offline-system-conversion/prepare_system.py
@@ -1,8 +1,7 @@
 import re
 import socket
 
-from conftest import SATELLITE_PKG_DST, SATELLITE_PKG_URL, SATELLITE_URL, SYSTEM_RELEASE_ENV
-from envparse import env
+from conftest import SATELLITE_PKG_DST, SATELLITE_PKG_URL, SATELLITE_URL, SYSTEM_RELEASE_ENV, TEST_VARS
 
 
 # Replace urls in rhsm.conf file to the satellite server
@@ -50,30 +49,34 @@ def test_prepare_system(shell):
     replace_urls_rhsm()
     shell("rm -rf /etc/yum.repos.d/*")
 
+    satellite_key = None
+
     # Subscribe system
     if "centos-7" in SYSTEM_RELEASE_ENV:
-        satellite_key = env.str("SATELLITE_OFFLINE_KEY_CENTOS7")
+        satellite_key = TEST_VARS["SATELLITE_OFFLINE_KEY_CENTOS7"]
     elif "centos-8" in SYSTEM_RELEASE_ENV:
-        satellite_key = env.str("SATELLITE_OFFLINE_KEY_CENTOS8")
+        satellite_key = TEST_VARS["SATELLITE_OFFLINE_KEY_CENTOS8"]
     elif "oracle-7" in SYSTEM_RELEASE_ENV:
-        satellite_key = env.str("SATELLITE_OFFLINE_KEY_ORACLE7")
+        satellite_key = TEST_VARS["SATELLITE_OFFLINE_KEY_ORACLE7"]
     elif "oracle-8" in SYSTEM_RELEASE_ENV:
-        satellite_key = env.str("SATELLITE_OFFLINE_KEY_ORACLE8")
+        satellite_key = TEST_VARS["SATELLITE_OFFLINE_KEY_ORACLE8"]
     elif "alma-8.6" in SYSTEM_RELEASE_ENV:
-        satellite_key = env.str("SATELLITE_OFFLINE_KEY_ALMA86")
+        satellite_key = TEST_VARS["SATELLITE_OFFLINE_KEY_ALMA86"]
     elif "alma-8.8" in SYSTEM_RELEASE_ENV:
-        satellite_key = env.str("SATELLITE_OFFLINE_KEY_ALMA88")
+        satellite_key = TEST_VARS["SATELLITE_OFFLINE_KEY_ALMA88"]
     elif "rocky-8.6" in SYSTEM_RELEASE_ENV:
-        satellite_key = env.str("SATELLITE_OFFLINE_KEY_ROCKY86")
+        satellite_key = TEST_VARS["SATELLITE_OFFLINE_KEY_ROCKY86"]
     elif "rocky-8.8" in SYSTEM_RELEASE_ENV:
-        satellite_key = env.str("SATELLITE_OFFLINE_KEY_ROCKY88")
+        satellite_key = TEST_VARS["SATELLITE_OFFLINE_KEY_ROCKY88"]
     elif "alma-8-latest" in SYSTEM_RELEASE_ENV:
-        satellite_key = env.str("SATELLITE_OFFLINE_KEY_ALMA8")
+        satellite_key = TEST_VARS["SATELLITE_OFFLINE_KEY_ALMA8"]
     elif "rocky-8-latest" in SYSTEM_RELEASE_ENV:
-        satellite_key = env.str("SATELLITE_OFFLINE_KEY_ROCKY8")
+        satellite_key = TEST_VARS["SATELLITE_OFFLINE_KEY_ROCKY8"]
     assert (
         shell(
-            "subscription-manager register --org={} --activationkey={}".format(env.str("SATELLITE_ORG"), satellite_key)
+            ("subscription-manager register --org={} --activationkey={}").format(
+                TEST_VARS["SATELLITE_ORG"], satellite_key
+            )
         ).returncode
         == 0
     )

--- a/tests/integration/tier0/destructive/offline-system-conversion/test_offline_system_conversion.py
+++ b/tests/integration/tier0/destructive/offline-system-conversion/test_offline_system_conversion.py
@@ -1,6 +1,6 @@
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 @pytest.mark.test_offline_system_conversion
@@ -9,8 +9,8 @@ def test_offline_system_conversion(convert2rhel):
 
     with convert2rhel(
         "-y -k {} -o {} --debug".format(
-            env.str("SATELLITE_KEY"),
-            env.str("SATELLITE_ORG"),
+            TEST_VARS["SATELLITE_KEY"],
+            TEST_VARS["SATELLITE_ORG"],
         )
     ) as c2r:
         pass

--- a/tests/integration/tier0/destructive/single-yum-transaction/test_check_for_latest_packages.py
+++ b/tests/integration/tier0/destructive/single-yum-transaction/test_check_for_latest_packages.py
@@ -1,7 +1,6 @@
 import pytest
 
-from conftest import SYSTEM_RELEASE_ENV
-from envparse import env
+from conftest import SYSTEM_RELEASE_ENV, TEST_VARS
 
 
 @pytest.mark.test_packages_upgraded_after_conversion
@@ -38,10 +37,10 @@ def test_packages_upgraded_after_conversion(convert2rhel, shell):
     # Run utility until the reboot
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         c2r.expect("Conversion successful!")

--- a/tests/integration/tier0/destructive/single-yum-transaction/test_single_yum_transaction.py
+++ b/tests/integration/tier0/destructive/single-yum-transaction/test_single_yum_transaction.py
@@ -2,8 +2,7 @@ import re
 
 import pytest
 
-from conftest import SYSTEM_RELEASE_ENV
-from envparse import env
+from conftest import SYSTEM_RELEASE_ENV, TEST_VARS
 
 
 @pytest.mark.test_single_yum_transaction
@@ -20,10 +19,10 @@ def test_single_yum_transaction(convert2rhel, shell):
 
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         c2r.expect("no modifications to the system will happen this time.", timeout=1200)

--- a/tests/integration/tier0/destructive/yum-distro-sync/test_yum_distro_sync.py
+++ b/tests/integration/tier0/destructive/yum-distro-sync/test_yum_distro_sync.py
@@ -1,6 +1,6 @@
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 @pytest.mark.test_yum_distro_sync
@@ -26,10 +26,10 @@ def test_yum_distro_sync(convert2rhel, shell):
 
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         c2r.expect("Conversion successful!")

--- a/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
+++ b/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
@@ -4,8 +4,7 @@ import re
 import jsonschema
 import pytest
 
-from conftest import _load_json_schema
-from envparse import env
+from conftest import TEST_VARS, _load_json_schema
 from pexpect import EOF
 
 
@@ -51,7 +50,7 @@ def test_failures_and_skips_in_report(convert2rhel):
     """
     with convert2rhel(
         "analyze --serverurl {} --username test --password test --pool a_pool --debug".format(
-            env.str("RHSM_SERVER_URL"),
+            TEST_VARS["RHSM_SERVER_URL"],
         )
     ) as c2r:
         # We need to get past the data collection acknowledgement.
@@ -99,10 +98,10 @@ def test_successful_report(convert2rhel):
     """
     with convert2rhel(
         "analyze --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         # We need to get past the data collection acknowledgement.
@@ -141,10 +140,10 @@ def test_convert_successful_report(convert2rhel):
     """
     with convert2rhel(
         "convert --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         # We need to get past the data collection acknowledgement.

--- a/tests/integration/tier0/non-destructive/duplicate-pkgs/test_duplicate_pkgs.py
+++ b/tests/integration/tier0/non-destructive/duplicate-pkgs/test_duplicate_pkgs.py
@@ -1,7 +1,6 @@
 import pytest
 
-from conftest import SYSTEM_RELEASE_ENV
-from envparse import env
+from conftest import SYSTEM_RELEASE_ENV, TEST_VARS
 
 
 DUPLICATE_PKG_URL_MAPPING = {
@@ -55,9 +54,9 @@ def test_duplicate_pkgs(convert2rhel, install_duplicate_pkg):
     """
     with convert2rhel(
         "analyze -y --serverurl {} --username {} --password {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
         )
     ) as c2r:
         # The error about duplicate packages should be included at the end of the pre-conversion analysis report

--- a/tests/integration/tier0/non-destructive/eus/test_eus_support.py
+++ b/tests/integration/tier0/non-destructive/eus/test_eus_support.py
@@ -2,7 +2,7 @@ import os.path
 
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 @pytest.fixture
@@ -88,7 +88,7 @@ def test_eus_support(
     eus_mapping_update(modified_mapping)
     with convert2rhel(
         "analyze -y --debug --serverurl {} -u {} -p {} {}".format(
-            env.str("RHSM_SERVER_URL"), env.str("RHSM_USERNAME"), env.str("RHSM_PASSWORD"), additional_option
+            TEST_VARS["RHSM_SERVER_URL"], TEST_VARS["RHSM_USERNAME"], TEST_VARS["RHSM_PASSWORD"], additional_option
         )
     ) as c2r:
         c2r.expect(repoid_message, timeout=120)

--- a/tests/integration/tier0/non-destructive/firewalld-inhibitor/test_firewalld_inhibitor.py
+++ b/tests/integration/tier0/non-destructive/firewalld-inhibitor/test_firewalld_inhibitor.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 FIREWALLD_CONFIG_FILE = "/etc/firewalld/firewalld.conf"
@@ -26,7 +26,7 @@ def test_firewalld_inhibitor(shell, convert2rhel):
 
     with convert2rhel(
         "-y --debug --serverurl {} --username {} --password {}".format(
-            env.str("RHSM_SERVER_URL"), env.str("RHSM_USERNAME"), env.str("RHSM_PASSWORD")
+            TEST_VARS["RHSM_SERVER_URL"], TEST_VARS["RHSM_USERNAME"], TEST_VARS["RHSM_PASSWORD"]
         ),
         unregister=True,
     ) as c2r:

--- a/tests/integration/tier0/non-destructive/kernel-modules/test_unsupported_kmod.py
+++ b/tests/integration/tier0/non-destructive/kernel-modules/test_unsupported_kmod.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 ORIGIN_KMOD_LOCATION = Path("/lib/modules/$(uname -r)/kernel/drivers/net/bonding/bonding.ko.xz")
@@ -66,10 +66,10 @@ def test_error_if_custom_module_loaded(kmod_in_different_directory, convert2rhel
     """
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         ),
         unregister=True,
     ) as c2r:
@@ -104,10 +104,10 @@ def test_do_not_error_if_module_is_not_loaded(shell, convert2rhel):
     # If custom module is not loaded the conversion should not raise an error
     with convert2rhel(
         "--serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         ),
         unregister=True,
     ) as c2r:
@@ -167,9 +167,9 @@ def test_tainted_kernel_modules_check_override(shell, convert2rhel, forced_kmods
     environment_variables(envars)
     with convert2rhel(
         "--serverurl {} --username {} --password {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
         ),
         unregister=True,
     ) as c2r:
@@ -197,10 +197,10 @@ def test_tainted_kernel_modules_error(custom_kmod, convert2rhel):
 
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         ),
         unregister=True,
     ) as c2r:
@@ -226,10 +226,10 @@ def test_envar_overrides_unsupported_module_loaded(
     environment_variables(envars)
     with convert2rhel(
         "--serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         c2r.expect("Continue with the system conversion?")

--- a/tests/integration/tier0/non-destructive/kernel/test_kernel_check_verification.py
+++ b/tests/integration/tier0/non-destructive/kernel/test_kernel_check_verification.py
@@ -3,8 +3,7 @@ import os
 
 import pytest
 
-from conftest import SYSTEM_RELEASE_ENV
-from envparse import env
+from conftest import SYSTEM_RELEASE_ENV, TEST_VARS
 
 
 @pytest.fixture(scope="function")
@@ -128,10 +127,10 @@ def test_non_latest_kernel_error(kernel, shell, convert2rhel):
     if os.environ["TMT_REBOOT_COUNT"] == "1":
         with convert2rhel(
             "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-                env.str("RHSM_SERVER_URL"),
-                env.str("RHSM_USERNAME"),
-                env.str("RHSM_PASSWORD"),
-                env.str("RHSM_POOL"),
+                TEST_VARS["RHSM_SERVER_URL"],
+                TEST_VARS["RHSM_USERNAME"],
+                TEST_VARS["RHSM_PASSWORD"],
+                TEST_VARS["RHSM_POOL"],
             )
         ) as c2r:
             c2r.expect("Check if the loaded kernel version is the most recent")

--- a/tests/integration/tier0/non-destructive/modified-releasever/test_modified_releasever.py
+++ b/tests/integration/tier0/non-destructive/modified-releasever/test_modified_releasever.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 @pytest.fixture(scope="function")
@@ -33,10 +33,10 @@ def test_releasever_as_mapping_config_modified(convert2rhel, os_release, c2r_con
     with c2r_config.replace_line(pattern="releasever=.*", repl="releasever=333"):
         with convert2rhel(
             "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-                env.str("RHSM_SERVER_URL"),
-                env.str("RHSM_USERNAME"),
-                env.str("RHSM_PASSWORD"),
-                env.str("RHSM_POOL"),
+                TEST_VARS["RHSM_SERVER_URL"],
+                TEST_VARS["RHSM_USERNAME"],
+                TEST_VARS["RHSM_PASSWORD"],
+                TEST_VARS["RHSM_POOL"],
             ),
             unregister=True,
         ) as c2r:
@@ -73,10 +73,10 @@ def test_releasever_as_mapping_not_existing_release(convert2rhel, config_at, os_
     ):
         with convert2rhel(
             "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-                env.str("RHSM_SERVER_URL"),
-                env.str("RHSM_USERNAME"),
-                env.str("RHSM_PASSWORD"),
-                env.str("RHSM_POOL"),
+                TEST_VARS["RHSM_SERVER_URL"],
+                TEST_VARS["RHSM_USERNAME"],
+                TEST_VARS["RHSM_PASSWORD"],
+                TEST_VARS["RHSM_POOL"],
             ),
             unregister=True,
         ) as c2r:

--- a/tests/integration/tier0/non-destructive/problematic-third-party-pkgs/test_problematic_third_party_pkgs.py
+++ b/tests/integration/tier0/non-destructive/problematic-third-party-pkgs/test_problematic_third_party_pkgs.py
@@ -1,6 +1,6 @@
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 @pytest.fixture
@@ -37,9 +37,9 @@ def test_list_third_party_pkgs_error(convert2rhel, problematic_third_party_packa
     """
     with convert2rhel(
         "analyze -y --serverurl {} --username {} --password {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
         )
     ) as c2r:
         # Verify that the analysis report is printed

--- a/tests/integration/tier0/non-destructive/rollback-handling/test_rollback_handling.py
+++ b/tests/integration/tier0/non-destructive/rollback-handling/test_rollback_handling.py
@@ -1,7 +1,6 @@
 import pytest
 
-from conftest import SYSTEM_RELEASE_ENV
-from envparse import env
+from conftest import SYSTEM_RELEASE_ENV, TEST_VARS
 
 
 @pytest.fixture(autouse=True)
@@ -158,10 +157,10 @@ def test_proper_rhsm_clean_up(shell, convert2rhel):
 
     with convert2rhel(
         "--serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         c2r.expect("Continue with the system conversion?")
@@ -223,9 +222,9 @@ def test_terminate_registration_start(convert2rhel):
     """
     with convert2rhel(
         "--debug -y --serverurl {} --username {} --password {}".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
         ),
         unregister=True,
     ) as c2r:
@@ -244,9 +243,9 @@ def test_terminate_registration_success(convert2rhel):
     """
     with convert2rhel(
         "--debug -y --serverurl {} --username {} --password {}".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
         ),
         unregister=True,
     ) as c2r:

--- a/tests/integration/tier0/non-destructive/single-yum-transaction-validation/test_single_yum_transaction_validation.py
+++ b/tests/integration/tier0/non-destructive/single-yum-transaction-validation/test_single_yum_transaction_validation.py
@@ -3,8 +3,7 @@ import re
 
 import pytest
 
-from conftest import SYSTEM_RELEASE_ENV
-from envparse import env
+from conftest import SYSTEM_RELEASE_ENV, TEST_VARS
 
 
 PKI_ENTITLEMENT_CERTS_PATH = "/etc/pki/entitlement"
@@ -98,10 +97,10 @@ def test_package_download_error(convert2rhel, shell, yum_cache):
     """
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         c2r.expect("Validate the {} transaction".format(PKGMANAGER))
@@ -140,10 +139,10 @@ def test_transaction_validation_error(convert2rhel, shell, yum_cache):
     """
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         c2r.expect(
@@ -202,10 +201,10 @@ def test_validation_packages_with_in_name_period(shell, convert2rhel, packages_w
 
     with convert2rhel(
         "analyze --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         # Swallow the data collection warning
@@ -244,10 +243,10 @@ def test_override_exclude_list_in_yum_config(convert2rhel, kernel, override_yum_
     if os.environ["TMT_REBOOT_COUNT"] == "1":
         with convert2rhel(
             "analyze --serverurl {} --username {} --password {} --pool {} --debug -y".format(
-                env.str("RHSM_SERVER_URL"),
-                env.str("RHSM_USERNAME"),
-                env.str("RHSM_PASSWORD"),
-                env.str("RHSM_POOL"),
+                TEST_VARS["RHSM_SERVER_URL"],
+                TEST_VARS["RHSM_USERNAME"],
+                TEST_VARS["RHSM_PASSWORD"],
+                TEST_VARS["RHSM_POOL"],
             )
         ) as c2r:
             c2r.expect("VALIDATE_PACKAGE_MANAGER_TRANSACTION has succeeded")

--- a/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
+++ b/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
@@ -1,6 +1,6 @@
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 @pytest.mark.test_pre_registered_wont_unregister
@@ -44,7 +44,7 @@ def test_pre_registered_re_register(shell, pre_registered, convert2rhel):
     """
     with convert2rhel(
         "--debug --serverurl {} --username {} --password {}".format(
-            env.str("RHSM_SERVER_URL"), env.str("RHSM_USERNAME"), env.str("RHSM_PASSWORD")
+            TEST_VARS["RHSM_SERVER_URL"], TEST_VARS["RHSM_USERNAME"], TEST_VARS["RHSM_PASSWORD"]
         )
     ) as c2r:
         # We need to get past the data collection acknowledgement.

--- a/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_rollback.py
+++ b/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_rollback.py
@@ -2,7 +2,7 @@ import os.path
 
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 @pytest.fixture(scope="function")
@@ -46,10 +46,10 @@ def test_sub_man_rollback(convert2rhel, shell, required_packages, convert2rhel_r
     for run in range(2):
         with convert2rhel(
             "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-                env.str("RHSM_SERVER_URL"),
-                env.str("RHSM_USERNAME"),
-                env.str("RHSM_PASSWORD"),
-                env.str("RHSM_POOL"),
+                TEST_VARS["RHSM_SERVER_URL"],
+                TEST_VARS["RHSM_USERNAME"],
+                TEST_VARS["RHSM_PASSWORD"],
+                TEST_VARS["RHSM_POOL"],
             )
         ) as c2r:
             assert c2r.expect("Validate the dnf transaction") == 0

--- a/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
+++ b/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
@@ -2,8 +2,7 @@ import re
 
 import pytest
 
-from conftest import SATELLITE_PKG_DST, SATELLITE_PKG_URL, SYSTEM_RELEASE_ENV
-from envparse import env
+from conftest import SATELLITE_PKG_DST, SATELLITE_PKG_URL, SYSTEM_RELEASE_ENV, TEST_VARS
 
 
 @pytest.fixture(scope="function")
@@ -110,8 +109,8 @@ def test_missing_system_release(shell, convert2rhel, system_release_missing):
     """
     with convert2rhel(
         "-y -k {} -o {} --debug".format(
-            env.str("SATELLITE_KEY"),
-            env.str("SATELLITE_ORG"),
+            TEST_VARS["SATELLITE_KEY"],
+            TEST_VARS["SATELLITE_ORG"],
         )
     ) as c2r:
         c2r.expect("Unable to find the /etc/system-release file containing the OS name and version")
@@ -131,8 +130,8 @@ def test_backup_os_release_no_envar(shell, convert2rhel, custom_subman, katello_
     assert shell("find /etc/os-release").returncode == 0
     with convert2rhel(
         "-y -k {} -o {} --debug".format(
-            env.str("SATELLITE_KEY"),
-            env.str("SATELLITE_ORG"),
+            TEST_VARS["SATELLITE_KEY"],
+            TEST_VARS["SATELLITE_ORG"],
         ),
         unregister=True,
     ) as c2r:
@@ -156,8 +155,8 @@ def test_backup_os_release_with_envar(shell, convert2rhel, custom_subman, katell
 
     with convert2rhel(
         "-y -k {} -o {} --debug".format(
-            env.str("SATELLITE_KEY"),
-            env.str("SATELLITE_ORG"),
+            TEST_VARS["SATELLITE_KEY"],
+            TEST_VARS["SATELLITE_ORG"],
         ),
         unregister=True,
     ) as c2r:

--- a/tests/integration/tier0/non-destructive/user-prompt-response/test_user_prompt_response.py
+++ b/tests/integration/tier0/non-destructive/user-prompt-response/test_user_prompt_response.py
@@ -1,6 +1,6 @@
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 @pytest.mark.test_empty_username_and_password
@@ -9,7 +9,7 @@ def test_check_user_response_user_and_password(convert2rhel):
     Run c2r registration with no username and password provided.
     Verify that user has to pass non-empty username/password string to continue, otherwise enforce the input prompt again.
     """
-    with convert2rhel("-y --serverurl {}".format(env.str("RHSM_SERVER_URL")), unregister=True) as c2r:
+    with convert2rhel("-y --serverurl {}".format(TEST_VARS["RHSM_SERVER_URL"]), unregister=True) as c2r:
         c2r.expect(" ... activation key not found, username and password required")
         c2r.expect("Username")
         c2r.sendline()
@@ -22,14 +22,14 @@ def test_check_user_response_user_and_password(convert2rhel):
 
         retries = 0
         while True:
-            c2r.sendline(env.str("RHSM_USERNAME"))
-            print("Sending username:", env.str("RHSM_USERNAME"))
+            c2r.sendline(TEST_VARS["RHSM_USERNAME"])
+            print("Sending username:", TEST_VARS["RHSM_USERNAME"])
             c2r.expect("Password: ")
             c2r.sendline()
             try:
                 assert c2r.expect("Password", timeout=300) == 0
                 # Provide password, expect successful registration and subscription prompt
-                c2r.sendline(env.str("RHSM_PASSWORD"))
+                c2r.sendline(TEST_VARS["RHSM_PASSWORD"])
                 print("Sending password")
                 assert c2r.expect("System registration succeeded", timeout=180) == 0
                 break

--- a/tests/integration/tier1/destructive/changed-grub-file/test_invalid_changed_grub.py
+++ b/tests/integration/tier1/destructive/changed-grub-file/test_invalid_changed_grub.py
@@ -4,7 +4,7 @@ import fileinput
 
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 target_line = "GRUB_CMDLINE_LINUX"
@@ -27,10 +27,10 @@ def test_modify_grub_invalid(convert2rhel):
 
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         assert c2r.expect("GRUB2 config file generation failed.") == 0

--- a/tests/integration/tier1/destructive/changed-grub-file/test_valid_changed_grub.py
+++ b/tests/integration/tier1/destructive/changed-grub-file/test_valid_changed_grub.py
@@ -4,7 +4,7 @@ import fileinput
 
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 target_line = "GRUB_CMDLINE_LINUX"
@@ -38,10 +38,10 @@ def test_modify_grub_valid(convert2rhel):
 
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         assert c2r.expect("Successfully updated GRUB2 on the system.") == 0

--- a/tests/integration/tier1/destructive/changed-yum-conf/test_patch_yum_conf.py
+++ b/tests/integration/tier1/destructive/changed-yum-conf/test_patch_yum_conf.py
@@ -1,6 +1,6 @@
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 @pytest.mark.test_yum_conf_patch
@@ -15,10 +15,10 @@ def test_yum_conf_patch(convert2rhel, shell):
 
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         c2r.expect("/etc/yum.conf patched.")

--- a/tests/integration/tier1/destructive/detect-bootloader-partition/test_detect_correct_boot_partition.py
+++ b/tests/integration/tier1/destructive/detect-bootloader-partition/test_detect_correct_boot_partition.py
@@ -3,7 +3,7 @@ import subprocess
 
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 EFI_BOOT_MOUNTPOINT = "/boot/efi"
@@ -55,10 +55,10 @@ def test_detect_correct_boot_partition(convert2rhel):
 
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         assert c2r.expect("Calling command '/usr/sbin/blkid -p -s PART_ENTRY_NUMBER %s'" % boot_device) == 0

--- a/tests/integration/tier1/destructive/excluded-packages-removed/test_excluded_pkgs_removed.py
+++ b/tests/integration/tier1/destructive/excluded-packages-removed/test_excluded_pkgs_removed.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 @pytest.mark.test_excluded_packages_removed
@@ -24,10 +24,10 @@ def test_excluded_packages_removed(shell, convert2rhel):
     # run utility until the reboot
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         pass

--- a/tests/integration/tier1/destructive/firewalld-disabled-ol8/test_firewalld_disabled_ol8.py
+++ b/tests/integration/tier1/destructive/firewalld-disabled-ol8/test_firewalld_disabled_ol8.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 FIREWALLD_CONFIG_FILE = "/etc/firewalld/firewalld.conf"
@@ -25,7 +25,7 @@ def test_firewalld_disabled_ol8(shell, convert2rhel):
 
     with convert2rhel(
         "-y --debug --serverurl {} --username {} --password {}".format(
-            env.str("RHSM_SERVER_URL"), env.str("RHSM_USERNAME"), env.str("RHSM_PASSWORD")
+            TEST_VARS["RHSM_SERVER_URL"], TEST_VARS["RHSM_USERNAME"], TEST_VARS["RHSM_PASSWORD"]
         ),
         unregister=True,
     ) as c2r:

--- a/tests/integration/tier1/destructive/host-metering/test_run_conversion_with_metering.py
+++ b/tests/integration/tier1/destructive/host-metering/test_run_conversion_with_metering.py
@@ -17,7 +17,7 @@
 
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 def setup_test_metering_endpoint():
@@ -58,9 +58,9 @@ def test_run_conversion_with_metering(shell, convert2rhel):
 
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
         )
     ) as c2r:
         c2r.expect("Installing host-metering packages")

--- a/tests/integration/tier1/destructive/kernel-boot-files/test_handle_corrupted_files.py
+++ b/tests/integration/tier1/destructive/kernel-boot-files/test_handle_corrupted_files.py
@@ -4,8 +4,7 @@ import subprocess
 
 import pytest
 
-from conftest import SYSTEM_RELEASE_ENV
-from envparse import env
+from conftest import SYSTEM_RELEASE_ENV, TEST_VARS
 
 
 INITRAMFS_FILE = "/boot/initramfs-%s.img"
@@ -87,10 +86,10 @@ def test_corrupted_initramfs_file(convert2rhel, shell):
 
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         c2r.expect("Convert: List remaining non-Red Hat packages")

--- a/tests/integration/tier1/destructive/kernel-boot-files/test_handle_missing_boot_files.py
+++ b/tests/integration/tier1/destructive/kernel-boot-files/test_handle_missing_boot_files.py
@@ -4,8 +4,7 @@ import subprocess
 
 import pytest
 
-from conftest import SYSTEM_RELEASE_ENV
-from envparse import env
+from conftest import SYSTEM_RELEASE_ENV, TEST_VARS
 
 
 INITRAMFS_FILE = "/boot/initramfs-%s.img"
@@ -59,10 +58,10 @@ def test_missing_kernel_boot_files(convert2rhel, shell):
 
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         c2r.expect("Convert: List remaining non-Red Hat packages")

--- a/tests/integration/tier1/destructive/kernel-check-skip/test_latest_kernel_check_skip.py
+++ b/tests/integration/tier1/destructive/kernel-check-skip/test_latest_kernel_check_skip.py
@@ -3,8 +3,7 @@ import re
 
 import pytest
 
-from conftest import SYSTEM_RELEASE_ENV
-from envparse import env
+from conftest import SYSTEM_RELEASE_ENV, TEST_VARS
 
 
 @pytest.mark.test_latest_kernel_check_skip
@@ -39,10 +38,10 @@ def test_skip_kernel_check(shell, convert2rhel):
 
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         # Make sure the kernel comparison is skipped

--- a/tests/integration/tier1/destructive/system-not-up-to-date/test_system_not_up_to_date.py
+++ b/tests/integration/tier1/destructive/system-not-up-to-date/test_system_not_up_to_date.py
@@ -2,8 +2,7 @@ import os
 
 import pytest
 
-from conftest import SYSTEM_RELEASE_ENV
-from envparse import env
+from conftest import SYSTEM_RELEASE_ENV, TEST_VARS
 
 
 @pytest.fixture()
@@ -55,10 +54,10 @@ def test_system_not_updated(shell, convert2rhel, downgrade_and_versionlock):
     """
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         c2r.expect("WARNING - YUM/DNF versionlock plugin is in use. It may cause the conversion to fail.")
@@ -73,10 +72,10 @@ def test_system_not_updated(shell, convert2rhel, downgrade_and_versionlock):
     # Run utility until the reboot
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         # TODO(danmyway) Uncomment when the https://issues.redhat.com/browse/RHELC-1291 gets fixed

--- a/tests/integration/tier1/destructive/unavailable-package/test_pkg_removed_from_centos_85.py
+++ b/tests/integration/tier1/destructive/unavailable-package/test_pkg_removed_from_centos_85.py
@@ -1,6 +1,6 @@
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 @pytest.mark.test_package_removed_from_centos_85
@@ -17,10 +17,10 @@ def test_removed_pkg_from_centos_85(convert2rhel, shell):
 
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         c2r.expect("Conversion successful!")

--- a/tests/integration/tier1/non-destructive/httpd-package-transaction-error/test_httpd_package_transaction_error.py
+++ b/tests/integration/tier1/non-destructive/httpd-package-transaction-error/test_httpd_package_transaction_error.py
@@ -1,6 +1,6 @@
 import pytest
 
-from envparse import env
+from conftest import TEST_VARS
 
 
 @pytest.fixture(scope="function")
@@ -62,10 +62,10 @@ def test_httpd_package_transaction_error(shell, convert2rhel, handle_packages):
     # run c2r analyze to verify the yum transaction
     with convert2rhel(
         "analyze -y --serverurl {} --username {} --password {} --pool {} --debug".format(
-            env.str("RHSM_SERVER_URL"),
-            env.str("RHSM_USERNAME"),
-            env.str("RHSM_PASSWORD"),
-            env.str("RHSM_POOL"),
+            TEST_VARS["RHSM_SERVER_URL"],
+            TEST_VARS["RHSM_USERNAME"],
+            TEST_VARS["RHSM_PASSWORD"],
+            TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
         index = c2r.expect_exact(


### PR DESCRIPTION
* the envparse is not maintained since 2015
* use python-dotenv instead

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1486](https://issues.redhat.com/browse/RHELC-1486)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [x] When merged: Jira issue has been updated to `Release Pending` if relevant
