### PR TITLE
[RHELC-1520] Remove leftover reposdir from package updates action

### DIFF
--- a/convert2rhel/actions/system_checks/package_updates.py
+++ b/convert2rhel/actions/system_checks/package_updates.py
@@ -19,7 +19,6 @@ import logging
 import os
 
 from convert2rhel import actions, pkgmanager, utils
-from convert2rhel.backup import get_backedup_system_repos
 from convert2rhel.pkghandler import get_total_packages_to_update
 from convert2rhel.systeminfo import system_info
 
@@ -52,10 +51,8 @@ class PackageUpdates(actions.Action):
             )
             return
 
-        reposdir = get_backedup_system_repos()
-
         try:
-            packages_to_update = sorted(get_total_packages_to_update(reposdir=reposdir))
+            packages_to_update = sorted(get_total_packages_to_update())
         except (utils.UnableToSerialize, pkgmanager.RepoError) as e:
             # As both yum and dnf have the same error class (RepoError), to
             # identify any problems when interacting with the repositories, we
@@ -81,14 +78,13 @@ class PackageUpdates(actions.Action):
             return
 
         if len(packages_to_update) > 0:
-            repos_message = "on repositories defined in the %s folder" % reposdir
             package_not_up_to_date_skip = os.environ.get("CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP", None)
             package_not_up_to_date_error_message = (
-                "The system has %s package(s) not updated based %s.\n"
+                "The system has %s package(s) not updated based on repositories defined in the system repositories.\n"
                 "List of packages to update: %s.\n\n"
                 "Not updating the packages may cause the conversion to fail.\n"
                 "Consider updating the packages before proceeding with the conversion."
-                % (len(packages_to_update), repos_message, " ".join(packages_to_update))
+                % (len(packages_to_update), " ".join(packages_to_update))
             )
             if not package_not_up_to_date_skip:
                 logger.warning(package_not_up_to_date_error_message)

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -878,7 +878,7 @@ def clear_versionlock():
 
 
 @utils.run_as_child_process
-def get_total_packages_to_update(reposdir):
+def get_total_packages_to_update():
     """
     Return the total number of packages to update in the system. It uses both
     yum/dnf depending on whether they are installed on the system, In case of
@@ -894,8 +894,6 @@ def get_total_packages_to_update(reposdir):
         We need to know about the signals to act on them, for example to
         execute a rollback when the user presses Ctrl + C.
 
-    :param reposdir: The path to the hardcoded repositories for EUS (If any).
-    :type reposdir: str | None
     :return: The packages that need to be updated.
     :rtype: list[str]
     """
@@ -904,9 +902,7 @@ def get_total_packages_to_update(reposdir):
     if pkgmanager.TYPE == "yum":
         packages = _get_packages_to_update_yum()
     elif pkgmanager.TYPE == "dnf":
-        # We're using the reposdir with dnf only because we currently hardcode
-        # the repofiles for RHEL 8 derivatives only.
-        packages = _get_packages_to_update_dnf(reposdir=reposdir)
+        packages = _get_packages_to_update_dnf()
 
     return set(packages)
 
@@ -928,20 +924,12 @@ def _get_packages_to_update_yum():
     return all_packages
 
 
-def _get_packages_to_update_dnf(reposdir):
-    """Query all the packages with dnf that has an update pending on the
-    system.
-    :param reposdir: The path to the hardcoded repositories for EUS (If any).
-    :type reposdir: str | None
+def _get_packages_to_update_dnf():
+    """
+    Query all the packages with dnf that has an update pending on the system.
     """
     packages = []
     base = pkgmanager.Base()
-
-    # If we have a reposdir, that means we are trying to check the packages
-    # under CentOS Linux 8.4 or 8.5 and Oracle Linux 8.4. That means we need to
-    # use our hardcoded repository files instead of the system ones.
-    if reposdir:
-        base.conf.reposdir = reposdir
 
     # Set DNF to read from the proper config files, at this moment, DNF can't
     # automatically read and load the config files so we have to specify it to

--- a/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
@@ -66,24 +66,22 @@ def test_check_package_updates_skip_on_not_latest_ol(pretend_os, caplog, package
 
 @centos8
 def test_check_package_updates(pretend_os, monkeypatch, caplog, package_updates_action):
-    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=lambda reposdir: [])
+    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=lambda: [])
 
     package_updates_action.run()
     assert "System is up-to-date." in caplog.records[-1].message
 
 
 @centos8
-def test_check_package_updates_not_up_to_date(pretend_os, monkeypatch, package_updates_action, caplog, tmpdir):
+def test_check_package_updates_not_up_to_date(pretend_os, monkeypatch, package_updates_action, caplog):
     packages = ["package-2", "package-1"]
-    reposdir = str(tmpdir.join("backup"))
     diagnosis = (
-        "The system has 2 package(s) not updated based on repositories defined in the %s folder.\n"
+        "The system has 2 package(s) not updated based on repositories defined in the system repositories.\n"
         "List of packages to update: package-1 package-2.\n\n"
         "Not updating the packages may cause the conversion to fail.\n"
         "Consider updating the packages before proceeding with the conversion."
-    ) % reposdir
-    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=lambda reposdir: packages)
-    monkeypatch.setattr(package_updates, "get_backedup_system_repos", lambda: reposdir)
+    )
+    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=lambda: packages)
 
     package_updates_action.run()
     unit_tests.assert_actions_result(
@@ -103,22 +101,20 @@ def test_check_package_updates_not_up_to_date(pretend_os, monkeypatch, package_u
 
 
 @centos8
-def test_check_package_updates_not_up_to_date_skip(pretend_os, monkeypatch, package_updates_action, tmpdir):
+def test_check_package_updates_not_up_to_date_skip(pretend_os, monkeypatch, package_updates_action):
     packages = ["package-2", "package-1"]
-    reposdir = str(tmpdir.join("backup"))
     diagnosis = (
-        "The system has 2 package(s) not updated based on repositories defined in the %s folder.\n"
+        "The system has 2 package(s) not updated based on repositories defined in the system repositories.\n"
         "List of packages to update: package-1 package-2.\n\n"
         "Not updating the packages may cause the conversion to fail.\n"
         "Consider updating the packages before proceeding with the conversion."
-    ) % reposdir
-    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=lambda reposdir: packages)
+    )
+    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=lambda: packages)
     monkeypatch.setattr(
         os,
         "environ",
         {"CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP": 1},
     )
-    monkeypatch.setattr(package_updates, "get_backedup_system_repos", lambda: reposdir)
 
     expected = set(
         (

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -816,7 +816,7 @@ def test_validate_parsed_fields_valid(package):
 
 
 @pytest.mark.parametrize(
-    ("package_manager_type", "packages", "expected", "reposdir"),
+    ("package_manager_type", "packages", "expected"),
     (
         (
             "yum",
@@ -830,7 +830,6 @@ def test_validate_parsed_fields_valid(package):
                     "convert2rhel.src-0.24-1.20211111151554764702.pr356.28.ge9ed160.el8",
                 )
             ),
-            None,
         ),
         (
             "yum",
@@ -839,7 +838,6 @@ def test_validate_parsed_fields_valid(package):
                 "convert2rhel.noarch-0.24-1.20211111151554764702.pr356.28.ge9ed160.el8",
             ],
             frozenset(("convert2rhel.noarch-0.24-1.20211111151554764702.pr356.28.ge9ed160.el8",)),
-            None,
         ),
         (
             "dnf",
@@ -855,7 +853,6 @@ def test_validate_parsed_fields_valid(package):
                     "java-11-openjdk-headless-1:11.0.13.0.8-2.fc35.x86_64",
                 )
             ),
-            None,
         ),
         (
             "dnf",
@@ -871,7 +868,6 @@ def test_validate_parsed_fields_valid(package):
                     "java-11-openjdk-headless-1:11.0.13.0.8-2.fc35.x86_64",
                 )
             ),
-            "test/reposdir",
         ),
         (
             "dnf",
@@ -886,7 +882,6 @@ def test_validate_parsed_fields_valid(package):
                     "java-11-openjdk-headless-1:11.0.13.0.8-2.fc35.x86_64",
                 )
             ),
-            "test/reposdir",
         ),
     ),
 )
@@ -895,7 +890,6 @@ def test_get_total_packages_to_update(
     package_manager_type,
     packages,
     expected,
-    reposdir,
     pretend_os,
     monkeypatch,
 ):
@@ -904,7 +898,7 @@ def test_get_total_packages_to_update(
         monkeypatch.setattr(
             pkghandler,
             "_get_packages_to_update_%s" % package_manager_type,
-            value=lambda reposdir: packages,
+            value=lambda: packages,
         )
     else:
         monkeypatch.setattr(
@@ -912,7 +906,7 @@ def test_get_total_packages_to_update(
             "_get_packages_to_update_%s" % package_manager_type,
             value=lambda: packages,
         )
-    assert get_total_packages_to_update(reposdir=reposdir) == expected
+    assert get_total_packages_to_update() == expected
 
 
 @pytest.mark.skipif(
@@ -953,20 +947,14 @@ def test_get_packages_to_update_yum_no_more_mirrors(monkeypatch, caplog):
     reason="No dnf module detected on the system, skipping it.",
 )
 @pytest.mark.parametrize(
-    ("packages", "reposdir"),
+    ("packages",),
     (
-        (
-            ["package-1", "package-2", "package-i3"],
-            None,
-        ),
-        (
-            ["package-1"],
-            "test/reposdir",
-        ),
+        (["package-1", "package-2", "package-i3"],),
+        (["package-1"],),
     ),
 )
 @all_systems
-def test_get_packages_to_update_dnf(packages, reposdir, pretend_os, monkeypatch):
+def test_get_packages_to_update_dnf(packages, pretend_os, monkeypatch):
     dummy_mock = mock.Mock()
     PkgName = namedtuple("PkgNames", ["name"])
     transaction_pkgs = [PkgName(package) for package in packages]
@@ -977,7 +965,7 @@ def test_get_packages_to_update_dnf(packages, reposdir, pretend_os, monkeypatch)
     monkeypatch.setattr(pkgmanager.Base, "resolve", value=dummy_mock)
     monkeypatch.setattr(pkgmanager.Base, "transaction", value=transaction_pkgs)
 
-    assert _get_packages_to_update_dnf(reposdir=reposdir) == packages
+    assert _get_packages_to_update_dnf() == packages
 
 
 class TestInstallGpgKeys:


### PR DESCRIPTION
A regression was detected in the package updates tier1 test as the pull request #1181 got merged in upstream.

This commit aims to remove the leftover reposdir from the packge updates action as the folder is empty and there is nothing backed up inside it.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues: [RHELC-1520](https://issues.redhat.com/browse/RHELC-1520)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
