### PR TITLE
Fix incorrect usages of rstrip with a string argument.

### DIFF
--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -272,8 +272,8 @@ def _extract_convert2rhel_versions(raw_versions):
     # relevant repoquery information to our check, otherwise, we just log the
     # information as debug and do nothing with it.
     for raw_version in precise_raw_version:
-        if "C2R" in raw_version:
-            parsed_versions.append(raw_version.lstrip("C2R "))
+        if raw_version.startswith("C2R "):
+            parsed_versions.append(raw_version[4:])
         else:
             # Mainly for debugging purposes to see what is happening if we got
             # anything else that does not have the C2R identifier at the start

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -159,7 +159,7 @@ def get_installed_pkg_information(pkg_name="*"):
                 # Special case for `gpg-pubkeys` package that does not contain
                 # an arch set.
                 if name.endswith(".(none)"):
-                    name = name.rstrip(".(none)")
+                    name = name[:-7]
 
                 name, epoch, version, release, arch = tuple(parse_pkg_string(name))
 


### PR DESCRIPTION
The bug underlying [RHELC-1225](https://issues.redhat.com/browse/RHELC-1225) was an incorrect use of the python  lstrip  function. This change fixes all the other places in the code where we make the same mistake.

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
