### PR TITLE
[RHELC-1547] Fix regression in installing removed packages during rollback

### DIFF
--- a/convert2rhel/pkgmanager/handlers/yum/__init__.py
+++ b/convert2rhel/pkgmanager/handlers/yum/__init__.py
@@ -67,7 +67,7 @@ def _resolve_yum_problematic_dependencies(output):
             packages_to_remove.append(str(resolve_error[0]).replace(" ", ""))
 
     if packages_to_remove:
-        packages_to_remove = set(packages_to_remove)
+        packages_to_remove = list(set(packages_to_remove))
         loggerinst.debug(
             "Removing problematic packages to continue with the conversion:\n%s",
             "\n".join(packages_to_remove),

--- a/convert2rhel/pkgmanager/handlers/yum/__init__.py
+++ b/convert2rhel/pkgmanager/handlers/yum/__init__.py
@@ -67,6 +67,7 @@ def _resolve_yum_problematic_dependencies(output):
             packages_to_remove.append(str(resolve_error[0]).replace(" ", ""))
 
     if packages_to_remove:
+        # Need to make each item in the list unique, one pkg can be present more times in the list.
         packages_to_remove = list(set(packages_to_remove))
         loggerinst.debug(
             "Removing problematic packages to continue with the conversion:\n%s",

--- a/convert2rhel/unit_tests/pkgmanager/handlers/yum/yum_test.py
+++ b/convert2rhel/unit_tests/pkgmanager/handlers/yum/yum_test.py
@@ -393,15 +393,17 @@ class TestYumTransactionHandler:
                 "python2-dnf-4.0.9.2-2.el7_9.noarch requires python2-hawkey >= 0.22.5",
                 "abrt-retrace-client-2.1.11-60.el7.centos.x86_64 requires abrt = 2.1.11-60.el7.centos",
             ],
-            frozenset(
-                (
-                    "redhat-lsb-trialuse-4.1-27.el7.centos.1.x86_64",
-                    "python2-dnf-plugins-core-4.0.2.2-3.el7_6.noarch",
-                    "redhat-lsb-trialuse-4.1-27.el7.centos.1.x86_64",
-                    "ldb-tools-1.5.4-2.el7.x86_64",
-                    "redhat-lsb-trialuse-4.1-27.el7.centos.1.x86_64",
-                    "python2-dnf-4.0.9.2-2.el7_9.noarch",
-                    "abrt-retrace-client-2.1.11-60.el7.centos.x86_64",
+            list(
+                set(
+                    [
+                        "redhat-lsb-trialuse-4.1-27.el7.centos.1.x86_64",
+                        "python2-dnf-plugins-core-4.0.2.2-3.el7_6.noarch",
+                        "redhat-lsb-trialuse-4.1-27.el7.centos.1.x86_64",
+                        "ldb-tools-1.5.4-2.el7.x86_64",
+                        "redhat-lsb-trialuse-4.1-27.el7.centos.1.x86_64",
+                        "python2-dnf-4.0.9.2-2.el7_9.noarch",
+                        "abrt-retrace-client-2.1.11-60.el7.centos.x86_64",
+                    ]
                 )
             ),
         ),
@@ -414,18 +416,20 @@ class TestYumTransactionHandler:
                 "python2-dnf-plugins-core-4.0.2.2-3.el7_6.noarch requires python2-hawkey >= 0.7.0",
                 "abrt-retrace-client-2.1.11-60.el7.centos.x86_64 requires abrt = 2.1.11-60.el7.centos",
             ],
-            frozenset(
-                (
-                    "redhat-lsb-trialuse-4.1-27.el7.centos.1.x86_64",
-                    "python2-dnf-plugins-core-4.0.2.2-3.el7_6.noarch",
-                    "abrt-retrace-client-2.1.11-60.el7.centos.x86_64",
+            list(
+                set(
+                    [
+                        "redhat-lsb-trialuse-4.1-27.el7.centos.1.x86_64",
+                        "python2-dnf-plugins-core-4.0.2.2-3.el7_6.noarch",
+                        "abrt-retrace-client-2.1.11-60.el7.centos.x86_64",
+                    ]
                 )
             ),
         ),
         # Random string - This might not happen that frequently.
         (
             ["testing the test random string"],
-            frozenset(()),
+            [],
         ),
     ),
 )


### PR DESCRIPTION
We were passing a set object to iterate over to compose a message of packages that got removed during yum transaction. This problem was not happening before as we were dealing with a success case of restoring packages. In this regression, we found out that a set object does not have indexing, therefore, thus bug was hidden from most of our tests and pipeline.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1547](https://issues.redhat.com/browse/RHELC-1547)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
