### PR TITLE
[RHELC-1493] Add rhel 9 version support up to 9.10

### DIFF
--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -38,6 +38,14 @@ CHECK_DBUS_STATUS_RETRIES = 3
 # Allowed conversion paths to RHEL. We want to prevent a conversion and minor
 # version update at the same time.
 RELEASE_VER_MAPPING = {
+    "9.10": "9.10",
+    "9.9": "9.9",
+    "9.8": "9.8",
+    "9.7": "9.7",
+    "9.6": "9.6",
+    "9.5": "9.5",
+    "9.4": "9.4",
+    "9.3": "9.3",
     "9.2": "9.2",
     "9.1": "9.1",
     "9.0": "9.0",

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -231,6 +231,7 @@ all_systems = pytest.mark.parametrize(
         ("7.9.1111", "Oracle Linux Server"),
         ("8.5.1111", "CentOS Linux"),
         ("8.6.1111", "Oracle Linux Server"),
+        ("9.3.1111", "Oracle Linux Server"),
     ),
     indirect=True,
 )
@@ -252,6 +253,11 @@ oracle7 = pytest.mark.parametrize(
 oracle8 = pytest.mark.parametrize(
     "pretend_os",
     (("8.6.1111", "Oracle Linux Server"),),
+    indirect=True,
+)
+oracle9 = pytest.mark.parametrize(
+    "pretend_os",
+    (("9.3.1111", "Oracle Linux Server"),),
     indirect=True,
 )
 


### PR DESCRIPTION
This PR adds rhel 9 versions up to 9.10 in systeminfo so customers can do conversions on all rhel 9 versions. 
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:[RHELC-1493 ](https://issues.redhat.com/browse/RHELC-1493)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
