### PR TITLE
Override pytest addopts for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ PYLINT_ARGS ?=
 VENV ?= .venv3
 PRE_COMMIT ?= pre-commit
 SHOW_CAPTURE ?= no
-PYTEST_ARGS ?= -p no:cacheprovider
+PYTEST_ARGS ?= --override-ini=addopts= -p no:cacheprovider
 BUILD_IMAGES ?= 1
 
 ifdef KEEP_TEST_CONTAINER


### PR DESCRIPTION
After the merge of https://github.com/oamg/convert2rhel/pull/1189, the spam of information of test setups is causing problems in github actions log rendering, as well as executing it locally/container.

This commit is intended to override the addopts option in pytest.ini when the
execution is inside a container/locally.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
