### PR TITLE
[RHELC-601] Install subscription-manager using package manager

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/subscription.py
+++ b/convert2rhel/actions/pre_ponr_changes/subscription.py
@@ -104,7 +104,7 @@ class PreSubscription(actions.Action):
                 # (Note: the function is marked private because this is a hack
                 # that should be replaced when we aren't under a release
                 # deadline.
-                update_pkgs = subscription._dependencies_to_update(subscription_manager_pkgs)
+                update_pkgs = subscription.dependencies_to_update(subscription_manager_pkgs)
                 subscription.install_rhel_subscription_manager(subscription_manager_pkgs, update_pkgs)
 
             logger.task("Prepare: Subscription Manager - Verify installation")

--- a/convert2rhel/actions/pre_ponr_changes/subscription.py
+++ b/convert2rhel/actions/pre_ponr_changes/subscription.py
@@ -99,13 +99,7 @@ class PreSubscription(actions.Action):
                 logger.info("Subscription Manager is already present")
             else:
                 logger.task("Prepare: Subscription Manager - Install packages")
-                # Hack for 1.4: if we install subscription-manager from the UBI repo, it
-                # may require newer versions of packages than provided by the vendor.
-                # (Note: the function is marked private because this is a hack
-                # that should be replaced when we aren't under a release
-                # deadline.
-                update_pkgs = subscription.dependencies_to_update(subscription_manager_pkgs)
-                subscription.install_rhel_subscription_manager(subscription_manager_pkgs, update_pkgs)
+                subscription.install_rhel_subscription_manager(subscription_manager_pkgs)
 
             logger.task("Prepare: Subscription Manager - Verify installation")
             subscription.verify_rhsm_installed()
@@ -113,7 +107,6 @@ class PreSubscription(actions.Action):
             logger.task("Prepare: Install a RHEL product certificate for RHSM")
             product_cert = RestorablePEMCert(_RHSM_PRODUCT_CERT_SOURCE_DIR, _RHSM_PRODUCT_CERT_TARGET_DIR)
             backup.backup_control.push(product_cert)
-
         except SystemExit as e:
             # This should not occur anymore as all the relevant SystemExits has been changed to a CriticalError
             # exception. This exception handler is just a precaution

--- a/convert2rhel/backup/packages.py
+++ b/convert2rhel/backup/packages.py
@@ -22,64 +22,14 @@ import os
 
 from convert2rhel import exceptions, repo, utils
 from convert2rhel.backup import BACKUP_DIR, RestorableChange
-from convert2rhel.pkgmanager import call_yum_cmd
 
 # Fine to import call_yum_cmd for now, but we really should figure out a way to
 # split this out.
-from convert2rhel.systeminfo import system_info
-from convert2rhel.utils import files
+from convert2rhel.pkgmanager import call_yum_cmd
 
 
 loggerinst = logging.getLogger(__name__)
 
-# Dirctory to temporarily store yum repo configuration to download rhs packages
-# from
-_RHSM_TMP_DIR = os.path.join(utils.TMP_DIR, "rhsm")
-
-# Directory to temporarily store rpms to be installed
-_SUBMGR_RPMS_DIR = os.path.join(utils.DATA_DIR, "subscription-manager")
-
-# Configuration of the repository to get Red Hat created packages for RHEL7
-# from before we have access to all of RHEL.
-_UBI_7_REPO_CONTENT = (
-    "[ubi-7-convert2rhel]\n"
-    "name=Red Hat Universal Base Image 7 - added by Convert2RHEL\n"
-    "baseurl=https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi/server/7/7Server/$basearch/os/\n"
-    "gpgcheck=1\n"
-    "enabled=1\n"
-)
-# Path to the repository file that we store the RHEL7-compatible repo file.
-_UBI_7_REPO_PATH = os.path.join(_RHSM_TMP_DIR, "ubi_7.repo")
-
-# Configuration of the repository to get Red Hat created packages for RHEL8
-# from before we have access to all of RHEL
-# We are using UBI 8 instead of CentOS Linux 8 because there's a bug in subscription-manager-rhsm-certificates on CentOS Linux 8
-# https://bugs.centos.org/view.php?id=17907
-_UBI_8_REPO_CONTENT = (
-    "[ubi-8-baseos-convert2rhel]\n"
-    "name=Red Hat Universal Base Image 8 - BaseOS added by Convert2RHEL\n"
-    "baseurl=https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/os/\n"
-    "gpgcheck=1\n"
-    "enabled=1\n"
-)
-# Path to the repository file that we store the RHEL8-compatible repo file.
-_UBI_8_REPO_PATH = os.path.join(_RHSM_TMP_DIR, "ubi_8.repo")
-
-_UBI_9_REPO_CONTENT = (
-    "[ubi-9-baseos-convert2rhel]\n"
-    "name=Red Hat Universal Base Image 9 - BaseOS added by Convert2RHEL\n"
-    "baseurl=https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/os/\n"
-    "gpgcheck=1\n"
-    "enabled=1\n"
-)
-_UBI_9_REPO_PATH = os.path.join(_RHSM_TMP_DIR, "ubi_9.repo")
-
-# Map repo_path and repo_content for each major version in UBI.
-_UBI_REPO_MAPPING = {
-    7: (_UBI_7_REPO_PATH, _UBI_7_REPO_CONTENT),
-    8: (_UBI_8_REPO_PATH, _UBI_8_REPO_CONTENT),
-    9: (_UBI_9_REPO_PATH, _UBI_9_REPO_CONTENT),
-}
 
 # NOTE: Over time we want to replace this with pkghandler.RestorablePackageSet.
 class RestorablePackage(RestorableChange):
@@ -228,36 +178,38 @@ class RestorablePackageSet(RestorableChange):
 
     .. warn:: This functionality is incomplete (These are things that need cleanup)
         Installing and restoring packagesets are very complex. This class needs work before it is
-        generic for any set of packages. It currently hardcodes values that are specific to
-        downloading subscription-manager and how we do that.
+        generic for any set of packages.
 
-        Implementing it in a half-ready state because we need it to install and remove
-        subscription-manager rpms at the right time relative to unregistering the system. As such,
-        this class relies heavily on the implementation of downloading and installing
-        subscription-manager. To make this generic, some pieces of that will need to move into
-        this class:
+        To make this generic, some pieces of that will need to move into this
+        class:
 
-        * Need a generic way to specify the UBI_X_REPO_PATH and UBI_X_REPO_CONTENT vars. Parameters
-          to __init__?  Parameter to install pkgs from "symbolic name" (vendor, pre-rhel, rhel,
-          enablerepos)? which we map to specific repo configurations?
-        * Backup and restore the vendor versions of packages which are in update_pkgs.
-        * Rename the global variables for SUBMGR_RPS_DIR, _RHSM_TMP_DIR, _UBI_7_REPO_CONTENT,
-          _UBI_7_REPO_PATH, _UBI_8_REPO_CONTENT, _UBI_8_REPO_PATH to more generic names
-        * Rename the helper functions: _download_rhsm_pkgs, _log_rhsm_download_directory_contents,
-          exit_on_failed_download
-        * Is the "We're using distro-sync" comment wrong?  We are using install, not distro-sync and
-          git log never shows us using distro-sync.
-        * This class is useful for package installation but not package removal. To replace backup.ChangedRPMPackagesController and back.RestorablePackage, we need to implement removal as well.  Should we do that here or in a second class?
-          * Note: ChangedRPMPackagesController might still have code that deals with package replacement.  AFAIK, that can be removed entirely.  As of 1.4, there's never a time where we replace rpms and can restore them.  (Installing might upgrade dependencies from the vendor to other vendor packages).
-        * Do we need to deal with dependency version issues?  With this code, if an installed dependency is an older version than the subscription-manager package we're installing needs to upgrade and the upgraded version is not present in the vendor's repo, then we will fail.
-        * Do we want to filter already installed packages from the package_list in this function
-          or leave it to the caller? If we leave it to the caller, then we need to backup vendor supplied previous files here and restore them on rollback. (Currently the
-          caller handles this via subscription.needed_subscription_manager_pkgs().  This could cause problems if we need to do extra handling in enable/restore for packages which already exist on the system.)
-        * Do we always want to pre-download the rpms and install from a directory of package files
-          or do we sometimes want yum to download and install as one step? (Current caller
-          doesn't care in subscription.install_rhel_subscription_manager().)
-        * Why is system_info.is_rpm_installed() implemented in syste_info? Evaluate if it should be
-          moved here.
+        * Parameter to install pkgs from "symbolic name" (vendor, pre-rhel,
+          rhel, enablerepos)? which we map to specific repo configurations?
+        * Backup and restore the vendor versions of packages which are in
+          update_pkgs.
+        * This class is useful for package installation but not package
+          removal. To replace backup.ChangedRPMPackagesController and
+          back.RestorablePackage, we need to implement removal as well.  Should
+          we do that here or in a second class?
+        * Note: ChangedRPMPackagesController might still have code that deals
+          with package replacement.  AFAIK, that can be removed entirely.  As
+          of 1.4, there's never a time where we replace rpms and can restore
+          them. (Installing might upgrade dependencies from the vendor to other
+          vendor packages).
+        * Do we need to deal with dependency version issues?  With this code,
+          if an installed dependency is an older version than the
+          subscription-manager package we're installing needs to upgrade and
+          the upgraded version is not present in the vendor's repo, then we
+          will fail.
+        * Do we want to filter already installed packages from the package_list
+          in this function or leave it to the caller? If we leave it to the
+          caller, then we need to backup vendor supplied previous files here
+          and restore them on rollback. (Currently the caller handles this via
+          subscription.needed_subscription_manager_pkgs().  This could cause
+          problems if we need to do extra handling in enable/restore for
+          packages which already exist on the system.)
+        * Why is system_info.is_rpm_installed() implemented in syste_info?
+          Evaluate if it should be moved here.
 
     .. warn:: Some things that are not handled by this class:
         * Packages installed as a dependency on packages listed here will not be rolled back to the
@@ -268,15 +220,28 @@ class RestorablePackageSet(RestorableChange):
         self,
         pkgs_to_install,
         pkgs_to_update=None,
+        repo_path=None,
+        repo_content=None,
+        enable_repos=None,
+        disable_repos=None,
         reposdir=None,
         set_releasever=False,
         custom_releasever=None,
         varsdir=None,
+        setopts=None,
     ):
         self.pkgs_to_install = pkgs_to_install
         self.pkgs_to_update = pkgs_to_update or []
         self.installed_pkgs = []
         self.updated_pkgs = []
+
+        self.repo_path = repo_path
+        self.repo_content = repo_content
+
+        self.enable_repos = enable_repos or []
+        self.disable_repos = disable_repos or []
+        self.setopts = setopts or []
+
         self.reposdir = reposdir
         self.set_releasever = set_releasever
         self.custom_releasever = custom_releasever
@@ -301,40 +266,28 @@ class RestorablePackageSet(RestorableChange):
             loggerinst.info("All packages were already installed")
             return
 
-        # Note, this use of mkdir_p is secure because SUBMGR_RPMS_DIR and
-        # _RHSM_TMP_DIR do not contain any path components writable by
-        # a different user.
-        files.mkdir_p(_SUBMGR_RPMS_DIR)
-        files.mkdir_p(_RHSM_TMP_DIR)
-
         loggerinst.info("Downloading requested packages")
         all_pkgs_to_install = self.pkgs_to_install + self.pkgs_to_update
 
-        ubi_repo_path, ubi_repo_content = _UBI_REPO_MAPPING[system_info.version.major]
-        _download_rhsm_pkgs(all_pkgs_to_install, ubi_repo_path, ubi_repo_content)
+        if self.repo_path:
+            _set_up_repository(self.repo_path, self.repo_content)
 
-        # installing the packages
-        rpms_to_install = [os.path.join(_SUBMGR_RPMS_DIR, filename) for filename in os.listdir(_SUBMGR_RPMS_DIR)]
-
-        loggerinst.info("Installing subscription-manager RPMs.")
-        loggerinst.debug("RPMs scheduled for installation: %s" % utils.format_sequence_as_message(rpms_to_install))
+        loggerinst.debug("RPMs scheduled for installation: %s" % utils.format_sequence_as_message(all_pkgs_to_install))
 
         output, ret_code = call_yum_cmd(
-            # We're using distro-sync as there might be various versions of the subscription-manager pkgs installed
-            # and we need these packages to be replaced with the provided RPMs from RHEL.
             command="install",
-            args=rpms_to_install,
+            args=all_pkgs_to_install,
             print_output=False,
             # When installing subscription-manager packages, the RHEL repos are
-            # not available yet for getting dependencies so we need to use the repos that are
-            # available on the system
-            enable_repos=[],
-            disable_repos=[],
-            # When using the original system repos, we need YUM/DNF to expand the $releasever by itself
+            # not available yet for getting dependencies so we need to use the
+            # repos that are available on the system
+            enable_repos=self.enable_repos,
+            disable_repos=self.disable_repos,
             set_releasever=self.set_releasever,
             custom_releasever=self.custom_releasever,
             reposdir=self.reposdir,
             varsdir=self.varsdir,
+            setopts=self.setopts,
         )
 
         if ret_code:
@@ -347,16 +300,14 @@ class RestorablePackageSet(RestorableChange):
                 title="Failed to install subscription-manager packages.",
                 description="convert2rhel was unable to install subscription-manager packages. These packages are required to subscribe the system and install RHEL packages.",
                 diagnosis="Failed to install packages %s. Output: %s, Status: %s"
-                % (utils.format_sequence_as_message(rpms_to_install), output, ret_code),
+                % (utils.format_sequence_as_message(all_pkgs_to_install), output, ret_code),
             )
 
         # Need to do this here instead of in pkghandler.call_yum_cmd() to avoid
         # double printing the output if an error occurred.
         loggerinst.info(output.rstrip("\n"))
-
-        installed_pkg_names = _get_pkg_names_from_rpm_paths(rpms_to_install)
         loggerinst.info(
-            "\nPackages we installed or updated:\n%s" % utils.format_sequence_as_message(installed_pkg_names)
+            "\nPackages we installed or updated:\n%s" % utils.format_sequence_as_message(all_pkgs_to_install)
         )
 
         # We could rely on these always being installed/updated when
@@ -382,65 +333,8 @@ class RestorablePackageSet(RestorableChange):
         super(RestorablePackageSet, self).restore()
 
 
-def _download_rhsm_pkgs(pkgs_to_download, repo_path, repo_content):
-    paths = None
+def _set_up_repository(repo_path, repo_content):
     try:
-        _log_rhsm_download_directory_contents(_SUBMGR_RPMS_DIR, "before RHEL rhsm packages download")
         utils.store_content_to_file(filename=repo_path, content=repo_content)
-        paths = utils.download_pkgs(pkgs_to_download, dest=_SUBMGR_RPMS_DIR, reposdir=_RHSM_TMP_DIR)
-        _log_rhsm_download_directory_contents(_SUBMGR_RPMS_DIR, "after RHEL rhsm packages download")
     except (OSError, IOError) as err:
         loggerinst.warning("OSError({0}): {1}".format(err.errno, err.strerror))
-    except SystemExit as e:
-        loggerinst.critical_no_exit(
-            "Unable to download the subscription-manager package and its dependencies. See details of"
-            " the failed yumdownloader call above. These packages are necessary for the conversion"
-            " unless you use the --no-rhsm option."
-        )
-        raise exceptions.CriticalError(
-            id_="FAILED_TO_DOWNLOAD_SUBSCRIPTION_MANAGER_PACKAGES",
-            title="Failed to download subscription-manager package and its dependencies.",
-            description="To be able to subscribe the system to Red Hat we need the subscription-manager package and its dependencies to do so. Without these packages we cannot subscribe the system and we cannot install Red Hat Enterprise Linux packages.",
-            diagnosis="Failed to download subscription-manager package %s." % (str(e)),
-        )
-
-    # TODO(r0x0d): Probably we need to check if paths is not empty before
-    # reaching this point. There are a couple of cases where this could happen
-    # and it would be ideal if we took care of that before reaching the point
-    # where we try this if statement.
-    if None in paths:
-        loggerinst.critical_no_exit(
-            "Unable to download the subscription-manager package or its dependencies. See details of"
-            " the failed yumdownloader call above. These packages are necessary for the conversion"
-            " unless you use the --no-rhsm option."
-        )
-        raise exceptions.CriticalError(
-            id_="FAILED_TO_DOWNLOAD_SUBSCRIPTION_MANAGER_PACKAGES",
-            title="Failed to download subscription-manager package and its dependencies.",
-            description="To be able to subscribe the system to Red Hat we need the subscription-manager package and its dependencies to do so. Without these packages we cannot subscribe the system and we cannot install Red Hat Enterprise Linux packages.",
-        )
-
-
-def _log_rhsm_download_directory_contents(directory, when_message):
-    pkgs = ["<download directory does not exist>"]
-    if os.path.isdir(directory):
-        pkgs = os.listdir(directory)
-    loggerinst.debug(
-        "Contents of %s directory %s:\n%s",
-        directory,
-        when_message,
-        "\n".join(pkgs),
-    )
-
-
-def _get_pkg_names_from_rpm_paths(rpm_paths):
-    """Return names of packages represented by locally stored rpm packages.
-    :param rpm_paths: List of rpm with filepaths.
-    :type rpm_paths: list[str]
-    :return: A list of package names extracted from the rpm filepath.
-    :rtype: list
-    """
-    pkg_names = []
-    for rpm_path in rpm_paths:
-        pkg_names.append(utils.get_package_name_from_rpm(rpm_path))
-    return pkg_names

--- a/convert2rhel/backup/packages.py
+++ b/convert2rhel/backup/packages.py
@@ -176,44 +176,35 @@ class RestorablePackage(RestorableChange):
 class RestorablePackageSet(RestorableChange):
     """Install a set of packages in a way that they can be uninstalled later.
 
-    .. warn:: This functionality is incomplete (These are things that need cleanup)
-        Installing and restoring packagesets are very complex. This class needs work before it is
-        generic for any set of packages.
+    .. warn::
+        This functionality is incomplete (These are things that need cleanup)
+        Installing and restoring packagesets are very complex. This class needs
+        work before it is generic for any set of packages. To make this
+        generic, some pieces of that will need to move into this class:
 
-        To make this generic, some pieces of that will need to move into this
-        class:
-
-        * Parameter to install pkgs from "symbolic name" (vendor, pre-rhel,
-          rhel, enablerepos)? which we map to specific repo configurations?
-        * Backup and restore the vendor versions of packages which are in
-          update_pkgs.
         * This class is useful for package installation but not package
-          removal. To replace backup.ChangedRPMPackagesController and
-          back.RestorablePackage, we need to implement removal as well.  Should
-          we do that here or in a second class?
-        * Note: ChangedRPMPackagesController might still have code that deals
-          with package replacement.  AFAIK, that can be removed entirely.  As
-          of 1.4, there's never a time where we replace rpms and can restore
-          them. (Installing might upgrade dependencies from the vendor to other
-          vendor packages).
-        * Do we need to deal with dependency version issues?  With this code,
-          if an installed dependency is an older version than the
-          subscription-manager package we're installing needs to upgrade and
-          the upgraded version is not present in the vendor's repo, then we
-          will fail.
-        * Do we want to filter already installed packages from the package_list
-          in this function or leave it to the caller? If we leave it to the
-          caller, then we need to backup vendor supplied previous files here
-          and restore them on rollback. (Currently the caller handles this via
-          subscription.needed_subscription_manager_pkgs().  This could cause
-          problems if we need to do extra handling in enable/restore for
-          packages which already exist on the system.)
-        * Why is system_info.is_rpm_installed() implemented in syste_info?
-          Evaluate if it should be moved here.
+        removal. To replace backup.ChangedRPMPackagesController and
+        back.RestorablePackage, we need to implement removal as well.  Should
+        we do that here or in a second class?
 
-    .. warn:: Some things that are not handled by this class:
-        * Packages installed as a dependency on packages listed here will not be rolled back to the
-          system default if we rollback the changes.
+        * Do we need to deal with dependency version issues?  With this code,
+        if an installed dependency is an older version than the
+        subscription-manager package we're installing needs to upgrade and the
+        upgraded version is not present in the vendor's repo, then we will
+        fail.
+
+        * Do we want to filter already installed packages from the package_list
+        in this function or leave it to the caller? If we leave it to the
+        caller, then we need to backup vendor supplied previous files here and
+        restore them on rollback. (Currently the caller handles this via
+        subscription.needed_subscription_manager_pkgs().  This could cause
+        problems if we need to do extra handling in enable/restore for packages
+        which already exist on the system.)
+
+    .. warn::
+        Some things that are not handled by this class:
+        * Packages installed as a dependency on packages listed here will not
+        be rolled back to the system default if we rollback the changes.
     """
 
     def __init__(

--- a/convert2rhel/backup/packages.py
+++ b/convert2rhel/backup/packages.py
@@ -224,10 +224,8 @@ class RestorablePackageSet(RestorableChange):
         repo_content=None,
         enable_repos=None,
         disable_repos=None,
-        reposdir=None,
         set_releasever=False,
         custom_releasever=None,
-        varsdir=None,
         setopts=None,
     ):
         self.pkgs_to_install = pkgs_to_install
@@ -242,10 +240,8 @@ class RestorablePackageSet(RestorableChange):
         self.disable_repos = disable_repos or []
         self.setopts = setopts or []
 
-        self.reposdir = reposdir
         self.set_releasever = set_releasever
         self.custom_releasever = custom_releasever
-        self.varsdir = varsdir
 
         super(RestorablePackageSet, self).__init__()
 
@@ -285,8 +281,6 @@ class RestorablePackageSet(RestorableChange):
             disable_repos=self.disable_repos,
             set_releasever=self.set_releasever,
             custom_releasever=self.custom_releasever,
-            reposdir=self.reposdir,
-            varsdir=self.varsdir,
             setopts=self.setopts,
         )
 

--- a/convert2rhel/backup/packages.py
+++ b/convert2rhel/backup/packages.py
@@ -220,8 +220,6 @@ class RestorablePackageSet(RestorableChange):
         self,
         pkgs_to_install,
         pkgs_to_update=None,
-        repo_path=None,
-        repo_content=None,
         enable_repos=None,
         disable_repos=None,
         set_releasever=False,
@@ -232,9 +230,6 @@ class RestorablePackageSet(RestorableChange):
         self.pkgs_to_update = pkgs_to_update or []
         self.installed_pkgs = []
         self.updated_pkgs = []
-
-        self.repo_path = repo_path
-        self.repo_content = repo_content
 
         self.enable_repos = enable_repos or []
         self.disable_repos = disable_repos or []
@@ -264,9 +259,6 @@ class RestorablePackageSet(RestorableChange):
 
         loggerinst.info("Downloading requested packages")
         all_pkgs_to_install = self.pkgs_to_install + self.pkgs_to_update
-
-        if self.repo_path:
-            _set_up_repository(self.repo_path, self.repo_content)
 
         loggerinst.debug("RPMs scheduled for installation: %s" % utils.format_sequence_as_message(all_pkgs_to_install))
 
@@ -325,10 +317,3 @@ class RestorablePackageSet(RestorableChange):
         utils.remove_pkgs(self.installed_pkgs, critical=False)
 
         super(RestorablePackageSet, self).restore()
-
-
-def _set_up_repository(repo_path, repo_content):
-    try:
-        utils.store_content_to_file(filename=repo_path, content=repo_content)
-    except (OSError, IOError) as err:
-        loggerinst.warning("OSError({0}): {1}".format(err.errno, err.strerror))

--- a/convert2rhel/pkgmanager/__init__.py
+++ b/convert2rhel/pkgmanager/__init__.py
@@ -153,6 +153,7 @@ def call_yum_cmd(
     reposdir=None,
     custom_releasever=None,
     varsdir=None,
+    setopts=None,
 ):
     """Call yum command and optionally print its output.
     The enable_repos and disable_repos function parameters accept lists and they override the default use of repos,
@@ -165,8 +166,14 @@ def call_yum_cmd(
     By default, for the above reason, we provide the --releasever option to each yum call. However before we remove the
     release package, we need YUM/DNF to expand the variable by itself (for that, use set_releasever=False).
     """
-    if args is None:
+    if isinstance(reposdir, str):
+        raise TypeError("reposdir must be a list, not str.")
+
+    if not args:
         args = []
+
+    if not setopts:
+        setopts = []
 
     cmd = ["yum", command, "-y"]
 
@@ -209,7 +216,14 @@ def call_yum_cmd(
         cmd.append("--enablerepo=%s" % repo)
 
     if reposdir:
+        reposdir = ",".join(reposdir)
         cmd.append("--setopt=reposdir=%s" % reposdir)
+
+    # Special option to override yum configuration without the need of
+    # modifying the /etc/yum.conf.
+    if setopts:
+        opts = ["--setopt=%s" % opt for opt in setopts]
+        cmd.extend(opts)
 
     cmd.extend(args)
 

--- a/convert2rhel/repo.py
+++ b/convert2rhel/repo.py
@@ -30,6 +30,7 @@ from convert2rhel.toolopts import tool_opts
 from convert2rhel.utils import TMP_DIR, store_content_to_file
 
 
+DEFAULT_YUM_REPOFILE_DIR = "/etc/yum.repos.d"
 DEFAULT_YUM_VARS_DIR = "/etc/yum/vars"
 DEFAULT_DNF_VARS_DIR = "/etc/dnf/vars"
 
@@ -90,7 +91,7 @@ def get_rhel_disable_repos_command(disable_repos):
 def download_repofile(repofile_url):
     """Download the official repofile pointing to a convert2rhel repository.
 
-    :raises exceptions.CriticalError: ...
+    :raises exceptions.CriticalError: When the repository file can't be accessed.
     :returns str: Path to a successfully downloaded repofile
     """
     try:

--- a/convert2rhel/repo.py
+++ b/convert2rhel/repo.py
@@ -99,12 +99,15 @@ def download_repofile(repofile_url):
             contents = response.read()
 
             if not contents:
-                loggerinst.critical_no_exit("")
+                description = (
+                    "The requested repository file seems to be empty. No content received when checking for url: %s"
+                    % repofile_url
+                )
+                loggerinst.critical_no_exit(description)
                 raise exceptions.CriticalError(
                     id_="REPOSITORY_FILE_EMPTY_CONTENT",
-                    title="No content was availble in requested repository file.",
-                    description="The requested repository file seems to be empty. No content received when checking for url: %s"
-                    % repofile_url,
+                    title="No content available in a repository file",
+                    description=description,
                 )
 
             loggerinst.info("Successfully downloaded the requested repofile from %s." % repofile_url)
@@ -112,14 +115,14 @@ def download_repofile(repofile_url):
     except urllib.error.URLError as err:
         raise exceptions.CriticalError(
             id_="DOWNLOAD_REPOSITORY_FILE_FAILED",
-            title="Failed to download repository file.",
+            title="Failed to download repository file",
             description="Failed to download the requested repository file from %s.\n"
             "Reason: %s" % (repofile_url, err.reason),
         )
 
 
 def write_temporary_repofile(contents):
-    """Write a temporary repository file inside the :py:TMP_DIR folder.
+    """Store a temporary repository file inside the :py:TMP_DIR folder.
 
     :param contents str: The contents to write to the file
     :returns: The path to the temporary repofile. If failed to write the
@@ -135,8 +138,8 @@ def write_temporary_repofile(contents):
             return f.name
         except (OSError, IOError) as err:
             raise exceptions.CriticalError(
-                id_="WRITE_REPOSITORY_FILE_FAILED",
-                title="Failed to write repository file.",
+                id_="STORE_REPOSITORY_FILE_FAILED",
+                title="Failed to store a repository file",
                 description="Failed to write the requested repository file contents to %s.\n"
                 "Reason: %s" % (f.name, str(err)),
             )

--- a/convert2rhel/repo.py
+++ b/convert2rhel/repo.py
@@ -95,7 +95,8 @@ def download_repofile(repofile_url):
     """
     try:
         with closing(urllib.request.urlopen(repofile_url, timeout=15)) as response:
-            filepath = write_temporary_repofile(contents=response.read())
+            contents = response.read()
+            filepath = write_temporary_repofile(contents=contents.decode())
             if filepath:
                 loggerinst.info("Successfully downloaded the requested repofile from %s." % repofile_url)
 
@@ -110,12 +111,20 @@ def download_repofile(repofile_url):
 
 
 def write_temporary_repofile(contents):
-    """ """
-    repofile_dir = tempfile.mkdtemp(prefix="convert2rhel_repo.", dir=TMP_DIR)
+    """Write a temporary repository file inside the :py:TMP_DIR folder.
 
+    :param contents: The contents to write to the file
+    :type contents: str
+    :returns: The path to the temporary repofile. If failed to write the
+        repofile, it will return None.
+    """
+    repofile_dir = tempfile.mkdtemp(prefix="convert2rhel_repo.", dir=TMP_DIR)
+    repofile_name = None
     with tempfile.NamedTemporaryFile(mode="w", suffix=".repo", delete=False, dir=repofile_dir) as f:
         try:
             store_content_to_file(filename=f.name, content=contents)
-            return f.name
+            repofile_name = f.name
         except (OSError, IOError) as err:
             loggerinst.warning("OSError({0}): {1}".format(err.errno, err.strerror))
+
+    return repofile_name

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -663,25 +663,23 @@ def install_rhel_subscription_manager(pkgs_to_install):
     backedup_varsdir = os.path.join(backup.BACKUP_DIR, hashlib.md5(varsdir.encode()).hexdigest())
 
     setopts = []
-    # Oracle Linux 7 needs to set the obsoletes option to avoid installing the
+    # Oracle Linux 7 needs to set the exclude option to avoid installing the
     # rhc-client-tools package instead of subscription-manager, as it is marked
     # as obsolete in the subscription-manager specfile for OL7. This option in
-    # yum will make sure to ignore the obsoletes request and install the
+    # yum will make sure to ignore the rhn-client-tools package and install the
     # correct packages we are requesting.
-    # WARNING: This obsoletes will be applicable to all packages in the
-    # transaction.
     if system_info.id == "oracle" and system_info.version.major == 7:
         setopts.append("exclude=rhn-client-tools")
 
-    client_tools_repofile = None
+    client_tools_repofile_path = None
     if system_info.id == "centos" and system_info.version.major == 8:
-        client_tools_repofile = repo.write_temporary_repofile(_CLIENT_TOOLS_RHEL_8_5_REPO)
+        client_tools_repofile_path = repo.write_temporary_repofile(_CLIENT_TOOLS_RHEL_8_5_REPO)
     else:
         repofile_url = _CLIENT_TOOLS_REPOFILE_MAPPING[system_info.version.major]
         contents = repo.download_repofile(repofile_url)
-        client_tools_repofile = repo.write_temporary_repofile(contents)
+        client_tools_repofile_path = repo.write_temporary_repofile(contents)
 
-    reposdir = [os.path.dirname(client_tools_repofile), backedup_reposdir]
+    reposdir = [os.path.dirname(client_tools_repofile_path), backedup_reposdir]
     setopts.append("reposdir=%s" % ",".join(reposdir))
     setopts.append("varsdir=%s" % backedup_varsdir)
     installed_pkg_set = RestorablePackageSet(

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -639,13 +639,25 @@ def is_registered():
     return False
 
 
-def install_rhel_subscription_manager(pkgs_to_install, pkgs_to_upgrade=None):
+def install_rhel_subscription_manager(pkgs_to_install):
     """
     Install the RHEL versions of the subscription-manager packages.
 
-    ..seealso:: :func:`_relevant_subscription_manager_pkgs` for the list of packages that we install.
+    ..seealso:: :func:`_relevant_subscription_manager_pkgs` for the list of
+    packages that we install.
+
+    ..warning::
+        With enabling the client-tools repo we can't ensure that on CentOS
+        Linux 7 the subscription-manager-rhsm-certificates is downloaded from
+        the client-tools repo and not from the CentOS Linux 7 repo.
+
+        The thing is that the CentOS one is missing the Red Hat certificate
+        /etc/rhsm/ca/redhat-uep.pem which is necessary for being able to
+        register the system to Red Hat Subscription Management (sometimes
+        referred to as Customer Portal). However, the
+        :class:`InstallRedHatCertForYumRepositories` action takes care of that
+        shortcoming by installing the certificate.
     """
-    pkgs_to_upgrade = pkgs_to_upgrade or []
     backedup_reposdir = backup.get_backedup_system_repos()
     varsdir = DEFAULT_YUM_VARS_DIR if system_info.version.major == 7 else DEFAULT_DNF_VARS_DIR
     backedup_varsdir = os.path.join(backup.BACKUP_DIR, hashlib.md5(varsdir.encode()).hexdigest())
@@ -659,21 +671,21 @@ def install_rhel_subscription_manager(pkgs_to_install, pkgs_to_upgrade=None):
     # WARNING: This obsoletes will be applicable to all packages in the
     # transaction.
     if system_info.id == "oracle" and system_info.version.major == 7:
-        setopts.append("obsoletes=0")
+        setopts.append("exclude=rhn-client-tools")
 
     client_tools_repofile = None
     if system_info.id == "centos" and system_info.version.major == 8:
         client_tools_repofile = repo.write_temporary_repofile(_CLIENT_TOOLS_RHEL_8_5_REPO)
     else:
         repofile_url = _CLIENT_TOOLS_REPOFILE_MAPPING[system_info.version.major]
-        client_tools_repofile = repo.download_repofile(repofile_url)
+        contents = repo.download_repofile(repofile_url)
+        client_tools_repofile = repo.write_temporary_repofile(contents)
 
     reposdir = [os.path.dirname(client_tools_repofile), backedup_reposdir]
     setopts.append("reposdir=%s" % ",".join(reposdir))
     setopts.append("varsdir=%s" % backedup_varsdir)
     installed_pkg_set = RestorablePackageSet(
         pkgs_to_install,
-        pkgs_to_upgrade,
         custom_releasever=system_info.version.major,
         set_releasever=True,
         setopts=setopts,
@@ -907,38 +919,6 @@ def needed_subscription_manager_pkgs():
     loggerinst.debug("Packages we will install: %s" % utils.format_sequence_as_message(to_install_pkgs))
 
     return to_install_pkgs
-
-
-def dependencies_to_update(pkg_list):
-    """
-    We are trying to get convert2rhel to only install the subset of subscription-manager packages
-    which it requires.  However, when we do have to install packages, we are getting them from the
-    UBI repositories where the version of subscription-manager may need a newer vrsion of
-    dependencies than the vendor has. For this reason, we may need to install some dependencies from
-    the UBI repositories even though the vendor versions of them are already installed.
-
-    Currently, python-syspurpose and json-c are the only problematic packages so make
-    sure that they are added to the install set.
-
-    .. seealso:: Bug report illustrating the version problem:
-        https://github.com/oamg/convert2rhel/pull/494
-    """
-    if not pkg_list:
-        return []
-
-    # Only apply this kludge on RHEL 8-based systems. We have detected the problem on CentOS/Alma/Rocky 8.
-    if not system_info.version.major == 8:
-        return []
-
-    # Package names that we require differ on various platforms so we need to
-    # extract them from the list for this platform.
-    pkgs_for_this_platform = _relevant_subscription_manager_pkgs()
-    upgrade_deps = (p for p in pkgs_for_this_platform if "syspurpose" in p or "json-c" in p)
-
-    # Make sure we don't call these upgrades if they need to be installed.
-    upgrade_deps = [p for p in upgrade_deps if p not in pkg_list]
-
-    return upgrade_deps
 
 
 def _relevant_subscription_manager_pkgs():

--- a/convert2rhel/unit_tests/backup/packages_test.py
+++ b/convert2rhel/unit_tests/backup/packages_test.py
@@ -29,11 +29,9 @@ from convert2rhel.systeminfo import Version
 from convert2rhel.unit_tests import (
     CallYumCmdMocked,
     DownloadPkgMocked,
-    GetInstalledPkgInformationMocked,
     MockFunctionObject,
     RemovePkgsMocked,
     RunSubprocessMocked,
-    StoreContentToFileMocked,
 )
 from convert2rhel.unit_tests.conftest import centos7
 
@@ -245,27 +243,27 @@ class TestRestorablePackageSet:
         return path.rsplit("-", 2)[0]
 
     @pytest.fixture
-    def package_set(self, monkeypatch, tmpdir):
+    def package_set(self):
         return RestorablePackageSet(["subscription-manager", "python-syspurpose"])
 
     @pytest.mark.parametrize(
-        ("pkgs_to_install", "pkgs_to_update", "reposdir"),
+        ("pkgs_to_install", "pkgs_to_update", "setopts"),
         (
-            (["pkg-1"], [], None),
-            (["pkg-1"], [], ["test-dir"]),
-            ([], ["pkg-1"], None),
-            ([], [], ["test-dir"]),
-            (["pkg-1"], ["pkg-2"], None),
+            (["pkg-1"], [], []),
+            (["pkg-1"], [], ["varsdir=test-dir"]),
+            ([], ["pkg-1"], []),
+            ([], [], ["reposdir=test-dir"]),
+            (["pkg-1"], ["pkg-2"], []),
         ),
     )
-    def test_smoketest_init(self, pkgs_to_install, pkgs_to_update, reposdir):
+    def test_smoketest_init(self, pkgs_to_install, pkgs_to_update, setopts):
         package_set = RestorablePackageSet(
-            pkgs_to_install=pkgs_to_install, pkgs_to_update=pkgs_to_update, reposdir=reposdir
+            pkgs_to_install=pkgs_to_install, pkgs_to_update=pkgs_to_update, setopts=setopts
         )
 
         assert package_set.pkgs_to_install == pkgs_to_install
         assert package_set.pkgs_to_update == pkgs_to_update
-        assert package_set.reposdir == reposdir
+        assert package_set.setopts == setopts
 
         assert package_set.enabled is False
         # We actually care that this is an empty list and not just False-y

--- a/convert2rhel/unit_tests/backup/packages_test.py
+++ b/convert2rhel/unit_tests/backup/packages_test.py
@@ -297,15 +297,11 @@ class TestRestorablePackageSet:
         assert "json-c.x86_64" not in package_set.installed_pkgs
 
     @centos7
-    def test_enable_set_custom_repository(self, pretend_os, caplog, monkeypatch, tmpdir):
-        repofile = tmpdir.join("test.repofile")
-        repofile = str(repofile)
+    def test_enable_set_custom_repository(self, pretend_os, caplog, monkeypatch):
         monkeypatch.setattr(packages, "call_yum_cmd", CallYumCmdMocked())
 
         package_set = RestorablePackageSet(["subscription-manager", "python-syspurpose"])
-
         package_set.pkgs_to_update = ["json-c.x86_64"]
-
         package_set.enable()
 
         assert package_set.enabled is True

--- a/convert2rhel/unit_tests/backup/packages_test.py
+++ b/convert2rhel/unit_tests/backup/packages_test.py
@@ -102,20 +102,6 @@ class TestRestorablePackage:
         assert len(global_backup_control._restorables) == 1
         assert len(rp._backedup_pkgs_paths) == len(pkgs)
 
-    def test_enable_eus_systems(self, monkeypatch, tmpdir, global_system_info):
-        monkeypatch.setattr(packages, "BACKUP_DIR", str(tmpdir))
-        monkeypatch.setattr(utils, "download_pkg", DownloadPkgMocked())
-        monkeypatch.setattr(packages, "system_info", global_system_info)
-
-        packages.system_info.eus_system = True
-        packages.system_info.id = "centos"
-
-        rp = RestorablePackage(pkgs=["test.rpm"])
-        rp._backedup_pkgs_paths = ["test.rpm"]
-        rp.enable()
-
-        assert utils.download_pkg.call_count == 1
-
     def test_package_already_enabled(self, monkeypatch, tmpdir):
         monkeypatch.setattr(packages, "BACKUP_DIR", str(tmpdir))
         monkeypatch.setattr(utils, "download_pkg", DownloadPkgMocked())
@@ -279,7 +265,6 @@ class TestRestorablePackageSet:
     )
     def test_enable_need_to_install(self, major, minor, package_set, global_system_info, caplog, monkeypatch):
         global_system_info.version = Version(major, minor)
-        monkeypatch.setattr(packages, "system_info", global_system_info)
         monkeypatch.setattr(packages, "call_yum_cmd", CallYumCmdMocked())
 
         package_set.pkgs_to_update = ["json-c.x86_64"]

--- a/convert2rhel/unit_tests/backup/packages_test.py
+++ b/convert2rhel/unit_tests/backup/packages_test.py
@@ -302,9 +302,7 @@ class TestRestorablePackageSet:
         repofile = str(repofile)
         monkeypatch.setattr(packages, "call_yum_cmd", CallYumCmdMocked())
 
-        package_set = RestorablePackageSet(
-            ["subscription-manager", "python-syspurpose"], repo_path=repofile, repo_content="test"
-        )
+        package_set = RestorablePackageSet(["subscription-manager", "python-syspurpose"])
 
         package_set.pkgs_to_update = ["json-c.x86_64"]
 
@@ -418,21 +416,3 @@ class TestRestorablePackageSet:
 
         assert previously_called >= 1
         assert mock_remove_pkgs.call_count == previously_called
-
-
-def test_set_up_repository(tmpdir):
-    repofile = tmpdir.join("test.repo")
-    repofile = str(repofile)
-    packages._set_up_repository(repofile, "test-content")
-
-    assert os.path.exists(repofile)
-
-    with open(repofile) as handler:
-        assert "test-content" in handler.read()
-
-
-def test_set_up_repository_oserror(monkeypatch, caplog):
-    monkeypatch.setattr(utils, "store_content_to_file", mock.Mock(side_effect=OSError(1, "test")))
-    packages._set_up_repository("non-existing", "test-content")
-
-    assert caplog.records[-1].message == "OSError(1): test"

--- a/convert2rhel/unit_tests/repo_test.py
+++ b/convert2rhel/unit_tests/repo_test.py
@@ -120,7 +120,7 @@ class URLOpenMock:
 
 
 def test_download_repofile(monkeypatch, tmpdir, caplog):
-    monkeypatch.setattr(repo.urllib.request, "urlopen", URLOpenMock(url=None, timeout=1, contents="test_file"))
+    monkeypatch.setattr(repo.urllib.request, "urlopen", URLOpenMock(url=None, timeout=1, contents=b"test_file"))
     tmp_dir = str(tmpdir)
     monkeypatch.setattr(repo, "TMP_DIR", tmp_dir)
 

--- a/convert2rhel/unit_tests/repo_test.py
+++ b/convert2rhel/unit_tests/repo_test.py
@@ -136,7 +136,7 @@ class TestDownloadRepofile:
             repo.download_repofile("https://test")
 
         assert "DOWNLOAD_REPOSITORY_FILE_FAILED" in execinfo._excinfo[1].id
-        assert "Failed to download repository file." in execinfo._excinfo[1].title
+        assert "Failed to download repository file" in execinfo._excinfo[1].title
         assert "test" in execinfo._excinfo[1].description
 
     def test_no_contents_in_request_url(self, monkeypatch):
@@ -148,7 +148,7 @@ class TestDownloadRepofile:
             repo.download_repofile("https://test")
 
         assert "REPOSITORY_FILE_EMPTY_CONTENT" == execinfo._excinfo[1].id
-        assert "No content was availble in requested repository file." in execinfo._excinfo[1].title
+        assert "No content available in a repository file" in execinfo._excinfo[1].title
         assert "The requested repository file seems to be empty." in execinfo._excinfo[1].description
 
 
@@ -169,6 +169,6 @@ def test_write_temporary_repofile_oserror(tmpdir, monkeypatch):
     with pytest.raises(exceptions.CriticalError) as execinfo:
         repo.write_temporary_repofile("test")
 
-    assert "WRITE_REPOSITORY_FILE_FAILED" in execinfo._excinfo[1].id
-    assert "Failed to write repository file." in execinfo._excinfo[1].title
+    assert "STORE_REPOSITORY_FILE_FAILED" in execinfo._excinfo[1].id
+    assert "Failed to store a repository file" in execinfo._excinfo[1].title
     assert "test" in execinfo._excinfo[1].description

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -29,7 +29,7 @@ import dbus.exceptions
 import pytest
 import six
 
-from convert2rhel import exceptions, pkghandler, pkgmanager, subscription, toolopts, unit_tests, utils
+from convert2rhel import exceptions, pkghandler, pkgmanager, repo, subscription, toolopts, unit_tests, utils
 from convert2rhel.backup import files
 from convert2rhel.systeminfo import Version, system_info
 from convert2rhel.unit_tests import (
@@ -364,6 +364,11 @@ class TestRestorableSystemSubscription:
 @all_systems
 def test_install_rhel_subsription_manager(pretend_os, monkeypatch):
     mock_backup_control = mock.Mock()
+    mock_write_temporary_repofile = mock.Mock(return_value="/test")
+    mock_download_repofile = mock.Mock(return_value="/test")
+
+    monkeypatch.setattr(repo, "write_temporary_repofile", mock_write_temporary_repofile)
+    monkeypatch.setattr(repo, "download_repofile", mock_download_repofile)
     monkeypatch.setattr(subscription.backup.backup_control, "push", mock_backup_control)
 
     subscription.install_rhel_subscription_manager(["subscription-manager", "json-c.x86_64"])

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -43,7 +43,7 @@ from convert2rhel.unit_tests import (
     get_pytest_marker,
     run_subprocess_side_effect,
 )
-from convert2rhel.unit_tests.conftest import centos7, centos8
+from convert2rhel.unit_tests.conftest import all_systems, centos7, centos8
 
 
 six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
@@ -183,7 +183,7 @@ class TestNeededSubscriptionManagerPkgs:
                 ]
             ),
         )
-        assert upgrade_deps == set(subscription._dependencies_to_update(pkg_list))
+        assert upgrade_deps == set(subscription.dependencies_to_update(pkg_list))
 
     def test__dependencies_to_update_no_pkgs(self, monkeypatch, global_system_info):
         global_system_info.version = Version(8, 5)
@@ -202,7 +202,7 @@ class TestNeededSubscriptionManagerPkgs:
                 ]
             ),
         )
-        assert [] == subscription._dependencies_to_update([])
+        assert [] == subscription.dependencies_to_update([])
 
     @pytest.mark.parametrize(
         (
@@ -361,7 +361,7 @@ class TestRestorableSystemSubscription:
         assert "subscription-manager not installed, skipping" == caplog.messages[-1]
 
 
-@centos7
+@all_systems
 def test_install_rhel_subsription_manager(pretend_os, monkeypatch):
     mock_backup_control = mock.Mock()
     monkeypatch.setattr(subscription.backup.backup_control, "push", mock_backup_control)

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -146,65 +146,6 @@ class TestNeededSubscriptionManagerPkgs:
         assert subscription.needed_subscription_manager_pkgs()
 
     @pytest.mark.parametrize(
-        ("rhel_version", "json_c_i686", "pkg_list", "upgrade_deps"),
-        (
-            (
-                Version(7, 10),
-                True,
-                ["subscription-manager"],
-                set(),
-            ),
-            (
-                Version(8, 5),
-                True,
-                ["subscription-manager"],
-                {"python3-syspurpose", "json-c.x86_64", "json-c.i686"},
-            ),
-            (Version(8, 5), False, ["subscription-manager"], {"python3-syspurpose", "json-c.x86_64"}),
-        ),
-    )
-    def test__dependencies_to_update(
-        self, rhel_version, json_c_i686, pkg_list, upgrade_deps, monkeypatch, global_system_info
-    ):
-        global_system_info.version = rhel_version
-        global_system_info.id = "centos"
-        global_system_info.is_rpm_installed = lambda _: json_c_i686
-        monkeypatch.setattr(subscription, "system_info", global_system_info)
-        monkeypatch.setattr(
-            pkghandler,
-            "get_installed_pkg_information",
-            mock.Mock(
-                return_value=[
-                    create_pkg_information(name="subscription-manager-rhsm-certificates.x86_64"),
-                    create_pkg_information(name="python3-subscription-manager-rhsm"),
-                    create_pkg_information(name="dnf-plugin-subscription-manager"),
-                    create_pkg_information(name="other-package"),
-                    create_pkg_information(name="centos-release"),
-                ]
-            ),
-        )
-        assert upgrade_deps == set(subscription.dependencies_to_update(pkg_list))
-
-    def test__dependencies_to_update_no_pkgs(self, monkeypatch, global_system_info):
-        global_system_info.version = Version(8, 5)
-        global_system_info.id = "centos"
-        monkeypatch.setattr(subscription, "system_info", global_system_info)
-        monkeypatch.setattr(
-            pkghandler,
-            "get_installed_pkg_information",
-            mock.Mock(
-                return_value=[
-                    create_pkg_information(name="subscription-manager-rhsm-certificates.x86_64"),
-                    create_pkg_information(name="python3-subscription-manager-rhsm"),
-                    create_pkg_information(name="dnf-plugin-subscription-manager"),
-                    create_pkg_information(name="other-package"),
-                    create_pkg_information(name="centos-release"),
-                ]
-            ),
-        )
-        assert [] == subscription.dependencies_to_update([])
-
-    @pytest.mark.parametrize(
         (
             "version",
             "json_c_i686_installed",


### PR DESCRIPTION
In this commit, we are introducing the installation of subscription-manager directly through a package manager, instead of downloading the package first and then installing it with system package manager.

This is necessary as we want to do GPG verification when installing those set of packages, in which case, it was not available when we used to download the packages and then install it via local install.

Notable changes in this commit are:
* Replacing installing subscription-manager to install it directly from the client-tools repository with gpg check enabled for all supported versions
* Minor refactor to RestorablePackageSet class to allow it to be generic and use custom repository paths and content to install packages
* Small tweak to call_yum_cmd to use the reposdir option as a list instead of a string
* Move subscription-manager constants to subscription.py module instead of the packages.py backup module

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-601](https://issues.redhat.com/browse/RHELC-601)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant


-----

# Depends on
- [x] https://github.com/oamg/convert2rhel/pull/1194
