### PR TITLE
Fix incorrect test mock in unit tests

### DIFF
--- a/convert2rhel/unit_tests/backup/packages_test.py
+++ b/convert2rhel/unit_tests/backup/packages_test.py
@@ -190,9 +190,9 @@ class TestRestorablePackage:
             )
         )
         monkeypatch.setattr(utils, "run_subprocess", value=run_subprocess_mock)
-
-        rp = RestorablePackage(pkgs=[pkg_name])
-        rp._backedup_pkgs_paths = pkg_name
+        pkgs = [pkg_name]
+        rp = RestorablePackage(pkgs=pkgs)
+        rp._backedup_pkgs_paths = pkgs
         result = rp._install_local_rpms(replace=False, critical=False)
 
         assert result == False
@@ -200,10 +200,10 @@ class TestRestorablePackage:
         assert "Couldn't install %s packages." % pkg_name in caplog.records[-1].message
 
     def test_test_install_local_rpms_system_exit(self, monkeypatch, caplog):
-        pkg_name = "pkg-1"
+        pkg_name = ["pkg-1"]
         run_subprocess_mock = RunSubprocessMocked(
             side_effect=unit_tests.run_subprocess_side_effect(
-                (("rpm", "-i", pkg_name), ("test", 1)),
+                (("rpm", "-i", " ".join(pkg_name)), ("test", 1)),
             )
         )
         monkeypatch.setattr(
@@ -212,13 +212,13 @@ class TestRestorablePackage:
             value=run_subprocess_mock,
         )
 
-        rp = RestorablePackage(pkgs=[pkg_name])
+        rp = RestorablePackage(pkgs=pkg_name)
         rp._backedup_pkgs_paths = pkg_name
         with pytest.raises(exceptions.CriticalError):
             rp._install_local_rpms(replace=False, critical=True)
 
         assert run_subprocess_mock.call_count == 1
-        assert "Error: Couldn't install %s packages." % pkg_name in caplog.records[-1].message
+        assert "Error: Couldn't install %s packages." % "".join(pkg_name) in caplog.records[-1].message
 
 
 class TestRestorablePackageSet:


### PR DESCRIPTION
There was an incorrect assigment in the test mock that caused one of the unit_tests to take a lot of time to finish.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
