### PR TITLE
[RHELC-1525] Fix cornercase with userpass and keyorg

### DIFF
--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -353,9 +353,10 @@ class CLI:
         config_opts = copy.copy(tool_opts)
         tool_opts.config_file = parsed_opts.config_file
         # corner case: password on CLI and activation-key in the config file
-        # password from CLI has precedence and activation-key must be deleted (unused)
+        # password from CLI has precedence and activation_key and org must be deleted (unused)
         if config_opts.activation_key and parsed_opts.password:
             tool_opts.activation_key = None
+            tool_opts.org = None
 
         if parsed_opts.no_rpm_va:
             if tool_opts.activity == "analysis":

--- a/convert2rhel/unit_tests/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts_test.py
@@ -694,3 +694,23 @@ def test_cli_userpass_specified(argv, message, monkeypatch, caplog, global_tool_
         # Don't care about the exception, focus on output message
         pass
     assert message in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("activation_key", "organization", "argv"),
+    (
+        ("activation_key", "org", []),
+        ("activation_key", "org", ["analyze", "-u name", "-p pass"]),
+        (None, None, ["analyze", "-u name", "-p pass"]),
+    ),
+)
+def test_cli_args_config_file_cornercase(activation_key, organization, argv, monkeypatch):
+    monkeypatch.setattr(sys, "argv", mock_cli_arguments(argv))
+    t_opts = convert2rhel.toolopts.ToolOpts()
+    t_opts.org = organization
+    t_opts.activation_key = activation_key
+    t_opts.no_rhsm = True
+    monkeypatch.setattr(convert2rhel.toolopts, "tool_opts", t_opts)
+
+    # Make sure it doesn't raise an exception
+    convert2rhel.toolopts.CLI()


### PR DESCRIPTION
If a user provided username and password CLI arguments and had set
activation key and organization in the config file, it would fail to
execute convert2rhel. Same also happens if organization is set and
activation key isn't.

This is addressed by also unsetting organization if we detect username
and password.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1525](https://issues.redhat.com/browse/RHELC-1525)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
