### PR TITLE
[RHELC-1291, RHELC-1292] Skip versionlock file in backup system actions

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -22,6 +22,7 @@ import re
 from convert2rhel import actions, backup, exceptions, subscription
 from convert2rhel.backup.files import MissingFile, RestorableFile
 from convert2rhel.logger import LOG_DIR
+from convert2rhel.pkghandler import _VERSIONLOCK_FILE_PATH
 from convert2rhel.redhatrelease import os_release_file, system_release_file
 from convert2rhel.repo import DEFAULT_DNF_VARS_DIR, DEFAULT_YUM_REPOFILE_DIR, DEFAULT_YUM_VARS_DIR
 from convert2rhel.systeminfo import system_info
@@ -148,7 +149,7 @@ class BackupPackageFiles(actions.Action):
         package_files_changes = self._get_changed_package_files()
 
         # Paths and files already backed up
-        backed_up_files = [system_release_file.filepath, os_release_file.filepath]
+        backed_up_files = [system_release_file.filepath, os_release_file.filepath, _VERSIONLOCK_FILE_PATH]
         backed_up_paths = ["/etc/yum.repos.d", "/etc/yum/vars", "/etc/dnf/vars"]
 
         for file in package_files_changes:

--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -22,7 +22,7 @@ import re
 from convert2rhel import actions, backup, exceptions, subscription
 from convert2rhel.backup.files import MissingFile, RestorableFile
 from convert2rhel.logger import LOG_DIR
-from convert2rhel.pkghandler import _VERSIONLOCK_FILE_PATH
+from convert2rhel.pkghandler import VERSIONLOCK_FILE_PATH
 from convert2rhel.redhatrelease import os_release_file, system_release_file
 from convert2rhel.repo import DEFAULT_DNF_VARS_DIR, DEFAULT_YUM_REPOFILE_DIR, DEFAULT_YUM_VARS_DIR
 from convert2rhel.systeminfo import system_info
@@ -149,7 +149,7 @@ class BackupPackageFiles(actions.Action):
         package_files_changes = self._get_changed_package_files()
 
         # Paths and files already backed up
-        backed_up_files = [system_release_file.filepath, os_release_file.filepath, _VERSIONLOCK_FILE_PATH]
+        backed_up_files = [system_release_file.filepath, os_release_file.filepath, VERSIONLOCK_FILE_PATH]
         backed_up_paths = ["/etc/yum.repos.d", "/etc/yum/vars", "/etc/dnf/vars"]
 
         for file in package_files_changes:

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -40,7 +40,7 @@ loggerinst = logging.getLogger(__name__)
 # an error.
 MAX_YUM_CMD_CALLS = 3
 
-_VERSIONLOCK_FILE_PATH = "/etc/yum/pluginconf.d/versionlock.list"  # This file is used by the dnf plugin as well
+VERSIONLOCK_FILE_PATH = "/etc/yum/pluginconf.d/versionlock.list"  # This file is used by the dnf plugin as well
 
 #
 # Regular expressions used to find package names in yum output
@@ -864,12 +864,12 @@ def clear_versionlock():
     YUM works correctly even with DNF thanks to symlinks created by DNF.
     """
 
-    if os.path.isfile(_VERSIONLOCK_FILE_PATH) and os.path.getsize(_VERSIONLOCK_FILE_PATH) > 0:
+    if os.path.isfile(VERSIONLOCK_FILE_PATH) and os.path.getsize(VERSIONLOCK_FILE_PATH) > 0:
         loggerinst.warning("YUM/DNF versionlock plugin is in use. It may cause the conversion to fail.")
         loggerinst.info("Upon continuing, we will clear all package version locks.")
         utils.ask_to_continue()
 
-        backup.backup_control.push(RestorableFile(_VERSIONLOCK_FILE_PATH))
+        backup.backup_control.push(RestorableFile(VERSIONLOCK_FILE_PATH))
 
         loggerinst.info("Clearing package versions locks...")
         pkgmanager.call_yum_cmd("versionlock", args=["clear"], print_output=False)

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
@@ -251,6 +251,10 @@ class TestBackupSystem:
         (
             ("S.5.?..T.     c   /etc/os-release", "File {filepath} already backed up - not backing up again"),
             ("S.5.?..T.     c   /etc/yum/vars/filename_4", "File {filepath} already backed up - not backing up again"),
+            (
+                "S.5....T.     c   /etc/yum/pluginconf.d/versionlock.list",
+                "File {filepath} already backed up - not backing up again",
+            ),
         ),
     )
     def test_backup_package_file_run(

--- a/tests/integration/tier1/destructive/system-not-up-to-date/test_system_not_up_to_date.py
+++ b/tests/integration/tier1/destructive/system-not-up-to-date/test_system_not_up_to_date.py
@@ -63,7 +63,7 @@ def test_system_not_updated(shell, convert2rhel, downgrade_and_versionlock):
         c2r.expect("WARNING - YUM/DNF versionlock plugin is in use. It may cause the conversion to fail.")
         c2r.expect(r"WARNING - The system has \d+ package\(s\) not updated")
         c2r.expect_exact("ERROR - (OVERRIDABLE) PACKAGE_UPDATES::OUT_OF_DATE_PACKAGES - Outdated packages detected")
-    assert c2r.exitstatus != 0
+    assert c2r.exitstatus == 2
 
     # We need to set envar to override the out of date packages check
     # to perform the full conversion
@@ -78,8 +78,7 @@ def test_system_not_updated(shell, convert2rhel, downgrade_and_versionlock):
             TEST_VARS["RHSM_POOL"],
         )
     ) as c2r:
-        # TODO(danmyway) Uncomment when the https://issues.redhat.com/browse/RHELC-1291 gets fixed
-        # c2r.expect("WARNING - YUM/DNF versionlock plugin is in use. It may cause the conversion to fail.")
+        c2r.expect("WARNING - YUM/DNF versionlock plugin is in use. It may cause the conversion to fail.")
         c2r.expect_exact("Detected 'CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP' environment variable")
         c2r.expect(r"WARNING - The system has \d+ package\(s\) not updated")
     assert c2r.exitstatus == 0


### PR DESCRIPTION
Versionlock file has been backed up and cleared before we run the backup action via a prepare_system() call in main.py, thus we should exclude it, so that we do not overwrite it with empty data.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1291](https://issues.redhat.com/browse/RHELC-1291)
- [RHELC-1292](https://issues.redhat.com/browse/RHELC-1292)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
