### PR TITLE
Fix typo in rollback task log

### DIFF
--- a/convert2rhel/backup/files.py
+++ b/convert2rhel/backup/files.py
@@ -174,7 +174,7 @@ class MissingFile(RestorableChange):
         if not self.enabled:
             return
 
-        loggerinst.task("Rollback: remove file created during conversion {filepath}".format(filepath=self.filepath))
+        loggerinst.task("Rollback: Remove file created during conversion {filepath}".format(filepath=self.filepath))
 
         if not os.path.isfile(self.filepath):
             loggerinst.info("File {filepath} wasn't created during conversion".format(filepath=self.filepath))


### PR DESCRIPTION
We were using `remove` instead of `Remove`. Always start with a capital letter.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-](https://issues.redhat.com/browse/RHELC-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
