### PR TITLE
[RHELC-1489] Fix an error message referring to a non-existing --organization option

### DIFF
--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -497,7 +497,7 @@ class CLI:
 
         if (tool_opts.org and not tool_opts.activation_key) or (not tool_opts.org and tool_opts.activation_key):
             loggerinst.critical(
-                "Either the --organization or the --activationkey option is missing. You can't use one without the other."
+                "Either the --org or the --activationkey option is missing. You can't use one without the other."
             )
 
 

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -513,11 +513,11 @@ def test_log_command_used(caplog, monkeypatch):
         (mock_cli_arguments(["-o", "org", "-k", "key"]), "-o ***** -k *****"),
         (
             mock_cli_arguments(["-o", "org"]),
-            "Either the --organization or the --activationkey option is missing. You can't use one without the other.",
+            "Either the --org or the --activationkey option is missing. You can't use one without the other.",
         ),
         (
             mock_cli_arguments(["-k", "key"]),
-            "Either the --organization or the --activationkey option is missing. You can't use one without the other.",
+            "Either the --org or the --activationkey option is missing. You can't use one without the other.",
         ),
     ),
 )


### PR DESCRIPTION
The title says it all. A quick kaizen-style fix.

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: -
- [RHELC-1489](https://issues.redhat.com/browse/RHELC-1489)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
