### PR TITLE
[RHELC-1554] Fix ELS repositories not fallback in case of error

### DIFF
--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -800,19 +800,19 @@ def enable_repos(rhel_repoids):
     else:
         repos_to_enable = rhel_repoids
 
-    if repos_to_enable == system_info.eus_rhsm_repoids:
+    if repos_to_enable in (system_info.eus_rhsm_repoids, system_info.els_rhsm_repoids):
         try:
             loggerinst.info(
-                "The system version corresponds to a RHEL Extended Update Support (EUS) release. "
-                "Trying to enable RHEL EUS repositories."
+                "The system version corresponds to a RHEL Extended Update Support (EUS) release or RHEL Lifecycle Support (ELS)."
             )
+            loggerinst.info("Trying to enable the repositories:\n%s" % "\n".join(repos_to_enable))
             # Try first if it's possible to enable EUS repoids. Otherwise try
             # enabling the default RHSM repoids. Otherwise, if it raiess an
             # exception, try to enable the default rhsm-repos
             _submgr_enable_repos(repos_to_enable)
         except SystemExit:
             loggerinst.info(
-                "The RHEL EUS repositories are not possible to enable.\n"
+                "The RHEL repositories are not possible to enable.\n"
                 "Trying to enable standard RHEL repositories as a fallback."
             )
             # Fallback to the default_rhsm_repoids


### PR DESCRIPTION
We want to try to enable the ELS repos, and if case that fails, we want to make sure we enable the default rhel repoids.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1554](https://issues.redhat.com/browse/RHELC-1554)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
