### PR TITLE
[RHELC-1528] Fix empty error message in Yum transaction failure

### DIFF
--- a/convert2rhel/exceptions.py
+++ b/convert2rhel/exceptions.py
@@ -26,7 +26,7 @@ class CriticalError(Exception):
     Exception with the information to construct the results of an Action.
 
     :meth:`convert2rhel.action.Action.run` needs to set a result which will report whether the
-    Action suceeded or failed and if it failed, then giving various diagnostic messages to help the
+    Action succeeded or failed and if it failed, then giving various diagnostic messages to help the
     user fix the problem. In many places, we are currently using `sys.exit()` from deep inside of the
     callstack of functions which run() calls. Those sites can be ported to use this function instead
     so that enough information is returned to make a good diagnostic message.

--- a/convert2rhel/pkgmanager/handlers/dnf/__init__.py
+++ b/convert2rhel/pkgmanager/handlers/dnf/__init__.py
@@ -231,7 +231,7 @@ class DnfTransactionHandler(TransactionHandlerBase):
                 id_="FAILED_TO_VALIDATE_TRANSACTION",
                 title="Failed to validate dnf transaction.",
                 description="During the dnf transaction execution an error occured and convert2rhel could no longer process the transaction.",
-                diagnosis="Transaction processing failed with error: %s" % (str(e)),
+                diagnosis="Transaction processing failed with error: %s" % str(e),
             )
 
         if validate_transaction:

--- a/convert2rhel/pkgmanager/handlers/dnf/__init__.py
+++ b/convert2rhel/pkgmanager/handlers/dnf/__init__.py
@@ -231,7 +231,7 @@ class DnfTransactionHandler(TransactionHandlerBase):
                 id_="FAILED_TO_VALIDATE_TRANSACTION",
                 title="Failed to validate dnf transaction.",
                 description="During the dnf transaction execution an error occured and convert2rhel could no longer process the transaction.",
-                diagnosis="Transaction processing failed with error %s." % (str(e)),
+                diagnosis="Transaction processing failed with error: %s" % (str(e)),
             )
 
         if validate_transaction:

--- a/convert2rhel/pkgmanager/handlers/yum/__init__.py
+++ b/convert2rhel/pkgmanager/handlers/yum/__init__.py
@@ -323,7 +323,7 @@ class YumTransactionHandler(TransactionHandlerBase):
                 id_="FAILED_TO_VALIDATE_TRANSACTION",
                 title="Failed to validate yum transaction.",
                 description="During the yum transaction execution an error occurred and convert2rhel could no longer process the transaction.",
-                diagnosis="Transaction processing failed with error: %s" % (" ".join(formatted_exec)),
+                diagnosis="Transaction processing failed with error: %s" % " ".join(e.value),
             )
 
         if validate_transaction:

--- a/convert2rhel/pkgmanager/handlers/yum/__init__.py
+++ b/convert2rhel/pkgmanager/handlers/yum/__init__.py
@@ -318,7 +318,6 @@ class YumTransactionHandler(TransactionHandlerBase):
             #  - pkgmanager.Errors.YumGPGCheckError
             loggerinst.debug("Got the following exception message: %s", e)
             loggerinst.critical_no_exit("Failed to validate the yum transaction.")
-            formatted_exec = e.value
             raise exceptions.CriticalError(
                 id_="FAILED_TO_VALIDATE_TRANSACTION",
                 title="Failed to validate yum transaction.",

--- a/convert2rhel/pkgmanager/handlers/yum/__init__.py
+++ b/convert2rhel/pkgmanager/handlers/yum/__init__.py
@@ -318,11 +318,12 @@ class YumTransactionHandler(TransactionHandlerBase):
             #  - pkgmanager.Errors.YumGPGCheckError
             loggerinst.debug("Got the following exception message: %s", e)
             loggerinst.critical_no_exit("Failed to validate the yum transaction.")
+            formatted_exec = e.value
             raise exceptions.CriticalError(
                 id_="FAILED_TO_VALIDATE_TRANSACTION",
                 title="Failed to validate yum transaction.",
                 description="During the yum transaction execution an error occurred and convert2rhel could no longer process the transaction.",
-                diagnosis="Transaction processing failed with error %s." % (" ".join(e)),
+                diagnosis="Transaction processing failed with error: %s" % (" ".join(formatted_exec)),
             )
 
         if validate_transaction:


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
This PR resolves an issue where the error result from the YumBaseError exception would not be displayed in the diagnosis of the Error - FAILED_TO_VALIDATE_TRANSACTION for yum transcations. The issue was that the type of the error was of YumBaseError so when a .join was used on it the output would be blank. This PR extracts the actual value from the YumBaseError class and properly displays it with the Error result. There are also updates to the unit tests for both yum and dnf transcation failures so we assert the proper content is in the Error result

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1528](https://issues.redhat.com/browse/RHELC-1528)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
