### PR TITLE
[RHELC-1484] Update efi check for PART_ENTRY_NUMBER

### DIFF
--- a/convert2rhel/grub.py
+++ b/convert2rhel/grub.py
@@ -172,7 +172,7 @@ def get_device_number(device):
         raise BootloaderError("Unable to get information about the '%s' device" % device)
     # We are spliting the partition entry number, and we are just taking that
     # output as our desired partition number
-    if not output:
+    if not output or output == "\n":
         raise BootloaderError("The '%s' device has no PART_ENTRY_NUMBER" % device)
     partition_number = output.split("PART_ENTRY_NUMBER=")[-1].replace('"', "")
     return int(partition_number)

--- a/convert2rhel/grub.py
+++ b/convert2rhel/grub.py
@@ -167,12 +167,13 @@ def get_device_number(device):
     output, ecode = utils.run_subprocess(
         ["/usr/sbin/blkid", "-p", "-s", "PART_ENTRY_NUMBER", device], print_output=False
     )
+    output = output.strip()
     if ecode:
         logger.debug("blkid output:\n-----\n%s\n-----" % output)
         raise BootloaderError("Unable to get information about the '%s' device" % device)
     # We are spliting the partition entry number, and we are just taking that
     # output as our desired partition number
-    if not output or output == "\n":
+    if not output:
         raise BootloaderError("The '%s' device has no PART_ENTRY_NUMBER" % device)
     partition_number = output.split("PART_ENTRY_NUMBER=")[-1].replace('"', "")
     return int(partition_number)

--- a/convert2rhel/unit_tests/grub_test.py
+++ b/convert2rhel/unit_tests/grub_test.py
@@ -159,8 +159,15 @@ def test_get_device_number(monkeypatch, caplog, expected_res, device, exc, subpr
         assert len(caplog.records) == 0
 
 
-def test_get_device_number_no_output(monkeypatch):
-    monkeypatch.setattr("convert2rhel.utils.run_subprocess", RunSubprocessMocked(return_value=("", 0)))
+@pytest.mark.parametrize(
+    ("output"),
+    (
+        (""),
+        ("\n"),
+    ),
+)
+def test_get_device_number_no_output(monkeypatch, output):
+    monkeypatch.setattr("convert2rhel.utils.run_subprocess", RunSubprocessMocked(return_value=(output, 0)))
     with pytest.raises(grub.BootloaderError, match="The '/dev/sda1' device has no PART_ENTRY_NUMBER"):
         grub.get_device_number("/dev/sda1")
 

--- a/convert2rhel/unit_tests/grub_test.py
+++ b/convert2rhel/unit_tests/grub_test.py
@@ -163,6 +163,7 @@ def test_get_device_number(monkeypatch, caplog, expected_res, device, exc, subpr
     ("output"),
     (
         (""),
+        (" "),
         ("\n"),
     ),
 )

--- a/convert2rhel/unit_tests/grub_test.py
+++ b/convert2rhel/unit_tests/grub_test.py
@@ -165,6 +165,8 @@ def test_get_device_number(monkeypatch, caplog, expected_res, device, exc, subpr
         (""),
         (" "),
         ("\n"),
+        (" \n \r"),
+        ("\r"),
     ),
 )
 def test_get_device_number_no_output(monkeypatch, output):


### PR DESCRIPTION
A customer reported an issue where the EFI check found an unexpected error related to the devices PART_ENTRY_NUMBER - https://github.com/oamg/convert2rhel/issues/1167. A PR was made to error when the PART_ENTRY_NUMBER is missing but the check was not set to expect the output from `blkid -p -s PART_ENTRY_NUMBER [device]` to be "\n". This PR adds a conditional to ensure we error when blkid returns an empty string, "\n" or " ".

Jira Issues: [RHELC-1484](https://issues.redhat.com/browse/RHELC-1484)
Closes #1167 

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
