### PR TITLE
[RHELC-1540] Fix bug with duplicate packages check when running with Satellite offline

### DIFF
--- a/convert2rhel/actions/system_checks/duplicate_packages.py
+++ b/convert2rhel/actions/system_checks/duplicate_packages.py
@@ -35,6 +35,8 @@ class DuplicatePackages(actions.Action):
         output, ret_code = utils.run_subprocess(["/usr/bin/package-cleanup", "--dupes", "--quiet"], print_output=False)
         if not output:
             return
+        # Catching situation when repositories cannot be accessed.
+        # The output from the package-cleanup is: [Errno -2] Name or service not known
         # For el7 machines we have to depend on this output to know the check failed
         if system_info.version.major == 7 and "name or service not known" in output.lower():
             self.duplicate_packages_failure()

--- a/convert2rhel/actions/system_checks/duplicate_packages.py
+++ b/convert2rhel/actions/system_checks/duplicate_packages.py
@@ -36,7 +36,7 @@ class DuplicatePackages(actions.Action):
         if not output:
             return
         # For el7 machines we have to depend on this output to know the check failed
-        if system_info.version.major == 7 and "[Errno -2] Name or service not known" in output:
+        if system_info.version.major == 7 and "name or service not known" in output.lower():
             self.duplicate_packages_failure()
             return
         # For el8 machines we can depend on just the return code being 1 to know the check failed

--- a/convert2rhel/actions/system_checks/duplicate_packages.py
+++ b/convert2rhel/actions/system_checks/duplicate_packages.py
@@ -18,6 +18,7 @@ __metaclass__ = type
 import logging
 
 from convert2rhel import actions, utils
+from convert2rhel.systeminfo import system_info
 
 
 logger = logging.getLogger(__name__)
@@ -31,10 +32,17 @@ class DuplicatePackages(actions.Action):
         super(DuplicatePackages, self).run()
 
         logger.task("Prepare: Check if there are any duplicate installed packages on the system")
-        output, _ = utils.run_subprocess(["/usr/bin/package-cleanup", "--dupes", "--quiet"], print_output=False)
+        output, ret_code = utils.run_subprocess(["/usr/bin/package-cleanup", "--dupes", "--quiet"], print_output=False)
         if not output:
             return
-
+        # For el7 machines we have to depend on this output to know the check failed
+        if system_info.version.major == 7 and "[Errno -2] Name or service not known" in output:
+            self.duplicate_packages_failure()
+            return
+        # For el8 machines we can depend on just the return code being 1 to know the check failed
+        if system_info.version.major == 8 and ret_code == 1:
+            self.duplicate_packages_failure()
+            return
         duplicate_packages = filter(None, output.split("\n"))
         if duplicate_packages:
             self.set_result(
@@ -47,3 +55,16 @@ class DuplicatePackages(actions.Action):
                 " The command 'package-cleanup' can be used to automatically remove duplicate packages"
                 " on the system.",
             )
+
+    def duplicate_packages_failure(self):
+        """Raise a warning in the event the duplicate packages check cannot be executed."""
+
+        self.add_message(
+            level="WARNING",
+            id="DUPLICATE_PACKAGES_FAILURE",
+            title="Duplicate packages check unsuccessful",
+            description="The duplicate packages check did not run successfully.",
+            diagnosis="The check likely failed due to lack of access to enabled repositories on the system.",
+            remediations="Ensure that you can access all repositories enabled on the system and re-run convert2rhel."
+            " If the issue still persists manually check if there are any package duplicates on the system and remove them to ensure a successful conversion.",
+        )

--- a/convert2rhel/unit_tests/actions/system_checks/duplicate_packages_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/duplicate_packages_test.py
@@ -85,7 +85,7 @@ def test_duplicate_packages_error(
 @pytest.mark.parametrize(
     ("version_string", "output", "ret_code"),
     (
-        (Version(7, 9), "[Errno -2] Name or service not known", 0),
+        (Version(7, 9), "Name or service not known", 0),
         (Version(8, 8), "Failed to download metadata for repo", 1),
     ),
 )
@@ -96,9 +96,6 @@ def test_duplicate_packages_unsuccessful(
     monkeypatch.setattr(system_info, "version", version_string)
     monkeypatch.setattr(systeminfo, "tool_opts", global_tool_opts)
     duplicate_packages_action.run()
-    print("HIiiiiiiiiiiiiiiiiiiiii")
-    print(duplicate_packages_action.messages)
-    print(duplicate_packages_action.result)
 
     expected = set(
         (

--- a/convert2rhel/unit_tests/actions/system_checks/duplicate_packages_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/duplicate_packages_test.py
@@ -81,7 +81,6 @@ def test_duplicate_packages_error(
     )
 
 
-# @all_systems
 @pytest.mark.parametrize(
     ("version_string", "output", "ret_code"),
     (

--- a/convert2rhel/unit_tests/actions/system_checks/duplicate_packages_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/duplicate_packages_test.py
@@ -63,9 +63,7 @@ def test_duplicate_packages_error(
 
     monkeypatch.setattr(utils, "run_subprocess", RunSubprocessMocked(return_value=(output, 0)))
     monkeypatch.setattr(system_info, "version", version_string)
-
     monkeypatch.setattr(systeminfo, "tool_opts", global_tool_opts)
-
     duplicate_packages_action.run()
 
     unit_tests.assert_actions_result(

--- a/convert2rhel/unit_tests/actions/system_checks/duplicate_packages_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/duplicate_packages_test.py
@@ -20,9 +20,11 @@ __metaclass__ = type
 
 import pytest
 
-from convert2rhel import unit_tests, utils
+from convert2rhel import actions, systeminfo, unit_tests, utils
 from convert2rhel.actions.system_checks import duplicate_packages
+from convert2rhel.systeminfo import Version, system_info
 from convert2rhel.unit_tests import RunSubprocessMocked
+from convert2rhel.unit_tests.conftest import all_systems
 
 
 @pytest.fixture
@@ -31,21 +33,39 @@ def duplicate_packages_action():
 
 
 @pytest.mark.parametrize(
-    ("output", "expected"),
+    ("version_string", "output", "expected"),
     (
         (
+            Version(7, 9),
             "package1.x86_64\npackage1.s390x\npackage2.x86_64\npackage2.ppc64le\n",
             ["package1.x86_64", "package1.s390x", "package2.x86_64", "package2.ppc64le"],
         ),
         (
+            Version(7, 9),
+            "package1.x86_64\npackage1.i686\npackage1.s390x\npackage2.x86_64\npackage2.ppc64le\n",
+            ["package1.x86_64", "package1.i686", "package1.s390x", "package2.x86_64", "package2.ppc64le"],
+        ),
+        (
+            Version(8, 8),
+            "package1.x86_64\npackage1.s390x\npackage2.x86_64\npackage2.ppc64le\n",
+            ["package1.x86_64", "package1.s390x", "package2.x86_64", "package2.ppc64le"],
+        ),
+        (
+            Version(8, 8),
             "package1.x86_64\npackage1.i686\npackage1.s390x\npackage2.x86_64\npackage2.ppc64le\n",
             ["package1.x86_64", "package1.i686", "package1.s390x", "package2.x86_64", "package2.ppc64le"],
         ),
     ),
 )
-def test_duplicate_packages_error(monkeypatch, output, expected, duplicate_packages_action):
+def test_duplicate_packages_error(
+    monkeypatch, version_string, output, expected, global_tool_opts, duplicate_packages_action
+):
 
     monkeypatch.setattr(utils, "run_subprocess", RunSubprocessMocked(return_value=(output, 0)))
+    monkeypatch.setattr(system_info, "version", version_string)
+
+    monkeypatch.setattr(systeminfo, "tool_opts", global_tool_opts)
+
     duplicate_packages_action.run()
 
     unit_tests.assert_actions_result(
@@ -59,6 +79,42 @@ def test_duplicate_packages_error(monkeypatch, output, expected, duplicate_packa
         " The command 'package-cleanup' can be used to automatically remove duplicate packages"
         " on the system.",
     )
+
+
+# @all_systems
+@pytest.mark.parametrize(
+    ("version_string", "output", "ret_code"),
+    (
+        (Version(7, 9), "[Errno -2] Name or service not known", 0),
+        (Version(8, 8), "Failed to download metadata for repo", 1),
+    ),
+)
+def test_duplicate_packages_unsuccessful(
+    monkeypatch, version_string, output, global_tool_opts, ret_code, duplicate_packages_action
+):
+    monkeypatch.setattr(utils, "run_subprocess", RunSubprocessMocked(return_value=(output, ret_code)))
+    monkeypatch.setattr(system_info, "version", version_string)
+    monkeypatch.setattr(systeminfo, "tool_opts", global_tool_opts)
+    duplicate_packages_action.run()
+    print("HIiiiiiiiiiiiiiiiiiiiii")
+    print(duplicate_packages_action.messages)
+    print(duplicate_packages_action.result)
+
+    expected = set(
+        (
+            actions.ActionMessage(
+                level="WARNING",
+                id="DUPLICATE_PACKAGES_FAILURE",
+                title="Duplicate packages check unsuccessful",
+                description="The duplicate packages check did not run successfully.",
+                diagnosis="The check likely failed due to lack of access to enabled repositories on the system.",
+                remediations="Ensure that you can access all repositories enabled on the system and re-run convert2rhel."
+                " If the issue still persists manually check if there are any package duplicates on the system and remove them to ensure a successful conversion.",
+            ),
+        )
+    )
+    assert expected.issuperset(duplicate_packages_action.messages)
+    assert expected.issubset(duplicate_packages_action.messages)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds handlers for errors raised when running the DUPLICATE_PACKAGES check with Satellite on an offline system. On EL7 systems for this particular error case the return code is 0 and the output is [Errno -2] Name or service not known. while on EL8 the return code is 1 and the output is Failed to download metadata for repo [example repo]: Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried.
For EL7 we check for that specific output and for EL8 we check the return code. Both cases raise a WARNING DUPLICATE_PACKAGE_CHECK_FAILED and inform the user we couldn't perform the check and recommend they ensure they can access all repos enabled on their system and re-run convert2rhel or check for duplicate packages themselves. This way we don't hinder the conversion for offline systems on satellite while informing them how to remediate the failure. 
<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1540](https://issues.redhat.com/browse/RHELC-1540)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
