### PR TITLE
chore: build RPMs on tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@
 name: Build release RPMs & Handle release
 
 on:
+  push:
+    tags: "*"
   release:
     types: [published]
 
@@ -31,6 +33,7 @@ jobs:
 
   update_jira_links:
     name: Update Jira links
+    if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds another trigger for the rpm builds so that we will be able to
attach rpms to specific tags. This primarily helps out with the weekly
tags we do on Fridays where we can easily link to it for the latest
RPM that should be decently stable

Note that these RPMs are still not extensively verified like we would
for an actual release. Instead they are weekly snapshots of the current
state of the repository.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
