### PR TITLE
[RHELC-1494, RHELC-1289] Restore disabled repos during conversion in rollback

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/subscription.py
+++ b/convert2rhel/actions/pre_ponr_changes/subscription.py
@@ -20,6 +20,11 @@ import os.path
 
 from convert2rhel import actions, backup, exceptions, pkghandler, repo, subscription, toolopts, utils
 from convert2rhel.backup.certs import RestorablePEMCert
+from convert2rhel.backup.subscription import (
+    RestorableAutoAttachmentSubscription,
+    RestorableDisableRepositories,
+    RestorableSystemSubscription,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -184,7 +189,7 @@ class SubscribeSystem(actions.Action):
                     "The system is registered with an RHSM account that has Simple Content Access (SCA) disabled but no subscription is attached. Without enabled SCA or an attached subscription the system can't access RHEL repositories. We'll try to auto-attach a subscription."
                 )
                 try:
-                    backup.backup_control.push(subscription.RestorableAutoAttachmentSubscription())
+                    backup.backup_control.push(RestorableAutoAttachmentSubscription())
                 except subscription.SubscriptionAutoAttachmentError:
                     self.set_result(
                         level="ERROR",
@@ -202,14 +207,14 @@ class SubscribeSystem(actions.Action):
             # have to disentangle the exception handling when we do that.
             if subscription.should_subscribe():
                 logger.task("Prepare: Subscription Manager - Subscribe system")
-                restorable_subscription = subscription.RestorableSystemSubscription()
+                restorable_subscription = RestorableSystemSubscription()
                 backup.backup_control.push(restorable_subscription)
 
             logger.task("Prepare: Get RHEL repository IDs")
             rhel_repoids = repo.get_rhel_repoids()
 
             logger.task("Prepare: Subscription Manager - Disable all repositories")
-            subscription.disable_repos()
+            backup.backup_control.push(RestorableDisableRepositories(rhel_repos_ignore=rhel_repoids))
 
             # we need to enable repos after removing repofile pkgs, otherwise
             # we don't get backups to restore from on a rollback

--- a/convert2rhel/actions/pre_ponr_changes/subscription.py
+++ b/convert2rhel/actions/pre_ponr_changes/subscription.py
@@ -210,11 +210,11 @@ class SubscribeSystem(actions.Action):
                 restorable_subscription = RestorableSystemSubscription()
                 backup.backup_control.push(restorable_subscription)
 
+            logger.task("Prepare: Subscription Manager - Disable all repositories")
+            backup.backup_control.push(RestorableDisableRepositories())
+
             logger.task("Prepare: Get RHEL repository IDs")
             rhel_repoids = repo.get_rhel_repoids()
-
-            logger.task("Prepare: Subscription Manager - Disable all repositories")
-            backup.backup_control.push(RestorableDisableRepositories(rhel_repos_ignore=rhel_repoids))
 
             # we need to enable repos after removing repofile pkgs, otherwise
             # we don't get backups to restore from on a rollback

--- a/convert2rhel/backup/subscription.py
+++ b/convert2rhel/backup/subscription.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2016 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import logging
+import re
+
+from convert2rhel import subscription, utils
+from convert2rhel.backup import RestorableChange
+
+
+loggerinst = logging.getLogger(__name__)
+
+
+class RestorableSystemSubscription(RestorableChange):
+    """
+    Register with RHSM in a fashion that can be reverted.
+    """
+
+    # We need this __init__ because it is an abstractmethod in the base class
+    def __init__(self):  # pylint: disable=useless-parent-delegation
+        super(RestorableSystemSubscription, self).__init__()
+
+    def enable(self):
+        """Register and attach a specific subscription to OS."""
+        if self.enabled:
+            return
+
+        subscription.register_system()
+        subscription.attach_subscription()
+
+        super(RestorableSystemSubscription, self).enable()
+
+    def restore(self):
+        """Rollback subscription related changes"""
+        loggerinst.task("Rollback: RHSM-related actions")
+
+        if self.enabled:
+            try:
+                subscription.unregister_system()
+            except subscription.UnregisterError as e:
+                loggerinst.warning(str(e))
+            except OSError:
+                loggerinst.warning("subscription-manager not installed, skipping")
+
+        super(RestorableSystemSubscription, self).restore()
+
+
+class RestorableAutoAttachmentSubscription(RestorableChange):
+    """
+    Auto attach subscriptions with RHSM in a fashion that can be reverted.
+    """
+
+    def __init__(self):
+        super(RestorableAutoAttachmentSubscription, self).__init__()
+        self._is_attached = False
+
+    def enable(self):
+        self._is_attached = subscription.auto_attach_subscription()
+        super(RestorableAutoAttachmentSubscription, self).enable()
+
+    def restore(self):
+        if self._is_attached:
+            subscription.remove_subscription()
+            super(RestorableAutoAttachmentSubscription, self).restore()
+
+
+class RestorableDisableRepositories(RestorableChange):
+    """
+    Gather repositories enabled on the system before we disable them and enable
+    them in the rollback.
+    """
+
+    # Look for the `Repo ID` key in the subscription-manager output, if there
+    # is a match, we save it in the named group `repo_id`. This will find all
+    # occurrences of the Repo ID in the output.
+    ENABLED_REPOS_PATTERN = re.compile(r"Repo ID:\s+(?P<repo_id>\S+)")
+
+    def __init__(self, rhel_repos_ignore):
+        super(RestorableDisableRepositories, self).__init__()
+        self._repos_to_enable = []
+        self._rhel_repos_ignore = rhel_repos_ignore or []
+
+    def _get_enabled_repositories(self):
+        """Get repositories that were enabled prior to the conversion.
+
+        :returns list[str]: List of repositories enabled prior the conversion.
+            If no repositories were enabled or match the ignored rhel
+            repositories, defaults to an empty list.
+        """
+        cmd = ["subscription-manager", "repos", "--list-enabled"]
+        output, _ = utils.run_subprocess(cmd, print_output=False)
+
+        repositories = []
+        matches = re.finditer(self.ENABLED_REPOS_PATTERN, output)
+        if matches:
+            repositories = [
+                match.group("repo_id") for match in matches if match.group("repo_id") not in self._rhel_repos_ignore
+            ]
+        return repositories
+
+    def enable(self):
+        repositories = self._get_enabled_repositories()
+
+        if repositories:
+            self._repos_to_enable = repositories
+            loggerinst.debug("Repositories enabled in the system prior to the conversion: %s" % ",".join(repositories))
+
+        subscription.disable_repos()
+        super(RestorableDisableRepositories, self).enable()
+
+    def restore(self):
+        if not self.enabled:
+            return
+
+        loggerinst.task("Rollback: Enabling RHSM repositories")
+
+        if self._repos_to_enable:
+            loggerinst.debug("Repositories to enable: %s" % ",".join(self._repos_to_enable))
+            subscription.submgr_enable_repos(self._repos_to_enable)
+
+        super(RestorableDisableRepositories, self).restore()

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -96,59 +96,6 @@ class SubscriptionAutoAttachmentError(Exception):
     """Raised when there is a failure in auto attaching a subscription via subscription-manager."""
 
 
-class RestorableSystemSubscription(backup.RestorableChange):
-    """
-    Register with RHSM in a fashion that can be reverted.
-    """
-
-    # We need this __init__ because it is an abstractmethod in the base class
-    def __init__(self):  # pylint: disable=useless-parent-delegation
-        super(RestorableSystemSubscription, self).__init__()
-
-    def enable(self):
-        """Register and attach a specific subscription to OS."""
-        if self.enabled:
-            return
-
-        register_system()
-        attach_subscription()
-
-        super(RestorableSystemSubscription, self).enable()
-
-    def restore(self):
-        """Rollback subscription related changes"""
-        loggerinst.task("Rollback: RHSM-related actions")
-
-        if self.enabled:
-            try:
-                unregister_system()
-            except UnregisterError as e:
-                loggerinst.warning(str(e))
-            except OSError:
-                loggerinst.warning("subscription-manager not installed, skipping")
-
-        super(RestorableSystemSubscription, self).restore()
-
-
-class RestorableAutoAttachmentSubscription(backup.RestorableChange):
-    """
-    Auto attach subscriptions with RHSM in a fashion that can be reverted.
-    """
-
-    def __init__(self):
-        super(RestorableAutoAttachmentSubscription, self).__init__()
-        self._is_attached = False
-
-    def enable(self):
-        self._is_attached = auto_attach_subscription()
-        super(RestorableAutoAttachmentSubscription, self).enable()
-
-    def restore(self):
-        if self._is_attached:
-            remove_subscription()
-            super(RestorableAutoAttachmentSubscription, self).restore()
-
-
 def remove_subscription():
     """Remove all subscriptions added from auto attachment"""
     loggerinst.info("Removing auto attached subscriptions.")
@@ -797,18 +744,14 @@ def disable_repos():
     """Before enabling specific repositories, all repositories should be
     disabled. This can be overriden by the --disablerepo option.
     """
-    disable_cmd = ["subscription-manager", "repos"]
-    disable_repos = []
-    for repo in tool_opts.disablerepo:
-        disable_repos.append("--disable=%s" % repo)
+    cmd = ["subscription-manager", "repos"]
+    disable_cmd = []
+    disabled_repos = ["*"] if not tool_opts.disablerepo else tool_opts.disablerepo
+    for repo in disabled_repos:
+        disable_cmd.append("--disable=%s" % repo)
 
-    if not disable_repos:
-        # Default is to disable all repos to make clean environment for
-        # enabling repos later
-        disable_repos.append("--disable=*")
-
-    disable_cmd.extend(disable_repos)
-    output, ret_code = utils.run_subprocess(disable_cmd, print_output=False)
+    cmd.extend(disable_cmd)
+    output, ret_code = utils.run_subprocess(cmd, print_output=False)
     if ret_code != 0:
         loggerinst.critical_no_exit("Could not disable subscription-manager repositories:\n%s" % output)
         raise exceptions.CriticalError(
@@ -853,7 +796,7 @@ def enable_repos(rhel_repoids):
             # Try first if it's possible to enable EUS repoids. Otherwise try
             # enabling the default RHSM repoids. Otherwise, if it raiess an
             # exception, try to enable the default rhsm-repos
-            _submgr_enable_repos(repos_to_enable)
+            submgr_enable_repos(repos_to_enable)
         except SystemExit:
             loggerinst.info(
                 "The RHEL EUS repositories are not possible to enable.\n"
@@ -861,16 +804,16 @@ def enable_repos(rhel_repoids):
             )
             # Fallback to the default_rhsm_repoids
             repos_to_enable = system_info.default_rhsm_repoids
-            _submgr_enable_repos(repos_to_enable)
+            submgr_enable_repos(repos_to_enable)
     else:
         # This could be either the default_rhsm repos or any user specific
         # repoids
-        _submgr_enable_repos(repos_to_enable)
+        submgr_enable_repos(repos_to_enable)
 
     system_info.submgr_enabled_repos = repos_to_enable
 
 
-def _submgr_enable_repos(repos_to_enable):
+def submgr_enable_repos(repos_to_enable):
     """Go through subscription manager repos and try to enable them through subscription-manager."""
     enable_cmd = ["subscription-manager", "repos"]
     for repo in repos_to_enable:

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -745,11 +745,8 @@ def disable_repos():
     disabled. This can be overriden by the --disablerepo option.
     """
     cmd = ["subscription-manager", "repos"]
-    disable_cmd = []
     disabled_repos = ["*"] if not tool_opts.disablerepo else tool_opts.disablerepo
-    for repo in disabled_repos:
-        disable_cmd.append("--disable=%s" % repo)
-
+    disable_cmd = ["".join("--disable=" + repo) for repo in disabled_repos]
     cmd.extend(disable_cmd)
     output, ret_code = utils.run_subprocess(cmd, print_output=False)
     if ret_code != 0:

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -760,8 +760,8 @@ def disable_repos():
             description="As part of the conversion process, convert2rhel disables all current subscription-manager repositories and enables only repositories required for the conversion. convert2rhel was unable to disable these repositories, and the conversion is unable to proceed.",
             diagnosis="Failed to disable repositories: %s." % (output),
         )
+
     loggerinst.info("Repositories disabled.")
-    return
 
 
 def enable_repos(rhel_repoids):

--- a/convert2rhel/unit_tests/backup/subscription_test.py
+++ b/convert2rhel/unit_tests/backup/subscription_test.py
@@ -144,50 +144,6 @@ class TestRestorableAutoAttachmentSubscription:
         auto_attach_subscription.restore()
         assert subscription.remove_subscription.call_count == 0
 
-    @pytest.mark.parametrize(
-        ("return_code", "exception"),
-        (
-            (1, True),
-            (0, False),
-        ),
-    )
-    def test_auto_attach_subscription(self, monkeypatch, return_code, exception):
-        monkeypatch.setattr(
-            utils,
-            "run_subprocess",
-            RunSubprocessMocked(return_code=return_code),
-        )
-        if exception:
-            with pytest.raises(subscription.SubscriptionAutoAttachmentError):
-                subscription.auto_attach_subscription()
-        else:
-            try:
-                subscription.auto_attach_subscription()
-            except subscription.SubscriptionAutoAttachmentError:
-                assert False
-
-    @pytest.mark.parametrize(
-        ("return_code", "exception"),
-        (
-            (1, True),
-            (0, False),
-        ),
-    )
-    def test_remove_subscription(self, monkeypatch, return_code, exception):
-        monkeypatch.setattr(
-            utils,
-            "run_subprocess",
-            RunSubprocessMocked(return_code=return_code),
-        )
-        if exception:
-            with pytest.raises(subscription.SubscriptionRemovalError):
-                subscription.remove_subscription()
-        else:
-            try:
-                subscription.remove_subscription()
-            except subscription.SubscriptionRemovalError:
-                assert False
-
 
 class TestRestorableDisableRepositories:
     @pytest.mark.parametrize(

--- a/convert2rhel/unit_tests/backup/subscription_test.py
+++ b/convert2rhel/unit_tests/backup/subscription_test.py
@@ -1,0 +1,324 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import errno
+
+import pytest
+import six
+
+from convert2rhel.backup.subscription import (
+    RestorableAutoAttachmentSubscription,
+    RestorableDisableRepositories,
+    RestorableSystemSubscription,
+)
+
+
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
+
+from convert2rhel import exceptions, subscription, utils
+from convert2rhel.unit_tests import (
+    AutoAttachSubscriptionMocked,
+    RegisterSystemMocked,
+    RemoveAutoAttachSubscriptionMocked,
+    RunSubprocessMocked,
+    UnregisterSystemMocked,
+)
+
+
+class TestRestorableSystemSubscription:
+    @pytest.fixture
+    def system_subscription(self):
+        return RestorableSystemSubscription()
+
+    def test_subscribe_system(self, system_subscription, global_tool_opts, monkeypatch):
+        monkeypatch.setattr(subscription, "register_system", RegisterSystemMocked())
+        monkeypatch.setattr(utils, "run_subprocess", RunSubprocessMocked())
+        global_tool_opts.username = "user"
+        global_tool_opts.password = "pass"
+
+        system_subscription.enable()
+
+        assert subscription.register_system.call_count == 1
+
+    def test_subscribe_system_already_enabled(self, monkeypatch, system_subscription):
+        monkeypatch.setattr(subscription, "register_system", RegisterSystemMocked())
+        system_subscription.enabled = True
+
+        system_subscription.enable()
+
+        assert not subscription.register_system.called
+
+    def test_enable_fail_once(self, system_subscription, global_tool_opts, caplog, monkeypatch):
+        monkeypatch.setattr(subscription, "register_system", RegisterSystemMocked())
+        monkeypatch.setattr(utils, "run_subprocess", RunSubprocessMocked(return_code=1))
+        global_tool_opts.username = "user"
+        global_tool_opts.password = "pass"
+
+        with pytest.raises(exceptions.CriticalError):
+            system_subscription.enable()
+
+        assert caplog.records[-1].levelname == "CRITICAL"
+
+    def test_restore(self, monkeypatch, system_subscription):
+        monkeypatch.setattr(subscription, "register_system", RegisterSystemMocked())
+        monkeypatch.setattr(subscription, "attach_subscription", mock.Mock(return_value=True))
+
+        monkeypatch.setattr(subscription, "unregister_system", UnregisterSystemMocked())
+        system_subscription.enable()
+
+        system_subscription.restore()
+        assert subscription.unregister_system.call_count == 1
+
+    def test_restore_not_enabled(self, monkeypatch, caplog, system_subscription):
+        monkeypatch.setattr(subscription, "unregister_system", UnregisterSystemMocked())
+
+        system_subscription.restore()
+
+        assert not subscription.unregister_system.called
+
+    def test_restore_unregister_call_fails(self, monkeypatch, caplog, system_subscription):
+        monkeypatch.setattr(subscription, "register_system", RegisterSystemMocked())
+        monkeypatch.setattr(subscription, "attach_subscription", mock.Mock(return_value=True))
+
+        mocked_unregister_system = UnregisterSystemMocked(side_effect=subscription.UnregisterError("Unregister failed"))
+        monkeypatch.setattr(subscription, "unregister_system", mocked_unregister_system)
+
+        system_subscription.enable()
+
+        system_subscription.restore()
+
+        assert mocked_unregister_system.call_count == 1
+        assert "Unregister failed" == caplog.records[-1].message
+
+    def test_restore_subman_uninstalled(self, caplog, monkeypatch, system_subscription):
+        monkeypatch.setattr(subscription, "register_system", RegisterSystemMocked())
+        monkeypatch.setattr(subscription, "attach_subscription", mock.Mock(return_value=True))
+        monkeypatch.setattr(
+            subscription,
+            "unregister_system",
+            UnregisterSystemMocked(side_effect=OSError(errno.ENOENT, "command not found")),
+        )
+        system_subscription.enable()
+
+        system_subscription.restore()
+
+        assert "subscription-manager not installed, skipping" == caplog.messages[-1]
+
+
+class TestRestorableAutoAttachmentSubscription:
+    @pytest.fixture
+    def auto_attach_subscription(self):
+        return RestorableAutoAttachmentSubscription()
+
+    def test_enable_auto_attach(self, auto_attach_subscription, monkeypatch):
+        monkeypatch.setattr(subscription, "auto_attach_subscription", AutoAttachSubscriptionMocked())
+        auto_attach_subscription.enable()
+        assert subscription.auto_attach_subscription.call_count == 1
+
+    def test_restore_auto_attach(self, auto_attach_subscription, monkeypatch):
+        monkeypatch.setattr(subscription, "remove_subscription", RemoveAutoAttachSubscriptionMocked())
+        monkeypatch.setattr(subscription, "auto_attach_subscription", mock.Mock(return_value=True))
+        auto_attach_subscription.enable()
+        auto_attach_subscription.restore()
+        assert subscription.remove_subscription.call_count == 1
+
+    def test_restore_auto_attach_not_enabled(self, auto_attach_subscription, monkeypatch):
+        monkeypatch.setattr(subscription, "remove_subscription", RemoveAutoAttachSubscriptionMocked())
+        auto_attach_subscription.restore()
+        assert subscription.remove_subscription.call_count == 0
+
+    @pytest.mark.parametrize(
+        ("return_code", "exception"),
+        (
+            (1, True),
+            (0, False),
+        ),
+    )
+    def test_auto_attach_subscription(self, monkeypatch, return_code, exception):
+        monkeypatch.setattr(
+            utils,
+            "run_subprocess",
+            RunSubprocessMocked(return_code=return_code),
+        )
+        if exception:
+            with pytest.raises(subscription.SubscriptionAutoAttachmentError):
+                subscription.auto_attach_subscription()
+        else:
+            try:
+                subscription.auto_attach_subscription()
+            except subscription.SubscriptionAutoAttachmentError:
+                assert False
+
+    @pytest.mark.parametrize(
+        ("return_code", "exception"),
+        (
+            (1, True),
+            (0, False),
+        ),
+    )
+    def test_remove_subscription(self, monkeypatch, return_code, exception):
+        monkeypatch.setattr(
+            utils,
+            "run_subprocess",
+            RunSubprocessMocked(return_code=return_code),
+        )
+        if exception:
+            with pytest.raises(subscription.SubscriptionRemovalError):
+                subscription.remove_subscription()
+        else:
+            try:
+                subscription.remove_subscription()
+            except subscription.SubscriptionRemovalError:
+                assert False
+
+
+class TestRestorableDisableRepositories:
+    @pytest.mark.parametrize(
+        (
+            "output",
+            "rhel_repos_ignore",
+            "expected",
+        ),
+        (
+            (
+                """
++----------------------------------------------------------+
+    Available Repositories in /etc/yum.repos.d/redhat.repo
++----------------------------------------------------------+
+Repo ID:   Test_Repository_ID
+Repo Name: Updates x86_64
+Repo URL:  https://test_repository.id
+Enabled:   1
+
+Repo ID:   Satellite_Engineering_CentOS_7_Base_x86_64
+Repo Name: Base x86_64
+Repo URL:  https://Satellite_Engineering_CentOS_7_Base.x86_64
+Enabled:   1
+""",
+                [],
+                ["Test_Repository_ID", "Satellite_Engineering_CentOS_7_Base_x86_64"],
+            ),
+            (
+                """
++----------------------------------------------------------+
+    Available Repositories in /etc/yum.repos.d/redhat.repo
++----------------------------------------------------------+
+Repo ID:   RHEL_Repository
+Repo Name: Updates x86_64
+Repo URL:  https://test_repository.id
+Enabled:   1
+
+Repo ID:   Satellite_Engineering_CentOS_7_Base_x86_64
+Repo Name: Base x86_64
+Repo URL:  https://Satellite_Engineering_CentOS_7_Base.x86_64
+Enabled:   1
+""",
+                ["RHEL_Repository"],
+                ["Satellite_Engineering_CentOS_7_Base_x86_64"],
+            ),
+            (
+                """
++----------------------------------------------------------+
+    Available Repositories in /etc/yum.repos.d/redhat.repo
++----------------------------------------------------------+
+Repo ID:   RHEL_Repository
+Repo Name: Updates x86_64
+Repo URL:  https://test_repository.id
+Enabled:   1
+""",
+                ["RHEL_Repository"],
+                [],
+            ),
+            ("There were no available repositories matching the specified criteria.", [], []),
+        ),
+    )
+    def test_get_enabled_repositories(self, output, rhel_repos_ignore, expected, monkeypatch):
+        monkeypatch.setattr(utils, "run_subprocess", mock.Mock(return_value=(output, 0)))
+        results = RestorableDisableRepositories(rhel_repos_ignore)._get_enabled_repositories()
+        assert results == expected
+        assert utils.run_subprocess.call_count == 1
+
+    @pytest.mark.parametrize(
+        (
+            "enabled_repositories",
+            "log_message",
+        ),
+        (
+            (
+                ["Test_Repo"],
+                "Repositories enabled in the system prior to the conversion: %s",
+            ),
+            (
+                [],
+                None,
+            ),
+        ),
+    )
+    def test_enable(self, enabled_repositories, log_message, monkeypatch, caplog):
+        monkeypatch.setattr(
+            RestorableDisableRepositories, "_get_enabled_repositories", mock.Mock(return_value=enabled_repositories)
+        )
+        monkeypatch.setattr(subscription, "disable_repos", mock.Mock())
+
+        action = RestorableDisableRepositories([])
+        action.enable()
+
+        assert action.enabled
+        assert subscription.disable_repos.call_count == 1
+
+        if log_message:
+            assert action._repos_to_enable == enabled_repositories
+            assert log_message % ",".join(enabled_repositories) in caplog.records[-1].message
+
+    @pytest.mark.parametrize(
+        (
+            "enabled_repositories",
+            "log_message",
+        ),
+        (
+            (
+                ["Test_Repo"],
+                "Repositories to enable: %s",
+            ),
+            (
+                [],
+                None,
+            ),
+        ),
+    )
+    def test_restore(self, enabled_repositories, log_message, monkeypatch, caplog):
+        monkeypatch.setattr(subscription, "submgr_enable_repos", mock.Mock())
+        action = RestorableDisableRepositories([])
+        action.enabled = True
+        action._repos_to_enable = enabled_repositories
+
+        action.restore()
+
+        assert not action.enabled
+        if log_message:
+            assert action._repos_to_enable == enabled_repositories
+            assert subscription.submgr_enable_repos.call_count == 1
+            assert log_message % ",".join(enabled_repositories) in caplog.records[-1].message
+
+    def test_not_enabled_restore(self):
+        action = RestorableDisableRepositories([])
+        action.restore()
+
+        assert not action.enabled

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -17,7 +17,6 @@
 
 __metaclass__ = type
 
-import errno
 import json
 import os
 
@@ -35,7 +34,6 @@ from convert2rhel.systeminfo import Version, system_info
 from convert2rhel.unit_tests import (
     AutoAttachSubscriptionMocked,
     PromptUserMocked,
-    RegisterSystemMocked,
     RemoveAutoAttachSubscriptionMocked,
     RunSubprocessMocked,
     UnregisterSystemMocked,
@@ -222,87 +220,7 @@ class TestNeededSubscriptionManagerPkgs:
         assert pkgs_to_download == frozenset(pkgs)
 
 
-class TestRestorableSystemSubscription:
-    @pytest.fixture
-    def system_subscription(self):
-        return subscription.RestorableSystemSubscription()
-
-    def test_subscribe_system(self, system_subscription, tool_opts, monkeypatch):
-        monkeypatch.setattr(subscription, "register_system", RegisterSystemMocked())
-        monkeypatch.setattr(utils, "run_subprocess", RunSubprocessMocked())
-        monkeypatch.setattr(tool_opts, "username", "user")
-        monkeypatch.setattr(tool_opts, "password", "pass")
-
-        system_subscription.enable()
-
-        assert subscription.register_system.call_count == 1
-
-    def test_subscribe_system_already_enabled(self, monkeypatch, system_subscription):
-        monkeypatch.setattr(subscription, "register_system", RegisterSystemMocked())
-        system_subscription.enabled = True
-
-        system_subscription.enable()
-
-        assert not subscription.register_system.called
-
-    def test_enable_fail_once(self, system_subscription, tool_opts, caplog, monkeypatch):
-        monkeypatch.setattr(subscription, "register_system", RegisterSystemMocked())
-        monkeypatch.setattr(utils, "run_subprocess", RunSubprocessMocked(return_code=1))
-        monkeypatch.setattr(tool_opts, "username", "user")
-        monkeypatch.setattr(tool_opts, "password", "pass")
-
-        with pytest.raises(exceptions.CriticalError):
-            system_subscription.enable()
-
-        assert caplog.records[-1].levelname == "CRITICAL"
-
-    def test_restore(self, monkeypatch, system_subscription):
-        monkeypatch.setattr(subscription, "register_system", RegisterSystemMocked())
-        monkeypatch.setattr(subscription, "attach_subscription", mock.Mock(return_value=True))
-
-        monkeypatch.setattr(subscription, "unregister_system", UnregisterSystemMocked())
-        system_subscription.enable()
-
-        system_subscription.restore()
-        assert subscription.unregister_system.call_count == 1
-
-    def test_restore_not_enabled(self, monkeypatch, caplog, system_subscription):
-        monkeypatch.setattr(subscription, "unregister_system", UnregisterSystemMocked())
-
-        system_subscription.restore()
-
-        assert not subscription.unregister_system.called
-
-    def test_restore_unregister_call_fails(self, monkeypatch, caplog, system_subscription):
-        monkeypatch.setattr(subscription, "register_system", RegisterSystemMocked())
-        monkeypatch.setattr(subscription, "attach_subscription", mock.Mock(return_value=True))
-
-        mocked_unregister_system = UnregisterSystemMocked(side_effect=subscription.UnregisterError("Unregister failed"))
-        monkeypatch.setattr(subscription, "unregister_system", mocked_unregister_system)
-
-        system_subscription.enable()
-
-        system_subscription.restore()
-
-        assert mocked_unregister_system.call_count == 1
-        assert "Unregister failed" == caplog.records[-1].message
-
-    def test_restore_subman_uninstalled(self, caplog, monkeypatch, system_subscription):
-        monkeypatch.setattr(subscription, "register_system", RegisterSystemMocked())
-        monkeypatch.setattr(subscription, "attach_subscription", mock.Mock(return_value=True))
-        monkeypatch.setattr(
-            subscription,
-            "unregister_system",
-            UnregisterSystemMocked(side_effect=OSError(errno.ENOENT, "command not found")),
-        )
-        system_subscription.enable()
-
-        system_subscription.restore()
-
-        assert "subscription-manager not installed, skipping" == caplog.messages[-1]
-
-
-@all_systems
+@centos7
 def test_install_rhel_subsription_manager(pretend_os, monkeypatch):
     mock_backup_control = mock.Mock()
     mock_write_temporary_repofile = mock.Mock(return_value="/test")
@@ -348,74 +266,6 @@ def test_is_subscription_attached(monkeypatch, return_string, expected):
     )
     result = subscription.is_subscription_attached()
     assert expected == result
-
-
-class TestRestorableAutoAttachmentSubscription:
-    @pytest.fixture
-    def auto_attach_subscription(self):
-        return subscription.RestorableAutoAttachmentSubscription()
-
-    def test_enable_auto_attach(self, auto_attach_subscription, monkeypatch):
-        monkeypatch.setattr(subscription, "auto_attach_subscription", AutoAttachSubscriptionMocked())
-        auto_attach_subscription.enable()
-        assert subscription.auto_attach_subscription.call_count == 1
-
-    def test_restore_auto_attach(self, auto_attach_subscription, monkeypatch):
-        monkeypatch.setattr(subscription, "remove_subscription", RemoveAutoAttachSubscriptionMocked())
-        monkeypatch.setattr(subscription, "auto_attach_subscription", mock.Mock(return_value=True))
-        auto_attach_subscription.enable()
-        auto_attach_subscription.restore()
-        assert subscription.remove_subscription.call_count == 1
-
-    def test_restore_auto_attach_not_enabled(self, auto_attach_subscription, monkeypatch):
-        monkeypatch.setattr(subscription, "remove_subscription", RemoveAutoAttachSubscriptionMocked())
-        auto_attach_subscription.restore()
-        assert subscription.remove_subscription.call_count == 0
-
-    @pytest.mark.parametrize(
-        ("return_code", "exception"),
-        (
-            (1, True),
-            (0, False),
-        ),
-    )
-    def test_auto_attach_subscription(self, auto_attach_subscription, monkeypatch, return_code, exception):
-
-        monkeypatch.setattr(
-            utils,
-            "run_subprocess",
-            RunSubprocessMocked(return_code=return_code),
-        )
-        if exception:
-            with pytest.raises(subscription.SubscriptionAutoAttachmentError):
-                subscription.auto_attach_subscription()
-        else:
-            try:
-                subscription.auto_attach_subscription()
-            except subscription.SubscriptionAutoAttachmentError:
-                assert False
-
-    @pytest.mark.parametrize(
-        ("return_code", "exception"),
-        (
-            (1, True),
-            (0, False),
-        ),
-    )
-    def test_remove_subscription(self, monkeypatch, return_code, exception):
-        monkeypatch.setattr(
-            utils,
-            "run_subprocess",
-            RunSubprocessMocked(return_code=return_code),
-        )
-        if exception:
-            with pytest.raises(subscription.SubscriptionRemovalError):
-                subscription.remove_subscription()
-        else:
-            try:
-                subscription.remove_subscription()
-            except subscription.SubscriptionRemovalError:
-                assert False
 
 
 @pytest.mark.usefixtures("tool_opts", scope="function")

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -39,7 +39,7 @@ from convert2rhel.unit_tests import (
     get_pytest_marker,
     run_subprocess_side_effect,
 )
-from convert2rhel.unit_tests.conftest import all_systems, centos7, centos8
+from convert2rhel.unit_tests.conftest import centos7, centos8
 
 
 six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))

--- a/pytest.ini
+++ b/pytest.ini
@@ -116,5 +116,6 @@ markers =
     test_rhsm_els_conversion
     test_els_support
     test_rhsm_non_els_account
+    test_enabled_repositories_after_analysis
 # Unit test related
     noautofixtures: disable all auto-use fixtures

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -806,7 +806,7 @@ def satellite_registration(shell, yum_conf_exclude, request):
     Register the system to the Satellite server
     By default it acquires the curl command from the satellite_curl_command function
     Can be parametrized with requesting a different key from the SAT_REG_FILE(.sat_reg_file):
-    @pytest.mark.parametrized("satellite_registration", ["DIFFERENT_KEY"], indirect=True)
+    @pytest.mark.parametrize("satellite_registration", ["DIFFERENT_KEY"], indirect=True)
     """
     # Get the curl command for the respective system
     # from the conftest function

--- a/tests/integration/tier0/destructive/conversion-method/test_satellite.py
+++ b/tests/integration/tier0/destructive/conversion-method/test_satellite.py
@@ -4,7 +4,7 @@ from conftest import TEST_VARS
 
 
 @pytest.mark.test_satellite_conversion
-def test_satellite_conversion(shell, convert2rhel, satellite_registration):
+def test_satellite_conversion(convert2rhel, satellite_registration):
     """
     Conversion method using the Satellite credentials for registration.
     Use the provided curl command to download the registration script to a file,

--- a/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
@@ -132,7 +132,7 @@ def test_c2r_latest_check_older_version_error(convert2rhel, c2r_version, version
         c2r.sendline("y")
 
         assert (
-            c2r.expect(
+            c2r.expect_exact(
                 "(OVERRIDABLE) CONVERT2RHEL_LATEST_VERSION::OUT_OF_DATE - Outdated convert2rhel version detected",
                 timeout=300,
             )

--- a/tests/integration/tier0/non-destructive/enabled-repositories-after-analysis/main.fmf
+++ b/tests/integration/tier0/non-destructive/enabled-repositories-after-analysis/main.fmf
@@ -1,0 +1,20 @@
+summary: |
+    Verify repositories stay enabled after analysis
+
+tag+:
+    - non-destructive
+    - satellite
+
+/enabled_repositories_after_analysis:
+    description: |
+        This test will perform the following operations:
+            - Collect the enabled repositories prior to the analysis start
+            - Run the analysis and assert that we successfully enabled the RHSM
+            repositories
+            - Collect the enabled repositories after the tool run to compare
+            with the repositories prior to the analysis
+
+    tag+:
+        - test-enabled-repositories-after-analysis
+    test: |
+      pytest -m test_enabled_repositories_after_analysis

--- a/tests/integration/tier0/non-destructive/enabled-repositories-after-analysis/main.fmf
+++ b/tests/integration/tier0/non-destructive/enabled-repositories-after-analysis/main.fmf
@@ -4,7 +4,11 @@ summary: |
 tag+:
     - non-destructive
     - satellite
-
+enabled: false
+adjust+:
+    enabled: true
+    when: distro == centos-7
+    because: currently we have satellite key only for CentOS7
 /enabled_repositories_after_analysis:
     description: |
         This test will perform the following operations:

--- a/tests/integration/tier0/non-destructive/enabled-repositories-after-analysis/test_enabled_repositories_after_analysis.py
+++ b/tests/integration/tier0/non-destructive/enabled-repositories-after-analysis/test_enabled_repositories_after_analysis.py
@@ -1,7 +1,5 @@
 import pytest
 
-from conftest import TEST_VARS
-
 
 def collect_enabled_repositories(shell):
     """
@@ -18,7 +16,7 @@ def collect_enabled_repositories(shell):
             # Get the repo_id as in that split it will be the last thing in the
             # array.
             repo_id = line.split("Repo ID:")[-1]
-            enabled_repositories.append(repo_id)
+            enabled_repositories.append(repo_id.strip())
 
     return enabled_repositories
 
@@ -41,4 +39,7 @@ def test_enabled_repositories_after_analysis(shell, convert2rhel, satellite_regi
 
     enabled_repositories_after_analysis = collect_enabled_repositories(shell)
 
-    assert enabled_repositories_prior_analysis == enabled_repositories_after_analysis
+    # Repositories can be listed in a different order than the one we captured
+    # before the analysis.
+    for repository in enabled_repositories_after_analysis:
+        assert repository in enabled_repositories_prior_analysis

--- a/tests/integration/tier0/non-destructive/enabled-repositories-after-analysis/test_enabled_repositories_after_analysis.py
+++ b/tests/integration/tier0/non-destructive/enabled-repositories-after-analysis/test_enabled_repositories_after_analysis.py
@@ -22,6 +22,7 @@ def collect_enabled_repositories(shell):
 
 
 @pytest.mark.test_enabled_repositories_after_analysis
+@pytest.mark.parametrize("satellite_registration", ["RHEL7_AND_CENTOS7_SAT_REG"], indirect=True)
 def test_enabled_repositories_after_analysis(shell, convert2rhel, satellite_registration):
     """Test analysis systems not connected to the Internet but requiring sub-mgr (e.g. managed by Satellite).
 
@@ -33,7 +34,9 @@ def test_enabled_repositories_after_analysis(shell, convert2rhel, satellite_regi
     enabled_repositories_prior_analysis = collect_enabled_repositories(shell)
 
     with convert2rhel("analyze -y --debug") as c2r:
-        c2r.expect("Rollback: Enabling RHSM repositories")
+        c2r.expect("Enabling RHEL repositories:")
+        c2r.expect("rhel-7-server-rpms")
+        c2r.expect("Rollback: Restoring state of the repositories")
 
     assert c2r.exitstatus == 0
 

--- a/tests/integration/tier0/non-destructive/enabled-repositories-after-analysis/test_enabled_repositories_after_analysis.py
+++ b/tests/integration/tier0/non-destructive/enabled-repositories-after-analysis/test_enabled_repositories_after_analysis.py
@@ -1,6 +1,9 @@
 import pytest
 
 
+RHEL_CERTIFICATE_69_PEM = "/usr/share/convert2rhel/rhel-certs/69.pem"
+
+
 def collect_enabled_repositories(shell):
     """
     Collect the enabled repositories through a subscription-manager call.
@@ -23,7 +26,10 @@ def collect_enabled_repositories(shell):
 
 @pytest.mark.test_enabled_repositories_after_analysis
 @pytest.mark.parametrize("satellite_registration", ["RHEL7_AND_CENTOS7_SAT_REG"], indirect=True)
-def test_enabled_repositories_after_analysis(shell, convert2rhel, satellite_registration):
+@pytest.mark.parametrize("rhel_repo_enabled", [False, True])
+def test_enabled_repositories_after_analysis(
+    shell, convert2rhel, satellite_registration, remove_repositories, rhel_repo_enabled
+):
     """Test analysis systems not connected to the Internet but requiring sub-mgr (e.g. managed by Satellite).
 
     This test will perform the following operations:
@@ -31,6 +37,17 @@ def test_enabled_repositories_after_analysis(shell, convert2rhel, satellite_regi
         - Run the analysis and assert that we successfully enabled the RHSM repositories
         - Collect the enabled repositories after the tool run to compare with the repositories prior to the analysis
     """
+
+    # Enable CentOS repos manually because they are disabled by default in our satellite instance
+    shell("subscription-manager repos --enable='Satellite_Engineering_CentOS_7_Updates_x86_64'")
+    shell("subscription-manager repos --enable='Satellite_Engineering_CentOS_7_Base_x86_64'")
+
+    if rhel_repo_enabled:
+        # To enable RHEL repos we also need to put the 69.pem certificate to the
+        # appropriate location
+        shell(f"cp {RHEL_CERTIFICATE_69_PEM} /etc/pki/product-default/")
+        shell("subscription-manager repos --enable='rhel-7-server-rpms'")
+
     enabled_repositories_prior_analysis = collect_enabled_repositories(shell)
 
     with convert2rhel("analyze -y --debug") as c2r:
@@ -46,3 +63,9 @@ def test_enabled_repositories_after_analysis(shell, convert2rhel, satellite_regi
     # before the analysis.
     for repository in enabled_repositories_after_analysis:
         assert repository in enabled_repositories_prior_analysis
+
+    if rhel_repo_enabled:
+        shell("rm -f /etc/pki/product-default/69.pem")
+
+    # No error reported in the log
+    assert shell("grep ERROR '/var/log/convert2rhel/convert2rhel-pre-conversion.txt'").returncode == 1

--- a/tests/integration/tier0/non-destructive/enabled-repositories-after-analysis/test_enabled_repositories_after_analysis.py
+++ b/tests/integration/tier0/non-destructive/enabled-repositories-after-analysis/test_enabled_repositories_after_analysis.py
@@ -1,0 +1,44 @@
+import pytest
+
+from conftest import TEST_VARS
+
+
+def collect_enabled_repositories(shell):
+    """
+    Collect the enabled repositories through a subscription-manager call.
+
+    This function will return a list of repositories enabled.
+    """
+    raw_output = shell("subscription-manager repos --list-enabled").output
+    assert raw_output
+
+    enabled_repositories = []
+    for line in raw_output.splitlines():
+        if line.startswith("Repo ID:"):
+            # Get the repo_id as in that split it will be the last thing in the
+            # array.
+            repo_id = line.split("Repo ID:")[-1]
+            enabled_repositories.append(repo_id)
+
+    return enabled_repositories
+
+
+@pytest.mark.test_enabled_repositories_after_analysis
+def test_enabled_repositories_after_analysis(shell, convert2rhel, satellite_registration):
+    """Test analysis systems not connected to the Internet but requiring sub-mgr (e.g. managed by Satellite).
+
+    This test will perform the following operations:
+        - Collect the enabled repositories prior to the analysis start
+        - Run the analysis and assert that we successfully enabled the RHSM repositories
+        - Collect the enabled repositories after the tool run to compare with the repositories prior to the analysis
+    """
+    enabled_repositories_prior_analysis = collect_enabled_repositories(shell)
+
+    with convert2rhel("analyze -y --debug") as c2r:
+        c2r.expect("Rollback: Enabling RHSM repositories")
+
+    assert c2r.exitstatus == 0
+
+    enabled_repositories_after_analysis = collect_enabled_repositories(shell)
+
+    assert enabled_repositories_prior_analysis == enabled_repositories_after_analysis


### PR DESCRIPTION
In a satellite analysis/conversion, we are disabling all repositories to not interfere with the rest of the execution.

With this commit, we are introducing a way of checking what repositories are enabled prior to disable them, and back the repositories names up. In the rollback phase, we enable the repositories back on the system to leave everything the way it was.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1494](https://issues.redhat.com/browse/RHELC-1494)
- [RHELC-1289](https://issues.redhat.com/browse/RHELC-1289)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant

-----

# Depends on 

- [x] https://github.com/oamg/convert2rhel/pull/1194
