### PR TITLE
[RHELC-1543] Update integrations tests for overridable config

### DIFF
--- a/tests/integration/tier0/non-destructive/config-file/main.fmf
+++ b/tests/integration/tier0/non-destructive/config-file/main.fmf
@@ -14,28 +14,28 @@ tier: 0
 tag+:
     - config-file
 
-/config_custom_path_custom_filename:
+/config_std_path_std_filename:
+    summary+: |
+        Config with standard name at standard path
+    description+: |
+        Verify that the standard path to the config file is accepted,
+        with the config file having standard filename.
+    tag+:
+        - config-std-path-std-filename
+    test: |
+        pytest -m test_std_path_std_filename
+
+/config_user_path_custom_filename:
     summary+: |
         Config with custom name at custom path
     description+: |
         Verify that both custom path and custom filename are accepted.
-        The config file is created at a custom path with a custom filename
-        and the path is passed to the utility command.
+        The config file is created at a custom path with a custom
+        filename and the path is passed to the utility command.
     tag+:
-        - config-custom-path-custom-filename
+        - config-user-path-custom-filename
     test: |
-        pytest -m test_config_custom_path_custom_filename
-
-/config_custom_path_standard_filename:
-    summary+: |
-        Confing with standard name at custom path
-    description+: |
-        Verify that the custom path to the config file is accepted,
-        with the config file having standard filename.
-    tag+:
-        - config-custom-path-standard-filename
-    test: |
-        pytest -m test_config_custom_path_standard_filename
+        pytest -m test_user_path_custom_filename
 
 /config_cli_priority:
     summary+: |

--- a/tests/integration/tier0/non-destructive/config-file/test_config_file.py
+++ b/tests/integration/tier0/non-destructive/config-file/test_config_file.py
@@ -2,6 +2,8 @@ import os
 
 from collections import namedtuple
 
+from conftest import TEST_VARS
+
 
 Config = namedtuple("Config", "path content")
 
@@ -19,20 +21,25 @@ def remove_files(config):
         os.remove(os.path.expanduser(cfg.path))
 
 
-def test_config_custom_path_custom_filename(convert2rhel):
-    config = [Config("~/.convert2rhel_custom.ini", "[subscription_manager]\nactivation_key = config_activationkey")]
-    create_files(config)
-
-    with convert2rhel('--debug -c "~/.convert2rhel_custom.ini"') as c2r:
-        c2r.expect("DEBUG - Found activation_key in /root/.convert2rhel_custom.ini")
-
-    assert c2r.exitstatus == 1
-
-    remove_files(config)
-
-
-def test_config_custom_path_standard_filename(convert2rhel):
-    config = [Config("~/.convert2rhel.ini", "[subscription_manager]\npassword = config_password")]
+def test_std_path_std_filename(convert2rhel):
+    """
+    Verify that the standard path to the config file is accepted,
+    with the config file having standard filename.
+    """
+    config = [
+        Config(
+            "~/.convert2rhel.ini",
+            # We disable the Black pre-commit hook because it changes formatting
+            # of the following configuration files, which makes them hard to read.
+            # https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#ignoring-sections
+            # fmt: off
+            (
+                "[subscription_manager]\n"
+                "password = config_password\n"
+            ),
+            # fmt: on
+        )
+    ]
     create_files(config)
 
     with convert2rhel("--debug") as c2r:
@@ -45,16 +52,55 @@ def test_config_custom_path_standard_filename(convert2rhel):
     remove_files(config)
 
 
-def test_config_cli_priority(convert2rhel):
+def test_user_path_custom_filename(convert2rhel):
+    """
+    Verify that both custom path and custom filename are accepted.
+    The config file is created at a custom path with a custom
+    filename and the path is passed to the utility command.
+    """
     config = [
         Config(
-            "~/.convert2rhel.ini",
-            "[subscription_manager]\nusername = config_username\npassword = config_password\nactivation_key = config_key\norg = config_org",
+            "~/.convert2rhel_custom.ini",
+            # fmt: off
+            (
+                "[subscription_manager]\n"
+                "activation_key = config_activationkey\n"
+            ),
+            # fmt: on
         )
     ]
     create_files(config)
 
-    with convert2rhel("--password password --debug") as c2r:
+    with convert2rhel('--debug -c "~/.convert2rhel_custom.ini"') as c2r:
+        c2r.expect("DEBUG - Found activation_key in /root/.convert2rhel_custom.ini")
+
+    assert c2r.exitstatus == 1
+
+    remove_files(config)
+
+
+def test_config_cli_priority(convert2rhel):
+    """
+    Verify that the values provided to the CLI command are preferred
+    to those provided in the config file.
+    """
+    config = [
+        Config(
+            "~/.convert2rhel.ini",
+            # fmt: off
+            (
+                "[subscription_manager]\n"
+                "username = config_username\n"
+                "password = config_password\n"
+                "activation_key = config_key\n"
+                "org = config_org\n"
+            ),
+            # fmt: on
+        )
+    ]
+    create_files(config)
+
+    with convert2rhel("--username username --password password --debug") as c2r:
         # Found options in config file
         c2r.expect("DEBUG - Found username in /root/.convert2rhel.ini", timeout=120)
         c2r.expect("DEBUG - Found password in /root/.convert2rhel.ini", timeout=120)
@@ -73,14 +119,39 @@ def test_config_cli_priority(convert2rhel):
     remove_files(config)
 
 
-def test_config_standard_paths_priority_diff_methods(convert2rhel):
+def test_config_standard_paths_priority_diff_methods(convert2rhel, shell):
+    """
+    Verify that with multiple config files each providing different method
+    (password and activation key) the activation key is preferred.
+    """
     config = [
-        Config("~/.convert2rhel.ini", "[subscription_manager]\npassword = config_password"),
-        Config("/etc/convert2rhel.ini", "[subscription_manager]\nactivation_key = config2_activationkey"),
+        Config(
+            "~/.convert2rhel.ini",
+            # fmt: off
+            (
+                "[subscription_manager]\n"
+                "password   = config_password\n"
+                "username   = config_username\n"
+            ),
+            # fmt: on
+        ),
+        Config(
+            "/etc/convert2rhel.ini",
+            # fmt: off
+            (
+                "[subscription_manager]\n"
+                f"activation_key    = {TEST_VARS['RHSM_KEY']}\n"
+                f"org               = {TEST_VARS['RHSM_ORG']}\n"
+            ),
+            # fmt: on
+        ),
     ]
     create_files(config)
 
-    with convert2rhel("--debug") as c2r:
+    # shell("cat ~/.convert2rhel.ini")
+    shell("cat /etc/convert2rhel.ini")
+
+    with convert2rhel(f"analyze --serverurl {TEST_VARS['RHSM_SERVER_URL']} -y --debug") as c2r:
         c2r.expect("DEBUG - Found password in /root/.convert2rhel.ini")
         c2r.expect("DEBUG - Found activation_key in /etc/convert2rhel.ini")
         c2r.expect(
@@ -93,24 +164,47 @@ def test_config_standard_paths_priority_diff_methods(convert2rhel):
             "WARNING - Either a password or an activation key can be used for system registration."
             " We're going to use the activation key."
         )
+        c2r.expect("SUBSCRIBE_SYSTEM has succeeded")
 
-    assert c2r.exitstatus == 1
+    assert c2r.exitstatus == 0
 
     remove_files(config)
 
 
 def test_config_standard_paths_priority(convert2rhel):
+    """
+    Verify priorities of standard config file paths.
+    Config file located in the home folder to be preferred.
+    """
     config = [
-        Config("~/.convert2rhel.ini", "[subscription_manager]\npassword = config_password"),
-        Config("/etc/convert2rhel.ini", "[subscription_manager]\npassword = config_password"),
+        Config(
+            "~/.convert2rhel.ini",
+            # fmt: off
+            (
+                "[subscription_manager]\n"
+                f"username = {TEST_VARS['RHSM_USERNAME']}\n"
+                f"password = {TEST_VARS['RHSM_PASSWORD']}\n"
+            ),
+            # fmt: on
+        ),
+        Config(
+            "/etc/convert2rhel.ini",
+            # fmt: off
+            (
+                "[subscription_manager]\n"
+                "username = config_username\n"
+                "password = config_password\n"
+            ),
+            # fmt: on
+        ),
     ]
     create_files(config)
 
-    with convert2rhel("--debug") as c2r:
+    with convert2rhel(f"analyze --serverurl {TEST_VARS['RHSM_SERVER_URL']} -y --debug") as c2r:
+        c2r.expect("DEBUG - Found username in /root/.convert2rhel.ini")
         c2r.expect("DEBUG - Found password in /root/.convert2rhel.ini")
-        c2r.expect("Continue with the system conversion?")
-        c2r.sendline("n")
+        c2r.expect("SUBSCRIBE_SYSTEM has succeeded")
 
-    assert c2r.exitstatus == 1
+    assert c2r.exitstatus == 0
 
     remove_files(config)


### PR DESCRIPTION
Updating the user_path_cli_priority int tests to test for the changes done in #1208.

The test had a small refactor to make it easier to read assert for multiple strings at once. Also removed the interrupt at the beginning to let the tool to process the changes.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1543](https://issues.redhat.com/browse/RHELC-1543)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
