### PR TITLE
[RHELC-1556] Raise when RestorablePackage fails to restore

### DIFF
--- a/convert2rhel/backup/packages.py
+++ b/convert2rhel/backup/packages.py
@@ -177,9 +177,17 @@ class RestorablePackage(RestorableChange):
         loggerinst.task("Rollback: Install removed packages")
         if not self._backedup_pkgs_paths:
             loggerinst.warning("Couldn't find a backup for %s package." % ",".join(self.pkgs))
-            return
+            raise exceptions.CriticalError(
+                id_="FAILED_TO_INSTALL_PACKAGES",
+                title="Couldn't find package backup",
+                description=(
+                    "While attempting to roll back changes, we encountered "
+                    "an unexpected failure while we cannot find a package backup."
+                ),
+                diagnosis="Couldn't find a backup for %s package." % utils.format_sequence_as_message(self.pkgs),
+            )
 
-        self._install_local_rpms(replace=True, critical=False)
+        self._install_local_rpms(replace=True, critical=True)
 
         super(RestorablePackage, self).restore()
 

--- a/convert2rhel/unit_tests/backup/packages_test.py
+++ b/convert2rhel/unit_tests/backup/packages_test.py
@@ -151,7 +151,11 @@ class TestRestorablePackage:
 
         rp = RestorablePackage(pkgs=["test.rpm"])
         rp.enabled = True
-        rp.restore()
+
+        with pytest.raises(exceptions.CriticalError) as err:
+            rp.restore()
+
+        assert err.value.diagnosis == "Couldn't find a backup for test.rpm package."
         assert utils.remove_orphan_folders.call_count == 1
         assert "Couldn't find a backup for test.rpm package." in caplog.records[-1].message
 


### PR DESCRIPTION
Raise exception when RestorablePackage cannot access the backup folder or the installation of the backed up packages fails.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of-->
- [RHELC-1556](https://issues.redhat.com/browse/RHELC-1556)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
