### PR TITLE
Check if rollback failed when handling InhibitorFound exception

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -209,7 +209,8 @@ def main_locked():
     except _InhibitorsFound as err:
         loggerinst.critical_no_exit(str(err))
         _handle_main_exceptions(process_phase, pre_conversion_results)
-        return ConversionExitCodes.INHIBITORS_FOUND
+
+        return _handle_inhibitors_found_exception()
     except exceptions.CriticalError as err:
         loggerinst.critical_no_exit(err.diagnosis)
         results = _pick_conversion_results(process_phase, pre_conversion_results, post_conversion_results)
@@ -307,6 +308,14 @@ def _handle_main_exceptions(process_phase, results=None):
         )
 
     return ConversionExitCodes.FAILURE
+
+
+def _handle_inhibitors_found_exception():
+    """Handle return code when handling InhibitorFound exception."""
+    if backup.backup_control.rollback_failed:
+        return ConversionExitCodes.FAILURE
+
+    return ConversionExitCodes.INHIBITORS_FOUND
 
 
 #

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -801,3 +801,12 @@ def test_main_already_running_conversion(monkeypatch, caplog, tmpdir):
     assert main.main() == 1
     assert "Another copy of convert2rhel is running.\n" in caplog.records[-2].message
     assert "\nNo changes were made to the system.\n" in caplog.records[-1].message
+
+
+@pytest.mark.parametrize(("rollback_failures", "return_code"), ((["test-fail"], 1), ([], 2)))
+def test_handle_inhibitors_found_exception(monkeypatch, rollback_failures, return_code, global_backup_control):
+    monkeypatch.setattr(global_backup_control, "_rollback_failures", rollback_failures)
+
+    ret = main._handle_inhibitors_found_exception()
+
+    assert ret == return_code


### PR DESCRIPTION
When InhibitorFound exception is raised, check if rollback was successful is needed. This will affect the result return code: 
- 1 - rollback fail
- 2 - inhibitor

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
