### PR TITLE
[RHELC-1521] Fix check for reposdir in RestorablePackage class

### DIFF
--- a/convert2rhel/backup/packages.py
+++ b/convert2rhel/backup/packages.py
@@ -137,9 +137,10 @@ class RestorablePackage(RestorableChange):
         loggerinst.debug("Using repository files stored in %s." % self.reposdir)
 
         if self.reposdir:
-            # If nothing is inside the directory, or it does not exist, let's
-            # just not use it to download the packages.
-            if len(os.listdir(self.reposdir)) == 0 or not os.path.exists(self.reposdir):
+            # Check if the reposdir exists and if the directory is empty
+            if (os.path.exists(self.reposdir) and len(os.listdir(self.reposdir)) == 0) or not os.path.exists(
+                self.reposdir
+            ):
                 loggerinst.info("The repository directory %s seems to be empty or non-existent.")
                 self.reposdir = None
 


### PR DESCRIPTION
The condition to check for the existence of the reposdir folder was set in an incorrect place. This caused the program to raise an exception as we are trying to list the contents of the directory before checking for the path availability of the folder.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1521](https://issues.redhat.com/browse/RHELC-1521)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
