### PR TITLE
Prevent workflows to execute in forks

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   tag:
+    if: always() && github.repository == 'oamg/convert2rhel'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build_and_publish:
     name: build-${{ matrix.el.distro }}${{ matrix.el.ver }}
+    if: always() && github.repository == 'oamg/convert2rhel'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze
+    if: always() && github.repository == 'oamg/convert2rhel'
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   coverage:
     name: coverage-${{ matrix.el.distro }}${{ matrix.el.ver }}
+    if: always() && github.repository == 'oamg/convert2rhel'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/enforce_labels.yml
+++ b/.github/workflows/enforce_labels.yml
@@ -5,7 +5,7 @@ on:
     types: [labeled, unlabeled, opened, edited, synchronize]
 jobs:
   enforce-label:
-    if: github.actor != 'dependabot' || github.actor != 'pre-commit-ci'
+    if: (always() && github.repository == 'oamg/convert2rhel') && (github.actor != 'dependabot' || github.actor != 'pre-commit-ci')
     runs-on: ubuntu-latest
     steps:
       - uses: yogevbd/enforce-label-action@2.2.2

--- a/.github/workflows/enforce_verification_labels.yml
+++ b/.github/workflows/enforce_verification_labels.yml
@@ -5,7 +5,7 @@ on:
     types: [labeled, unlabeled, opened, edited, synchronize]
 jobs:
   enforce-label:
-    if: github.actor != 'dependabot' || github.actor != 'pre-commit-ci'
+    if: (always() && github.repository == 'oamg/convert2rhel') && (github.actor != 'dependabot' || github.actor != 'pre-commit-ci')
     runs-on: ubuntu-latest
     steps:
       - uses: yogevbd/enforce-label-action@2.2.2

--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   generate-manpages:
     runs-on: ubuntu-latest
+    if: always() && github.repository == 'oamg/convert2rhel'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   comment:
     runs-on: ubuntu-latest
+    if: always() && github.repository == 'oamg/convert2rhel'
     steps:
       - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build_rpms:
     name: Build EL${{ matrix.el.ver }} RPM
+    if: always() && github.repository == 'oamg/convert2rhel'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   testing:
     name: testing-${{ matrix.el.distro }}${{ matrix.el.ver }}
+    if: always() && github.repository == 'oamg/convert2rhel'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Forks might not always have the same setup as the upstream repositories, to prevent email spams from failed workflows, let's prevent them from running in the forks.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
