### PR TITLE
[RHELC-1303, RHELC-1527, RHELC-1557] Enhance exit code testing

### DIFF
--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -64,8 +64,12 @@ description+: |
             adjust+:
                 - enabled: true
                   when: distro == oracle-7, centos-7
-            environment+:
-                PACKAGES: gnome-documents-libs shim-x64 libreport-plugin-mantisbt
+                - environment+:
+                    PACKAGES: gnome-documents-libs shim-x64 libreport-plugin-mantisbt
+                  when: distro == oracle
+                - environment+:
+                    PACKAGES: gnome-documents-libs libreport-plugin-mantisbt
+                  when: distro == centos
 
 
     /one_kernel_scenario:

--- a/pytest.ini
+++ b/pytest.ini
@@ -51,11 +51,13 @@ markers =
     test_logfile_starts_with_command
     test_modified_config
     test_unknown_release
+    test_polluted_yumdownloader_output_by_yum_plugin_local
     test_rhsm_cleanup
     test_missing_credentials_rollback
     test_packages_untracked_graceful_rollback
     test_terminate_on_registration_start
     test_terminate_on_registration_success
+    test_rollback_failure
     test_package_download_error
     test_transaction_validation_error
     test_validation_packages_with_in_name_period

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -902,14 +902,14 @@ def install_and_set_up_subman_to_stagecdn(shell, yum_conf_exclude):
         _remove_client_tools_repo(shell)
 
 
-@pytest.fixture(autouse=True)
-def workaround_remove_uek(shell):
+@pytest.fixture(scope="session", autouse=True)
+def workaround_remove_uek():
     """
     Fixture to remove the Unbreakable Enterprise Kernel package.
     The package might cause dependency issues.
     Reference issue https://issues.redhat.com/browse/RHELC-1544
     """
     if SystemInformationRelease.distribution == "oracle":
-        shell("yum remove -y kernel-uek", silent=True)
+        subprocess.run(["yum", "remove", "-y", "kernel-uek"], check=False)
 
     yield

--- a/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
+++ b/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
@@ -125,6 +125,8 @@ def test_successful_report(convert2rhel):
             assert AssertionError("Error header in the analysis report.")
         elif c2r_report_header_index == 2:
             assert AssertionError("Skip header in the analysis report.")
+        else:
+            assert AssertionError("Some unexpected string found in the report")
 
     assert c2r.exitstatus == 0
 
@@ -173,8 +175,9 @@ def test_convert_successful_report(convert2rhel):
             assert AssertionError("Error header in the analysis report.")
         elif c2r_report_header_index == 3:
             assert AssertionError("Skip header in the analysis report.")
-
+        else:
+            assert AssertionError("No header found.")
     # Exitstatus is 1 due to user cancelling the conversion
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
 
     _validate_report()

--- a/tests/integration/tier0/non-destructive/config-file/test_config_file.py
+++ b/tests/integration/tier0/non-destructive/config-file/test_config_file.py
@@ -28,9 +28,8 @@ def test_user_path_custom_filename(convert2rhel):
 
     with convert2rhel('--debug -c "~/.convert2rhel_custom.ini"') as c2r:
         c2r.expect("DEBUG - Found activation_key in /root/.convert2rhel_custom.ini")
-        c2r.sendcontrol("c")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
 
     remove_files(config)
 
@@ -42,9 +41,10 @@ def test_user_path_std_filename(convert2rhel):
 
     with convert2rhel("--debug") as c2r:
         c2r.expect("DEBUG - Found password in /root/.convert2rhel.ini")
-        c2r.sendcontrol("c")
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("n")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
 
     remove_files(config)
 
@@ -61,17 +61,19 @@ def test_user_path_cli_priority(convert2rhel):
 
     with convert2rhel("--password password --debug") as c2r:
         # Found options in config file
-        c2r.expect("DEBUG - Found username in /root/.convert2rhel.ini")
-        c2r.expect("DEBUG - Found password in /root/.convert2rhel.ini")
-        c2r.expect("DEBUG - Found activation_key in /root/.convert2rhel.ini")
-        c2r.expect("DEBUG - Found org in /root/.convert2rhel.ini")
+        c2r.expect("DEBUG - Found username in /root/.convert2rhel.ini", timeout=120)
+        c2r.expect("DEBUG - Found password in /root/.convert2rhel.ini", timeout=120)
+        c2r.expect("DEBUG - Found activation_key in /root/.convert2rhel.ini", timeout=120)
+        c2r.expect("DEBUG - Found org in /root/.convert2rhel.ini", timeout=120)
         c2r.expect(
             "WARNING - You have passed either the RHSM password or activation key through both the command line and"
-            " the configuration file. We're going to use the command line values."
+            " the configuration file. We're going to use the command line values.",
+            timeout=120,
         )
-        c2r.sendcontrol("c")
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("n")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
 
     remove_files(config)
 
@@ -97,9 +99,8 @@ def test_std_paths_priority_diff_methods(convert2rhel):
             "WARNING - Either a password or an activation key can be used for system registration."
             " We're going to use the activation key."
         )
-        c2r.sendcontrol("c")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
 
     remove_files(config)
 
@@ -114,8 +115,9 @@ def test_std_paths_priority(convert2rhel):
 
     with convert2rhel("--debug") as c2r:
         c2r.expect("DEBUG - Found password in /root/.convert2rhel.ini")
-        c2r.sendcontrol("c")
+        c2r.expect("Continue with the system conversion?")
+        c2r.sendline("n")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
 
     remove_files(config)

--- a/tests/integration/tier0/non-destructive/custom-repository/test_custom_repository.py
+++ b/tests/integration/tier0/non-destructive/custom-repository/test_custom_repository.py
@@ -61,7 +61,7 @@ def test_good_conversion_without_rhsm(shell, convert2rhel, custom_repository):
         c2r.expect("The repositories passed through the --enablerepo option are all accessible.")
         c2r.sendcontrol("c")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
 
 
 @pytest.mark.test_custom_invalid_repo_provided
@@ -75,6 +75,6 @@ def test_bad_conversion_without_rhsm(shell, convert2rhel, custom_repository):
     with convert2rhel("-y --no-rhsm --enablerepo fake-rhel-8-for-x86_64-baseos-rpms --debug", unregister=True) as c2r:
         c2r.expect("CUSTOM_REPOSITORIES_ARE_VALID::UNABLE_TO_ACCESS_REPOSITORIES")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 2
 
     assert shell("rpm -qi kernel").returncode == 0

--- a/tests/integration/tier0/non-destructive/cve-2022-1662/test_cve-2022-1662.py
+++ b/tests/integration/tier0/non-destructive/cve-2022-1662/test_cve-2022-1662.py
@@ -36,7 +36,7 @@ def test_passing_password_to_submgr(convert2rhel):
                 print(watcher.get())
                 assert not [cmdline for cmdline in watcher.get() if password in cmdline]
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 2
 
 
 @pytest.mark.test_passing_activation_key_to_submgr
@@ -59,4 +59,4 @@ def test_passing_activation_key_to_submgr(convert2rhel):
                 print(watcher.get())
                 assert not [cmdline for cmdline in watcher.get() if activation_key in cmdline]
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 2

--- a/tests/integration/tier0/non-destructive/file-backup/test_file_backup.py
+++ b/tests/integration/tier0/non-destructive/file-backup/test_file_backup.py
@@ -145,3 +145,4 @@ def test_file_backup(convert2rhel, shell, file_action_fixture, request):
         # Verify the rollback starts and analysis report is printed out
         c2r.expect("Abnormal exit! Performing rollback")
         c2r.expect("Pre-conversion analysis report")
+    assert c2r.exitstatus == 0

--- a/tests/integration/tier0/non-destructive/kernel-modules/test_unsupported_kmod.py
+++ b/tests/integration/tier0/non-destructive/kernel-modules/test_unsupported_kmod.py
@@ -75,7 +75,7 @@ def test_error_if_custom_module_loaded(kmod_in_different_directory, convert2rhel
     ) as c2r:
         c2r.expect("ENSURE_KERNEL_MODULES_COMPATIBILITY::UNSUPPORTED_KERNEL_MODULES")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 2
 
 
 @pytest.mark.test_custom_module_not_loaded
@@ -118,7 +118,7 @@ def test_do_not_error_if_module_is_not_loaded(shell, convert2rhel):
         assert c2r.expect("All loaded kernel modules are available in RHEL") == 0
         c2r.sendcontrol("c")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
 
 
 @pytest.fixture()
@@ -151,7 +151,7 @@ def test_error_if_module_is_force_loaded(shell, convert2rhel, forced_kmods):
         assert c2r.expect("TAINTED_KMODS::TAINTED_KMODS_DETECTED - Tainted kernel modules detected") == 0
         c2r.sendcontrol("c")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
 
 
 @pytest.mark.parametrize("envars", [["CONVERT2RHEL_TAINTED_KERNEL_MODULE_CHECK_SKIP"]])
@@ -184,7 +184,7 @@ def test_tainted_kernel_modules_check_override(shell, convert2rhel, forced_kmods
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("n")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
 
 
 @pytest.mark.test_tainted_kernel_modules_error
@@ -210,7 +210,7 @@ def test_tainted_kernel_modules_error(custom_kmod, convert2rhel):
         )
         c2r.sendcontrol("c")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
 
 
 @pytest.mark.parametrize("envars", [["CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS"]])
@@ -240,4 +240,4 @@ def test_envar_overrides_unsupported_module_loaded(
 
         c2r.sendcontrol("c")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1

--- a/tests/integration/tier0/non-destructive/kernel/test_custom_kernel.py
+++ b/tests/integration/tier0/non-destructive/kernel/test_custom_kernel.py
@@ -117,4 +117,4 @@ def test_custom_kernel(convert2rhel, shell, custom_kernel, hybrid_rocky_image):
 
             c2r.sendcontrol("c")
 
-        assert c2r.exitstatus != 0
+        assert c2r.exitstatus == 1

--- a/tests/integration/tier0/non-destructive/kernel/test_kernel_check_verification.py
+++ b/tests/integration/tier0/non-destructive/kernel/test_kernel_check_verification.py
@@ -46,7 +46,7 @@ def test_verify_latest_kernel_check_passes_with_failed_repoquery(convert2rhel, t
         )
         c2r.sendcontrol("c")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
 
 
 @pytest.mark.parametrize("yum_conf_exclude", [["kernel", "kernel-core"]], indirect=True)
@@ -66,7 +66,7 @@ def test_latest_kernel_check_with_exclude_kernel_option(convert2rhel, yum_conf_e
         else:
             assert AssertionError, "Utility did not raise IS_LOADED_KERNEL_LATEST has succeeded"
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
 
 
 @pytest.mark.test_non_latest_kernel_error
@@ -88,4 +88,4 @@ def test_non_latest_kernel_error(kernel, shell, convert2rhel):
             c2r.expect_exact("(OVERRIDABLE) IS_LOADED_KERNEL_LATEST:INVALID_KERNEL_VERSION")
             c2r.sendcontrol("c")
 
-        assert c2r.exitstatus != 0
+        assert c2r.exitstatus == 1

--- a/tests/integration/tier0/non-destructive/kernel/test_oracle_unsupported_uek.py
+++ b/tests/integration/tier0/non-destructive/kernel/test_oracle_unsupported_uek.py
@@ -38,6 +38,5 @@ def test_bad_conversion(shell, convert2rhel, unbreakable_kernel):
                 "RHEL_COMPATIBLE_KERNEL::INCOMPATIBLE_VERSION - Incompatible booted kernel version",
                 timeout=600,
             )
-            c2r.sendcontrol("c")
 
-            assert c2r.exitstatus != 0
+        assert c2r.exitstatus == 2

--- a/tests/integration/tier0/non-destructive/logged-command/test_logged_command.py
+++ b/tests/integration/tier0/non-destructive/logged-command/test_logged_command.py
@@ -70,4 +70,4 @@ def test_verify_logfile_starts_with_command(convert2rhel):
             assert username not in command
             assert organization not in command
 
-        assert c2r.exitstatus != 0
+        assert c2r.exitstatus == 1

--- a/tests/integration/tier0/non-destructive/modified-releasever/test_modified_releasever.py
+++ b/tests/integration/tier0/non-destructive/modified-releasever/test_modified_releasever.py
@@ -42,7 +42,7 @@ def test_releasever_as_mapping_config_modified(convert2rhel, os_release, c2r_con
         ) as c2r:
             c2r.expect("--releasever=333")
             c2r.sendcontrol("c")
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
 
 
 @pytest.fixture(scope="function")
@@ -83,4 +83,4 @@ def test_releasever_as_mapping_not_existing_release(convert2rhel, config_at, os_
             c2r.expect(
                 f"CRITICAL - {os_release.name} of version {os_release.version[0]}.1 is not allowed for conversion."
             )
-        assert c2r.exitstatus != 0
+        assert c2r.exitstatus == 1

--- a/tests/integration/tier0/non-destructive/rollback-handling/main.fmf
+++ b/tests/integration/tier0/non-destructive/rollback-handling/main.fmf
@@ -94,3 +94,16 @@ tag+:
             - terminate-on-registration-success
         test: |
             pytest -m test_terminate_on_registration_success
+
+/test_rollback_failure:
+    summary+: |
+        Unsuccessful rollback exits with code 1
+    description+: |
+        Make os-release file immutable. This will cause the
+        conversion rollback to fail (https://issues.redhat.com/browse/RHELC-1248).
+        Verify that the analysis and conversion ends with exit code 1
+        respecting the failure (https://issues.redhat.com/browse/RHELC-1275).
+    tag+:
+        - test-rollback-failure
+    test: |
+        pytest -m test_rollback_failure

--- a/tests/integration/tier0/non-destructive/rollback-handling/test_rollback_handling.py
+++ b/tests/integration/tier0/non-destructive/rollback-handling/test_rollback_handling.py
@@ -176,7 +176,7 @@ def test_proper_rhsm_clean_up(shell, convert2rhel):
         c2r.expect("Calling command 'subscription-manager unregister'", timeout=120)
         c2r.expect("System unregistered successfully.", timeout=120)
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
 
     is_installed_post_rollback(shell, assign_packages())
     remove_packages(shell, packages_to_remove_at_cleanup)
@@ -194,7 +194,7 @@ def test_missing_credentials_rollback(convert2rhel, shell):
     with convert2rhel("--debug -y") as c2r:
         c2r.expect_exact("ERROR - (ERROR) SUBSCRIBE_SYSTEM::SYSTEM_NOT_REGISTERED")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 2
 
     is_installed_post_rollback(shell, assign_packages())
     remove_packages(shell, packages_to_remove_at_cleanup)
@@ -210,7 +210,8 @@ def test_check_untrack_pkgs_graceful(convert2rhel, shell):
     password = "bar"
     packages_to_remove_at_cleanup = install_packages(shell, assign_packages())
     with convert2rhel(f"--debug -y --username {username} --password {password}") as c2r:
-        assert c2r.exitstatus != 0
+        pass
+    assert c2r.exitstatus == 2
 
     is_installed_post_rollback(shell, assign_packages())
     remove_packages(shell, packages_to_remove_at_cleanup)
@@ -232,7 +233,7 @@ def test_terminate_registration_start(convert2rhel):
     ) as c2r:
         c2r.expect("Registering the system using subscription-manager")
         terminate_and_assert_good_rollback(c2r)
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
 
 
 @pytest.mark.skip(reason="SIGINT is sent too soon which breaks the rollback")
@@ -258,4 +259,4 @@ def test_terminate_registration_success(convert2rhel):
         c2r.expect("DEBUG - Calling command 'subscription-manager attach --auto'", timeout=180)
         c2r.expect("Status:       Subscribed", timeout=180)
         terminate_and_assert_good_rollback(c2r)
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1

--- a/tests/integration/tier0/non-destructive/single-yum-transaction-validation/test_single_yum_transaction_validation.py
+++ b/tests/integration/tier0/non-destructive/single-yum-transaction-validation/test_single_yum_transaction_validation.py
@@ -99,7 +99,7 @@ def test_package_download_error(convert2rhel, shell, yum_cache):
         else:
             c2r.expect("VALIDATE_PACKAGE_MANAGER_TRANSACTION::FAILED_TO_LOAD_REPOSITORIES")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 2
 
 
 @pytest.mark.test_transaction_validation_error
@@ -140,7 +140,7 @@ def test_transaction_validation_error(convert2rhel, shell, yum_cache):
             timeout=600,
         )
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 2
 
 
 @pytest.fixture

--- a/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
+++ b/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
@@ -27,7 +27,7 @@ def test_pre_registered_wont_unregister(shell, pre_registered, convert2rhel):
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("n")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
 
 
 @pytest.mark.test_pre_registered_re_register
@@ -56,7 +56,7 @@ def test_pre_registered_re_register(shell, pre_registered, convert2rhel):
         c2r.sendline("n")
         c2r.expect("System unregistered successfully.", timeout=120)
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
     assert "This system is not yet registered" in shell("subscription-manager identity").output
 
 
@@ -74,7 +74,7 @@ def test_unregistered_no_credentials(shell, convert2rhel):
 
         c2r.expect("SUBSCRIBE_SYSTEM::SYSTEM_NOT_REGISTERED - Not registered with RHSM", timeout=300)
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 2
 
 
 @pytest.mark.test_no_sca_not_subscribed
@@ -93,7 +93,7 @@ def test_no_sca_no_subscribed(shell, pre_registered, convert2rhel):
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("n")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
 
     assert "No consumed subscription pools were found" in shell("subscription-manager list --consumed").output
 
@@ -115,4 +115,4 @@ def test_no_sca_subscription_attachment_error(shell, convert2rhel, pre_registere
         c2r.expect("We'll try to auto-attach a subscription")
         c2r.expect_exact("(ERROR) SUBSCRIBE_SYSTEM::NO_ACCESS_TO_RHEL_REPOS - No access to RHEL repositories")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 2

--- a/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_rollback.py
+++ b/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_rollback.py
@@ -63,4 +63,4 @@ def test_sub_man_rollback(convert2rhel, shell, required_packages, convert2rhel_r
             # Expect rollback, otherwise TIMEOUT
             c2r.expect("WARNING - Abnormal exit! Performing rollback", timeout=10)
 
-        assert c2r.exitstatus != 0
+        assert c2r.exitstatus == 1

--- a/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
+++ b/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
@@ -37,7 +37,7 @@ def test_missing_system_release(shell, convert2rhel, system_release_missing):
     ) as c2r:
         c2r.expect("Unable to find the /etc/system-release file containing the OS name and version")
 
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1
 
 
 @pytest.mark.parametrize("satellite_registration", ["RHEL_CONTENT_SAT_REG"], indirect=True)
@@ -54,7 +54,7 @@ def test_backup_os_release_no_envar(shell, convert2rhel, satellite_registration,
     """
     assert shell("find /etc/os-release").returncode == 0
 
-    with convert2rhel("--debug") as c2r:
+    with convert2rhel("--debug", unregister=True) as c2r:
         # We need to get past the data collection acknowledgement.
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("y")

--- a/tests/integration/tier0/non-destructive/user-prompt-response/test_user_prompt_response.py
+++ b/tests/integration/tier0/non-destructive/user-prompt-response/test_user_prompt_response.py
@@ -40,4 +40,4 @@ def test_check_user_response_user_and_password(convert2rhel):
                 continue
 
         c2r.sendcontrol("c")
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 1

--- a/tests/integration/tier1/destructive/excluded-packages-removed/test_excluded_pkgs_removed.py
+++ b/tests/integration/tier1/destructive/excluded-packages-removed/test_excluded_pkgs_removed.py
@@ -34,4 +34,7 @@ def test_excluded_packages_removed(shell, convert2rhel):
     assert c2r.exitstatus == 0
 
     # Verify, the excluded packages were really removed
-    assert shell(f"rpm -qi {packages}").returncode == 1
+    # RPM return code depends on the number of packages that are not installed.
+    # If the query contains 3 packages and none of them is installed then the
+    # return code is 3.
+    assert shell(f"rpm -qi {packages}").returncode == len(packages.split(" "))

--- a/tests/integration/tier1/destructive/excluded-packages-removed/test_excluded_pkgs_removed.py
+++ b/tests/integration/tier1/destructive/excluded-packages-removed/test_excluded_pkgs_removed.py
@@ -34,4 +34,4 @@ def test_excluded_packages_removed(shell, convert2rhel):
     assert c2r.exitstatus == 0
 
     # Verify, the excluded packages were really removed
-    assert shell(f"rpm -qi {packages}").returncode != 0
+    assert shell(f"rpm -qi {packages}").returncode == 1

--- a/tests/integration/tier1/destructive/system-not-up-to-date/test_system_not_up_to_date.py
+++ b/tests/integration/tier1/destructive/system-not-up-to-date/test_system_not_up_to_date.py
@@ -63,6 +63,7 @@ def test_system_not_updated(shell, convert2rhel, downgrade_and_versionlock):
         c2r.expect("WARNING - YUM/DNF versionlock plugin is in use. It may cause the conversion to fail.")
         c2r.expect(r"WARNING - The system has \d+ package\(s\) not updated")
         c2r.expect_exact("ERROR - (OVERRIDABLE) PACKAGE_UPDATES::OUT_OF_DATE_PACKAGES - Outdated packages detected")
+
     assert c2r.exitstatus == 2
 
     # We need to set envar to override the out of date packages check


### PR DESCRIPTION
This PR fixes exit code asserts in the integration tests. Also adds one new integration test case with broken rollback scenario. 
Jira Issues:

-  [RHELC-1303](https://issues.redhat.com/browse/RHELC-1303) 
-  [RHELC-1301](https://issues.redhat.com/browse/RHELC-1301)
-  [RHELC-1527](https://issues.redhat.com/browse/RHELC-1527)
-  [RHELC-1557](https://issues.redhat.com/browse/RHELC-1557)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-1303]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [x] When merged: Jira issue has been updated to `Release Pending` if relevant
