### PR TITLE
[RHELC-1490, RHELC-1498] Move environment variables to tests metadata

### DIFF
--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -76,6 +76,8 @@ description+: |
                     - conversion-method/rhsm_non_eus_account_conversion
 
         /custom_repositories_conversion:
+            environment+:
+                SUBMGR_DISABLED_SKIP_CHECK_RHSM_CUSTOM_FACTS: 1
             prepare+:
                 - name: Add custom repositories
                   how: ansible
@@ -108,7 +110,7 @@ description+: |
                 prepare+:
                     - name: Install ntp package and remove one dependency
                       how: shell
-                      script: pytest -svv tests/integration/*/destructive/single-yum-transaction/install_ntp_and_remove_dependency.py
+                      script: pytest --setup-show -svv tests/integration/*/destructive/single-yum-transaction/install_ntp_and_remove_dependency.py
 
             /excluded_packages:
                 adjust+:
@@ -117,7 +119,7 @@ description+: |
                 prepare+:
                     - name: Remove some packages from the excluded packages config list
                       how: shell
-                      script: pytest -svv tests/integration/*/destructive/single-yum-transaction/remove_excld_pkgs_from_config.py
+                      script: pytest --setup-show -svv tests/integration/*/destructive/single-yum-transaction/remove_excld_pkgs_from_config.py
 
             /mismatch_errors:
                 adjust+:
@@ -127,7 +129,7 @@ description+: |
                 prepare+:
                     - name: Install multilib packages with dnf
                       how: shell
-                      script: pytest -svv tests/integration/*/destructive/single-yum-transaction/install_multilib_packages.py
+                      script: pytest --setup-show -svv tests/integration/*/destructive/single-yum-transaction/install_multilib_packages.py
 
             /resolve_dependency:
                 adjust+:
@@ -144,7 +146,7 @@ description+: |
                 prepare+:
                     - name: Install dependency packages
                       how: shell
-                      script: pytest -svv tests/integration/*/destructive/single-yum-transaction/install_dependency_packages.py
+                      script: pytest --setup-show -svv tests/integration/*/destructive/single-yum-transaction/install_dependency_packages.py
 
         /yum_distro_sync:
             prepare+:
@@ -153,7 +155,7 @@ description+: |
                     playbook: tests/integration/tier0/destructive/yum-distro-sync/add-extras-repo/main.yml
                   - name: Install problematic package
                     how: shell
-                    script: pytest -svv tests/integration/*/destructive/yum-distro-sync/install_problematic_package.py
+                    script: pytest --setup-show -svv tests/integration/*/destructive/yum-distro-sync/install_problematic_package.py
             discover+:
                 test+<:
                     - yum-distro-sync/yum_distro_sync
@@ -177,7 +179,7 @@ description+: |
               playbook: tests/ansible_collections/roles/install-submgr/main.yml
             - name: Allow access to Satellite only
               how: shell
-              script: pytest -svv tests/integration/*/destructive/offline-system-conversion/prepare_system.py
+              script: pytest --setup-show -svv tests/integration/*/destructive/offline-system-conversion/prepare_system.py
         discover+:
             test+<:
                 - offline-system-conversion/offline_system_conversion

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -73,6 +73,17 @@ description+: |
         adjust+:
             - enabled: true
               when: distro == centos-7, oracle-7
+        environment+:
+            CONVERT2RHEL_INCOMPLETE_ROLLBACK: 1
+            CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK: 1
+
+            # Unavailable kmods may be present on the system due to the kernel package
+            # not being updated. Mitigate the issues by exporting CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS.
+            CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS: 1
+
+            # We need to skip check for collected rhsm custom facts after the conversion
+            # due to disabled submgr, thus adding envar
+            SUBMGR_DISABLED_SKIP_CHECK_RHSM_CUSTOM_FACTS: 1
         prepare+:
             - name: Add custom repositories
               how: ansible
@@ -93,7 +104,7 @@ description+: |
         prepare+:
             - name: Set non english locale
               how: shell
-              script: pytest -svv tests/integration/*/destructive/set-locale/use_non_english_language.py
+              script: pytest --setup-show -svv tests/integration/*/destructive/set-locale/use_non_english_language.py
         discover+:
             test+<:
                 - conversion-method/activation_key_conversion
@@ -103,7 +114,7 @@ description+: |
         prepare+:
             - name: Remove the /etc/os-release file
               how: shell
-              script: pytest -svv tests/integration/*/destructive/os-release-removal/remove_os_release.py
+              script: pytest --setup-show -svv tests/integration/*/destructive/os-release-removal/remove_os_release.py
         discover+:
             test+<:
                 - conversion-method/rhsm_conversion
@@ -121,18 +132,27 @@ description+: |
                 - enabled: true
                   when: distro == centos-7, oracle-7
             environment+:
+                # Bypass the kernel check, since the installed kernel is an older version
                 CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK: 1
+
+                # We need to set envar to override the out of date packages check
+                # to perform the full conversion
+                # The packages are outdated because the repoquery check is done
+                # against the rhel-7-server-rpms repository, not CentOS'.
+                CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP: 1
+
                 # Since we are removing all the repositories other than rhel-7-server-rpms
                 # we need pass CONVERT2RHEL_INCOMPLETE_ROLLBACK due to the inability
                 # to download and backup packages
                 CONVERT2RHEL_INCOMPLETE_ROLLBACK: 1
+
                 # Unavailable kmods may be present on the system due to the kernel package
                 # not being updated. Mitigate the issues by exporting CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS.
                 CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS: 1
             prepare+:
                 - name: Prepare non latest kernel
                   how: shell
-                  script: pytest -svv tests/integration/*/destructive/kernel-check-skip/install_older_kernel.py
+                  script: pytest --setup-show -svv tests/integration/*/destructive/kernel-check-skip/install_older_kernel.py
                 - name: Add custom repos
                   how: ansible
                   playbook: tests/ansible_collections/roles/add-custom-repos/main.yml
@@ -208,7 +228,7 @@ description+: |
         prepare+:
             - name: Make sure the 'kernel-core' is the only installed kernel package
               how: shell
-              script: pytest -svv tests/integration/*/destructive/kernel-core-only/remove_kernel_pkg.py
+              script: pytest --setup-show -svv tests/integration/*/destructive/kernel-core-only/remove_kernel_pkg.py
             - name: Reboot after kernel package removal leaving only kernel-core on the system
               how: ansible
               playbook: tests/ansible_collections/roles/reboot/main.yml
@@ -241,7 +261,7 @@ description+: |
         prepare+:
             - name: Verify multiple NIC are present
               how: shell
-              script: pytest -svv tests/integration/*/destructive/multiple-nic/multiple_nic.py
+              script: pytest --setup-show -svv tests/integration/*/destructive/multiple-nic/multiple_nic.py
         discover+:
             test+<:
                 - conversion-method/rhsm_conversion

--- a/tests/integration/common/checks-after-conversion/main.fmf
+++ b/tests/integration/common/checks-after-conversion/main.fmf
@@ -24,14 +24,14 @@ order: 52
             RHEL present in /etc/os-release
         description: |
             Sanity check to verify, that Red Hat Enterprise Linux is present in /etc/os-release
-        test: pytest -svv -m test_conversion_sanity_rhel_in_os_release
+        test: pytest --setup-show -svv -m test_conversion_sanity_rhel_in_os_release
 
     /correct_distro:
         summary+: |
             Correct distro
         description+: |
             Verify, that the conversion successfully converted to the correct target system.
-        test: pytest -svv -m test_correct_distro
+        test: pytest --setup-show -svv -m test_correct_distro
 
 
 /data_collection:
@@ -39,7 +39,7 @@ order: 52
         Data collection
     description: |
         Verify that after conversion the convert2rhel.facts file exists.
-    test: pytest -svv -m test_check_data_collection
+    test: pytest --setup-show -svv -m test_check_data_collection
 
 
 /deleted_temporary_folder:
@@ -47,7 +47,7 @@ order: 52
         Temporary folder deleted
     description: |
         Verify, that the temporary folder `/var/lib/convert2rhel/` was successfully removed after the conversion.
-    test: pytest -svv -m test_deleted_temporary_folder
+    test: pytest --setup-show -svv -m test_deleted_temporary_folder
 
 
 /enabled_repositories:
@@ -60,7 +60,7 @@ order: 52
         verify that the non-EUS repositories are enabled after conversion.
         When running the conversion on an EUS machine with an EUS RHSM account
         verify that the EUS repositories are enabled after the conversion.
-    test: pytest -svv -m test_enabled_repositories
+    test: pytest --setup-show -svv -m test_enabled_repositories
 
 
 /flag_system_as_converted:
@@ -68,7 +68,7 @@ order: 52
         Flag system as converted
     description: |
         Verify, that the breadcrumbs file was created and corresponds to the JSON schema after the conversion.
-    test: pytest -svv -m test_flag_system_as_converted
+    test: pytest --setup-show -svv -m test_flag_system_as_converted
 
 
 /log_lines_not_duplicated:
@@ -79,7 +79,7 @@ order: 52
         Iterate over the log file and check that the lines are unique and not duplicated.
     tag+:
         - log-file
-    test: pytest -svv -m test_verify_logging_is_not_duplicated
+    test: pytest --setup-show -svv -m test_verify_logging_is_not_duplicated
 
 
 /rhel_kernel:
@@ -89,7 +89,7 @@ order: 52
         Verify, that each of installed kernels on the system is signed by Red Hat.
     tag+:
         - rhel-kernel
-    test: pytest -svv -m test_rhel_kernel
+    test: pytest --setup-show -svv -m test_rhel_kernel
 
 
 /rhel_subman:
@@ -101,7 +101,7 @@ order: 52
         either replaced or installed by convert2rhel.
     tag+:
         - rhel-subman
-    test: pytest -svv -m test_rhel_subscription_manager
+    test: pytest --setup-show -svv -m test_rhel_subscription_manager
 
 /verify_string_in_log:
     summary+: |
@@ -123,7 +123,7 @@ order: 52
             and validating that the initramfs file is not corrupted.
         tag+:
             - initramfs-and-vmlinuz-present
-        test: pytest -svv -m test_initramfs_and_vmlinuz_present
+        test: pytest --setup-show -svv -m test_initramfs_and_vmlinuz_present
 
     /failed_to_parse_package_not_present:
         summary+: |
@@ -133,7 +133,7 @@ order: 52
             the message Failed to parse a package does not appear during the conversion run.
         tag+:
             - failed-to-parse-package-not-present
-        test: pytest -svv -m test_failed_to_parse_package_info_empty_arch_not_present
+        test: pytest --setup-show -svv -m test_failed_to_parse_package_info_empty_arch_not_present
 
     /traceback_not_present:
         summary+: |
@@ -142,18 +142,18 @@ order: 52
             Verify that there is not a traceback raised in the log file during the conversion run.
         tag+:
             - traceback-not-present
-        test: pytest -svv -m test_traceback_not_present
+        test: pytest --setup-show -svv -m test_traceback_not_present
 
 /yum_check:
     summary+: |
         Run yum check
     description+: |
         After conversion check verifying yum check is able to finis without any issues.
-    test: pytest -svv -m test_yum_check
+    test: pytest --setup-show -svv -m test_yum_check
 
 /check_firewalld_errors:
     summary+: |
         Firewalld issues after the conversion
     description+: |
         Verify that firewalld is not reporting any issues in the logs.
-    test: pytest -svv -m check_firewalld_errors
+    test: pytest --setup-show -svv -m check_firewalld_errors

--- a/tests/integration/common/checks-after-conversion/test_flag_system_as_converted.py
+++ b/tests/integration/common/checks-after-conversion/test_flag_system_as_converted.py
@@ -17,8 +17,6 @@ def test_flag_system_as_converted(shell):
     Verify, that the breadcrumbs file was created and corresponds to the JSON schema after the conversion.
     """
 
-    # We need to skip check for collected rhsm custom facts after the conversion
-    # due to disabled submgr, thus adding envar
     submgr_disabled_var = "SUBMGR_DISABLED_SKIP_CHECK_RHSM_CUSTOM_FACTS=1"
     query = shell(f"set | grep {submgr_disabled_var}").output
 
@@ -31,6 +29,8 @@ def test_flag_system_as_converted(shell):
         print(data_json)
         raise
 
+    # We need to validate the schema just in case the SUBMGR_DISABLED_SKIP_CHECK_RHSM_CUSTOM_FACTS
+    # envar is not set (we might set the envar for example due to disabled submgr)
     if submgr_disabled_var not in query:
         data_json = _load_json_schema(C2R_RHSM_CUSTOM_FACTS)
 

--- a/tests/integration/common/utils/reboot-after-conversion/main.fmf
+++ b/tests/integration/common/utils/reboot-after-conversion/main.fmf
@@ -5,6 +5,6 @@ description: |
     to perform multiple checks after conversion.
     This suits only the purpose of rebooting the system.
 
-test: pytest -svv -m reboot_after_conversion
+test: pytest --setup-show -svv -m reboot_after_conversion
 result: info
 order: 51

--- a/tests/integration/tier0/destructive/conversion-method/main.fmf
+++ b/tests/integration/tier0/destructive/conversion-method/main.fmf
@@ -15,7 +15,7 @@ order: 49
         Basic conversion method using the RHSM activation key and organization for registration.
     tag+:
         - activation-key-conversion
-    test: pytest -svv -m test_activation_key_conversion
+    test: pytest --setup-show -svv -m test_activation_key_conversion
 
 
 /config_file_conversion:
@@ -29,7 +29,7 @@ order: 49
     link:
         - verifies: https://issues.redhat.com/browse/RHELC-411
         - verifies: https://issues.redhat.com/browse/RHELC-413
-    test: pytest -svv -m test_conversion_with_config_file
+    test: pytest --setup-show -svv -m test_conversion_with_config_file
 
 
 /custom_repos_conversion:
@@ -43,7 +43,7 @@ order: 49
         {rhel7: [server rpms, extras rpms, optional rpms], rhel8: [[eus-]?baseos], [eus-]?appstream}.
     tag+:
         - custom-repos-conversion
-    test: pytest -svv -m test_custom_repos_conversion
+    test: pytest --setup-show -svv -m test_custom_repos_conversion
 
 /rhsm_conversion:
     summary: |
@@ -52,7 +52,7 @@ order: 49
         Basic conversion method using the RHSM to register with username, password and pool credentials.
     tag+:
         - rhsm-conversion
-    test: pytest -svv -m test_rhsm_conversion
+    test: pytest --setup-show -svv -m test_rhsm_conversion
 
 /rhsm_non_eus_account_conversion:
     summary: |
@@ -62,7 +62,7 @@ order: 49
         Verify, that the conversion finishes and suitable repositories are enabled after the conversion.
     tag+:
         - rhsm-non-eus-account-conversion
-    test: pytest -svv -m test_rhsm_non_eus_account_conversion
+    test: pytest --setup-show -svv -m test_rhsm_non_eus_account_conversion
 
 /satellite_conversion:
     summary: |
@@ -73,7 +73,7 @@ order: 49
         The katello-ca-consumer package is installed from the Satellite server.
     tag+:
         - satellite-conversion
-    test: pytest -svv -m test_satellite_conversion
+    test: pytest --setup-show -svv -m test_satellite_conversion
 
 /pre_registered_system_conversion:
     summary: |
@@ -85,4 +85,4 @@ order: 49
         registration is accepted.
     tag+:
         - pre-registered-system-conversion
-    test: pytest -svv -m test_pre_registered_conversion
+    test: pytest --setup-show -svv -m test_pre_registered_conversion

--- a/tests/integration/tier0/destructive/conversion-method/test_custom_repos.py
+++ b/tests/integration/tier0/destructive/conversion-method/test_custom_repos.py
@@ -29,10 +29,6 @@ def test_run_conversion_using_custom_repos(shell, convert2rhel):
     The repositories enabled in this scenario are
     {rhel7: [server rpms, extras rpms, optional rpms], rhel8: [[eus-]?baseos], [eus-]?appstream}.
     """
-    # We need to skip check for collected rhsm custom facts after the conversion
-    # due to disabled submgr, thus we are adding the environment variable
-    submgr_disabled_var = "SUBMGR_DISABLED_SKIP_CHECK_RHSM_CUSTOM_FACTS=1"
-    shell(f"echo '{submgr_disabled_var}' >> /etc/profile")
 
     with open("/etc/system-release", "r") as file:
         system_release = file.read()

--- a/tests/integration/tier0/destructive/offline-system-conversion/main.fmf
+++ b/tests/integration/tier0/destructive/offline-system-conversion/main.fmf
@@ -11,4 +11,4 @@ tag+:
     - satellite
 
 /offline_system_conversion:
-    test: pytest -svv -m test_offline_system_conversion
+    test: pytest --setup-show -svv -m test_offline_system_conversion

--- a/tests/integration/tier0/destructive/single-yum-transaction/main.fmf
+++ b/tests/integration/tier0/destructive/single-yum-transaction/main.fmf
@@ -16,7 +16,7 @@ link:
 
 
 /single_yum_transaction:
-    test: pytest -svv -m test_single_yum_transaction
+    test: pytest --setup-show -svv -m test_single_yum_transaction
 
 /packages_upgraded_after_conversion:
-    test: pytest -svv -m test_packages_upgraded_after_conversion
+    test: pytest --setup-show -svv -m test_packages_upgraded_after_conversion

--- a/tests/integration/tier0/destructive/yum-distro-sync/main.fmf
+++ b/tests/integration/tier0/destructive/yum-distro-sync/main.fmf
@@ -8,7 +8,7 @@ link:
     - verifies: https://issues.redhat.com/browse/RHELC-150
 
 /yum_distro_sync:
-    test: pytest -svv -m test_yum_distro_sync
+    test: pytest --setup-show -svv -m test_yum_distro_sync
 
 
 #TODO(danmyway) merge with single-yum-transaction

--- a/tests/integration/tier0/non-destructive/application-lock/main.fmf
+++ b/tests/integration/tier0/non-destructive/application-lock/main.fmf
@@ -25,4 +25,4 @@ tag+:
     tag+:
         - simultaneous-runs
     test: |
-        pytest -svv -m test_simultaneous_runs
+        pytest --setup-show -svv -m test_simultaneous_runs

--- a/tests/integration/tier0/non-destructive/assessment-report/main.fmf
+++ b/tests/integration/tier0/non-destructive/assessment-report/main.fmf
@@ -25,7 +25,7 @@ tag+:
     tag+:
         - failed-report
     test: |
-        pytest -svv -m test_failures_and_skips_in_report
+        pytest --setup-show -svv -m test_failures_and_skips_in_report
 
 /successful_report:
     summary+: |
@@ -37,7 +37,7 @@ tag+:
         - success-report
         - sanity
     test: |
-        pytest -svv -m test_successful_report
+        pytest --setup-show -svv -m test_successful_report
 
 /convert_successful_report:
     summary+: |
@@ -51,4 +51,4 @@ tag+:
     tag+:
         - convert-success-report
     test: |
-        pytest -svv -m test_convert_successful_report
+        pytest --setup-show -svv -m test_convert_successful_report

--- a/tests/integration/tier0/non-destructive/basic-sanity-checks/main.fmf
+++ b/tests/integration/tier0/non-destructive/basic-sanity-checks/main.fmf
@@ -21,7 +21,7 @@ tag+:
         - root-privileges
         - sanity
     test: |
-      pytest -svv -m test_root_privileges
+      pytest --setup-show -svv -m test_root_privileges
 
 
 /manpage:
@@ -32,7 +32,7 @@ tag+:
     tag+:
         - manpage
     test: |
-      pytest -svv -m test_manpage
+      pytest --setup-show -svv -m test_manpage
 
 
 /smoke:
@@ -45,7 +45,7 @@ tag+:
         - smoke
         - sanity
     test: |
-      pytest -svv -m test_smoke
+      pytest --setup-show -svv -m test_smoke
 
 
 /log_file_exists:
@@ -57,7 +57,7 @@ tag+:
         - log-file
         - sanity
     test: |
-      pytest -svv -m test_log_file_exists
+      pytest --setup-show -svv -m test_log_file_exists
 
 
 /convert2rhel_version:
@@ -73,7 +73,7 @@ tag+:
             - version-latest-or-newer
             - sanity
         test: |
-          pytest -svv -m test_version_latest_or_newer
+          pytest --setup-show -svv -m test_version_latest_or_newer
 
     /c2r_version_older_no_envar:
         summary+: |
@@ -84,7 +84,7 @@ tag+:
         tag+:
             - version-older-no-envar
         test: |
-          pytest -svv -m test_version_older_no_envar
+          pytest --setup-show -svv -m test_version_older_no_envar
 
     /c2r_version_older_with_envar:
         summary+: |
@@ -92,10 +92,13 @@ tag+:
         description+: |
             Verify that running an older version of convert2rhel with CONVERT2RHEL_ALLOW_OLDER_VERSION
             environment variable in place, does not raise CONVERT2RHEL_LATEST_VERSION.OUT_OF_DATE.
+        adjust+:
+            environment+:
+                CONVERT2RHEL_ALLOW_OLDER_VERSION: 1
         tag+:
             - version-older-with-envar
         test: |
-          pytest -svv -m test_version_older_with_envar
+          pytest --setup-show -svv -m test_version_older_with_envar
 
 
 /clean_cache:
@@ -106,7 +109,7 @@ tag+:
     tag+:
         - clean-cache
     test: |
-      pytest -svv -m test_clean_cache
+      pytest --setup-show -svv -m test_clean_cache
 
 
 /log_rhsm_error:
@@ -118,7 +121,7 @@ tag+:
     tag+:
         - log-rhsm-error
     test: |
-      pytest -svv -m test_log_rhsm_error
+      pytest --setup-show -svv -m test_log_rhsm_error
 
 
 /data_collection:
@@ -132,7 +135,7 @@ tag+:
         tag+:
             - data-collection-acknowledgement
         test: |
-          pytest -svv -m test_data_collection_acknowledgement
+          pytest --setup-show -svv -m test_data_collection_acknowledgement
 
 /incomplete_rollback_in_analyze:
     summary+: |
@@ -147,10 +150,13 @@ tag+:
            honored and the conversion should end
         2/ convert2rhel is run in conversion mode, the envar should be
            accepted and conversion continues
+    adjust+:
+        environment+:
+            CONVERT2RHEL_INCOMPLETE_ROLLBACK: 1
     tag+:
         - incomplete-rollback-in-analyze
     test: |
-        pytest -svv -m test_analyze_incomplete_rollback
+        pytest --setup-show -svv -m test_analyze_incomplete_rollback
 
 /analyze_no_rpm_va_option:
     summary+: |
@@ -159,8 +165,11 @@ tag+:
         This test verifies a basic incompatibility of the analyze and --no-rpm-va options.
         The user should be warned that the --no-rpm-va option will be ignored and the command
         will be called.
+    adjust+:
+        environment+:
+            CONVERT2RHEL_INCOMPLETE_ROLLBACK: 1
     tag+:
         - analyze-no-rpm-va-option
         - sanity
     test: |
-        pytest -svv -m test_analyze_no_rpm_va_option
+        pytest --setup-show -svv -m test_analyze_no_rpm_va_option

--- a/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
@@ -142,22 +142,9 @@ def test_c2r_latest_check_older_version_error(convert2rhel, c2r_version, version
     assert c2r.exitstatus != 0
 
 
-@pytest.fixture
-def older_version_envar():
-    """
-    Fixture to set and remove CONVERT2RHEL_ALLOW_OLDER_VERSION environment variable.
-    """
-    # Set the environment variable
-    os.environ["CONVERT2RHEL_ALLOW_OLDER_VERSION"] = "1"
-
-    yield
-    # Delete the environment variable
-    del os.environ["CONVERT2RHEL_ALLOW_OLDER_VERSION"]
-
-
 @pytest.mark.test_version_older_with_envar
 @pytest.mark.parametrize("version", ["0.01.0"])
-def test_c2r_latest_older_unsupported_version(convert2rhel, c2r_version, version, older_version_envar):
+def test_c2r_latest_older_unsupported_version(convert2rhel, c2r_version, version):
     """
     Verify that running older version of Convert2RHEL with the environment
     variable "CONVERT2RHEL_ALLOW_OLDER_VERSION" continues the conversion.
@@ -267,17 +254,8 @@ def test_data_collection_acknowledgement(shell, convert2rhel):
     assert c2r.exitstatus != 0
 
 
-@pytest.fixture
-def analyze_incomplete_rollback_envar():
-    os.environ["CONVERT2RHEL_INCOMPLETE_ROLLBACK"] = "1"
-
-    yield
-
-    del os.environ["CONVERT2RHEL_INCOMPLETE_ROLLBACK"]
-
-
 @pytest.mark.test_analyze_incomplete_rollback
-def test_analyze_incomplete_rollback(repositories, convert2rhel, analyze_incomplete_rollback_envar):
+def test_analyze_incomplete_rollback(remove_repositories, convert2rhel):
     """
     This test verifies that the CONVERT2RHEL_(UNSUPPORTED_)INCOMPLETE_ROLLBACK envar
     is not honored when running with the analyze switch.
@@ -319,7 +297,7 @@ def test_analyze_incomplete_rollback(repositories, convert2rhel, analyze_incompl
 
 
 @pytest.mark.test_analyze_no_rpm_va_option
-def test_analyze_no_rpm_va_option(convert2rhel, analyze_incomplete_rollback_envar):
+def test_analyze_no_rpm_va_option(convert2rhel):
     """
     This test verifies a basic incompatibility of the analyze and --no-rpm-va options.
     The user should be warned that the --no-rpm-va option will be ignored and the command

--- a/tests/integration/tier0/non-destructive/config-file/main.fmf
+++ b/tests/integration/tier0/non-destructive/config-file/main.fmf
@@ -24,7 +24,7 @@ tag+:
     tag+:
         - config-custom-path-custom-filename
     test: |
-        pytest -svv -m test_config_custom_path_custom_filename
+        pytest --setup-show -svv -m test_config_custom_path_custom_filename
 
 /config_custom_path_standard_filename:
     summary+: |
@@ -35,7 +35,7 @@ tag+:
     tag+:
         - config-custom-path-standard-filename
     test: |
-        pytest -svv -m test_config_custom_path_standard_filename
+        pytest --setup-show -svv -m test_config_custom_path_standard_filename
 
 /config_cli_priority:
     summary+: |
@@ -47,7 +47,7 @@ tag+:
         - config-cli-priority
         - sanity
     test: |
-        pytest -svv -m test_config_cli_priority
+        pytest --setup-show -svv -m test_config_cli_priority
 
 /config_standard_paths_priority_diff_methods:
     summary+: |
@@ -58,7 +58,7 @@ tag+:
     tag+:
         - config-standard-paths-priority-diff-methods
     test: |
-        pytest -svv -m test_config_standard_paths_priority_diff_methods
+        pytest --setup-show -svv -m test_config_standard_paths_priority_diff_methods
 
 /config_standard_paths_priority:
     summary+: |
@@ -69,4 +69,4 @@ tag+:
     tag+:
         - config-standard-paths-priority
     test: |
-        pytest -svv -m test_config_standard_paths_priority
+        pytest --setup-show -svv -m test_config_standard_paths_priority

--- a/tests/integration/tier0/non-destructive/custom-repository/main.fmf
+++ b/tests/integration/tier0/non-destructive/custom-repository/main.fmf
@@ -17,7 +17,7 @@ tag+:
     tag+:
         - custom-valid-repo-provided
     test: |
-        pytest -svv -m test_custom_valid_repo_provided
+        pytest --setup-show -svv -m test_custom_valid_repo_provided
 
 /custom_invalid_repo_provided:
     summary+: |
@@ -28,4 +28,4 @@ tag+:
     tag+:
         - custom-invalid-repo-provided
     test: |
-        pytest -svv -m test_custom_invalid_repo_provided
+        pytest --setup-show -svv -m test_custom_invalid_repo_provided

--- a/tests/integration/tier0/non-destructive/cve-2022-1662/main.fmf
+++ b/tests/integration/tier0/non-destructive/cve-2022-1662/main.fmf
@@ -18,7 +18,7 @@ tag+:
     tag+:
         - passing-password-to-submgr
     test: |
-      pytest -svv -m test_passing_password_to_submgr
+      pytest --setup-show -svv -m test_passing_password_to_submgr
 
 /passing_activation_key_to_submgr:
     summary+: |
@@ -28,4 +28,4 @@ tag+:
     tag+:
         - passing-activation-key-to-submgr
     test: |
-      pytest -svv -m test_passing_activation_key_to_submgr
+      pytest --setup-show -svv -m test_passing_activation_key_to_submgr

--- a/tests/integration/tier0/non-destructive/duplicate-pkgs/main.fmf
+++ b/tests/integration/tier0/non-destructive/duplicate-pkgs/main.fmf
@@ -17,4 +17,4 @@ description+: |
     tag+:
         - test-duplicate-pkgs
     test: |
-        pytest -svv -m test_duplicate_pkgs
+        pytest --setup-show -svv -m test_duplicate_pkgs

--- a/tests/integration/tier0/non-destructive/eus/main.fmf
+++ b/tests/integration/tier0/non-destructive/eus/main.fmf
@@ -29,4 +29,4 @@ tag+:
     tag+:
         - test-eus-support
     test: |
-      pytest -svv -m test_eus_support
+      pytest --setup-show -svv -m test_eus_support

--- a/tests/integration/tier0/non-destructive/file-backup/main.fmf
+++ b/tests/integration/tier0/non-destructive/file-backup/main.fmf
@@ -23,4 +23,4 @@ tag+:
     - sanity
 
 test: |
-    pytest -svv -m test_file_backup
+    pytest --setup-show -svv -m test_file_backup

--- a/tests/integration/tier0/non-destructive/firewalld-inhibitor/main.fmf
+++ b/tests/integration/tier0/non-destructive/firewalld-inhibitor/main.fmf
@@ -16,4 +16,4 @@ adjust+:
     tag+:
         - firewalld-inhibitor
     test: |
-        pytest -svv -m test_firewalld_inhibitor
+        pytest --setup-show -svv -m test_firewalld_inhibitor

--- a/tests/integration/tier0/non-destructive/internet-connection-check/main.fmf
+++ b/tests/integration/tier0/non-destructive/internet-connection-check/main.fmf
@@ -18,7 +18,7 @@ tag+:
     tag+:
         - available-connection
     test: |
-        pytest -svv -m test_available_connection
+        pytest --setup-show -svv -m test_available_connection
 
 /unavailable_connection:
     summary+: |
@@ -33,4 +33,4 @@ tag+:
         - unavailable-connection
         - sanity
     test: |
-        pytest -svv -m test_unavailable_connection
+        pytest --setup-show -svv -m test_unavailable_connection

--- a/tests/integration/tier0/non-destructive/kernel-modules/main.fmf
+++ b/tests/integration/tier0/non-destructive/kernel-modules/main.fmf
@@ -30,7 +30,7 @@ tag+:
             - custom-module-loaded
             - sanity
         test: |
-            pytest -svv -m test_custom_module_loaded
+            pytest --setup-show -svv -m test_custom_module_loaded
 
     /custom_module_not_loaded:
         summary+: |
@@ -45,7 +45,7 @@ tag+:
         tag+:
             - custom-module-not-loaded
         test: |
-            pytest -svv -m test_custom_module_not_loaded
+            pytest --setup-show -svv -m test_custom_module_not_loaded
 
     /unsupported_kmod_with_envar:
         summary+: |
@@ -57,7 +57,7 @@ tag+:
         tag+:
             - unsupported-kmod-with-envar
         test: |
-            pytest -svv -m test_unsupported_kmod_with_envar
+            pytest --setup-show -svv -m test_unsupported_kmod_with_envar
         link:
             verifies: https://issues.redhat.com/browse/RHELC-244
 
@@ -78,7 +78,7 @@ tag+:
     tag+:
         - force-loaded-kmod
     test: |
-        pytest -svv -m test_force_loaded_kmod
+        pytest --setup-show -svv -m test_force_loaded_kmod
 
 
 /tainted_kernel_modules_error:
@@ -91,7 +91,7 @@ tag+:
     tag+:
         - tainted-kernel-modules-error
     test: |
-        pytest -svv -m test_tainted_kernel_modules_error
+        pytest --setup-show -svv -m test_tainted_kernel_modules_error
 
 
 /tainted_kernel_modules_check_override:
@@ -111,4 +111,4 @@ tag+:
     tag+:
         - tainted-kernel-modules-check-skip
     test: |
-        pytest -svv -m test_tainted_kernel_modules_check_override
+        pytest --setup-show -svv -m test_tainted_kernel_modules_check_override

--- a/tests/integration/tier0/non-destructive/kernel/main.fmf
+++ b/tests/integration/tier0/non-destructive/kernel/main.fmf
@@ -17,7 +17,7 @@ tag+:
     tag+:
         - custom-kernel
     test: |
-        pytest -svv -m test_custom_kernel
+        pytest --setup-show -svv -m test_custom_kernel
 
 
 /failed_repoquery:
@@ -30,7 +30,7 @@ tag+:
     tag+:
         - failed-repoquery
     test: |
-        pytest -svv -m test_failed_repoquery
+        pytest --setup-show -svv -m test_failed_repoquery
 
 
 /yum_exclude_kernel:
@@ -44,7 +44,7 @@ tag+:
     tag+:
         - yum-exclude-kernel
     test: |
-        pytest -svv -m test_yum_exclude_kernel
+        pytest --setup-show -svv -m test_yum_exclude_kernel
 
 
 /non_latest_kernel_error:
@@ -56,7 +56,7 @@ tag+:
     tag+:
         - non-latest-kernel-error
     test: |
-        pytest -svv -m test_non_latest_kernel_error
+        pytest --setup-show -svv -m test_non_latest_kernel_error
 
 
 /unsupported_unbreakable_enterprise_kernel:
@@ -73,4 +73,4 @@ tag+:
     tag+:
         - unsupported-unbreakable-enterprise-kernel
     test: |
-        pytest -svv -m test_unsupported_unbreakable_enterprise_kernel
+        pytest --setup-show -svv -m test_unsupported_unbreakable_enterprise_kernel

--- a/tests/integration/tier0/non-destructive/logged-command/main.fmf
+++ b/tests/integration/tier0/non-destructive/logged-command/main.fmf
@@ -13,4 +13,4 @@ tag+:
         - logfile-starts-with-command
         - sanity
     test: |
-        pytest -svv -m test_logfile_starts_with_command
+        pytest --setup-show -svv -m test_logfile_starts_with_command

--- a/tests/integration/tier0/non-destructive/modified-releasever/main.fmf
+++ b/tests/integration/tier0/non-destructive/modified-releasever/main.fmf
@@ -18,7 +18,7 @@ tag+:
     tag+:
         - modified-releasever-in-configs
     test: |
-      pytest -svv -m test_modified_config
+      pytest --setup-show -svv -m test_modified_config
 
 /modified_releasever_to_unknown_release:
     summary+: |
@@ -29,4 +29,4 @@ tag+:
     tag+:
         - releasever-unknown-release
     test: |
-      pytest -svv -m test_unknown_release
+      pytest --setup-show -svv -m test_unknown_release

--- a/tests/integration/tier0/non-destructive/problematic-third-party-pkgs/main.fmf
+++ b/tests/integration/tier0/non-destructive/problematic-third-party-pkgs/main.fmf
@@ -17,4 +17,4 @@ description+: |
     tag+:
         - test-list-third-party-pkgs-error
     test: |
-        pytest -svv -m test_list_third_party_pkgs_error
+        pytest --setup-show -svv -m test_list_third_party_pkgs_error

--- a/tests/integration/tier0/non-destructive/rhsm-facts/main.fmf
+++ b/tests/integration/tier0/non-destructive/rhsm-facts/main.fmf
@@ -13,7 +13,7 @@ description+: |
     tag+:
         - test-rhsm-facts-called-in-analysis
     test: |
-        pytest -svv -m test_rhsm_facts_called_in_analysis
+        pytest --setup-show -svv -m test_rhsm_facts_called_in_analysis
     adjust+:
         - enabled: false
           when: distro == oracle-7, oracle-8

--- a/tests/integration/tier0/non-destructive/rollback-handling/main.fmf
+++ b/tests/integration/tier0/non-destructive/rollback-handling/main.fmf
@@ -27,7 +27,7 @@ tag+:
     tag+:
         - polluted-yumdownloader-output-by-yum-plugin-local
     test: |
-        pytest -svv -m test_polluted_yumdownloader_output_by_yum_plugin_local
+        pytest --setup-show -svv -m test_polluted_yumdownloader_output_by_yum_plugin_local
 
 /rhsm_cleanup:
     summary+: |
@@ -43,7 +43,7 @@ tag+:
     tag+:
         - rhsm-cleanup
     test: |
-        pytest -svv -m test_rhsm_cleanup
+        pytest --setup-show -svv -m test_rhsm_cleanup
 
 /packages_untracked_graceful_rollback:
     summary+: |
@@ -54,7 +54,7 @@ tag+:
     tag+:
         - packages-untracked-graceful-rollback
     test: |
-        pytest -svv -m test_packages_untracked_graceful_rollback
+        pytest --setup-show -svv -m test_packages_untracked_graceful_rollback
 
 /test_missing_credentials_rollback:
     summary+: |
@@ -66,7 +66,7 @@ tag+:
     tag+:
         - missing-credentials-rollback
     test: |
-        pytest -svv -m test_missing_credentials_rollback
+        pytest --setup-show -svv -m test_missing_credentials_rollback
 
 /terminate_on_registration:
     summary+: |
@@ -82,7 +82,7 @@ tag+:
         tag+:
             - terminate-on-registration-start
         test: |
-            pytest -svv -m test_terminate_on_registration_start
+            pytest --setup-show -svv -m test_terminate_on_registration_start
     /registration_success:
         summary+: |
             Terminate after successful registration
@@ -93,4 +93,4 @@ tag+:
         tag+:
             - terminate-on-registration-success
         test: |
-            pytest -svv -m test_terminate_on_registration_success
+            pytest --setup-show -svv -m test_terminate_on_registration_success

--- a/tests/integration/tier0/non-destructive/single-yum-transaction-validation/main.fmf
+++ b/tests/integration/tier0/non-destructive/single-yum-transaction-validation/main.fmf
@@ -30,7 +30,7 @@ tag+:
     tag+:
         - transaction-validation-error
     test: |
-        pytest -svv -m test_transaction_validation_error
+        pytest --setup-show -svv -m test_transaction_validation_error
 
 /package_download_error:
     summary+: |
@@ -40,7 +40,7 @@ tag+:
     tag+:
         - package-download-error
     test: |
-        pytest -svv -m test_package_download_error
+        pytest --setup-show -svv -m test_package_download_error
 
 
 /validating_packages_with_in_name_period:
@@ -64,9 +64,11 @@ tag+:
         - validation-packages-with-in-name-period
         - sanity
     test: |
-        pytest -svv -m test_validation_packages_with_in_name_period
+        pytest --setup-show -svv -m test_validation_packages_with_in_name_period
 
 /override_exclude_list_in_yum_config:
+    environment+:
+        CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK: 1
     summary+: |
         Override exclude in yum config to avoid dependency problems
     description+: |
@@ -86,4 +88,4 @@ tag+:
         - override-exclude-list-in-yum-config
         - sanity
     test: |
-        pytest -svv -m test_override_exclude_list_in_yum_config
+        pytest --setup-show -svv -m test_override_exclude_list_in_yum_config

--- a/tests/integration/tier0/non-destructive/single-yum-transaction-validation/test_single_yum_transaction_validation.py
+++ b/tests/integration/tier0/non-destructive/single-yum-transaction-validation/test_single_yum_transaction_validation.py
@@ -226,7 +226,7 @@ def test_validation_packages_with_in_name_period(shell, convert2rhel, packages_w
 
 
 @pytest.mark.test_override_exclude_list_in_yum_config
-def test_override_exclude_list_in_yum_config(convert2rhel, kernel, kernel_check_envar, override_yum_conf):
+def test_override_exclude_list_in_yum_config(convert2rhel, kernel, override_yum_conf):
     """
     This test verifies that packages that are defined in the exclude
     section in the /etc/yum.conf file are ignored during the analysis and

--- a/tests/integration/tier0/non-destructive/subscription-manager/main.fmf
+++ b/tests/integration/tier0/non-destructive/subscription-manager/main.fmf
@@ -26,7 +26,7 @@ tag+:
             TEST_REQUIRES: subscription-manager
 
     test: |
-        pytest -svv -m test_sub_man_rollback
+        pytest --setup-show -svv -m test_sub_man_rollback
 
     tag+:
         - sub-man-rollback
@@ -55,7 +55,7 @@ tag+:
             - environment+:
                 C2R_TESTS_SUBMAN_CLEANUP: 1
         test: |
-            pytest -svv -m test_pre_registered_wont_unregister
+            pytest --setup-show -svv -m test_pre_registered_wont_unregister
         tag+:
             - pre-registered-wont-unregister
             - sanity
@@ -76,7 +76,7 @@ tag+:
             - environment+:
                 C2R_TESTS_SUBMAN_CLEANUP: 1
         test: |
-            pytest -svv -m test_pre_registered_re_register
+            pytest --setup-show -svv -m test_pre_registered_re_register
         tag+:
             - pre-registered-re-register
     /unregistered_system_no_credentials:
@@ -87,6 +87,6 @@ tag+:
             and credentials are not provided to the convert2rhel command.
             Expected ERROR: SUBSCRIBE_SYSTEM::SYSTEM_NOT_REGISTERED - Not registered with RHSM
         test: |
-            pytest -svv -m test_unregistered_no_credentials
+            pytest --setup-show -svv -m test_unregistered_no_credentials
         tag+:
             - unregistered-no-credentials

--- a/tests/integration/tier0/non-destructive/system-release-backup/main.fmf
+++ b/tests/integration/tier0/non-destructive/system-release-backup/main.fmf
@@ -25,11 +25,14 @@ tag+:
                 This case runs the conversion with no repositories available.
                 Verify that this condition disables the package backup,
                 convert2rhel warns the user and inhibits the conversion.
+            adjust+:
+                environment+:
+                    CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK: 1
             tag+:
                 - no-envar
                 - sanity
             test: |
-                pytest -svv -m test_backup_os_release_no_envar
+                pytest --setup-show -svv -m test_backup_os_release_no_envar
 
         /backup_os_release_with_envar:
             summary+: |
@@ -39,10 +42,14 @@ tag+:
                 and "CONVERT2RHEL_INCOMPLETE_ROLLBACK" envar set.
                 Verify that this condition disables the package backup,
                 convert2rhel warns the user, but continues the conversion.
+            adjust+:
+                environment+:
+                    CONVERT2RHEL_INCOMPLETE_ROLLBACK: 1
+                    CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK: 1
             tag+:
                 - with-envar
             test: |
-                pytest -svv -m test_backup_os_release_with_envar
+                pytest --setup-show -svv -m test_backup_os_release_with_envar
             link:
                 - verifies: https://issues.redhat.com/browse/OAMG-5457
 
@@ -54,7 +61,7 @@ tag+:
         tag+:
             - unsuccessful-satellite-registration
         test: |
-            pytest -svv -m test_unsuccessful_satellite_registration
+            pytest --setup-show -svv -m test_unsuccessful_satellite_registration
         link:
             - verifies: https://issues.redhat.com/browse/RHELC-51
 
@@ -67,4 +74,4 @@ tag+:
     tag+:
         - missing-system-release
     test: |
-        pytest -svv -m test_missing_system_release
+        pytest --setup-show -svv -m test_missing_system_release

--- a/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
+++ b/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
@@ -1,4 +1,3 @@
-import os
 import re
 
 import pytest
@@ -121,9 +120,7 @@ def test_missing_system_release(shell, convert2rhel, system_release_missing):
 
 
 @pytest.mark.test_backup_os_release_no_envar
-def test_backup_os_release_no_envar(
-    shell, convert2rhel, custom_subman, katello_package, repositories, kernel_check_envar
-):
+def test_backup_os_release_no_envar(shell, convert2rhel, custom_subman, katello_package, remove_repositories):
     """
     This test case removes all the repos on the system which prevents the backup of some files.
     Satellite is being used in all of test cases.
@@ -145,19 +142,8 @@ def test_backup_os_release_no_envar(
     assert shell("find /etc/os-release").returncode == 0
 
 
-@pytest.fixture(scope="function")
-def unsupported_rollback_envar(shell):
-    os.environ["CONVERT2RHEL_INCOMPLETE_ROLLBACK"] = "1"
-
-    yield
-
-    del os.environ["CONVERT2RHEL_INCOMPLETE_ROLLBACK"]
-
-
 @pytest.mark.test_backup_os_release_with_envar
-def test_backup_os_release_with_envar(
-    shell, convert2rhel, custom_subman, katello_package, repositories, unsupported_rollback_envar, kernel_check_envar
-):
+def test_backup_os_release_with_envar(shell, convert2rhel, custom_subman, katello_package, remove_repositories):
     """
     In this scenario the variable `CONVERT2RHEL_INCOMPLETE_ROLLBACK` is set.
     This test case removes all the repos on the system and validates that

--- a/tests/integration/tier0/non-destructive/user-prompt-response/main.fmf
+++ b/tests/integration/tier0/non-destructive/user-prompt-response/main.fmf
@@ -21,4 +21,4 @@ tag+:
     tag+:
         - empty-username-and-password
     test: |
-      pytest -svv -m test_empty_username_and_password
+      pytest --setup-show -svv -m test_empty_username_and_password

--- a/tests/integration/tier1/destructive/changed-grub-file/main.fmf
+++ b/tests/integration/tier1/destructive/changed-grub-file/main.fmf
@@ -17,7 +17,7 @@ tag+:
         Verify a successful conversion.
     tag+:
         - grub-change-valid
-    test: pytest -svv -m test_valid_changes_to_grub_file
+    test: pytest --setup-show -svv -m test_valid_changes_to_grub_file
 
 /invalid_changes_to_grub_file:
     summary+: |
@@ -27,4 +27,4 @@ tag+:
         Verify a successful conversion.
     tag+:
         - grub-change-invalid
-    test: pytest -svv -m test_invalid_changes_to_grub_file
+    test: pytest --setup-show -svv -m test_invalid_changes_to_grub_file

--- a/tests/integration/tier1/destructive/changed-yum-conf/main.fmf
+++ b/tests/integration/tier1/destructive/changed-yum-conf/main.fmf
@@ -15,4 +15,4 @@ link:
         - yum
         - yum-patch
 
-    test: pytest -svv -m test_yum_conf_patch
+    test: pytest --setup-show -svv -m test_yum_conf_patch

--- a/tests/integration/tier1/destructive/detect-bootloader-partition/main.fmf
+++ b/tests/integration/tier1/destructive/detect-bootloader-partition/main.fmf
@@ -13,4 +13,4 @@ link:
     - verifies: https://issues.redhat.com/browse/RHELC-733
 
 /detect_correct_boot_partition:
-    test: pytest -svv -m test_detect_correct_boot_partition
+    test: pytest --setup-show -svv -m test_detect_correct_boot_partition

--- a/tests/integration/tier1/destructive/excluded-packages-removed/main.fmf
+++ b/tests/integration/tier1/destructive/excluded-packages-removed/main.fmf
@@ -11,4 +11,4 @@ tag+:
     - excluded-packages
 
 /excluded_packages_removed:
-    test: pytest -svv -m test_excluded_packages_removed
+    test: pytest --setup-show -svv -m test_excluded_packages_removed

--- a/tests/integration/tier1/destructive/firewalld-disabled-ol8/main.fmf
+++ b/tests/integration/tier1/destructive/firewalld-disabled-ol8/main.fmf
@@ -10,4 +10,4 @@ tag+:
     - firewalld-disabled
 
 test: |
-    pytest -svv -m test_firewalld_disabled
+    pytest --setup-show -svv -m test_firewalld_disabled

--- a/tests/integration/tier1/destructive/host-metering/main.fmf
+++ b/tests/integration/tier1/destructive/host-metering/main.fmf
@@ -10,11 +10,14 @@ link:
     - https://issues.redhat.com/browse/RHELC-1226
 
 /test_host_metering_conversion:
+    adjust+:
+        environment+:
+            CONVERT2RHEL_CONFIGURE_HOST_METERING: force
     tag+:
         - test-host-metering-conversion
-    test: pytest -svv -m test_host_metering_conversion
+    test: pytest --setup-show -svv -m test_host_metering_conversion
 
 /check_active_host_metering:
     tag+:
         - check-active-host-metering
-    test: pytest -svv -m test_active_host_metering
+    test: pytest --setup-show -svv -m test_active_host_metering

--- a/tests/integration/tier1/destructive/host-metering/test_run_conversion_with_metering.py
+++ b/tests/integration/tier1/destructive/host-metering/test_run_conversion_with_metering.py
@@ -15,20 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os
-
 import pytest
 
 from envparse import env
-
-
-@pytest.fixture
-def force_hostmetering_envar():
-    os.environ["CONVERT2RHEL_CONFIGURE_HOST_METERING"] = "force"
-
-    yield
-
-    del os.environ["CONVERT2RHEL_CONFIGURE_HOST_METERING"]
 
 
 def setup_test_metering_endpoint():
@@ -60,7 +49,7 @@ write_url=http://localhost:9090/api/v1/write
 
 
 @pytest.mark.test_host_metering_conversion
-def test_run_conversion_with_metering(shell, convert2rhel, force_hostmetering_envar):
+def test_run_conversion_with_metering(shell, convert2rhel):
     """
     Verify that convert2rhel automatically installs, enables and starts host-metering
     service on hyperscalers on RHEL 7.9.

--- a/tests/integration/tier1/destructive/kernel-boot-files/main.fmf
+++ b/tests/integration/tier1/destructive/kernel-boot-files/main.fmf
@@ -23,7 +23,7 @@ tag+:
         a disk space in the /boot partition, the kernel scriptlet will fail to copy
         the uncompressed initramfs file to /boot/initramfs-*.img, thus, leaving the
         file in a partial state and corrupted.
-    test: pytest -svv -m test_handle_corrupted_initramfs_file
+    test: pytest --setup-show -svv -m test_handle_corrupted_initramfs_file
 
 /missing_kernel_boot_files:
     summary+: |
@@ -40,4 +40,4 @@ tag+:
         isn't sufficient disk space available in there. This test has the intention
         to verify that the warning with the correct steps are provided to the
         user in order to overcome this case and fix it for them.
-    test: pytest -svv -m test_missing_kernel_boot_files
+    test: pytest --setup-show -svv -m test_missing_kernel_boot_files

--- a/tests/integration/tier1/destructive/kernel-check-skip/main.fmf
+++ b/tests/integration/tier1/destructive/kernel-check-skip/main.fmf
@@ -14,4 +14,4 @@ tag+:
     - kernel
 
 /latest_kernel_check_skip:
-    test: pytest -svv -m test_latest_kernel_check_skip
+    test: pytest --setup-show -svv -m test_latest_kernel_check_skip

--- a/tests/integration/tier1/destructive/kernel-check-skip/test_latest_kernel_check_skip.py
+++ b/tests/integration/tier1/destructive/kernel-check-skip/test_latest_kernel_check_skip.py
@@ -28,18 +28,8 @@ def test_skip_kernel_check(shell, convert2rhel):
         assert shell(f"mkdir {eus_backup_dir}").returncode == 0
         assert shell(f"mv /usr/share/convert2rhel/repos/* {eus_backup_dir}").returncode == 0
 
-    # Verify the environment variable to bypass the check is in place
-    # Intentionally use the deprecated variable to verify its compatibility
-    assert os.environ["CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK"] == "1"
-
-    # We need to set envar to override the out of date packages check
-    # to perform the full conversion
-    # The packages are outdated because the repoquery check is done
-    # against the rhel-7-server-rpms repository, not CentOS'.
-    os.environ["CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP"] = "1"
-
     # Resolve the $releasever for CentOS 7 latest manually as it gets resolved to `7` instead of required `7Server`
-    if "centos-7" in SYSTEM_RELEASE_ENV:
+    if SYSTEM_RELEASE_ENV in ["centos-7", "oracle-7"]:
         shell("sed -i 's/\$releasever/7Server/g' /etc/yum.repos.d/rhel7.repo")
 
     # Disable all repositories

--- a/tests/integration/tier1/destructive/multiple-nic/main.fmf
+++ b/tests/integration/tier1/destructive/multiple-nic/main.fmf
@@ -7,4 +7,4 @@ description+: |
   The test uses RHSM as a conversion method.
 
 test: |
-  pytest -svv
+  pytest --setup-show -svv

--- a/tests/integration/tier1/destructive/one-kernel-scenario/main.fmf
+++ b/tests/integration/tier1/destructive/one-kernel-scenario/main.fmf
@@ -23,4 +23,4 @@ adjust+:
         distro == centos-7, oracle-7
 
 /one_kernel_scenario:
-    test: pytest -svv -m test_one_kernel_scenario
+    test: pytest --setup-show -svv -m test_one_kernel_scenario

--- a/tests/integration/tier1/destructive/one-kernel-scenario/test_one_kernel_scenario.py
+++ b/tests/integration/tier1/destructive/one-kernel-scenario/test_one_kernel_scenario.py
@@ -42,10 +42,6 @@ def test_one_kernel_scenario(shell, convert2rhel, one_kernel):
     """TODO(r0x0d) better description and function name"""
 
     if os.environ["TMT_REBOOT_COUNT"] == "2":
-        # We need to skip check for collected rhsm custom facts after the conversion
-        # due to disabled submgr, thus adding envar
-        submgr_disabled_var = "SUBMGR_DISABLED_SKIP_CHECK_RHSM_CUSTOM_FACTS=1"
-        shell(f"echo '{submgr_disabled_var}' >> /etc/profile")
 
         # The nfnetlink kmod is causing issues on OracleLinux 7
         if "oracle-7" in SYSTEM_RELEASE_ENV:
@@ -71,12 +67,6 @@ def test_one_kernel_scenario(shell, convert2rhel, one_kernel):
             # This internal repo breaks the conversion on the instances we are getting
             # from Testing Farm
             shell("rm /etc/yum.repos.d/copr_build-convert2rhel-1.repo")
-
-        os.environ["CONVERT2RHEL_INCOMPLETE_ROLLBACK"] = "1"
-        os.environ["CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK"] = "1"
-        # Unavailable kmods may be present on the system due to the kernel package
-        # not being updated. Mitigate the issues by exporting CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS.
-        os.environ["CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS"] = "1"
 
         with convert2rhel("-y --no-rhsm {} --debug".format(enable_repo_opt)) as c2r:
             c2r.expect("Conversion successful!")

--- a/tests/integration/tier1/destructive/system-not-up-to-date/main.fmf
+++ b/tests/integration/tier1/destructive/system-not-up-to-date/main.fmf
@@ -7,4 +7,4 @@ description: |
     Verify that CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP overrides the out of date pkg check.
 
 /system_not_updated:
-    test: pytest -svv -m test_system_not_updated
+    test: pytest --setup-show -svv -m test_system_not_updated

--- a/tests/integration/tier1/destructive/unavailable-package/main.fmf
+++ b/tests/integration/tier1/destructive/unavailable-package/main.fmf
@@ -11,4 +11,4 @@ description: |
 
 
 /package_removed_from_centos_85:
-    test: pytest -svv -m test_package_removed_from_centos_85
+    test: pytest --setup-show -svv -m test_package_removed_from_centos_85

--- a/tests/integration/tier1/non-destructive/httpd-package-transaction-error/main.fmf
+++ b/tests/integration/tier1/non-destructive/httpd-package-transaction-error/main.fmf
@@ -19,4 +19,4 @@ tag+:
         when: distro == centos-7
         because: The bug is reproducible only on centos-7
     test: |
-        pytest -svv -m test_httpd_package_transaction_error
+        pytest --setup-show -svv -m test_httpd_package_transaction_error

--- a/tests/integration/tier1/non-destructive/httpd-package-transaction-error/test_httpd_package_transaction_error.py
+++ b/tests/integration/tier1/non-destructive/httpd-package-transaction-error/test_httpd_package_transaction_error.py
@@ -73,7 +73,7 @@ def test_httpd_package_transaction_error(shell, convert2rhel, handle_packages):
                 "Package centos-logos will be swapped to redhat-logos during conversion",
                 "Error (Must fix before conversion)",
             ],
-            timeout=600,
+            timeout=900,
         )
         assert index == 0, "The analysis found an error. Probably related to the transaction check."
         assert c2r.expect_exact("VALIDATE_PACKAGE_MANAGER_TRANSACTION has succeeded") == 0


### PR DESCRIPTION
* tmt is able to handle the environment variables for each session isolated
* move the setting and unsetting the envars from python to the test metadata where possible

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1490](https://issues.redhat.com/browse/RHELC-1490)
- [RHELC-1498](https://issues.redhat.com/browse/RHELC-1498)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [x] When merged: Jira issue has been updated to `Release Pending` if relevant
