### PR TITLE
[RHELC-1551 Fix report duplication after analysis

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -200,11 +200,6 @@ def main_locked():
         if backup.backup_control.rollback_failed:
             return ConversionExitCodes.FAILURE
 
-        report.pre_conversion_report(
-            results=pre_conversion_results,
-            include_all_reports=True,
-            disable_colors=logger_module.should_disable_color_output(),
-        )
         return ConversionExitCodes.SUCCESSFUL
     except _InhibitorsFound as err:
         loggerinst.critical_no_exit(str(err))

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -571,7 +571,7 @@ class TestRollbackFromMain:
         assert pkghandler.clear_versionlock.call_count == 1
         assert pkgmanager.clean_yum_metadata.call_count == 1
         assert actions.run_pre_actions.call_count == 1
-        assert report._summary.call_count == 2
+        assert report._summary.call_count == 1
         assert breadcrumbs.finish_collection.call_count == 1
         assert subscription.should_subscribe.call_count == 1
         assert subscription.update_rhsm_custom_facts.call_count == 0
@@ -633,7 +633,7 @@ class TestRollbackFromMain:
         assert collect_early_data_mock.call_count == 1
         assert clean_yum_metadata_mock.call_count == 1
         assert run_pre_actions_mock.call_count == 1
-        assert report_summary_mock.call_count == 2
+        assert report_summary_mock.call_count == 1
         assert clear_versionlock_mock.call_count == 1
         assert finish_collection_mock.call_count == 1
         assert should_subscribe_mock.call_count == 1


### PR DESCRIPTION
The report was being printed to the user twice after the analysis was done. This commit patches this by removing the second call to the report as it is not necessary.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1551](https://issues.redhat.com/browse/RHELC-1551)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
