### PR TITLE
[RHELC-884] Disable RHEL repos when performing checks

### DIFF
--- a/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
+++ b/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
@@ -18,7 +18,7 @@ __metaclass__ = type
 import logging
 import os
 
-from convert2rhel import actions
+from convert2rhel import actions, repo
 from convert2rhel.pkghandler import compare_package_versions
 from convert2rhel.systeminfo import system_info
 from convert2rhel.utils import run_subprocess
@@ -44,10 +44,14 @@ class IsLoadedKernelLatest(actions.Action):
             )
             return
 
+        # RHELC-884 disable the RHEL repos to avoid reaching them when checking original system.
+        disable_repo_command = repo.get_rhel_disable_repos_command(repo.get_rhel_repos_to_disable())
+
         cmd = [
             "repoquery",
             "--setopt=exclude=",
             "--quiet",
+            disable_repo_command,
             "--qf",
             "C2R\\t%{BUILDTIME}\\t%{VERSION}-%{RELEASE}\\t%{REPOID}",
         ]

--- a/convert2rhel/repo.py
+++ b/convert2rhel/repo.py
@@ -19,7 +19,7 @@ __metaclass__ = type
 
 import logging
 
-from convert2rhel.systeminfo import system_info
+from convert2rhel.systeminfo import system_info, tool_opts
 
 
 DEFAULT_YUM_REPOFILE_DIR = "/etc/yum.repos.d"
@@ -47,3 +47,34 @@ def get_rhel_repoids():
     loggerinst.info("RHEL repository IDs to enable: %s" % ", ".join(repos_needed))
 
     return repos_needed
+
+
+def get_rhel_repos_to_disable():
+    """Get the list of repositories which should be disabled when performing pre-conversion checks. Avoid downloading
+    backup and up-to-date checks from them. The output list can looks like:
+    ['rhel*', 'user-provided', 'user-provided1']
+
+    :return: List of repositories to disable when performing checks.
+    :rtype: List[str]
+    """
+    # RHELC-884 disable the RHEL repos to avoid reaching them when checking original system.
+    # Also disable repositories enabled by the user for the conversion.
+    return ["rhel*"] + tool_opts.enablerepo
+
+
+def get_rhel_disable_repos_command(disable_repos):
+    """Build command containing all the repos for disable. The result looks like
+    '--disablerepo repo --disablerepo repo1 --disablerepo repo2'
+    If provided list is empty, empty string is returned.
+
+    :param disable_repos: List of repo IDs to disable
+    :type disable_repos: List[str]
+    :return: String for disabling the rhel and user provided repositories while performing checks.
+    :rtype: str
+    """
+    if not disable_repos:
+        return ""
+
+    disable_repo_command = " ".join("--disablerepo=" + repo for repo in disable_repos)
+
+    return disable_repo_command

--- a/convert2rhel/unit_tests/repo_test.py
+++ b/convert2rhel/unit_tests/repo_test.py
@@ -78,3 +78,26 @@ def test_get_rhel_repoids_el7(pretend_os, is_els_release, expected, monkeypatch)
     monkeypatch.setattr(repo.system_info, "els_system", value=is_els_release)
     repos = repo.get_rhel_repoids()
     assert repos == expected
+
+
+@pytest.mark.parametrize(("enablerepo", "disablerepos"), (([], ["rhel*"]), (["test-repo"], ["rhel*", "test-repo"])))
+def test_get_rhel_repos_to_disable(monkeypatch, enablerepo, disablerepos):
+    monkeypatch.setattr(repo.tool_opts, "enablerepo", enablerepo)
+
+    repos = repo.get_rhel_repos_to_disable()
+
+    assert repos == disablerepos
+
+
+@pytest.mark.parametrize(
+    ("disable_repos", "command"),
+    (
+        ([], ""),
+        (["test-repo"], "--disablerepo=test-repo"),
+        (["rhel*", "test-repo"], "--disablerepo=rhel* --disablerepo=test-repo"),
+    ),
+)
+def test_get_rhel_disable_repos_command(disable_repos, command):
+    output = repo.get_rhel_disable_repos_command(disable_repos)
+
+    assert output == command


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
We need to disable RHEL repos. If user registers the system to satellite which provides Centos and RHEL repos and the RHEL repos would be enabled, it would cause a fail. The recommended way is to disable the rhel repos prior the conversion, but is expected it might be forgotten. This helps avoiding the problems caused by wrong setup of the repos.

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues: https://issues.redhat.com/browse/RHELC-884

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
