### PR TITLE
[RHELC-465] Remove deprecated todo comment about pool ids

### DIFF
--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -583,8 +583,6 @@ def attach_subscription():
     subscription ID has been provided through command line, let the user
     interactively choose one.
     """
-    # TODO: Support attaching multiple pool IDs.
-
     # check if SCA is enabled
     output, _ = utils.run_subprocess(["subscription-manager", "status"], print_output=False)
     if "content access mode is set to simple content access." in output.lower():


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Jira issue, add multiple if necessary -->

Jira Issues: [RHELC-465](https://issues.redhat.com/browse/RHELC-465)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
