### PR TITLE
[RHELC-1521] Always backup redhat.repo

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -92,10 +92,6 @@ class BackupRepository(actions.Action):
                 loggerinst.info("Skipping backup as %s is not a repository file." % repo)
                 continue
 
-            if not subscription.should_subscribe() and repo == "redhat.repo":
-                loggerinst.info("Skipping backup of redhat.repo as it is not needed.")
-                continue
-
             repo_path = os.path.join(DEFAULT_YUM_REPOFILE_DIR, repo)
             restorable_file = RestorableFile(repo_path)
             backup.backup_control.push(restorable_file)

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
@@ -385,17 +385,6 @@ class TestBackupRepository:
         with open(yum_repo, mode="r") as f:
             assert f.read() == os.path.basename(yum_repo)
 
-    def test_backup_repository_redhat(self, monkeypatch, tmpdir, backup_repository_action, caplog):
-        """Test if redhat.repo is not backed up."""
-        redhat_repo = generate_repo(tmpdir, "redhat.repo")
-
-        monkeypatch.setattr(backup_system, "DEFAULT_YUM_REPOFILE_DIR", os.path.dirname(redhat_repo))
-        monkeypatch.setattr(subscription, "should_subscribe", mock.Mock(side_effect=lambda: False))
-        backup_repository = backup_repository_action
-        backup_repository.run()
-
-        assert "Skipping backup of redhat.repo as it is not needed." == caplog.records[-1].message
-
     def test_backup_repository_other_files(self, monkeypatch, tmpdir, backup_repository_action, caplog):
         """Test if redhat.repo is not backed up."""
         non_repo_file = generate_repo(tmpdir, "redhat.nonrepo")


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
After discussion on tech cabal, the exception for not backing up the `redhat.repo` file is not needed anymore, and we can back up this file. 

This fact will help in case of downloading backup of pkg when system is connected to satellite. At that moment, there can be only  `redhat.repo` in reposdir.

- condition checking if the filename is `redhat.repo` was removed
- unit tests testing this were removed 

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1521](https://issues.redhat.com/browse/RHELC-1521)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
