### PR TITLE
[RHELC-1561] Change result of the c2r version check to OVERRIDABLE

### DIFF
--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -228,7 +228,7 @@ class Convert2rhelLatest(actions.Action):
 
                 else:
                     self.set_result(
-                        level="ERROR",
+                        level="OVERRIDABLE",
                         id="OUT_OF_DATE",
                         title="Outdated convert2rhel version detected",
                         description="An outdated convert2rhel version has been detected",

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -139,7 +139,7 @@ class TestCheckConvert2rhelLatest:
 
         unit_tests.assert_actions_result(
             convert2rhel_latest_action,
-            level="ERROR",
+            level="OVERRIDABLE",
             id="OUT_OF_DATE",
             title="Outdated convert2rhel version detected",
             description="An outdated convert2rhel version has been detected",
@@ -557,7 +557,7 @@ class TestCheckConvert2rhelLatest:
 
         unit_tests.assert_actions_result(
             convert2rhel_latest_action,
-            level="ERROR",
+            level="OVERRIDABLE",
             id="OUT_OF_DATE",
             title="Outdated convert2rhel version detected",
             description="An outdated convert2rhel version has been detected",
@@ -742,7 +742,7 @@ class TestCheckConvert2rhelLatest:
 
         unit_tests.assert_actions_result(
             convert2rhel_latest_action,
-            level="ERROR",
+            level="OVERRIDABLE",
             id="OUT_OF_DATE",
             title="Outdated convert2rhel version detected",
             description="An outdated convert2rhel version has been detected",

--- a/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
@@ -133,7 +133,7 @@ def test_c2r_latest_check_older_version_error(convert2rhel, c2r_version, version
 
         assert (
             c2r.expect(
-                "CONVERT2RHEL_LATEST_VERSION::OUT_OF_DATE - Outdated convert2rhel version detected",
+                "(OVERRIDABLE) CONVERT2RHEL_LATEST_VERSION::OUT_OF_DATE - Outdated convert2rhel version detected",
                 timeout=300,
             )
             == 0


### PR DESCRIPTION
When a newer convert2rhel version was detected, the check result was set to ERROR however we allow overriding the check by setting the CONVERT2RHEL_ALLOW_OLDER_VERSION=1 enironment variable meaning that the result is supposed to be OVERRIDABLE.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1561](https://issues.redhat.com/browse/RHELC-RHELC-1561)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
