### PR TITLE
[RHELC-1503] Fix RHSM facts filepath in a log message

### DIFF
--- a/convert2rhel/breadcrumbs.py
+++ b/convert2rhel/breadcrumbs.py
@@ -213,16 +213,16 @@ class Breadcrumbs:
     def print_data_collection(self):
         """Print information about data collection and ask for acknowledgement."""
         loggerinst.info(
-            "The convert2rhel utility generates a /etc/rhsm/facts/convert2rhel.fact file that contains the below data"
-            " about the system conversion. The subscription-manager then uploads the data to the server the system is"
-            " registered to.\n"
+            "The convert2rhel utility generates a %s file that contains the below data about the system conversion."
+            " The subscription-manager then uploads the data to the server the system is registered to.\n"
             "- The Convert2RHEL command as executed\n"
             "- The Convert2RHEL RPM version and GPG signature\n"
             "- Success or failure status of the conversion\n"
             "- Conversion start and end timestamps\n"
             "- Source OS vendor and version\n"
             "- Target RHEL version\n"
-            "- Convert2RHEL related environment variables\n\n"
+            "- Convert2RHEL related environment variables\n\n",
+            RHSM_CUSTOM_FACTS_FILE,
         )
 
         utils.ask_to_continue()

--- a/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
@@ -240,7 +240,7 @@ def test_data_collection_acknowledgement(shell, convert2rhel):
         assert c2r.expect("Prepare: Inform about data collection", timeout=300) == 0
         assert (
             c2r.expect(
-                "The convert2rhel utility generates a /etc/rhsm/facts/convert2rhel.fact file that contains the below data about the system conversion.",
+                "The convert2rhel utility generates a /etc/rhsm/facts/convert2rhel.facts file that contains the below data about the system conversion.",
                 timeout=300,
             )
             == 0

--- a/tests/integration/tier0/non-destructive/single-yum-transaction-validation/test_single_yum_transaction_validation.py
+++ b/tests/integration/tier0/non-destructive/single-yum-transaction-validation/test_single_yum_transaction_validation.py
@@ -211,7 +211,7 @@ def test_validation_packages_with_in_name_period(shell, convert2rhel, packages_w
         assert c2r.expect("Prepare: Inform about data collection", timeout=300) == 0
         assert (
             c2r.expect(
-                "The convert2rhel utility generates a /etc/rhsm/facts/convert2rhel.fact file that contains the below data about the system conversion.",
+                "The convert2rhel utility generates a /etc/rhsm/facts/convert2rhel.facts file that contains the below data about the system conversion.",
                 timeout=300,
             )
             == 0


### PR DESCRIPTION
The message said convert2rhel.fact while it should be convert2rhel.facts.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:
- [RHELC-1503](https://issues.redhat.com/browse/RHELC-1503)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
