### PR TITLE
Fix: Remove version lock on centos7 devcontainer

### DIFF
--- a/.devcontainer/centos7/devcontainer.json
+++ b/.devcontainer/centos7/devcontainer.json
@@ -41,7 +41,7 @@
 				"GitHub.vscode-pull-request-github",
 				"Cameron.vscode-pytest",
 				"njpwerner.autodocstring",
-				"ms-python.python@2022.8.1"
+				"ms-python.python"
 			]
 		}
 	}


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
When trying to use the CentOS 7 devcontainer, the syntax highlight didn't work. Removing the version lock solved this problem. 

The same as #1129 

<!-- Link to relevant Jira issue, add multiple if necessary -->

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
