### PR TITLE
[RHELC-1314, RHELC-1524, RHELC-1387] Drop the use of the katello package from the tests

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -33,17 +33,17 @@ adjust+:
       when: distro == rocky-8-latest
 
 prepare+:
+    - name: install latest copr build
+      how: install
+      copr: '@oamg/convert2rhel'
+      package: convert2rhel
+      missing: fail
     - name: main preparation step
       how: ansible
       playbook: tests/ansible_collections/main.yml
     - name: reboot system after update
       how: ansible
       playbook: tests/ansible_collections/roles/reboot/main.yml
-    - name: install latest copr build
-      how: install
-      copr: '@oamg/convert2rhel'
-      package: convert2rhel
-      missing: fail
 
     # We need to remove all the repositories that were used to install c2r package.
     # The updated packages check may find that installed c2r is not latest and it then

--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -160,10 +160,10 @@ description+: |
 
 
     /offline_system_conversion:
-        adjust:
-          enabled: false
-          when: distro == oracle-7
-          because: It will be disabled as a validation of https://issues.redhat.com/browse/RHELC-1544 fix
+        adjust+:
+          - enabled: false
+            when: distro == oracle-7
+            because: It will be enabled as a validation of https://issues.redhat.com/browse/RHELC-1544 fix
         prepare+:
             - name: Allow access to Satellite only
               how: shell

--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -39,11 +39,6 @@ description+: |
 
             /pre_registered_system_conversion:
                 adjust+:
-                  - enabled: false
-                    when: distro == oracle
-                    because: |
-                        There is no subscription-manager package in Oracle Linux repositories
-                        and no documentation is provided - https://issues.redhat.com/browse/RHELC-1485.
                   - environment+:
                       C2R_TESTS_CHECK_RHSM_UUID_MATCH: 1
                       C2R_TESTS_SUBMAN_REMAIN_REGISTERED: 1
@@ -165,21 +160,7 @@ description+: |
 
 
     /offline_system_conversion:
-        adjust+:
-          # Disabled due to known issue: https://issues.redhat.com/browse/RHELC-1040
-          # Enable once this gets fixed
-          - enabled: false
-            when: distro == oracle-7
-        environment+:
-            CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP: 1
-            when: distro == oracle-8
-            because: |
-                The subman is installed from CentOS repo, resulting in outdated python3-ethtool
-                package which is then interfering with the test, inhibiting the conversion.
         prepare+:
-            - name: Install subscription manager
-              how: ansible
-              playbook: tests/ansible_collections/roles/install-submgr/main.yml
             - name: Allow access to Satellite only
               how: shell
               script: pytest --setup-show -svv tests/integration/*/destructive/offline-system-conversion/prepare_system.py

--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -160,6 +160,10 @@ description+: |
 
 
     /offline_system_conversion:
+        adjust:
+          enabled: false
+          when: distro == oracle-7
+          because: It will be disabled as a validation of https://issues.redhat.com/browse/RHELC-1544 fix
         prepare+:
             - name: Allow access to Satellite only
               how: shell

--- a/pytest.ini
+++ b/pytest.ini
@@ -110,12 +110,6 @@ markers =
     test_no_sca_not_subscribed
     test_no_sca_subscription_attachment_error
     test_proxy_conversion
-    yum_conf_exclude
-    config_files_modified
-    config_files_removed
-    c2r_config_releasever
-    system_release_backup
-    system_release_missing
     prepare_offline_system
 # Unit test related
     noautofixtures: disable all auto-use fixtures

--- a/pytest.ini
+++ b/pytest.ini
@@ -110,5 +110,12 @@ markers =
     test_no_sca_not_subscribed
     test_no_sca_subscription_attachment_error
     test_proxy_conversion
+    yum_conf_exclude
+    config_files_modified
+    config_files_removed
+    c2r_config_releasever
+    system_release_backup
+    system_release_missing
+    prepare_offline_system
 # Unit test related
     noautofixtures: disable all auto-use fixtures

--- a/tests/ansible_collections/roles/get-test-vars/tasks/get-test-vars.yml
+++ b/tests/ansible_collections/roles/get-test-vars/tasks/get-test-vars.yml
@@ -5,3 +5,10 @@
     validate_certs: false
     dest: /var/tmp/.env
     mode: '0444'
+
+- name: Download the Satellite file
+  get_url:
+    url: https://gitlab.cee.redhat.com/oamg/convert2rhel/convert2rhel-secrets/-/raw/main/.env_sat_reg
+    validate_certs: false
+    dest: /var/tmp/.env_sat_reg
+    mode: '0444'

--- a/tests/ansible_collections/roles/remove-tf-artifact-leftovers/tasks/clean_up_el7.yml
+++ b/tests/ansible_collections/roles/remove-tf-artifact-leftovers/tasks/clean_up_el7.yml
@@ -34,5 +34,24 @@
     - beaker-harness.repo
     - beaker-tasks.repo
 
+- name: Remove epel repositories
+  ansible.builtin.file:
+    path: "/etc/yum.repos.d/{{ item }}"
+    state: absent
+  with_items:
+    - epel-testing.repo
+    - epel.repo
+
+# We remove the packages with rpm -e --nodeps as a safety measure to not remove any possibly dependent packages
+# for example removing python-jsonpatch with yum removes cloud-init and subsequently python-six as dependencies
+# causing problems with python versions compatibility and failing tests
+- name: Remove packages installed by Testing Farm
+  ansible.builtin.shell: rpm -e --nodeps {{ item }}
+  with_items:
+    - epel-release
+    - tps-devel
+    - python-jsonpatch
+  ignore_errors: true
+
 - name: Clean yum metadata
   ansible.builtin.shell: yum clean metadata

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -711,7 +711,6 @@ def kernel(shell):
 
 
 @pytest.fixture()
-@pytest.mark.yum_conf_exclude
 def yum_conf_exclude(shell, backup_directory, request):
     """
     Fixture.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -29,10 +29,33 @@ logging.basicConfig(level=os.environ.get("DEBUG", "INFO"), stream=sys.stderr)
 logger = logging.getLogger(__name__)
 
 TEST_VARS = dotenv_values("/var/tmp/.env")
+SAT_REG_FILE = dotenv_values("/var/tmp/.env_sat_reg")
 
-SATELLITE_URL = "satellite.sat.engineering.redhat.com"
-SATELLITE_PKG_URL = "https://satellite.sat.engineering.redhat.com/pub/katello-ca-consumer-latest.noarch.rpm"
-SATELLITE_PKG_DST = "/usr/share/convert2rhel/subscription-manager/katello-ca-consumer-latest.noarch.rpm"
+
+def satellite_registration_command():
+    """
+    Get the Satellite registration command for the respective system.
+    """
+    sat_reg_command = None
+    if SYSTEM_RELEASE_ENV == "alma-8-latest":
+        sat_reg_command = SAT_REG_FILE["ALMA8_SAT_REG"]
+    elif SYSTEM_RELEASE_ENV == "alma-8.8":
+        sat_reg_command = SAT_REG_FILE["ALMA88_SAT_REG"]
+    elif SYSTEM_RELEASE_ENV == "rocky-8-latest":
+        sat_reg_command = SAT_REG_FILE["ROCKY8_SAT_REG"]
+    elif SYSTEM_RELEASE_ENV == "rocky-8.8":
+        sat_reg_command = SAT_REG_FILE["ROCKY88_SAT_REG"]
+    elif SYSTEM_RELEASE_ENV == "oracle-8-latest":
+        sat_reg_command = SAT_REG_FILE["ORACLE8_SAT_REG"]
+    elif SYSTEM_RELEASE_ENV == "centos-8-latest":
+        sat_reg_command = SAT_REG_FILE["CENTOS8_SAT_REG"]
+    elif SYSTEM_RELEASE_ENV == "oracle-7":
+        sat_reg_command = SAT_REG_FILE["ORACLE7_SAT_REG"]
+    elif SYSTEM_RELEASE_ENV == "centos-7":
+        sat_reg_command = SAT_REG_FILE["CENTOS7_SAT_REG"]
+
+    return sat_reg_command
+
 
 SYSTEM_RELEASE_ENV = os.environ["SYSTEM_RELEASE_ENV"]
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -735,13 +735,13 @@ def yum_conf_exclude(shell, backup_directory, request):
 
     assert shell(f"cp -v {yum_config} {config_bak}").returncode == 0
 
-    for pkg in exclude:
-        # If there is already an `exclude` section, append to the existing value
-        if config.has_option("main", "exclude"):
-            pre_existing_value = config.get("main", "exclude")
-            config.set("main", "exclude", f"{pre_existing_value} {pkg}")
-        else:
-            config.set("main", "exclude", pkg)
+    pkgs_to_exclude = " ".join(exclude)
+    # If there is already an `exclude` section, append to the existing value
+    if config.has_option("main", "exclude"):
+        pre_existing_value = config.get("main", "exclude")
+        config.set("main", "exclude", f"{pre_existing_value} {pkgs_to_exclude}")
+    else:
+        config.set("main", "exclude", pkgs_to_exclude)
 
     with open(yum_config, "w") as configfile:
         config.write(configfile, space_around_delimiters=False)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -65,8 +65,12 @@ SYSTEM_RELEASE_ENV = os.environ["SYSTEM_RELEASE_ENV"]
 def shell(tmp_path):
     """Live shell."""
 
-    def factory(command, silent=False):
-        if not silent:
+    def factory(command, silent=False, hide_command=False):
+        if silent:
+            click.echo("The fixture is set to silent=True, therefore no output will be printed.")
+        if hide_command:
+            click.echo("The fixture is set to hide_command=False, so it won't show the called command.")
+        if not silent and not hide_command:
             click.echo(
                 "\nExecuting a command:\n{}\n\n".format(command),
                 color="green",
@@ -722,7 +726,7 @@ def yum_conf_exclude(shell, backup_directory, request):
     """
     yum_config = "/etc/yum.conf"
     backup_dir = os.path.join(backup_directory, "yum")
-    shell(f"mkdir {backup_dir}")
+    shell(f"mkdir -v {backup_dir}")
     config_bak = os.path.join(backup_dir, os.path.basename(yum_config))
     config = configparser.ConfigParser()
     config.read(yum_config)

--- a/tests/integration/tier0/destructive/conversion-method/main.fmf
+++ b/tests/integration/tier0/destructive/conversion-method/main.fmf
@@ -70,7 +70,8 @@ order: 49
     description: |
         Conversion method using the Satellite credentials for registration.
         The subscription-manager package is removed for this conversion method.
-        Subscribe to the Satellite server using the curl command.
+        Use the provided curl command to download the registration script to a file,
+        then run the registration script file.
     tag+:
         - satellite-conversion
     test: pytest -m test_satellite_conversion

--- a/tests/integration/tier0/destructive/conversion-method/main.fmf
+++ b/tests/integration/tier0/destructive/conversion-method/main.fmf
@@ -70,7 +70,7 @@ order: 49
     description: |
         Conversion method using the Satellite credentials for registration.
         The subscription-manager package is removed for this conversion method.
-        The katello-ca-consumer package is installed from the Satellite server.
+        Subscribe to the Satellite server using the curl command.
     tag+:
         - satellite-conversion
     test: pytest -m test_satellite_conversion

--- a/tests/integration/tier0/destructive/conversion-method/test_satellite.py
+++ b/tests/integration/tier0/destructive/conversion-method/test_satellite.py
@@ -1,6 +1,6 @@
 import pytest
 
-from conftest import SATELLITE_PKG_DST, SATELLITE_PKG_URL, TEST_VARS
+from conftest import TEST_VARS, satellite_registration_command
 
 
 @pytest.mark.test_satellite_conversion
@@ -8,19 +8,12 @@ def test_satellite_conversion(shell, convert2rhel):
     """
     Conversion method using the Satellite credentials for registration.
     The subscription-manager package is removed for this conversion method.
-    The katello-ca-consumer package is installed from the Satellite server.
+    Subscribe to the Satellite server using the curl command.
     """
-    # Remove subscription manager if installed
-    assert shell("yum remove subscription-manager -y").returncode == 0
 
-    assert shell("yum install wget -y").returncode == 0
+    sat_reg_command = satellite_registration_command()
 
-    assert (
-        shell(
-            "wget --no-check-certificate --output-document {} {}".format(SATELLITE_PKG_DST, SATELLITE_PKG_URL)
-        ).returncode
-        == 0
-    )
+    assert shell(sat_reg_command).returncode == 0
 
     with convert2rhel(
         "-y -k {} -o {} --debug".format(

--- a/tests/integration/tier0/destructive/conversion-method/test_satellite.py
+++ b/tests/integration/tier0/destructive/conversion-method/test_satellite.py
@@ -8,7 +8,8 @@ def test_satellite_conversion(shell, convert2rhel, satellite_registration):
     """
     Conversion method using the Satellite credentials for registration.
     The subscription-manager package is removed for this conversion method.
-    Subscribe to the Satellite server using the curl command.
+    Use the provided curl command to download the registration script to a file,
+    then run the registration script file.
     """
     with convert2rhel(
         "-y -k {} -o {} --debug".format(

--- a/tests/integration/tier0/destructive/conversion-method/test_satellite.py
+++ b/tests/integration/tier0/destructive/conversion-method/test_satellite.py
@@ -1,20 +1,15 @@
 import pytest
 
-from conftest import TEST_VARS, satellite_registration_command
+from conftest import TEST_VARS
 
 
 @pytest.mark.test_satellite_conversion
-def test_satellite_conversion(shell, convert2rhel):
+def test_satellite_conversion(shell, convert2rhel, satellite_registration):
     """
     Conversion method using the Satellite credentials for registration.
     The subscription-manager package is removed for this conversion method.
     Subscribe to the Satellite server using the curl command.
     """
-
-    sat_reg_command = satellite_registration_command()
-
-    assert shell(sat_reg_command).returncode == 0
-
     with convert2rhel(
         "-y -k {} -o {} --debug".format(
             TEST_VARS["SATELLITE_KEY"],

--- a/tests/integration/tier0/destructive/conversion-method/test_satellite.py
+++ b/tests/integration/tier0/destructive/conversion-method/test_satellite.py
@@ -7,7 +7,6 @@ from conftest import TEST_VARS
 def test_satellite_conversion(shell, convert2rhel, satellite_registration):
     """
     Conversion method using the Satellite credentials for registration.
-    The subscription-manager package is removed for this conversion method.
     Use the provided curl command to download the registration script to a file,
     then run the registration script file.
     """

--- a/tests/integration/tier0/destructive/offline-system-conversion/prepare_system.py
+++ b/tests/integration/tier0/destructive/offline-system-conversion/prepare_system.py
@@ -2,7 +2,7 @@ import os
 import re
 import socket
 
-from conftest import TEST_VARS, satellite_registration_command
+from conftest import TEST_VARS
 
 
 def replace_urls_rhsm():
@@ -39,7 +39,7 @@ def configure_connection():
         f.write("nameserver 127.0.0.1")
 
 
-def test_prepare_system(shell):
+def test_prepare_system(shell, satellite_registration):
     """
     Perform all the steps to make the system appear to be offline.
     Register to the Satellite server.
@@ -47,10 +47,6 @@ def test_prepare_system(shell):
     so there is only the redhat.repo created by subscription-manager.
     """
     assert shell("yum install dnsmasq -y").returncode == 0
-    sat_reg_command = satellite_registration_command()
-
-    # Register system to the satellite server
-    assert shell(sat_reg_command).returncode == 0
 
     repos_dir = "/etc/yum.repos.d"
     # Remove all repofiles except the redhat.repo

--- a/tests/integration/tier0/destructive/offline-system-conversion/prepare_system.py
+++ b/tests/integration/tier0/destructive/offline-system-conversion/prepare_system.py
@@ -1,5 +1,4 @@
 import os
-import re
 import socket
 
 import pytest
@@ -7,32 +6,18 @@ import pytest
 from conftest import TEST_VARS
 
 
-# def replace_urls_rhsm():
-#     """
-#     Replace urls in rhsm.conf file to the satellite server
-#     Without doing this we get obsolete dogfood server as source of repositories
-#     """
-#     with open("/etc/rhsm/rhsm.conf", "r+") as f:
-#         file = f.read()
-#         # Replacing the urls
-#         file = re.sub("hostname = .*", "hostname = {}".format(TEST_VARS["SATELLITE_URL"]), file)
-#         file = re.sub("baseurl = .*", "baseurl = https://{}/pulp/repos".format(TEST_VARS["SATELLITE_URL"]), file)
-#
-#         # Setting the position to the top of the page to insert data
-#         f.seek(0)
-#         f.write(file)
-#         f.truncate()
-
-
 def configure_connection():
     """
     Configure and limit connection to the satellite server only
     """
     satellite_ip = socket.gethostbyname(TEST_VARS["SATELLITE_URL"])
+    # Get fully qualified domain name for the Satellite URL
+    # With this we can disable the nameservers without the need to rely on resolving the hostname alias
+    satellite_fqdn = socket.getfqdn(TEST_VARS["SATELLITE_URL"])
 
     with open("/etc/dnsmasq.conf", "a") as f:
         # Satellite url
-        f.write("address=/{}/{}\n".format(TEST_VARS["SATELLITE_URL"], satellite_ip))
+        f.write("address=/{}/{}\n".format(satellite_fqdn, satellite_ip))
 
         # Everything else is resolved to localhost
         f.write("address=/#/127.0.0.1")
@@ -58,8 +43,6 @@ def test_prepare_system(shell, satellite_registration):
             os.remove(os.path.join(repos_dir, file))
 
     assert os.path.isfile("/etc/yum.repos.d/redhat.repo")
-
-    # replace_urls_rhsm()
 
     configure_connection()
 

--- a/tests/integration/tier0/destructive/offline-system-conversion/prepare_system.py
+++ b/tests/integration/tier0/destructive/offline-system-conversion/prepare_system.py
@@ -17,6 +17,7 @@ def configure_connection():
 
     with open("/etc/dnsmasq.conf", "a") as f:
         # Satellite url
+        f.write("address=/{}/{}\n".format(TEST_VARS["SATELLITE_URL"], satellite_ip))
         f.write("address=/{}/{}\n".format(satellite_fqdn, satellite_ip))
 
         # Everything else is resolved to localhost
@@ -33,6 +34,7 @@ def test_prepare_system(shell, satellite_registration):
     Register to the Satellite server.
     Remove all the repositories before the Satellite subscription,
     so there is only the redhat.repo created by subscription-manager.
+    The original system repositories are then used from the synced Satellite server.
     """
     assert shell("yum install dnsmasq -y").returncode == 0
 

--- a/tests/integration/tier0/destructive/offline-system-conversion/prepare_system.py
+++ b/tests/integration/tier0/destructive/offline-system-conversion/prepare_system.py
@@ -2,24 +2,26 @@ import os
 import re
 import socket
 
+import pytest
+
 from conftest import TEST_VARS
 
 
-def replace_urls_rhsm():
-    """
-    Replace urls in rhsm.conf file to the satellite server
-    Without doing this we get obsolete dogfood server as source of repositories
-    """
-    with open("/etc/rhsm/rhsm.conf", "r+") as f:
-        file = f.read()
-        # Replacing the urls
-        file = re.sub("hostname = .*", "hostname = {}".format(TEST_VARS["SATELLITE_URL"]), file)
-        file = re.sub("baseurl = .*", "baseurl = https://{}/pulp/repos".format(TEST_VARS["SATELLITE_URL"]), file)
-
-        # Setting the position to the top of the page to insert data
-        f.seek(0)
-        f.write(file)
-        f.truncate()
+# def replace_urls_rhsm():
+#     """
+#     Replace urls in rhsm.conf file to the satellite server
+#     Without doing this we get obsolete dogfood server as source of repositories
+#     """
+#     with open("/etc/rhsm/rhsm.conf", "r+") as f:
+#         file = f.read()
+#         # Replacing the urls
+#         file = re.sub("hostname = .*", "hostname = {}".format(TEST_VARS["SATELLITE_URL"]), file)
+#         file = re.sub("baseurl = .*", "baseurl = https://{}/pulp/repos".format(TEST_VARS["SATELLITE_URL"]), file)
+#
+#         # Setting the position to the top of the page to insert data
+#         f.seek(0)
+#         f.write(file)
+#         f.truncate()
 
 
 def configure_connection():
@@ -39,6 +41,7 @@ def configure_connection():
         f.write("nameserver 127.0.0.1")
 
 
+@pytest.mark.prepare_offline_system
 def test_prepare_system(shell, satellite_registration):
     """
     Perform all the steps to make the system appear to be offline.
@@ -56,7 +59,7 @@ def test_prepare_system(shell, satellite_registration):
 
     assert os.path.isfile("/etc/yum.repos.d/redhat.repo")
 
-    replace_urls_rhsm()
+    # replace_urls_rhsm()
 
     configure_connection()
 

--- a/tests/integration/tier0/destructive/offline-system-conversion/prepare_system.py
+++ b/tests/integration/tier0/destructive/offline-system-conversion/prepare_system.py
@@ -1,17 +1,20 @@
+import os
 import re
 import socket
 
-from conftest import SATELLITE_PKG_DST, SATELLITE_PKG_URL, SATELLITE_URL, SYSTEM_RELEASE_ENV, TEST_VARS
+from conftest import TEST_VARS, satellite_registration_command
 
 
-# Replace urls in rhsm.conf file to the satellite server
-# Without doing this we get obsolete dogfood server as source of repositories
 def replace_urls_rhsm():
+    """
+    Replace urls in rhsm.conf file to the satellite server
+    Without doing this we get obsolete dogfood server as source of repositories
+    """
     with open("/etc/rhsm/rhsm.conf", "r+") as f:
         file = f.read()
         # Replacing the urls
-        file = re.sub("hostname = .*", "hostname = {}".format(SATELLITE_URL), file)
-        file = re.sub("baseurl = .*", "baseurl = https://{}/pulp/repos".format(SATELLITE_URL), file)
+        file = re.sub("hostname = .*", "hostname = {}".format(TEST_VARS["SATELLITE_URL"]), file)
+        file = re.sub("baseurl = .*", "baseurl = https://{}/pulp/repos".format(TEST_VARS["SATELLITE_URL"]), file)
 
         # Setting the position to the top of the page to insert data
         f.seek(0)
@@ -19,13 +22,15 @@ def replace_urls_rhsm():
         f.truncate()
 
 
-# Configure and limit connection to the satellite server only
 def configure_connection():
-    satellite_ip = socket.gethostbyname(SATELLITE_URL)
+    """
+    Configure and limit connection to the satellite server only
+    """
+    satellite_ip = socket.gethostbyname(TEST_VARS["SATELLITE_URL"])
 
     with open("/etc/dnsmasq.conf", "a") as f:
         # Satellite url
-        f.write("address=/{}/{}\n".format(SATELLITE_URL, satellite_ip))
+        f.write("address=/{}/{}\n".format(TEST_VARS["SATELLITE_URL"], satellite_ip))
 
         # Everything else is resolved to localhost
         f.write("address=/#/127.0.0.1")
@@ -35,47 +40,27 @@ def configure_connection():
 
 
 def test_prepare_system(shell):
-    assert shell("yum install dnsmasq wget -y").returncode == 0
+    """
+    Perform all the steps to make the system appear to be offline.
+    Register to the Satellite server.
+    Remove all the repositories before the Satellite subscription,
+    so there is only the redhat.repo created by subscription-manager.
+    """
+    assert shell("yum install dnsmasq -y").returncode == 0
+    sat_reg_command = satellite_registration_command()
 
-    # Install katello package
-    assert (
-        shell(
-            "wget --no-check-certificate --output-document {} {}".format(SATELLITE_PKG_DST, SATELLITE_PKG_URL)
-        ).returncode
-        == 0
-    )
-    assert shell("rpm -i {}".format(SATELLITE_PKG_DST)).returncode == 0
+    # Register system to the satellite server
+    assert shell(sat_reg_command).returncode == 0
+
+    repos_dir = "/etc/yum.repos.d"
+    # Remove all repofiles except the redhat.repo
+    for file in os.listdir(repos_dir):
+        if not file.endswith("redhat.repo"):
+            os.remove(os.path.join(repos_dir, file))
+
+    assert os.path.isfile("/etc/yum.repos.d/redhat.repo")
 
     replace_urls_rhsm()
-    shell("rm -rf /etc/yum.repos.d/*")
-
-    satellite_key = None
-
-    # Subscribe system
-    if "centos-7" in SYSTEM_RELEASE_ENV:
-        satellite_key = TEST_VARS["SATELLITE_OFFLINE_KEY_CENTOS7"]
-    elif "centos-8" in SYSTEM_RELEASE_ENV:
-        satellite_key = TEST_VARS["SATELLITE_OFFLINE_KEY_CENTOS8"]
-    elif "oracle-7" in SYSTEM_RELEASE_ENV:
-        satellite_key = TEST_VARS["SATELLITE_OFFLINE_KEY_ORACLE7"]
-    elif "oracle-8" in SYSTEM_RELEASE_ENV:
-        satellite_key = TEST_VARS["SATELLITE_OFFLINE_KEY_ORACLE8"]
-    elif "alma-8.8" in SYSTEM_RELEASE_ENV:
-        satellite_key = TEST_VARS["SATELLITE_OFFLINE_KEY_ALMA88"]
-    elif "rocky-8.8" in SYSTEM_RELEASE_ENV:
-        satellite_key = TEST_VARS["SATELLITE_OFFLINE_KEY_ROCKY88"]
-    elif "alma-8-latest" in SYSTEM_RELEASE_ENV:
-        satellite_key = TEST_VARS["SATELLITE_OFFLINE_KEY_ALMA8"]
-    elif "rocky-8-latest" in SYSTEM_RELEASE_ENV:
-        satellite_key = TEST_VARS["SATELLITE_OFFLINE_KEY_ROCKY8"]
-    assert (
-        shell(
-            ("subscription-manager register --org={} --activationkey={}").format(
-                TEST_VARS["SATELLITE_ORG"], satellite_key
-            )
-        ).returncode
-        == 0
-    )
 
     configure_connection()
 

--- a/tests/integration/tier0/destructive/single-yum-transaction/test_check_for_latest_packages.py
+++ b/tests/integration/tier0/destructive/single-yum-transaction/test_check_for_latest_packages.py
@@ -27,8 +27,8 @@ def test_packages_upgraded_after_conversion(convert2rhel, shell):
 
     for package in checked_packages:
         latest_version = shell(f"repoquery --quiet --latest-limit=1 {package}").output.strip("\n")
-        is_installed = shell(f"rpm -q {package}").output
-        if "is not installed" in is_installed:
+        is_installed = shell(f"rpm -q {package}").returncode
+        if is_installed == 1:
             shell(f"yum install -y {package}")
         # although not really used, keep the assembled dictionary if needed for version comparison
         # also the dictionary gets appended only when there is the package available to install

--- a/tests/integration/tier0/non-destructive/eus/test_eus_support.py
+++ b/tests/integration/tier0/non-destructive/eus/test_eus_support.py
@@ -13,8 +13,7 @@ def eus_mapping_update(shell, backup_directory):
     Restores the original version after the test is done.
     """
     eus_mapping_file = shell("find /usr -path '*/convert2rhel/systeminfo.py'").output.strip()
-    backup_dir = backup_directory
-    backup_file = os.path.join(backup_dir, "systeminfo.py.bkp")
+    backup_file = os.path.join(backup_directory, "systeminfo.py.bkp")
     assert shell(f"cp {eus_mapping_file} {backup_file}").returncode == 0
 
     original_mapping_value = '"8.8": "2023-11-14"'

--- a/tests/integration/tier0/non-destructive/eus/test_eus_support.py
+++ b/tests/integration/tier0/non-destructive/eus/test_eus_support.py
@@ -6,17 +6,15 @@ from conftest import TEST_VARS
 
 
 @pytest.fixture
-def eus_mapping_update(shell):
+def eus_mapping_update(shell, backup_directory):
     """
     Fixture to mock different scenarios while handling the EUS candidates.
     Backs up the convert2rhel/systeminfo.py and modifies the EUS_MINOR_VERISONS mapping.
     Restores the original version after the test is done.
     """
     eus_mapping_file = shell("find /usr -path '*/convert2rhel/systeminfo.py'").output.strip()
-    backup_dir = "/tmp/c2r_tests_backup/"
-    backup_file = f"{backup_dir}systeminfo.py.bkp"
-    if not os.path.exists(backup_dir):
-        shell(f"mkdir {backup_dir}")
+    backup_dir = backup_directory
+    backup_file = os.path.join(backup_dir, "systeminfo.py.bkp")
     assert shell(f"cp {eus_mapping_file} {backup_file}").returncode == 0
 
     original_mapping_value = '"8.8": "2023-11-14"'

--- a/tests/integration/tier0/non-destructive/file-backup/test_file_backup.py
+++ b/tests/integration/tier0/non-destructive/file-backup/test_file_backup.py
@@ -31,17 +31,15 @@ def config_files_modified(shell, backup_directory):
     """
     backup_paths = {}
 
-    backup_dir = backup_directory
-    modified_files_dir = os.path.join(backup_dir, "modified")
+    modified_files_dir = os.path.join(backup_directory, "modified")
     # Create the backup directories
-    for directory in backup_dir, modified_files_dir:
-        if not os.path.exists(directory):
-            shell(f"mkdir -v {directory}")
+    if not os.path.exists(modified_files_dir):
+        shell(f"mkdir -v {modified_files_dir}")
 
     for pkg, config in PACKAGES.items():
         file_name = os.path.basename(config)
         modified_file_path = os.path.join(modified_files_dir, f"{file_name}.modified")
-        bkp_file_path = os.path.join(backup_dir, file_name)
+        bkp_file_path = os.path.join(backup_directory, file_name)
         # Install the packages if not installed already
         if shell(f"rpm -q {pkg}").returncode == 1:
             shell(f"yum install -y {pkg}")
@@ -50,7 +48,7 @@ def config_files_modified(shell, backup_directory):
         if not os.path.exists(config):
             shell(f"touch {config}")
         # Backup the original file
-        shell(f"cp {config} {backup_dir}")
+        shell(f"cp {config} {backup_directory}")
 
         # Append the modified content to the config
         # The file will be created if not already
@@ -92,13 +90,6 @@ def config_files_removed(shell, backup_directory):
     """
     backup_paths = {}
 
-    backup_dir = backup_directory
-    modified_files_dir = os.path.join(backup_dir, "modified")
-    # Create the backup directories
-    for directory in backup_dir, modified_files_dir:
-        if not os.path.exists(directory):
-            shell(f"mkdir -v {directory}")
-
     for pkg, config in PACKAGES.items():
         file_name = os.path.basename(config)
         # Install the packages if not installed already
@@ -108,8 +99,8 @@ def config_files_removed(shell, backup_directory):
         if not os.path.exists(config):
             shell(f"touch {config}")
         # Backup the original file
-        shell(f"cp {config} {backup_dir}")
-        bkp_file_path = os.path.join(backup_dir, file_name)
+        shell(f"cp {config} {backup_directory}")
+        bkp_file_path = os.path.join(backup_directory, file_name)
         # Remove the config to validate it won't get restored
         # during the rollback
         shell(f"rm -f {config}")

--- a/tests/integration/tier0/non-destructive/file-backup/test_file_backup.py
+++ b/tests/integration/tier0/non-destructive/file-backup/test_file_backup.py
@@ -13,12 +13,11 @@ PACKAGES = {
     "yum": "/etc/logrotate.d/yum",
     "dnf": "/etc/logrotate.d/dnf",
 }
-BACKUP_DIR = "/tmp/c2r_tests_backup/"
-MODIFIED_FILES_DIR = "/tmp/c2r_tests_backup/modified/"
 
 
 @pytest.fixture
-def config_files_modified(shell):
+@pytest.mark.config_files_modified
+def config_files_modified(shell, backup_directory):
     """
     This fixture modifies contents of configuration files: "/etc/cloud/cloud.cfg",
     "/etc/NetworkManager/NetworkManager.conf", "/etc/logrotate.d/yum"
@@ -32,15 +31,17 @@ def config_files_modified(shell):
     """
     backup_paths = {}
 
+    backup_dir = backup_directory
+    modified_files_dir = os.path.join(backup_dir, "modified")
     # Create the backup directories
-    for directory in BACKUP_DIR, MODIFIED_FILES_DIR:
+    for directory in backup_dir, modified_files_dir:
         if not os.path.exists(directory):
             shell(f"mkdir -v {directory}")
 
     for pkg, config in PACKAGES.items():
         file_name = os.path.basename(config)
-        modified_file_path = os.path.join(MODIFIED_FILES_DIR, f"{file_name}.modified")
-        bkp_file_path = os.path.join(BACKUP_DIR, file_name)
+        modified_file_path = os.path.join(modified_files_dir, f"{file_name}.modified")
+        bkp_file_path = os.path.join(backup_dir, file_name)
         # Install the packages if not installed already
         if "is not installed" in shell(f"rpm -q {pkg}").output:
             shell(f"yum install -y {pkg}")
@@ -49,7 +50,7 @@ def config_files_modified(shell):
         if not os.path.exists(config):
             shell(f"touch {config}")
         # Backup the original file
-        shell(f"cp {config} {BACKUP_DIR}")
+        shell(f"cp {config} {backup_dir}")
 
         # Append the modified content to the config
         # The file will be created if not already
@@ -75,11 +76,12 @@ def config_files_modified(shell):
         # Restore the original file
         assert shell(f"mv -f -v {bkp_file_path} {default_config_path}").returncode == 0
 
-    shell(f"rm -rf {MODIFIED_FILES_DIR}")
+    shell(f"rm -rf {modified_files_dir}")
 
 
 @pytest.fixture
-def config_files_removed(shell):
+@pytest.mark.config_files_removed
+def config_files_removed(shell, backup_directory):
     """
     This fixture removes completely configuration files: "/etc/cloud/cloud.cfg",
     "/etc/NetworkManager/NetworkManager.conf", "/etc/logrotate.d/yum"
@@ -90,8 +92,10 @@ def config_files_removed(shell):
     """
     backup_paths = {}
 
+    backup_dir = backup_directory
+    modified_files_dir = os.path.join(backup_dir, "modified")
     # Create the backup directories
-    for directory in BACKUP_DIR, MODIFIED_FILES_DIR:
+    for directory in backup_dir, modified_files_dir:
         if not os.path.exists(directory):
             shell(f"mkdir -v {directory}")
 
@@ -104,8 +108,8 @@ def config_files_removed(shell):
         if not os.path.exists(config):
             shell(f"touch {config}")
         # Backup the original file
-        shell(f"cp {config} {BACKUP_DIR}")
-        bkp_file_path = os.path.join(BACKUP_DIR, file_name)
+        shell(f"cp {config} {backup_dir}")
+        bkp_file_path = os.path.join(backup_dir, file_name)
         # Remove the config to validate it won't get restored
         # during the rollback
         shell(f"rm -f {config}")

--- a/tests/integration/tier0/non-destructive/file-backup/test_file_backup.py
+++ b/tests/integration/tier0/non-destructive/file-backup/test_file_backup.py
@@ -43,7 +43,7 @@ def config_files_modified(shell, backup_directory):
         modified_file_path = os.path.join(modified_files_dir, f"{file_name}.modified")
         bkp_file_path = os.path.join(backup_dir, file_name)
         # Install the packages if not installed already
-        if "is not installed" in shell(f"rpm -q {pkg}").output:
+        if shell(f"rpm -q {pkg}").returncode == 1:
             shell(f"yum install -y {pkg}")
 
         # Create the config file, if not present already
@@ -102,7 +102,7 @@ def config_files_removed(shell, backup_directory):
     for pkg, config in PACKAGES.items():
         file_name = os.path.basename(config)
         # Install the packages if not installed already
-        if "is not installed" in shell(f"rpm -q {pkg}").output:
+        if shell(f"rpm -q {pkg}").returncode == 1:
             shell(f"yum install -y {pkg}")
         # Create the config file, if not present already
         if not os.path.exists(config):

--- a/tests/integration/tier0/non-destructive/file-backup/test_file_backup.py
+++ b/tests/integration/tier0/non-destructive/file-backup/test_file_backup.py
@@ -16,7 +16,6 @@ PACKAGES = {
 
 
 @pytest.fixture
-@pytest.mark.config_files_modified
 def config_files_modified(shell, backup_directory):
     """
     This fixture modifies contents of configuration files: "/etc/cloud/cloud.cfg",
@@ -78,7 +77,6 @@ def config_files_modified(shell, backup_directory):
 
 
 @pytest.fixture
-@pytest.mark.config_files_removed
 def config_files_removed(shell, backup_directory):
     """
     This fixture removes completely configuration files: "/etc/cloud/cloud.cfg",

--- a/tests/integration/tier0/non-destructive/kernel/test_kernel_check_verification.py
+++ b/tests/integration/tier0/non-destructive/kernel/test_kernel_check_verification.py
@@ -49,16 +49,15 @@ def test_verify_latest_kernel_check_passes_with_failed_repoquery(convert2rhel, t
     assert c2r.exitstatus != 0
 
 
-@pytest.mark.parametrize("exclude", [["kernel", "kernel-core"]])
+@pytest.mark.parametrize("yum_conf_exclude", [["kernel", "kernel-core"]], indirect=True)
 @pytest.mark.test_yum_exclude_kernel
-def test_latest_kernel_check_with_exclude_kernel_option(convert2rhel, yum_conf_exclude, exclude):
+def test_latest_kernel_check_with_exclude_kernel_option(convert2rhel, yum_conf_exclude):
     """
     Verify, the conversion does not raise:
     'Could not find any kernel from repositories to compare against the loaded kernel.'
     When `exclude=kernel kernel-core` is defined in yum.conf
     Verify IS_LOADED_KERNEL_LATEST has succeeded is raised and terminate the utility.
     """
-    yum_conf_exclude(exclude)
     # Run the conversion and verify that it proceeds past the latest kernel check
     # if so, interrupt the conversion
     with convert2rhel("-y --debug") as c2r:

--- a/tests/integration/tier0/non-destructive/kernel/test_oracle_unsupported_uek.py
+++ b/tests/integration/tier0/non-destructive/kernel/test_oracle_unsupported_uek.py
@@ -26,7 +26,7 @@ def unbreakable_kernel(shell):
 
 
 @pytest.mark.test_unsupported_unbreakable_enterprise_kernel
-def test_bad_conversion(shell, convert2rhel):
+def test_bad_conversion(shell, convert2rhel, unbreakable_kernel):
     """
     Verify that the check for compatible kernel on Oracle Linux works.
     Install unsupported kernel and run the conversion.

--- a/tests/integration/tier0/non-destructive/main.fmf
+++ b/tests/integration/tier0/non-destructive/main.fmf
@@ -10,4 +10,4 @@ tag+:
     - non-destructive
 
 environment+:
-    INT_TESTS_NONDESTRUCTIVE: 1
+    C2R_TESTS_NONDESTRUCTIVE: 1

--- a/tests/integration/tier0/non-destructive/modified-releasever/test_modified_releasever.py
+++ b/tests/integration/tier0/non-destructive/modified-releasever/test_modified_releasever.py
@@ -8,7 +8,6 @@ from conftest import TEST_VARS
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.c2r_config_releasever
 def c2r_config_releasever(shell, backup_directory):
     """
     Fixture.
@@ -47,7 +46,6 @@ def test_releasever_as_mapping_config_modified(convert2rhel, os_release, c2r_con
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.system_release_backup
 def system_release_backup(shell, backup_directory):
     """
     Fixture.

--- a/tests/integration/tier0/non-destructive/modified-releasever/test_modified_releasever.py
+++ b/tests/integration/tier0/non-destructive/modified-releasever/test_modified_releasever.py
@@ -1,3 +1,5 @@
+import os.path
+
 from pathlib import Path
 
 import pytest
@@ -6,7 +8,8 @@ from conftest import TEST_VARS
 
 
 @pytest.fixture(scope="function")
-def c2r_config_releasever(shell):
+@pytest.mark.c2r_config_releasever
+def c2r_config_releasever(shell, backup_directory):
     """
     Fixture.
     Modify the releasever inside the convert2rhel configs.
@@ -15,14 +18,13 @@ def c2r_config_releasever(shell):
 
     # Backup configs
     path_to_configs = "/usr/share/convert2rhel/configs/"
-    backup_dir = "/tmp/c2rconfigs_backup/"
-    assert shell(f"mkdir {backup_dir} && cp -r {path_to_configs} {backup_dir}").returncode == 0
+    backup_dir = backup_directory
+    assert shell(f"cp -r {path_to_configs} {backup_dir}").returncode == 0
 
     yield
 
     # Restore configs
     assert shell(f"mv -f {backup_dir}* {path_to_configs}").returncode == 0
-    assert shell(f"rm -rf {backup_dir}").returncode == 0
 
 
 @pytest.mark.test_modified_config
@@ -46,14 +48,16 @@ def test_releasever_as_mapping_config_modified(convert2rhel, os_release, c2r_con
 
 
 @pytest.fixture(scope="function")
-def system_release_backup(shell):
+@pytest.mark.system_release_backup
+def system_release_backup(shell, backup_directory):
     """
     Fixture.
     Backup /etc/system-release before the test makes modifications to it.
     Restore the file after the test
     """
     # Backup /etc/system-release
-    backup_file = "/tmp/system-release.bkp"
+    backup_dir = backup_directory
+    backup_file = os.path.join(backup_dir, "system-release.bkp")
     assert shell(f"cp /etc/system-release {backup_file}").returncode == 0
 
     yield

--- a/tests/integration/tier0/non-destructive/modified-releasever/test_modified_releasever.py
+++ b/tests/integration/tier0/non-destructive/modified-releasever/test_modified_releasever.py
@@ -18,13 +18,12 @@ def c2r_config_releasever(shell, backup_directory):
 
     # Backup configs
     path_to_configs = "/usr/share/convert2rhel/configs/"
-    backup_dir = backup_directory
-    assert shell(f"cp -r {path_to_configs} {backup_dir}").returncode == 0
+    assert shell(f"cp -r {path_to_configs} {backup_directory}").returncode == 0
 
     yield
 
     # Restore configs
-    assert shell(f"mv -f {backup_dir}* {path_to_configs}").returncode == 0
+    assert shell(f"mv -f {backup_directory}/* {path_to_configs}").returncode == 0
 
 
 @pytest.mark.test_modified_config
@@ -56,8 +55,7 @@ def system_release_backup(shell, backup_directory):
     Restore the file after the test
     """
     # Backup /etc/system-release
-    backup_dir = backup_directory
-    backup_file = os.path.join(backup_dir, "system-release.bkp")
+    backup_file = os.path.join(backup_directory, "system-release.bkp")
     assert shell(f"cp /etc/system-release {backup_file}").returncode == 0
 
     yield

--- a/tests/integration/tier0/non-destructive/rhsm-facts/main.fmf
+++ b/tests/integration/tier0/non-destructive/rhsm-facts/main.fmf
@@ -2,7 +2,7 @@ summary+: |
     RHSM facts update when in analysis mode
 description+: |
     Verify that the subscription-manager facts command is called after the
-    analysis is done (either succeeding or failling).
+    analysis is done (either succeeding or failing).
 
 /rhsm_facts_update_in_analysis:
     summary+: |
@@ -14,7 +14,3 @@ description+: |
         - test-rhsm-facts-called-in-analysis
     test: |
         pytest -m test_rhsm_facts_called_in_analysis
-    adjust+:
-        - enabled: false
-          when: distro == oracle-7, oracle-8
-          because: RHSM package not available in oracle repos

--- a/tests/integration/tier0/non-destructive/rollback-handling/test_rollback_handling.py
+++ b/tests/integration/tier0/non-destructive/rollback-handling/test_rollback_handling.py
@@ -60,7 +60,8 @@ def install_packages(shell, packages):
     """
     packages_to_remove_at_cleanup = []
     for package in packages:
-        if f"{package} is not installed" in shell(f"rpm -q {package}").output:
+        is_installed = shell(f"rpm -q {package}").returncode
+        if is_installed == 1:
             packages_to_remove_at_cleanup.append(package)
 
     # Run this only once as package managers take too long to figure out
@@ -90,8 +91,9 @@ def is_installed_post_rollback(shell, packages):
     """
     for package in packages:
         print(f"CHECK: Checking for {package}")
-        query = shell(f"rpm -q {package}")
-        assert f"{package} is not installed" not in query.output
+        is_installed = shell(f"rpm -q {package}").returncode
+        # rpm -q command returns 0 when package is installed, returns 1 otherwise
+        assert is_installed == 0
 
 
 def terminate_and_assert_good_rollback(c2r):

--- a/tests/integration/tier0/non-destructive/single-yum-transaction-validation/test_single_yum_transaction_validation.py
+++ b/tests/integration/tier0/non-destructive/single-yum-transaction-validation/test_single_yum_transaction_validation.py
@@ -200,9 +200,9 @@ def test_validation_packages_with_in_name_period(shell, convert2rhel, packages_w
     assert c2r.exitstatus == 0
 
 
-@pytest.mark.parametrize("exclude", [["redhat-release-server"]])
+@pytest.mark.parametrize("yum_conf_exclude", [["redhat-release-server"]])
 @pytest.mark.test_override_exclude_list_in_yum_config
-def test_override_exclude_list_in_yum_config(convert2rhel, kernel, yum_conf_exclude, exclude):
+def test_override_exclude_list_in_yum_config(convert2rhel, kernel, yum_conf_exclude):
     """
     This test verifies that packages that are defined in the exclude
     section in the /etc/yum.conf file are ignored during the analysis and

--- a/tests/integration/tier0/non-destructive/subscription-manager/main.fmf
+++ b/tests/integration/tier0/non-destructive/subscription-manager/main.fmf
@@ -34,10 +34,6 @@ tag+:
 /registration:
     adjust+:
         - enabled: true
-          when: distro == centos, alma, rocky
-          because: |
-            There is no subscription-manager package in Oracle Linux repositories
-            and no documentation is provided - https://issues.redhat.com/browse/RHELC-1485.
     tag+:
         - sub-man-registration
     /pre_registered_system_wont_unregister:

--- a/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
+++ b/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
@@ -3,8 +3,11 @@ import pytest
 from conftest import TEST_VARS
 
 
+# We need to exclude the rhn-client* packages, since we want to install the subman package
+# on the Oracle Linux systems
+@pytest.mark.parametrize("exclude", [["rhn-client*"]])
 @pytest.mark.test_pre_registered_wont_unregister
-def test_pre_registered_wont_unregister(shell, pre_registered, convert2rhel):
+def test_pre_registered_wont_unregister(shell, pre_registered, convert2rhel, yum_conf_exclude, exclude):
     """
     This test verifies that running conversion on pre-registered system won't unregister the system.
     1. Install subscription-manager, download the SSL certificate
@@ -30,8 +33,11 @@ def test_pre_registered_wont_unregister(shell, pre_registered, convert2rhel):
     assert c2r.exitstatus != 0
 
 
+# We need to exclude the rhn-client* packages, since we want to install the subman package
+# on the Oracle Linux systems
+@pytest.mark.parametrize("exclude", [["rhn-client*"]])
 @pytest.mark.test_pre_registered_re_register
-def test_pre_registered_re_register(shell, pre_registered, convert2rhel):
+def test_pre_registered_re_register(shell, pre_registered, convert2rhel, yum_conf_exclude, exclude):
     """
     This test verifies that running conversion on pre-registered system and providing convert2rhel
     with credentials, will re-register the system.
@@ -77,8 +83,11 @@ def test_unregistered_no_credentials(shell, convert2rhel):
     assert c2r.exitstatus != 0
 
 
+# We need to exclude the rhn-client* packages, since we want to install the subman package
+# on the Oracle Linux systems
+@pytest.mark.parametrize("exclude", [["rhn-client*"]])
 @pytest.mark.test_no_sca_not_subscribed
-def test_no_sca_no_subscribed(shell, pre_registered, convert2rhel):
+def test_no_sca_no_subscribed(shell, pre_registered, convert2rhel, yum_conf_exclude, exclude):
     """
     This test verifies that running conversion on pre-registered system
     without an attached subscription will try auto attaching the subscription.
@@ -98,11 +107,14 @@ def test_no_sca_no_subscribed(shell, pre_registered, convert2rhel):
     assert "No consumed subscription pools were found" in shell("subscription-manager list --consumed").output
 
 
+# We need to exclude the rhn-client* packages, since we want to install the subman package
+# on the Oracle Linux systems
+@pytest.mark.parametrize("exclude", [["rhn-client*"]])
 @pytest.mark.parametrize(
     "pre_registered", [(TEST_VARS["RHSM_NOSUB_USERNAME"], TEST_VARS["RHSM_NOSUB_PASSWORD"])], indirect=True
 )
 @pytest.mark.test_no_sca_subscription_attachment_error
-def test_no_sca_subscription_attachment_error(shell, convert2rhel, pre_registered):
+def test_no_sca_subscription_attachment_error(shell, convert2rhel, pre_registered, yum_conf_exclude, exclude):
     """
     This test verifies that running conversion on pre-registered system
     without an attached subscription will try auto attaching the subscription.

--- a/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
+++ b/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
@@ -98,9 +98,7 @@ def test_no_sca_no_subscribed(shell, pre_registered, convert2rhel):
     assert "No consumed subscription pools were found" in shell("subscription-manager list --consumed").output
 
 
-@pytest.mark.parametrize(
-    "pre_registered", [(TEST_VARS["RHSM_NOSUB_USERNAME"], TEST_VARS["RHSM_NOSUB_PASSWORD"])], indirect=True
-)
+@pytest.mark.parametrize("pre_registered", [("RHSM_NOSUB_USERNAME", "RHSM_NOSUB_PASSWORD")], indirect=True)
 @pytest.mark.test_no_sca_subscription_attachment_error
 def test_no_sca_subscription_attachment_error(shell, convert2rhel, pre_registered):
     """

--- a/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
+++ b/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
@@ -4,7 +4,7 @@ from conftest import TEST_VARS
 
 
 @pytest.mark.test_pre_registered_wont_unregister
-def test_pre_registered_wont_unregister(shell, pre_registered, convert2rhel, yum_conf_exclude):
+def test_pre_registered_wont_unregister(shell, pre_registered, convert2rhel):
     """
     This test verifies that running conversion on pre-registered system won't unregister the system.
     1. Install subscription-manager, download the SSL certificate
@@ -31,7 +31,7 @@ def test_pre_registered_wont_unregister(shell, pre_registered, convert2rhel, yum
 
 
 @pytest.mark.test_pre_registered_re_register
-def test_pre_registered_re_register(shell, pre_registered, convert2rhel, yum_conf_exclude):
+def test_pre_registered_re_register(shell, pre_registered, convert2rhel):
     """
     This test verifies that running conversion on pre-registered system and providing convert2rhel
     with credentials, will re-register the system.
@@ -78,7 +78,7 @@ def test_unregistered_no_credentials(shell, convert2rhel):
 
 
 @pytest.mark.test_no_sca_not_subscribed
-def test_no_sca_no_subscribed(shell, pre_registered, convert2rhel, yum_conf_exclude):
+def test_no_sca_no_subscribed(shell, pre_registered, convert2rhel):
     """
     This test verifies that running conversion on pre-registered system
     without an attached subscription will try auto attaching the subscription.
@@ -102,7 +102,7 @@ def test_no_sca_no_subscribed(shell, pre_registered, convert2rhel, yum_conf_excl
     "pre_registered", [(TEST_VARS["RHSM_NOSUB_USERNAME"], TEST_VARS["RHSM_NOSUB_PASSWORD"])], indirect=True
 )
 @pytest.mark.test_no_sca_subscription_attachment_error
-def test_no_sca_subscription_attachment_error(shell, convert2rhel, pre_registered, yum_conf_exclude):
+def test_no_sca_subscription_attachment_error(shell, convert2rhel, pre_registered):
     """
     This test verifies that running conversion on pre-registered system
     without an attached subscription will try auto attaching the subscription.

--- a/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
+++ b/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
@@ -3,11 +3,8 @@ import pytest
 from conftest import TEST_VARS
 
 
-# We need to exclude the rhn-client* packages, since we want to install the subman package
-# on the Oracle Linux systems
-@pytest.mark.parametrize("exclude", [["rhn-client*"]])
 @pytest.mark.test_pre_registered_wont_unregister
-def test_pre_registered_wont_unregister(shell, pre_registered, convert2rhel, yum_conf_exclude, exclude):
+def test_pre_registered_wont_unregister(shell, pre_registered, convert2rhel, yum_conf_exclude):
     """
     This test verifies that running conversion on pre-registered system won't unregister the system.
     1. Install subscription-manager, download the SSL certificate
@@ -33,11 +30,8 @@ def test_pre_registered_wont_unregister(shell, pre_registered, convert2rhel, yum
     assert c2r.exitstatus != 0
 
 
-# We need to exclude the rhn-client* packages, since we want to install the subman package
-# on the Oracle Linux systems
-@pytest.mark.parametrize("exclude", [["rhn-client*"]])
 @pytest.mark.test_pre_registered_re_register
-def test_pre_registered_re_register(shell, pre_registered, convert2rhel, yum_conf_exclude, exclude):
+def test_pre_registered_re_register(shell, pre_registered, convert2rhel, yum_conf_exclude):
     """
     This test verifies that running conversion on pre-registered system and providing convert2rhel
     with credentials, will re-register the system.
@@ -83,11 +77,8 @@ def test_unregistered_no_credentials(shell, convert2rhel):
     assert c2r.exitstatus != 0
 
 
-# We need to exclude the rhn-client* packages, since we want to install the subman package
-# on the Oracle Linux systems
-@pytest.mark.parametrize("exclude", [["rhn-client*"]])
 @pytest.mark.test_no_sca_not_subscribed
-def test_no_sca_no_subscribed(shell, pre_registered, convert2rhel, yum_conf_exclude, exclude):
+def test_no_sca_no_subscribed(shell, pre_registered, convert2rhel, yum_conf_exclude):
     """
     This test verifies that running conversion on pre-registered system
     without an attached subscription will try auto attaching the subscription.
@@ -107,14 +98,11 @@ def test_no_sca_no_subscribed(shell, pre_registered, convert2rhel, yum_conf_excl
     assert "No consumed subscription pools were found" in shell("subscription-manager list --consumed").output
 
 
-# We need to exclude the rhn-client* packages, since we want to install the subman package
-# on the Oracle Linux systems
-@pytest.mark.parametrize("exclude", [["rhn-client*"]])
 @pytest.mark.parametrize(
     "pre_registered", [(TEST_VARS["RHSM_NOSUB_USERNAME"], TEST_VARS["RHSM_NOSUB_PASSWORD"])], indirect=True
 )
 @pytest.mark.test_no_sca_subscription_attachment_error
-def test_no_sca_subscription_attachment_error(shell, convert2rhel, pre_registered, yum_conf_exclude, exclude):
+def test_no_sca_subscription_attachment_error(shell, convert2rhel, pre_registered, yum_conf_exclude):
     """
     This test verifies that running conversion on pre-registered system
     without an attached subscription will try auto attaching the subscription.

--- a/tests/integration/tier0/non-destructive/system-release-backup/main.fmf
+++ b/tests/integration/tier0/non-destructive/system-release-backup/main.fmf
@@ -14,22 +14,22 @@ tag+:
         Restore the os-release file during rollback
     /related_environment_variable:
         description+: |
-            Subscribe to the Satellite server using the curl command.
-            Remove all repositories from the system.
+            We remove all the system repositories from the usual location.
+            Since the host is registered through Satellite having access only to the RHEL repositories,
+            convert2rhel is unable to perform back-up of some packages.
             Set the "CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK" envar to bypass kernel check.
             Verify that the /etc/os-release file is restored after the rollback.
         /backup_os_release_no_envar:
             summary+: |
                 Restore os-release without CONVERT2RHEL_INCOMPLETE_ROLLBACK
             description+: |
-                This case runs the conversion with no repositories available.
-                Verify that this condition disables the package backup,
-                convert2rhel warns the user and inhibits the conversion.
+                In this scenario the variable `CONVERT2RHEL_INCOMPLETE_ROLLBACK` is not set, therefore
+                using analyze we expect convert2rhel to raise an error and return code 1.
             adjust+:
                 environment+:
                     CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK: 1
             tag+:
-                - no-envar
+                - backup-os-release-no-envar
                 - sanity
             test: |
                 pytest -m test_backup_os_release_no_envar
@@ -38,32 +38,21 @@ tag+:
             summary+: |
                 Restore os-release with CONVERT2RHEL_INCOMPLETE_ROLLBACK
             description+: |
-                This case runs the conversion with no repositories available
-                and "CONVERT2RHEL_INCOMPLETE_ROLLBACK" envar set.
-                Verify that this condition disables the package backup,
-                convert2rhel warns the user, but continues the conversion.
+                In this scenario the variable `CONVERT2RHEL_INCOMPLETE_ROLLBACK` is set.
+                Ref ticket: OAMG-5457.
+                Note that after the test, the $releasever variable is unset.
+                That is due to the incomplete rollback not being able to back up/restore the *-linux-release
+                package, the issue gets resolved by the (autoused) missing_os_release_package_workaround fixture.
             adjust+:
                 environment+:
                     CONVERT2RHEL_INCOMPLETE_ROLLBACK: 1
                     CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK: 1
             tag+:
-                - with-envar
+                - backup-os-release-with-envar
             test: |
                 pytest -m test_backup_os_release_with_envar
             link:
                 - verifies: https://issues.redhat.com/browse/OAMG-5457
-
-    /unsuccessful_satellite_registration:
-        summary+: |
-            Rollback caused by failed registration
-        description+: |
-            Verify that the os-release is restored, when the registration to the Satellite servers fails.
-        tag+:
-            - unsuccessful-satellite-registration
-        test: |
-            pytest -m test_unsuccessful_satellite_registration
-        link:
-            - verifies: https://issues.redhat.com/browse/RHELC-51
 
 
 /missing_system_release:

--- a/tests/integration/tier0/non-destructive/system-release-backup/main.fmf
+++ b/tests/integration/tier0/non-destructive/system-release-backup/main.fmf
@@ -14,7 +14,7 @@ tag+:
         Restore the os-release file during rollback
     /related_environment_variable:
         description+: |
-            Install subscription-manager and katello package from the Satellite.
+            Subscribe to the Satellite server using the curl command.
             Remove all repositories from the system.
             Set the "CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK" envar to bypass kernel check.
             Verify that the /etc/os-release file is restored after the rollback.

--- a/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
+++ b/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from conftest import SAT_REG_FILE, TEST_VARS
+from conftest import TEST_VARS
 
 
 @pytest.fixture(scope="function")
@@ -13,13 +13,15 @@ def system_release_missing(shell, backup_directory):
     Back up and remove the /etc/system-release file.
     Restore in the teardown phase.
     """
+    system_release_bak = os.path.join(backup_directory, "system-release")
+    system_release = "/etc/system-release"
     # Make backup copy of the file
-    assert shell(f"mv -v /etc/system-release {backup_directory}").returncode == 0
+    assert shell(f"mv -v {system_release} {system_release_bak}").returncode == 0
 
     yield
 
     # Restore the system
-    assert shell(f"mv -v {os.path.join(backup_directory, 'system_release')} /etc/").returncode == 0
+    assert shell(f"mv -v {system_release_bak} {system_release}").returncode == 0
 
 
 @pytest.mark.test_missing_system_release
@@ -39,7 +41,7 @@ def test_missing_system_release(shell, convert2rhel, system_release_missing):
     assert c2r.exitstatus != 0
 
 
-@pytest.mark.parametrize("satellite_registration", [SAT_REG_FILE["RHEL_CONTENT_SAT_REG"]], indirect=True)
+@pytest.mark.parametrize("satellite_registration", ["RHEL_CONTENT_SAT_REG"], indirect=True)
 @pytest.mark.test_backup_os_release_no_envar
 def test_backup_os_release_no_envar(shell, convert2rhel, satellite_registration, remove_repositories):
     """
@@ -65,7 +67,7 @@ def test_backup_os_release_no_envar(shell, convert2rhel, satellite_registration,
     assert shell("find /etc/os-release").returncode == 0
 
 
-@pytest.mark.parametrize("satellite_registration", [SAT_REG_FILE["RHEL_CONTENT_SAT_REG"]], indirect=True)
+@pytest.mark.parametrize("satellite_registration", ["RHEL_CONTENT_SAT_REG"], indirect=True)
 @pytest.mark.test_backup_os_release_with_envar
 def test_backup_os_release_with_envar(
     shell,

--- a/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
+++ b/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
@@ -14,13 +14,12 @@ def system_release_missing(shell, backup_directory):
     Restore in the teardown phase.
     """
     # Make backup copy of the file
-    backup_dir = backup_directory
-    assert shell(f"mv -v /etc/system-release {backup_dir}").returncode == 0
+    assert shell(f"mv -v /etc/system-release {backup_directory}").returncode == 0
 
     yield
 
     # Restore the system
-    assert shell(f"mv -v {os.path.join(backup_dir, 'system_release')} /etc/").returncode == 0
+    assert shell(f"mv -v {os.path.join(backup_directory, 'system_release')} /etc/").returncode == 0
 
 
 @pytest.mark.test_missing_system_release
@@ -54,10 +53,7 @@ def test_backup_os_release_no_envar(shell, convert2rhel, satellite_registration,
     """
     assert shell("find /etc/os-release").returncode == 0
 
-    with convert2rhel(
-        "--debug",
-        unregister=True,
-    ) as c2r:
+    with convert2rhel("--debug") as c2r:
         # We need to get past the data collection acknowledgement.
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("y")
@@ -91,10 +87,7 @@ def test_backup_os_release_with_envar(
     """
     assert shell("find /etc/os-release").returncode == 0
 
-    with convert2rhel(
-        "--debug",
-        unregister=True,
-    ) as c2r:
+    with convert2rhel("--debug") as c2r:
         # We need to get past the data collection acknowledgement.
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("y")

--- a/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
+++ b/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
@@ -6,7 +6,6 @@ from conftest import TEST_VARS
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.system_release_missing
 def system_release_missing(shell, backup_directory):
     """
     Fixture.

--- a/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
+++ b/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
@@ -1,25 +1,26 @@
+import os
+
 import pytest
 
 from conftest import SAT_REG_FILE, TEST_VARS
 
 
 @pytest.fixture(scope="function")
-def system_release_missing(shell):
+@pytest.mark.system_release_missing
+def system_release_missing(shell, backup_directory):
     """
     Fixture.
     Back up and remove the /etc/system-release file.
     Restore in the teardown phase.
     """
     # Make backup copy of the file
-    backup_folder = "/tmp/missing-system-release_sysrelease_backup/"
-    assert shell(f"mkdir {backup_folder}").returncode == 0
-    assert shell(f"mv -v /etc/system-release {backup_folder}").returncode == 0
+    backup_dir = backup_directory
+    assert shell(f"mv -v /etc/system-release {backup_dir}").returncode == 0
 
     yield
 
     # Restore the system
-    assert shell(f"mv -v {backup_folder}system-release /etc/").returncode == 0
-    assert shell(f"rm -rf -v {backup_folder}").returncode == 0
+    assert shell(f"mv -v {os.path.join(backup_dir, 'system_release')} /etc/").returncode == 0
 
 
 @pytest.mark.test_missing_system_release
@@ -39,9 +40,9 @@ def test_missing_system_release(shell, convert2rhel, system_release_missing):
     assert c2r.exitstatus != 0
 
 
-@pytest.mark.parametrize("rhel_content_key", [SAT_REG_FILE["RHEL_CONTENT_SAT_REG"]])
+@pytest.mark.parametrize("satellite_registration", [SAT_REG_FILE["RHEL_CONTENT_SAT_REG"]], indirect=True)
 @pytest.mark.test_backup_os_release_no_envar
-def test_backup_os_release_no_envar(shell, convert2rhel, satellite_registration, rhel_content_key, remove_repositories):
+def test_backup_os_release_no_envar(shell, convert2rhel, satellite_registration, remove_repositories):
     """
     We remove all the system repositories from the usual location.
     Since the host is registered through Satellite having access only to the RHEL repositories,
@@ -51,29 +52,29 @@ def test_backup_os_release_no_envar(shell, convert2rhel, satellite_registration,
     The test validates, that the /etc/os-release file got correctly backed-up and restored
     during the utility run.
     """
-    # Register to the Satellite to access only the RHEL repositories
-    satellite_registration(rhel_content_key)
-
     assert shell("find /etc/os-release").returncode == 0
 
     with convert2rhel(
-        "analyze -y --debug",
+        "--debug",
         unregister=True,
     ) as c2r:
-        c2r.expect("set the environment variable 'CONVERT2RHEL_INCOMPLETE_ROLLBACK")
-        # We expect the return code to be 1, given an error is raised
-        assert c2r.exitstatus == 1
+        # We need to get past the data collection acknowledgement.
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("y")
+
+        c2r.expect_exact("set the environment variable 'CONVERT2RHEL_INCOMPLETE_ROLLBACK", timeout=600)
+    # We expect the return code to be 2, given an error is raised
+    assert c2r.exitstatus == 2
 
     assert shell("find /etc/os-release").returncode == 0
 
 
-@pytest.mark.parametrize("rhel_content_key", [SAT_REG_FILE["RHEL_CONTENT_SAT_REG"]])
+@pytest.mark.parametrize("satellite_registration", [SAT_REG_FILE["RHEL_CONTENT_SAT_REG"]], indirect=True)
 @pytest.mark.test_backup_os_release_with_envar
 def test_backup_os_release_with_envar(
     shell,
     convert2rhel,
     satellite_registration,
-    rhel_content_key,
     remove_repositories,
 ):
     """
@@ -88,19 +89,20 @@ def test_backup_os_release_with_envar(
     That is due to the incomplete rollback not being able to back up/restore the *-linux-release
     package, the issue gets resolved by the (autoused) missing_os_release_package_workaround fixture.
     """
-    # Register to the Satellite to access only the RHEL repositories
-    satellite_registration(rhel_content_key)
-
     assert shell("find /etc/os-release").returncode == 0
 
     with convert2rhel(
-        "analyze -y --debug",
+        "--debug",
         unregister=True,
     ) as c2r:
+        # We need to get past the data collection acknowledgement.
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("y")
+
         c2r.expect("'CONVERT2RHEL_INCOMPLETE_ROLLBACK' environment variable detected, continuing conversion.")
 
-        # We bypass the error by using the environment variable,
-        # the analysis should therefore finish successfully
-        assert c2r.exitstatus == 0
+        c2r.expect("Continue with the system conversion")
+        c2r.sendline("n")
+    assert c2r.exitstatus == 1
 
     assert shell("find /etc/os-release").returncode == 0

--- a/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
+++ b/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
@@ -1,60 +1,15 @@
-import re
-
 import pytest
 
-from conftest import SYSTEM_RELEASE_ENV, TEST_VARS
-
-
-@pytest.fixture(scope="function")
-def custom_subman(shell, repository=None):
-    """ """
-    # Setup repositories to install the subscription-manager from.
-    epel7_repository = "ubi"
-    epel8_repository = "baseos"
-    if re.match(r"^(centos|oracle)-7$", SYSTEM_RELEASE_ENV):
-        repository = epel7_repository
-    elif re.match(r"^(centos|oracle|alma|rocky)-8", SYSTEM_RELEASE_ENV):
-        repository = epel8_repository
-
-    # On Oracle Linux 7 a "rhn-client-tools" package may be present on
-    # the system which prevents "subscription-manager" to be installed.
-    # Remove package rhn-client-tools from Oracle Linux 7.
-    if "oracle-7" in SYSTEM_RELEASE_ENV:
-        assert shell("yum remove -y rhn-client-tools")
-    assert shell(f"cp files/{repository}.repo /etc/yum.repos.d/")
-    # Install subscription-manager from 'custom' repositories, disable others for the transaction.
-    assert shell(f"yum -y --disablerepo=* --enablerepo={repository} install subscription-manager").returncode == 0
-
-    yield
-
-    # Remove custom subscription-manager
-    assert shell(f"yum remove -y --disablerepo=* --enablerepo={repository} subscription-manager*").returncode == 0
-    assert shell(f"rm -f /etc/yum.repos.d/{repository}.repo").returncode == 0
-
-    # Some packages might get downgraded during the setup; update just to be sure the system is fine
-    shell("yum update -y")
-
-
-@pytest.mark.test_unsuccessful_satellite_registration
-def test_backup_os_release_wrong_registration(shell, convert2rhel, custom_subman):
-    """
-    Verify that the os-release file is restored when the satellite registration fails.
-    Reference issue: RHELC-51
-    """
-    assert shell("find /etc/os-release").returncode == 0
-
-    with convert2rhel("-y -k wrong_key -o rUbBiSh_pWd --debug") as c2r:
-        c2r.expect("Unable to register the system through subscription-manager.")
-        c2r.expect("Restore /etc/os-release from backup")
-
-    assert c2r.exitstatus != 0
-
-    assert shell("find /etc/os-release").returncode == 0
+from conftest import SAT_REG_FILE, TEST_VARS
 
 
 @pytest.fixture(scope="function")
 def system_release_missing(shell):
-
+    """
+    Fixture.
+    Back up and remove the /etc/system-release file.
+    Restore in the teardown phase.
+    """
     # Make backup copy of the file
     backup_folder = "/tmp/missing-system-release_sysrelease_backup/"
     assert shell(f"mkdir {backup_folder}").returncode == 0
@@ -84,56 +39,68 @@ def test_missing_system_release(shell, convert2rhel, system_release_missing):
     assert c2r.exitstatus != 0
 
 
+@pytest.mark.parametrize("rhel_content_key", [SAT_REG_FILE["RHEL_CONTENT_SAT_REG"]])
 @pytest.mark.test_backup_os_release_no_envar
-def test_backup_os_release_no_envar(shell, convert2rhel, custom_subman, satellite_registration, remove_repositories):
+def test_backup_os_release_no_envar(shell, convert2rhel, satellite_registration, rhel_content_key, remove_repositories):
     """
-    This test case removes all the repos on the system which prevents the backup of some files.
-    Satellite is being used in all of test cases.
-    In this scenario there is no variable `CONVERT2RHEL_INCOMPLETE_ROLLBACK` set.
-    This means the conversion is inhibited in early stage.
+    We remove all the system repositories from the usual location.
+    Since the host is registered through Satellite having access only to the RHEL repositories,
+    convert2rhel is unable to perform back-up of some packages.
+    In this scenario the variable `CONVERT2RHEL_INCOMPLETE_ROLLBACK` is not set, therefore
+    using analyze we expect convert2rhel to raise an error and return code 1.
+    The test validates, that the /etc/os-release file got correctly backed-up and restored
+    during the utility run.
     """
+    # Register to the Satellite to access only the RHEL repositories
+    satellite_registration(rhel_content_key)
 
     assert shell("find /etc/os-release").returncode == 0
+
     with convert2rhel(
-        "-y -k {} -o {} --debug".format(
-            TEST_VARS["SATELLITE_KEY"],
-            TEST_VARS["SATELLITE_ORG"],
-        ),
+        "analyze -y --debug",
         unregister=True,
     ) as c2r:
         c2r.expect("set the environment variable 'CONVERT2RHEL_INCOMPLETE_ROLLBACK")
-        assert c2r.exitstatus != 0
+        # We expect the return code to be 1, given an error is raised
+        assert c2r.exitstatus == 1
 
     assert shell("find /etc/os-release").returncode == 0
 
 
+@pytest.mark.parametrize("rhel_content_key", [SAT_REG_FILE["RHEL_CONTENT_SAT_REG"]])
 @pytest.mark.test_backup_os_release_with_envar
 def test_backup_os_release_with_envar(
     shell,
     convert2rhel,
-    custom_subman,
     satellite_registration,
+    rhel_content_key,
     remove_repositories,
 ):
     """
+    We remove all the system repositories from the usual location.
+    Since the host is registered through Satellite having access only to the RHEL repositories,
+    convert2rhel is unable to perform back-up of some packages.
     In this scenario the variable `CONVERT2RHEL_INCOMPLETE_ROLLBACK` is set.
-    This test case removes all the repos on the system and validates that
-    the /etc/os-release package is being backed up and restored during rollback.
-    Ref ticket: OAMG-5457. Note that after the test, the $releasever
-    variable is unset.
+    The test validates, that the /etc/os-release file got correctly backed-up and restored
+    during the utility run.
+    Ref ticket: OAMG-5457.
+    Note that after the test, the $releasever variable is unset.
+    That is due to the incomplete rollback not being able to back up/restore the *-linux-release
+    package, the issue gets resolved by the (autoused) missing_os_release_package_workaround fixture.
     """
+    # Register to the Satellite to access only the RHEL repositories
+    satellite_registration(rhel_content_key)
 
     assert shell("find /etc/os-release").returncode == 0
 
     with convert2rhel(
-        "-y -k {} -o {} --debug".format(
-            TEST_VARS["SATELLITE_KEY"],
-            TEST_VARS["SATELLITE_ORG"],
-        ),
+        "analyze -y --debug",
         unregister=True,
     ) as c2r:
         c2r.expect("'CONVERT2RHEL_INCOMPLETE_ROLLBACK' environment variable detected, continuing conversion.")
-        c2r.sendcontrol("c")
 
-    assert c2r.exitstatus != 0
+        # We bypass the error by using the environment variable,
+        # the analysis should therefore finish successfully
+        assert c2r.exitstatus == 0
+
     assert shell("find /etc/os-release").returncode == 0

--- a/tests/integration/tier1/destructive/firewalld-disabled-ol8/test_firewalld_disabled_ol8.py
+++ b/tests/integration/tier1/destructive/firewalld-disabled-ol8/test_firewalld_disabled_ol8.py
@@ -27,7 +27,6 @@ def test_firewalld_disabled_ol8(shell, convert2rhel):
         "-y --debug --serverurl {} --username {} --password {}".format(
             TEST_VARS["RHSM_SERVER_URL"], TEST_VARS["RHSM_USERNAME"], TEST_VARS["RHSM_PASSWORD"]
         ),
-        unregister=True,
     ) as c2r:
         c2r.expect("Firewalld service reported that it is not running.")
 

--- a/tests/integration/tier1/destructive/kernel-check-skip/test_latest_kernel_check_skip.py
+++ b/tests/integration/tier1/destructive/kernel-check-skip/test_latest_kernel_check_skip.py
@@ -17,14 +17,13 @@ def test_skip_kernel_check(shell, convert2rhel, backup_directory):
         3/ Enable *just* the rhel-7-server-rpms repository prior to conversion
         4/ Run conversion verifying the conversion is not inhibited and completes successfully
     """
-    backup_dir = backup_directory
-    eus_backup_dir = os.path.join(backup_dir, "eus")
+    eus_backup_dir = os.path.join(backup_directory, "eus")
     repodir = "/etc/yum.repos.d/"
 
     # Move all the repos away except the rhel7.repo
     for file in os.listdir(repodir):
         old_filepath = os.path.join(repodir, file)
-        new_filepath = os.path.join(backup_dir, file)
+        new_filepath = os.path.join(backup_directory, file)
         if file != "rhel7.repo":
             os.rename(old_filepath, new_filepath)
 

--- a/tests/integration/tier1/destructive/proxy-conversion/test_proxy_conversion.py
+++ b/tests/integration/tier1/destructive/proxy-conversion/test_proxy_conversion.py
@@ -71,19 +71,22 @@ def setup_proxy(shell):
 
 def configure_yum_proxy(shell):
     """Configure yum to use the proxy server"""
-    shell(f"echo 'proxy=http://{TEST_VARS['PROXY_SERVER']}:{TEST_VARS['PROXY_PORT']}' >> /etc/yum.conf")
+    shell(f"echo 'proxy=http://{TEST_VARS['PROXY_SERVER']}:{TEST_VARS['PROXY_PORT']}' >> /etc/yum.conf", silent=True)
 
 
 def setup_rhsm(shell):
     """
     Set up the RHSM according to the documentation.
     Shortened link to doc: https://url.corp.redhat.com/6d22a76
+    We don't use the pre_registered fixture on purpose, to validate
+    that the procedure in official documentation works.
     """
 
     assert (
         shell(
             f"curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release https://www.redhat.com/security/data/fd431d51.txt \
-                  --proxy http://{TEST_VARS['PROXY_SERVER']}:{TEST_VARS['PROXY_PORT']}"
+                  --proxy http://{TEST_VARS['PROXY_SERVER']}:{TEST_VARS['PROXY_PORT']}",
+            silent=True,
         ).returncode
         == 0
     )
@@ -91,7 +94,8 @@ def setup_rhsm(shell):
         assert (
             shell(
                 f"curl -o /etc/yum.repos.d/client-tools.repo https://cdn-public.redhat.com/content/public/repofiles/client-tools-for-rhel-7-server.repo \
-                    --proxy http://{TEST_VARS['PROXY_SERVER']}:{TEST_VARS['PROXY_PORT']}"
+                    --proxy http://{TEST_VARS['PROXY_SERVER']}:{TEST_VARS['PROXY_PORT']}",
+                silent=True,
             ).returncode
             == 0
         )
@@ -99,7 +103,8 @@ def setup_rhsm(shell):
         assert (
             shell(
                 f"curl -o /etc/yum.repos.d/client-tools.repo https://cdn-public.redhat.com/content/public/repofiles/client-tools-for-rhel-8.repo \
-                    --proxy http://{TEST_VARS['PROXY_SERVER']}:{TEST_VARS['PROXY_PORT']}"
+                    --proxy http://{TEST_VARS['PROXY_SERVER']}:{TEST_VARS['PROXY_PORT']}",
+                silent=True,
             ).returncode
             == 0
         )
@@ -117,14 +122,16 @@ def setup_rhsm(shell):
     shell("yum -y install subscription-manager subscription-manager-rhsm-certificates")
 
     shell(
-        f"subscription-manager config --server.proxy_hostname={TEST_VARS['PROXY_SERVER']} --server.proxy_port={TEST_VARS['PROXY_PORT']}"
+        f"subscription-manager config --server.proxy_hostname={TEST_VARS['PROXY_SERVER']} --server.proxy_port={TEST_VARS['PROXY_PORT']}",
+        silent=True,
     )
 
     shell(
-        f"subscription-manager register --password={TEST_VARS['RHSM_SCA_PASSWORD']} --username={TEST_VARS['RHSM_SCA_USERNAME']} --serverurl={TEST_VARS['RHSM_SERVER_URL']}"
+        f"subscription-manager register --password={TEST_VARS['RHSM_SCA_PASSWORD']} --username={TEST_VARS['RHSM_SCA_USERNAME']} --serverurl={TEST_VARS['RHSM_SERVER_URL']}",
+        hide_command=True,
     )
 
-    shell(f"subscription-manager config --rhsm.baseurl=https://{TEST_VARS['RHSM_STAGECDN']}")
+    shell(f"subscription-manager config --rhsm.baseurl=https://{TEST_VARS['RHSM_STAGECDN']}", silent=True)
 
 
 @pytest.mark.test_proxy_conversion

--- a/tests/integration/tier1/destructive/proxy-conversion/test_proxy_conversion.py
+++ b/tests/integration/tier1/destructive/proxy-conversion/test_proxy_conversion.py
@@ -80,6 +80,8 @@ def setup_rhsm(shell):
     Shortened link to doc: https://url.corp.redhat.com/6d22a76
     We don't use the pre_registered fixture on purpose, to validate
     that the procedure in official documentation works.
+    More information in the following JIRA Comment (URL Shortened)
+    https://url.corp.redhat.com/7a722af
     """
 
     assert (

--- a/tests/integration/tier1/destructive/proxy-conversion/test_proxy_conversion.py
+++ b/tests/integration/tier1/destructive/proxy-conversion/test_proxy_conversion.py
@@ -31,6 +31,7 @@ def setup_proxy(shell):
     ]
     for url in allowed_urls:
         ip_address = socket.gethostbyname(url)
+
         assert (
             shell(
                 f"firewall-cmd --permanent --direct --add-rule ipv4 filter OUTPUT 0 -p tcp -m tcp -d {ip_address} --dport=443 -j ACCEPT"

--- a/tests/integration/tier1/non-destructive/main.fmf
+++ b/tests/integration/tier1/non-destructive/main.fmf
@@ -10,4 +10,4 @@ tag+:
     - non-destructive
 
 environment+:
-    INT_TESTS_NONDESTRUCTIVE: 1
+    C2R_TESTS_NONDESTRUCTIVE: 1


### PR DESCRIPTION
* do not use the katello-ca-consumer package for registration to the Satellite since it will be deprecated in the near future
* use the API call to register instead

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1314](https://issues.redhat.com/browse/RHELC-1314)
- [RHELC-1524](https://issues.redhat.com/browse/RHELC-1524)
- [RHELC-1387](https://issues.redhat.com/browse/RHELC-1524)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [x] When merged: Jira issue has been updated to `Release Pending` if relevant
