### PR TITLE
Add version lock of python extensions in CentOS 7 Devcontainer

### DIFF
--- a/.devcontainer/centos7/devcontainer.json
+++ b/.devcontainer/centos7/devcontainer.json
@@ -36,12 +36,14 @@
 				"python.languageServer": "Pylance"
 			},
 			"extensions": [
-				"ms-python.vscode-pylance",
+				// The lock is needed for having linting, syntax highlight and
+				// unit testing module. Without the locks there are dependency problems.
+				"ms-python.vscode-pylance@2023.11.10",
+				"ms-python.python@2022.8.1",
 				"eamodio.gitlens",
 				"GitHub.vscode-pull-request-github",
 				"Cameron.vscode-pytest",
-				"njpwerner.autodocstring",
-				"ms-python.python"
+				"njpwerner.autodocstring"
 			]
 		}
 	}


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
After releasing the VS Code 1.88 and the new versions of the extensions, there are problems with CentOS 7 devcontainer.

Without the lock there are problems with dependencies resulting in not working linting, syntax highlight or unit testing module. With the lock, the mentioned things works.

There is still problem with not working visual debugging of the unit tests, it seems there is some infinite loop.  But other things works.

For the feature, the working versions for the CentOS 7 devcontainer today:
VS Code: 1.87.2
Dev Container extension for VS Code:  0.348.0 (in the newer version 0.354.0, it waits for choosing the right image)

<!-- Link to relevant Red Hat Jira issues -->

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
