### PR TITLE
[RHELC-1488]  Remove packages left after the TF artifact installation 

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -60,6 +60,7 @@ markers =
     test_package_download_error
     test_transaction_validation_error
     test_validation_packages_with_in_name_period
+    test_override_exclude_list_in_yum_config
     test_unsuccessful_satellite_registration
     test_missing_system_release
     test_backup_os_release_no_envar

--- a/tests/ansible_collections/main.yml
+++ b/tests/ansible_collections/main.yml
@@ -9,6 +9,8 @@
         and (ansible_facts['distribution'] == "AlmaLinux"
         or ansible_facts['distribution'] == "Rocky")
 
+    - role: remove-tf-artifact-leftovers
+
     - role: update-system
 
     - role: oracle-linux-specific

--- a/tests/ansible_collections/roles/remove-tf-artifact-leftovers/tasks/clean_up_el7.yml
+++ b/tests/ansible_collections/roles/remove-tf-artifact-leftovers/tasks/clean_up_el7.yml
@@ -1,0 +1,38 @@
+---
+- name: Remove rcmtools packages installed on the system
+  # We cannot use yum remove as it also removes dependency packages (like even c2r) that we need to keep installed.
+  # Use `rpm -e --nodeps` instead.
+  ansible.builtin.shell: yum list installed | grep @rcmtools | awk '{print $1}' | xargs rpm -e --nodeps
+  ignore_errors: true
+- name: Remove rcmtools repo from the system
+  ansible.builtin.file:
+    path: "/etc/yum.repos.d/rcmtools.repo"
+    state: absent
+
+- name: Remove qa-tools packages installed on the system
+  ansible.builtin.shell: yum list installed | grep @.*qa-tools$ | awk '{print $1}' | xargs rpm -e --nodeps
+  ignore_errors: true
+- name: Remove qa-tools repo from the system
+  ansible.builtin.file:
+    path: "/etc/yum.repos.d/qa-tools.repo"
+    state: absent
+
+# lshw.x86_64 package somehow breaks the listing of all the beaker packages.
+# To workaround this simply just remove the package first.
+- name: Remove lshw.x86_64 beaker package
+  ansible.builtin.shell: rpm -e --nodeps lshw.x86_64
+  ignore_errors: true
+- name: Remove beaker packages installed on the system
+  ansible.builtin.shell: yum list installed | grep @beaker | awk '{print $1}' | xargs rpm -e --nodeps
+  ignore_errors: true
+- name: Remove beaker repo from the system
+  ansible.builtin.file:
+    path: "/etc/yum.repos.d/{{ item }}"
+    state: absent
+  with_items:
+    - beaker-client.repo
+    - beaker-harness.repo
+    - beaker-tasks.repo
+
+- name: Clean yum metadata
+  ansible.builtin.shell: yum clean metadata

--- a/tests/ansible_collections/roles/remove-tf-artifact-leftovers/tasks/clean_up_el8.yml
+++ b/tests/ansible_collections/roles/remove-tf-artifact-leftovers/tasks/clean_up_el8.yml
@@ -1,0 +1,34 @@
+---
+- name: Remove rcmtools packages installed on the system
+  ansible.builtin.shell: dnf list --installed | grep @rcmtools | awk '{print $1}' | xargs dnf remove -y
+  ignore_errors: true
+- name: Remove rcmtools repo from the system
+  ansible.builtin.file:
+    path: "/etc/yum.repos.d/rcmtools.repo"
+    state: absent
+
+- name: Remove qa-tools packages installed on the system
+  ansible.builtin.shell: dnf list --installed | grep @.*qa-tools$ | awk '{print $1}' | xargs dnf remove -y
+  ignore_errors: true
+- name: Remove qa-tools repo from the system
+  ansible.builtin.file:
+    path: "/etc/yum.repos.d/qa-tools.repo"
+    state: absent
+
+- name: Remove beaker packages installed on the system
+  ansible.builtin.shell: dnf list --installed | grep @beaker | awk '{print $1}' | xargs dnf remove -y
+  ignore_errors: true
+- name: Remove beaker repo from the system
+  ansible.builtin.file:
+    path: "/etc/yum.repos.d/{{ item }}"
+    state: absent
+  with_items:
+    - beaker-client.repo
+    - beaker-client-testing.repo
+    - beaker-harness.repo
+    - beaker-tasks.repo
+    - beakerlib-libraries.repo
+    - rhel-CRB-latest.repo
+
+- name: Clean yum metadata
+  ansible.builtin.shell: yum clean metadata

--- a/tests/ansible_collections/roles/remove-tf-artifact-leftovers/tasks/main.yml
+++ b/tests/ansible_collections/roles/remove-tf-artifact-leftovers/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+# After the artifact installation phase (which is done by the TF) there are
+# some third-party packages and repos left on the system.
+# Remove those packages and corresponding repositories.
+- include_tasks: clean_up_el7.yml
+  when: ansible_facts['distribution_major_version'] == "7"
+- include_tasks: clean_up_el8.yml
+  when: ansible_facts['distribution_major_version'] == "8"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -548,40 +548,6 @@ def tmt_reboot_count_reset(shell):
     shell("export TMT_REBOOT_COUNT=0 && export REBOOTCOUNT=0 && export RSTRNT_REBOOTCOUNT=0")
 
 
-@pytest.fixture(scope="session", autouse=True)
-def rcmtools_cleanup():
-    """
-    Fixture to clean up rcmtools packages and repository from the host.
-    These are an artifact of Testing Farm installation, which have no usage for our testing
-    and can negatively impact the test results in some scenarios.
-    """
-    reponame = "rcmtools"
-
-    conflicting_pkgs = ["libcomps"]
-
-    # Get list of packages installed from the rcmtools repository
-    yum_command = f"yum list installed --disablerepo=* --enablerepo={reponame} | awk '$3==\"@{reponame}\" {{print $1}}'"
-
-    installed_packages = subprocess.run(
-        f"{yum_command} | wc -l",
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        shell=True,
-        check=True,
-        universal_newlines=True,
-    )
-
-    result = subprocess.run(yum_command, stdout=subprocess.PIPE, shell=True, check=True, universal_newlines=True)
-
-    # Remove the packages installed from the rcmtools repo
-    if "oracle-7" in SYSTEM_RELEASE_ENV and installed_packages.stdout.splitlines()[-1].strip() != "0":
-        for pkg in conflicting_pkgs:
-            if pkg in result.stdout:
-                subprocess.run(f"yum remove -y {pkg}", check=True, shell=True)
-
-    yield
-
-
 @pytest.fixture()
 def environment_variables(request):
     """

--- a/tests/integration/tier0/non-destructive/kernel/files/alma_old.repo
+++ b/tests/integration/tier0/non-destructive/kernel/files/alma_old.repo
@@ -1,5 +1,0 @@
-[alma_old]
-name=Old repo of Alma Linux
-baseurl=https://repo.almalinux.org/vault/8.6/BaseOS/$basearch/os/
-enabled=0
-gpgcheck=0

--- a/tests/integration/tier0/non-destructive/kernel/files/rocky_old.repo
+++ b/tests/integration/tier0/non-destructive/kernel/files/rocky_old.repo
@@ -1,5 +1,0 @@
-[rocky_old]
-name=Old repo of Rocky Linux
-baseurl=https://download.rockylinux.org/vault/rocky/8.6/BaseOS/$basearch/os/
-enabled=0
-gpgcheck=0

--- a/tests/integration/tier0/non-destructive/single-yum-transaction-validation/main.fmf
+++ b/tests/integration/tier0/non-destructive/single-yum-transaction-validation/main.fmf
@@ -48,7 +48,8 @@ tag+:
     adjust+:
         - enabled: true
           when: >
-            distro == oracle-8, centos-8
+            distro == oracle-8, centos-8, alma-8, rocky-8
+          because: The bug was reported on EL8 https://issues.redhat.com/browse/RHELC-1060
     summary+: |
         Unhandled exception for packages with in name period
     description+: |
@@ -66,11 +67,6 @@ tag+:
         pytest -svv -m test_validation_packages_with_in_name_period
 
 /override_exclude_list_in_yum_config:
-    enabled: false
-    adjust+:
-        - enabled: true
-          when: >
-            distro == oracle-7, centos-7
     summary+: |
         Override exclude in yum config to avoid dependency problems
     description+: |
@@ -87,7 +83,7 @@ tag+:
         3/ Boot into an older kernel
         4/ Run the analysis and check that the transaction was successful.
     tag+:
-        - validation-packages-with-in-name-period
+        - override-exclude-list-in-yum-config
         - sanity
     test: |
-        pytest -svv -m test_validation_packages_with_in_name_period
+        pytest -svv -m test_override_exclude_list_in_yum_config


### PR DESCRIPTION
After the artifact installation done by TF there are some packages left on the system.
They are considered as a third party packages so we want to remove them from the system as well
as the corresponding repositories.

Also fix single-yum-transaction-validation int tests

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1488](https://issues.redhat.com/browse/RHELC-1488)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
