### PR TITLE
[RHELC-1276] Modify exit code for conversion when inhibitor is found

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -306,8 +306,6 @@ def _handle_main_exceptions(process_phase, results=None):
             disable_colors=logger_module.should_disable_color_output(),
         )
 
-        subscription.update_rhsm_custom_facts()
-
     return ConversionExitCodes.FAILURE
 
 

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -239,12 +239,11 @@ def _raise_for_skipped_failures(results):
     failures = actions.find_actions_of_severity(results, "SKIP", level_for_raw_action_data)
     if failures:
         # The report will be handled in the error handler, after rollback.
-        method = "conversion" if toolopts.tool_opts.activity == "conversion" else "analysis"
         message = (
             "The {method} process failed.\n\n"
             "A problem was encountered during {method} and a rollback will be "
             "initiated to restore the system as the previous state."
-        ).format(method=method)
+        ).format(method=toolopts.tool_opts.activity)
         raise _InhibitorsFound(message)
 
 

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -432,8 +432,8 @@ class TestRollbackFromMain:
         assert rollback_changes_mock.call_count == 1
         assert summary_as_json_mock.call_count == 1
         assert summary_as_txt_mock.call_count == 1
-        assert caplog.records[-4].message == "Conversion failed."
-        assert caplog.records[-4].levelname == "CRITICAL"
+        assert caplog.records[-3].message == "Analysis failed."
+        assert caplog.records[-3].levelname == "CRITICAL"
 
     def test_main_rollback_analyze_exit_phase_without_subman(self, global_tool_opts, monkeypatch, tmp_path):
         """
@@ -598,7 +598,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
         monkeypatch.setattr(report, "summary_as_txt", summary_as_txt_mock)
 
-        assert main.main() == 2
+        assert main.main() == 1
         assert require_root_mock.call_count == 1
         assert initialize_file_logging_mock.call_count == 1
         assert toolopts_cli_mock.call_count == 1
@@ -640,7 +640,7 @@ class TestRollbackFromMain:
                 },
             },
             SystemExit,
-            "Conversion failed.",
+            "Analysis failed.",
             "analisys",
         ),
         (
@@ -659,7 +659,7 @@ class TestRollbackFromMain:
                 },
             },
             SystemExit,
-            "Conversion failed.",
+            "Analysis failed.",
             "analisys",
         ),
         (

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -413,7 +413,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
         monkeypatch.setattr(report, "summary_as_txt", summary_as_txt_mock)
 
-        assert main.main() == 1
+        assert main.main() == 2
         assert require_root_mock.call_count == 1
         assert initialize_file_logging_mock.call_count == 1
         assert toolopts_cli_mock.call_count == 1
@@ -432,7 +432,7 @@ class TestRollbackFromMain:
         assert rollback_changes_mock.call_count == 1
         assert summary_as_json_mock.call_count == 1
         assert summary_as_txt_mock.call_count == 1
-        assert caplog.records[-3].message == "Analysis failed."
+        assert "The analysis process failed." in caplog.records[-3].message
         assert caplog.records[-3].levelname == "CRITICAL"
 
     def test_main_rollback_analyze_exit_phase_without_subman(self, global_tool_opts, monkeypatch, tmp_path):
@@ -639,8 +639,12 @@ class TestRollbackFromMain:
                     },
                 },
             },
-            SystemExit,
-            "Analysis failed.",
+            main._InhibitorsFound,
+            (
+                "The analysis process failed.\n\n"
+                "A problem was encountered during analysis and a rollback will be "
+                "initiated to restore the system as the previous state."
+            ),
             "analisys",
         ),
         (
@@ -658,8 +662,12 @@ class TestRollbackFromMain:
                     },
                 },
             },
-            SystemExit,
-            "Analysis failed.",
+            main._InhibitorsFound,
+            (
+                "The analysis process failed.\n\n"
+                "A problem was encountered during analysis and a rollback will be "
+                "initiated to restore the system as the previous state."
+            ),
             "analisys",
         ),
         (
@@ -677,8 +685,12 @@ class TestRollbackFromMain:
                     },
                 },
             },
-            main._AnalyzeInhibitorFound,
-            "",
+            main._InhibitorsFound,
+            (
+                "The conversion process failed.\n\n"
+                "A problem was encountered during conversion and a rollback will be "
+                "initiated to restore the system as the previous state."
+            ),
             "conversion",
         ),
     ),
@@ -687,7 +699,7 @@ def test_raise_for_skipped_failures(data, exception, match, activity, global_too
     monkeypatch.setattr(toolopts, "tool_opts", global_tool_opts)
     global_tool_opts.activity = activity
     with pytest.raises(exception, match=match):
-        main._raise_for_skipped_failures(main.ConversionPhase.PRE_PONR_CHANGES, data)
+        main._raise_for_skipped_failures(data)
 
 
 def test_main_already_running_conversion(monkeypatch, caplog, tmpdir):

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -432,8 +432,6 @@ class TestRollbackFromMain:
         assert rollback_changes_mock.call_count == 1
         assert summary_as_json_mock.call_count == 1
         assert summary_as_txt_mock.call_count == 1
-        assert "The analysis process failed." in caplog.records[-3].message
-        assert caplog.records[-3].levelname == "CRITICAL"
 
     def test_main_rollback_analyze_exit_phase_without_subman(self, global_tool_opts, monkeypatch, tmp_path):
         """
@@ -645,7 +643,7 @@ class TestRollbackFromMain:
                 "A problem was encountered during analysis and a rollback will be "
                 "initiated to restore the system as the previous state."
             ),
-            "analisys",
+            "analysis",
         ),
         (
             {
@@ -668,7 +666,7 @@ class TestRollbackFromMain:
                 "A problem was encountered during analysis and a rollback will be "
                 "initiated to restore the system as the previous state."
             ),
-            "analisys",
+            "analysis",
         ),
         (
             {

--- a/tests/integration/tier0/non-destructive/firewalld-inhibitor/test_firewalld_inhibitor.py
+++ b/tests/integration/tier0/non-destructive/firewalld-inhibitor/test_firewalld_inhibitor.py
@@ -36,6 +36,6 @@ def test_firewalld_inhibitor(shell, convert2rhel):
             timeout=600,
         )
 
-    assert c2r.exitstatus == 1
+    assert c2r.exitstatus == 2
 
     shell(f"sed -i 's/CleanupModulesOnExit=yes/CleanupModulesOnExit=no/g' {FIREWALLD_CONFIG_FILE}")


### PR DESCRIPTION
If an inhibitor is found during the analysis and we are running it in conversion mode, we want to exit with code 2 to differentiate from the others errors mode.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-1276](https://issues.redhat.com/browse/RHELC-1276)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
