### PR TITLE
[RHELC-1385] Satellite package backup failure fix

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -89,11 +89,11 @@ class BackupRepository(actions.Action):
             # backing up redhat.repo so repo files are properly backed up when doing satellite conversions
 
             if not repo.endswith(".repo"):
-                loggerinst.info("No .repo files backed up.")
+                loggerinst.info("Skipping backup as file is not a repository file.")
                 return
 
             if not subscription.should_subscribe() and repo == "redhat.repo":
-                loggerinst.info("No .repo files backed up.")
+                loggerinst.info("Skipping backup of redhat.repo as it is not needed.")
                 return
 
             repo_path = os.path.join(DEFAULT_YUM_REPOFILE_DIR, repo)

--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -82,8 +82,8 @@ class BackupRepository(actions.Action):
 
         loggerinst.info("Backing up .repo files from %s." % DEFAULT_YUM_REPOFILE_DIR)
 
-        if os.listdir(DEFAULT_YUM_REPOFILE_DIR) == []:
-            loggerinst.info("No .repo files to back up.")
+        if not os.listdir(DEFAULT_YUM_REPOFILE_DIR):
+            loggerinst.info("Repository folder %s seems to be empty.", DEFAULT_YUM_REPOFILE_DIR)
 
         for repo in os.listdir(DEFAULT_YUM_REPOFILE_DIR):
             # backing up redhat.repo so repo files are properly backed up when doing satellite conversions

--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -89,10 +89,10 @@ class BackupRepository(actions.Action):
                 loggerinst.info("No .repo files backed up.")
                 return
 
-            if not subscription.should_subscribe and repo == "redhat.repo":
+            if not subscription.should_subscribe() and repo == "redhat.repo":
                 loggerinst.info("No .repo files backed up.")
-
                 return
+
             repo_path = os.path.join(DEFAULT_YUM_REPOFILE_DIR, repo)
             restorable_file = RestorableFile(repo_path)
             backup.backup_control.push(restorable_file)

--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -19,7 +19,7 @@ import logging
 import os
 import re
 
-from convert2rhel import actions, backup, exceptions, repo
+from convert2rhel import actions, backup, exceptions, repo, subscription
 from convert2rhel.backup.files import MissingFile, RestorableFile
 from convert2rhel.logger import LOG_DIR
 from convert2rhel.redhatrelease import os_release_file, system_release_file
@@ -89,11 +89,12 @@ class BackupRepository(actions.Action):
         repo_files_backed_up = False
 
         for repo in os.listdir(DEFAULT_YUM_REPOFILE_DIR):
-            if repo.endswith(".repo") and repo != "redhat.repo":
-                repo_path = os.path.join(DEFAULT_YUM_REPOFILE_DIR, repo)
-                restorable_file = RestorableFile(repo_path)
-                backup.backup_control.push(restorable_file)
-                repo_files_backed_up = True
+            if not subscription.should_subscribe:
+                if repo.endswith(".repo") and repo != "redhat.repo":
+                    repo_path = os.path.join(DEFAULT_YUM_REPOFILE_DIR, repo)
+                    restorable_file = RestorableFile(repo_path)
+                    backup.backup_control.push(restorable_file)
+                    repo_files_backed_up = True
 
         if not repo_files_backed_up:
             loggerinst.info("No .repo files backed up.")

--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -82,6 +82,9 @@ class BackupRepository(actions.Action):
 
         loggerinst.info("Backing up .repo files from %s." % DEFAULT_YUM_REPOFILE_DIR)
 
+        if os.listdir(DEFAULT_YUM_REPOFILE_DIR) == []:
+            loggerinst.info("No .repo files to back up.")
+
         for repo in os.listdir(DEFAULT_YUM_REPOFILE_DIR):
             # backing up redhat.repo so repo files are properly backed up when doing satellite conversions
 

--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -75,34 +75,27 @@ class BackupRepository(actions.Action):
     id = "BACKUP_REPOSITORY"
 
     def run(self):
-        """Backup repository files before starting conversion process"""
+        """Backup .repo files in /etc/yum.repos.d/ so the repositories can be restored on rollback."""
         loggerinst.task("Prepare: Backup Repository Files")
 
         super(BackupRepository, self).run()
 
-        self.backup_yum_repos()
-
-    def backup_yum_repos(self):
-        """Backup .repo files in /etc/yum.repos.d/ so the repositories can be restored on rollback."""
         loggerinst.info("Backing up .repo files from %s." % DEFAULT_YUM_REPOFILE_DIR)
 
-        repo_files_backed_up = False
         for repo in os.listdir(DEFAULT_YUM_REPOFILE_DIR):
             # backing up redhat.repo so repo files are properly backed up when doing satellite conversions
 
             if not repo.endswith(".repo"):
+                loggerinst.info("No .repo files backed up.")
                 return
 
             if not subscription.should_subscribe and repo == "redhat.repo":
-                return
+                loggerinst.info("No .repo files backed up.")
 
+                return
             repo_path = os.path.join(DEFAULT_YUM_REPOFILE_DIR, repo)
             restorable_file = RestorableFile(repo_path)
             backup.backup_control.push(restorable_file)
-            repo_files_backed_up = True
-
-        if not repo_files_backed_up:
-            loggerinst.info("No .repo files backed up.")
 
 
 class BackupYumVariables(actions.Action):

--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -19,7 +19,7 @@ import logging
 import os
 import re
 
-from convert2rhel import actions, backup, exceptions, repo, subscription
+from convert2rhel import actions, backup, exceptions, subscription
 from convert2rhel.backup.files import MissingFile, RestorableFile
 from convert2rhel.logger import LOG_DIR
 from convert2rhel.redhatrelease import os_release_file, system_release_file
@@ -88,6 +88,7 @@ class BackupRepository(actions.Action):
 
         repo_files_backed_up = False
         for repo in os.listdir(DEFAULT_YUM_REPOFILE_DIR):
+            # backing up redhat.repo so repo files are properly backed up when doing satellite conversions
             if (repo.endswith(".repo") and repo != "redhat.repo") or (
                 subscription.should_subscribe and repo == "redhat.repo"
             ):

--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -87,14 +87,14 @@ class BackupRepository(actions.Action):
         loggerinst.info("Backing up .repo files from %s." % DEFAULT_YUM_REPOFILE_DIR)
 
         repo_files_backed_up = False
-
         for repo in os.listdir(DEFAULT_YUM_REPOFILE_DIR):
-            if not subscription.should_subscribe:
-                if repo.endswith(".repo") and repo != "redhat.repo":
-                    repo_path = os.path.join(DEFAULT_YUM_REPOFILE_DIR, repo)
-                    restorable_file = RestorableFile(repo_path)
-                    backup.backup_control.push(restorable_file)
-                    repo_files_backed_up = True
+            if (repo.endswith(".repo") and repo != "redhat.repo") or (
+                subscription.should_subscribe and repo == "redhat.repo"
+            ):
+                repo_path = os.path.join(DEFAULT_YUM_REPOFILE_DIR, repo)
+                restorable_file = RestorableFile(repo_path)
+                backup.backup_control.push(restorable_file)
+                repo_files_backed_up = True
 
         if not repo_files_backed_up:
             loggerinst.info("No .repo files backed up.")

--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -89,12 +89,12 @@ class BackupRepository(actions.Action):
             # backing up redhat.repo so repo files are properly backed up when doing satellite conversions
 
             if not repo.endswith(".repo"):
-                loggerinst.info("Skipping backup as file is not a repository file.")
-                return
+                loggerinst.info("Skipping backup as %s is not a repository file." % repo)
+                continue
 
             if not subscription.should_subscribe() and repo == "redhat.repo":
                 loggerinst.info("Skipping backup of redhat.repo as it is not needed.")
-                return
+                continue
 
             repo_path = os.path.join(DEFAULT_YUM_REPOFILE_DIR, repo)
             restorable_file = RestorableFile(repo_path)

--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -89,13 +89,17 @@ class BackupRepository(actions.Action):
         repo_files_backed_up = False
         for repo in os.listdir(DEFAULT_YUM_REPOFILE_DIR):
             # backing up redhat.repo so repo files are properly backed up when doing satellite conversions
-            if (repo.endswith(".repo") and repo != "redhat.repo") or (
-                subscription.should_subscribe and repo == "redhat.repo"
-            ):
-                repo_path = os.path.join(DEFAULT_YUM_REPOFILE_DIR, repo)
-                restorable_file = RestorableFile(repo_path)
-                backup.backup_control.push(restorable_file)
-                repo_files_backed_up = True
+
+            if not repo.endswith(".repo"):
+                return
+
+            if not subscription.should_subscribe and repo == "redhat.repo":
+                return
+
+            repo_path = os.path.join(DEFAULT_YUM_REPOFILE_DIR, repo)
+            restorable_file = RestorableFile(repo_path)
+            backup.backup_control.push(restorable_file)
+            repo_files_backed_up = True
 
         if not repo_files_backed_up:
             loggerinst.info("No .repo files backed up.")

--- a/convert2rhel/actions/system_checks/duplicate_packages.py
+++ b/convert2rhel/actions/system_checks/duplicate_packages.py
@@ -31,7 +31,7 @@ class DuplicatePackages(actions.Action):
         super(DuplicatePackages, self).run()
 
         logger.task("Prepare: Check if there are any duplicate installed packages on the system")
-        output, _ = utils.run_subprocess(["/usr/bin/package-cleanup", "--dupes", "--quiet"], print_output=False)
+        output, ret = utils.run_subprocess(["/usr/bin/package-cleanup", "--dupes", "--quiet"], print_output=False)
         if not output:
             return
 

--- a/convert2rhel/actions/system_checks/duplicate_packages.py
+++ b/convert2rhel/actions/system_checks/duplicate_packages.py
@@ -31,7 +31,7 @@ class DuplicatePackages(actions.Action):
         super(DuplicatePackages, self).run()
 
         logger.task("Prepare: Check if there are any duplicate installed packages on the system")
-        output, ret = utils.run_subprocess(["/usr/bin/package-cleanup", "--dupes", "--quiet"], print_output=False)
+        output, _ = utils.run_subprocess(["/usr/bin/package-cleanup", "--dupes", "--quiet"], print_output=False)
         if not output:
             return
 

--- a/convert2rhel/backup/packages.py
+++ b/convert2rhel/backup/packages.py
@@ -86,7 +86,7 @@ _UBI_REPO_MAPPING = {
 class RestorablePackage(RestorableChange):
     def __init__(self, pkgs, reposdir=None, set_releasever=False, custom_releasever=None, varsdir=None):
         """
-        Keep control of systme packages before their removal to backup and
+        Keep control of system packages before their removal to backup and
         restore in case of rollback.
 
         :param pkgs list[str]: List of packages to backup.
@@ -135,37 +135,20 @@ class RestorablePackage(RestorableChange):
             if system_info.eus_system and system_info.id == "centos":
                 self.reposdir = get_hardcoded_repofiles_dir()
 
-            if not system_info.has_internet_access:
-                if self.reposdir:
-                    loggerinst.debug(
-                        "Not using repository files stored in %s due to the absence of internet access." % self.reposdir
-                    )
+            if self.reposdir:
+                loggerinst.debug("Using repository files stored in %s." % self.reposdir)
 
-                for pkg in self.pkgs:
-                    self._backedup_pkgs_paths.append(
-                        utils.download_pkg(
-                            pkg=pkg,
-                            dest=BACKUP_DIR,
-                            set_releasever=self.set_releasever,
-                            custom_releasever=self.custom_releasever,
-                            varsdir=self.varsdir,
-                        )
+            for pkg in self.pkgs:
+                self._backedup_pkgs_paths.append(
+                    utils.download_pkg(
+                        pkg=pkg,
+                        dest=BACKUP_DIR,
+                        set_releasever=self.set_releasever,
+                        custom_releasever=self.custom_releasever,
+                        varsdir=self.varsdir,
+                        reposdir=self.reposdir,
                     )
-            else:
-                if self.reposdir:
-                    loggerinst.debug("Using repository files stored in %s." % self.reposdir)
-
-                for pkg in self.pkgs:
-                    self._backedup_pkgs_paths.append(
-                        utils.download_pkg(
-                            pkg=pkg,
-                            dest=BACKUP_DIR,
-                            set_releasever=self.set_releasever,
-                            custom_releasever=self.custom_releasever,
-                            varsdir=self.varsdir,
-                            reposdir=self.reposdir,
-                        )
-                    )
+                )
         else:
             loggerinst.warning("Can't access %s" % BACKUP_DIR)
 

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
@@ -19,12 +19,10 @@ __metaclass__ = type
 import hashlib
 import os
 
-from functools import partial
-
 import pytest
 import six
 
-from convert2rhel import subscription, toolopts, unit_tests
+from convert2rhel import subscription, unit_tests
 from convert2rhel.actions.pre_ponr_changes import backup_system
 from convert2rhel.backup import files
 from convert2rhel.backup.files import RestorableFile
@@ -387,19 +385,16 @@ class TestBackupRepository:
         with open(yum_repo, mode="r") as f:
             assert f.read() == os.path.basename(yum_repo)
 
-    def test_backup_repository_redhat(self, monkeypatch, tmpdir, backup_repository_action, global_tool_opts, caplog):
+    def test_backup_repository_redhat(self, monkeypatch, tmpdir, backup_repository_action, caplog):
         """Test if redhat.repo is not backed up."""
         redhat_repo = generate_repo(tmpdir, "redhat.repo")
 
-        global_tool_opts.no_rhsm = True
-
         monkeypatch.setattr(backup_system, "DEFAULT_YUM_REPOFILE_DIR", os.path.dirname(redhat_repo))
-        monkeypatch.setattr(subscription, "should_subscribe", partial(toolopts._should_subscribe, global_tool_opts))
-
+        monkeypatch.setattr(subscription, "should_subscribe", mock.Mock(side_effect=lambda: False))
         backup_repository = backup_repository_action
         backup_repository.run()
 
-        assert "No .repo files backed upp." == caplog.records[-1].message
+        assert "No .repo files backed up." == caplog.records[-1].message
 
     def test_backup_repository_no_repofile_presence(self, tmpdir, monkeypatch, caplog, backup_repository_action):
         """Test empty path, nothing for backup."""

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
@@ -394,7 +394,16 @@ class TestBackupRepository:
         backup_repository = backup_repository_action
         backup_repository.run()
 
-        assert "No .repo files backed up." == caplog.records[-1].message
+        assert "Skipping backup of redhat.repo as it is not needed." == caplog.records[-1].message
+
+    def test_backup_repository_other_files(self, monkeypatch, tmpdir, backup_repository_action, caplog):
+        """Test if redhat.repo is not backed up."""
+        non_repo_file = generate_repo(tmpdir, "redhat.nonrepo")
+
+        monkeypatch.setattr(backup_system, "DEFAULT_YUM_REPOFILE_DIR", os.path.dirname(non_repo_file))
+        backup_repository = backup_repository_action
+        backup_repository.run()
+        assert "Skipping backup as file is not a repository file." == caplog.records[-1].message
 
     def test_backup_repository_no_repofile_presence(self, tmpdir, monkeypatch, caplog, backup_repository_action):
         """Test empty path, nothing for backup."""
@@ -405,7 +414,7 @@ class TestBackupRepository:
         backup_repository = backup_repository_action
 
         backup_repository.run()
-        assert "No .repo files to back up." in caplog.text
+        assert ("Repository folder %s seems to be empty." % etc) in caplog.text
 
 
 class TestBackupVariables:

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
@@ -405,7 +405,7 @@ class TestBackupRepository:
         backup_repository = backup_repository_action
 
         backup_repository.run()
-        assert "No .repo files backed up." in caplog.text
+        assert "No .repo files to back up." in caplog.text
 
 
 class TestBackupVariables:

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
@@ -403,7 +403,7 @@ class TestBackupRepository:
         monkeypatch.setattr(backup_system, "DEFAULT_YUM_REPOFILE_DIR", os.path.dirname(non_repo_file))
         backup_repository = backup_repository_action
         backup_repository.run()
-        assert "Skipping backup as file is not a repository file." == caplog.records[-1].message
+        assert "Skipping backup as redhat.nonrepo is not a repository file." == caplog.records[-1].message
 
     def test_backup_repository_no_repofile_presence(self, tmpdir, monkeypatch, caplog, backup_repository_action):
         """Test empty path, nothing for backup."""

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
@@ -22,7 +22,7 @@ import os
 import pytest
 import six
 
-from convert2rhel import unit_tests
+from convert2rhel import subscription, unit_tests
 from convert2rhel.actions.pre_ponr_changes import backup_system
 from convert2rhel.backup import files
 from convert2rhel.backup.files import RestorableFile
@@ -390,6 +390,7 @@ class TestBackupRepository:
         redhat_repo = generate_repo(tmpdir, "redhat.repo")
 
         monkeypatch.setattr(backup_system, "DEFAULT_YUM_REPOFILE_DIR", os.path.dirname(redhat_repo))
+        monkeypatch.setattr(subscription, "should_subscribe", value=False)
 
         backup_repository = backup_repository_action
         backup_repository.run()

--- a/convert2rhel/unit_tests/actions/system_checks/duplicate_packages_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/duplicate_packages_test.py
@@ -61,9 +61,13 @@ def test_duplicate_packages_error(monkeypatch, output, expected, duplicate_packa
     )
 
 
-def test_duplicate_packages_success(monkeypatch, duplicate_packages_action):
+@pytest.mark.parametrize(
+    ("output"),
+    ((""),),
+)
+def test_duplicate_packages_success(monkeypatch, duplicate_packages_action, output):
 
-    monkeypatch.setattr(utils, "run_subprocess", RunSubprocessMocked(return_value=("", 0)))
+    monkeypatch.setattr(utils, "run_subprocess", RunSubprocessMocked(return_value=(output, 0)))
     duplicate_packages_action.run()
     unit_tests.assert_actions_result(
         duplicate_packages_action,

--- a/convert2rhel/unit_tests/backup/packages_test.py
+++ b/convert2rhel/unit_tests/backup/packages_test.py
@@ -120,39 +120,6 @@ class TestRestorablePackage:
         assert packages.get_hardcoded_repofiles_dir.call_count == 1
         assert utils.download_pkg.call_count == 1
 
-    @pytest.mark.parametrize(
-        (
-            "has_internet_access",
-            "expected",
-        ),
-        (
-            (
-                True,
-                "Using repository files stored in %s",
-            ),
-            (
-                False,
-                "Not using repository files stored in %s due to the absence of internet access.",
-            ),
-        ),
-    )
-    def test_enable_has_internet_connection(
-        self, has_internet_access, expected, monkeypatch, tmpdir, global_system_info, caplog
-    ):
-        tmpdir = str(tmpdir)
-        monkeypatch.setattr(packages, "BACKUP_DIR", tmpdir)
-        monkeypatch.setattr(utils, "download_pkg", DownloadPkgMocked())
-        monkeypatch.setattr(packages, "system_info", global_system_info)
-
-        global_system_info.has_internet_access = has_internet_access
-
-        rp = RestorablePackage(pkgs=["test.rpm"], reposdir=tmpdir)
-        rp._backedup_pkgs_paths = ["test.rpm"]
-        rp.enable()
-
-        assert utils.download_pkg.call_count == 1
-        assert expected % tmpdir in caplog.records[-1].message
-
     def test_package_already_enabled(self, monkeypatch, tmpdir):
         monkeypatch.setattr(packages, "BACKUP_DIR", str(tmpdir))
         monkeypatch.setattr(utils, "download_pkg", DownloadPkgMocked())


### PR DESCRIPTION
This PR changes our backups to now backup the redhat.repo file when running with satellite. The reason backups were failing on satellite was due to the redhat.repo file being excluded from backups which in turn causes the .repo files not to be backed up. This change also removes the requirement for internet access to backup using hardcoded repository files and defaults to always using the the hardcoded repository files. 

A similiar failure with backing up repo files has been reported for offline conversions with satellite - [RHELC-1040](https://issues.redhat.com/browse/RHELC-1040), however this PR does not fix the issue
<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-1385](https://issues.redhat.com/browse/RHELC-1385) -->
- [RHELC-1385](https://issues.redhat.com/browse/RHELC-1385)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
