### PR TITLE
[RHELC-1526] Add the libreport-plugin-mantisbt to excluded list

### DIFF
--- a/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
+++ b/convert2rhel/data/7/x86_64/configs/centos-7-x86_64.cfg
@@ -17,6 +17,7 @@ excluded_pkgs =
   rhn*
   yum-rhn-plugin
   gnome-documents-libs
+  libreport-plugin-mantisbt
 
 # Mapping of packages that need to be swapped during the transaction
 swap_pkgs =


### PR DESCRIPTION
The package needs to be excluded because it's not available in RHEL repos and has dependency requirements (requires libreport-web and libreport of specific NEVRA) which cannot be satisfied.

When it's not in this list it is removed from the system without notifying the user in the safety net of the yum transaction. This is better handling of known problematic package.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1526](https://issues.redhat.com/browse/RHELC-1526)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
