### PR TITLE
[RHELC-1289] Add a one key conversion method

### DIFF
--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -37,6 +37,17 @@ description+: |
                     test+<:
                         - conversion-method/satellite_conversion
 
+            /one_key_satellite_conversion:
+              enabled: false
+              adjust+:
+                - enabled: true
+                  when: >
+                    distro == centos-7
+                  because: So far we have only one key set up, covering CentOS7->RHEL7
+              discover+:
+                test+<:
+                  - conversion-method/one_key_satellite_conversion
+
             /pre_registered_system_conversion:
                 adjust+:
                   - environment+:

--- a/pytest.ini
+++ b/pytest.ini
@@ -117,5 +117,6 @@ markers =
     test_els_support
     test_rhsm_non_els_account
     test_enabled_repositories_after_analysis
+    test_one_key_satellite_conversion
 # Unit test related
     noautofixtures: disable all auto-use fixtures

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -419,8 +419,9 @@ def remove_repositories(shell, backup_directory):
 
     yield
 
-    # Return repositories to their original location
-    assert shell(f"mv {backup_dir}/* /etc/yum.repos.d/").returncode == 0
+    if "C2R_TESTS_NONDESTRUCTIVE" in os.environ:
+        # Return repositories to their original location
+        assert shell(f"mv {backup_dir}/* /etc/yum.repos.d/").returncode == 0
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/tier0/destructive/conversion-method/main.fmf
+++ b/tests/integration/tier0/destructive/conversion-method/main.fmf
@@ -97,3 +97,14 @@ order: 49
     tag+:
         - rhsm-els-conversion
     test: pytest -m test_rhsm_els_conversion
+
+/one_key_satellite_conversion:
+    summary: |
+        Satellite conversion of pre-registered system
+    description: |
+        Conversion method using the Satellite credentials for a registration.
+        The system is pre-registered to the Satellite instance prior to the conversion.
+        We use one activation key containing both the original OS and RHEL repositories.
+    tag+:
+        - one-key-satellite-conversion
+    test: pytest -m test_one_key_satellite_conversion

--- a/tests/integration/tier0/destructive/conversion-method/test_one_key_satellite.py
+++ b/tests/integration/tier0/destructive/conversion-method/test_one_key_satellite.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+@pytest.mark.parametrize("satellite_registration", ["RHEL7_AND_CENTOS7_SAT_REG"])
+@pytest.mark.test_one_key_satellite_conversion
+def test_one_key_satellite_conversion(shell, convert2rhel, satellite_registration, remove_repositories):
+    """
+    Conversion method using the Satellite credentials for a registration.
+    The system is pre-registered to the Satellite instance prior to the conversion.
+    We use one activation key containing both the original OS and RHEL repositories.
+    """
+    with convert2rhel("-y --debug") as c2r:
+        c2r.expect("Conversion successful!")
+    assert c2r.exitstatus == 0

--- a/tests/integration/tier0/destructive/conversion-method/test_one_key_satellite.py
+++ b/tests/integration/tier0/destructive/conversion-method/test_one_key_satellite.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.parametrize("satellite_registration", ["RHEL7_AND_CENTOS7_SAT_REG"])
+@pytest.mark.parametrize("satellite_registration", ["RHEL7_AND_CENTOS7_SAT_REG"], indirect=True)
 @pytest.mark.test_one_key_satellite_conversion
 def test_one_key_satellite_conversion(shell, convert2rhel, satellite_registration, remove_repositories):
     """
@@ -9,6 +9,9 @@ def test_one_key_satellite_conversion(shell, convert2rhel, satellite_registratio
     The system is pre-registered to the Satellite instance prior to the conversion.
     We use one activation key containing both the original OS and RHEL repositories.
     """
+    # We need to enable the current system repositories prior to the conversion
+    shell("subscription-manager repos --enable=*")
+
     with convert2rhel("-y --debug") as c2r:
         c2r.expect("Conversion successful!")
     assert c2r.exitstatus == 0


### PR DESCRIPTION
* add a full conversion test validating, that systems pre-registered to the satellite with one activation key containing both original OS and RHEL repos work

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1289](https://issues.redhat.com/browse/RHELC-1289)
- 

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [x] When merged: Jira issue has been updated to `Release Pending` if relevant
