### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/convert2rhel/__init__.py
+++ b/convert2rhel/__init__.py
@@ -1,2 +1,2 @@
 __metaclass__ = type
-__version__ = "1.7.1"
+__version__ = "2.0.0"

--- a/packaging/convert2rhel.spec
+++ b/packaging/convert2rhel.spec
@@ -9,7 +9,7 @@
 %endif
 
 Name:           convert2rhel
-Version:        1.7.1
+Version:        2.0.0
 Release:        1%{?dist}
 Summary:        Automates the conversion of RHEL derivative distributions to RHEL
 
@@ -122,6 +122,56 @@ install -m 0600 config/convert2rhel.ini %{buildroot}%{_sysconfdir}/convert2rhel.
 %attr(0644,root,root) %{_mandir}/man8/%{name}.8*
 
 %changelog
+* Mon May 27 2024 Adam Hosek <ahosek@redhat.com> 2.0.0
+- Breaking change: Remove deprecated CLI arguments
+- Breaking change: Remove deprecated latest kernel check env variable
+- Breaking change: Remove deprecated unsupported convert2rhel version env variable
+- Breaking change: Remove `--disable-submgr` arg
+- Breaking change: Rename incomplete rollback envvar
+- Breaking change: Remove `-v|--variant` arg
+- Port RestorablePackage and ChangedRPMPackagesController
+- Remove backup controller partition
+- Update RHSM custom facts during analysis
+- Remove ppc64 architecture from data
+- Add debug logs to host-metering
+- Add post conversion stages for Action Framework
+- Set consistent task prefix for pre-conversion
+- Migrate post conversion transaction function
+- Improve efi error check for PART_ENTRY_NUMBER
+- Unify parsing of the system release string
+- Drop support for 8.6 EUS conversions
+- Improve detection of RHSM credentials in subscription check
+- Update report to include post conversion actions
+- Satellite package backup failure fix
+- Drop internet connection check and its dependencies
+- Don't report on skipping dbus check
+- Modify exit code for conversion when inhibitor is found
+- Add RHEL 9 version support up to 9.10
+- Allow converting to RHEL 7 ELS
+- Exit with 1 when rollback fails
+- Fix empty error message in Yum transaction failure
+- Disable RHEL repos when performing checks
+- Update the Red Hat package signing key
+- Install subscription-manager using package manager
+- Change result of the c2r version check to OVERRIDABLE
+- Restore disabled repos during conversion in rollback
+- Rollback task using "Convert" instead of "Rollback"
+- Override yum config exclude list
+- Fix an error message referring to a non-existing --organization option
+- Fix RHSM facts filepath in a log message
+- Remove leftover reposdir from package updates action
+- Require username and password to be specified
+- Fix check for reposdir in RestorablePackage class
+- Add the libreport-plugin-mantisbt to excluded list
+- Always backup redhat.repo
+- Fix cornercase with userpass and keyorg
+- Fix report duplication after analysis
+- Fix regression in installing removed packages during rollback
+- Check if rollback failed when handling InhibitorFound exception
+- Skip versionlock file in backup system actions
+- Fix bug with duplicate packages check when running with Satellite offline
+- Raise when RestorablePackage fails to restore
+- Return a list instead of string for disablerepo command
 
 * Mon Mar 04 2024 Freya Gustavsson <fgustavs@redhat.com> 1.7.1
 - Set downgrade to strict mode to not miss dependencies


### PR DESCRIPTION
## What's Changed
### Breaking Changes 🛠
* [RHELC-1425] Remove deprecated CLI arguments by @Venefilyn in https://github.com/oamg/convert2rhel/pull/1058
* [RHELC-1425] Remove deprecated latest kernel check env variable by @Venefilyn in https://github.com/oamg/convert2rhel/pull/1056
* [RHELC-1425] Remove deprecated unsupported convert2rhel version env variable by @Venefilyn in https://github.com/oamg/convert2rhel/pull/1057
* [RHELC-1425, RHELC-1429] Remove `--disable-submgr` arg by @Venefilyn in https://github.com/oamg/convert2rhel/pull/1148
* [RHELC-1430, RHELC-1500] Rename incomplete rollback envvar by @Venefilyn in https://github.com/oamg/convert2rhel/pull/1147
* [RHELC-1425, RHELC-1429] Remove `-v|--variant` arg by @Venefilyn in https://github.com/oamg/convert2rhel/pull/1149
### Enhancements 🎉
* [RHELC-1382] Port RestorablePackage and ChangedRPMPackagesController by @r0x0d in https://github.com/oamg/convert2rhel/pull/1091
* [RHELC-1376] Remove backup controller partition by @r0x0d in https://github.com/oamg/convert2rhel/pull/1096
* [RHELC-1164] Update RHSM custom facts during analysis by @r0x0d in https://github.com/oamg/convert2rhel/pull/1043
* [RHELC-1391, RHELC-340] Remove ppc64 architecture from data by @r0x0d in https://github.com/oamg/convert2rhel/pull/1133
* [RHELC-1582] Add debug logs to host-metering by @r0x0d in https://github.com/oamg/convert2rhel/pull/1141
* [RHELC-1342] Add post conversion stages for Action Framework by @r0x0d in https://github.com/oamg/convert2rhel/pull/1144
* [RHELC-1465] Set consistent task prefix for pre-conversion by @r0x0d in https://github.com/oamg/convert2rhel/pull/1154
* [RHELC-1328] Migrate post conversion transaction function by @r0x0d in https://github.com/oamg/convert2rhel/pull/1152
* [RHELC-1484] Improve efi error check for PART_ENTRY_NUMBER by @pr-watson in https://github.com/oamg/convert2rhel/pull/1169
* [RHELC-676] Unify parsing of the system release string by @bookwar in https://github.com/oamg/convert2rhel/pull/897
* [RHELC-1426, RHELC-1428] Drop support for 8.6 EUS conversions by @r0x0d in https://github.com/oamg/convert2rhel/pull/1132
* [RHELC-1228, RHELC-1231] Improve detection of RHSM credentials in subscription check by @pr-watson in https://github.com/oamg/convert2rhel/pull/1022
* [RHELC-1347] Update report to include post conversion actions by @r0x0d in https://github.com/oamg/convert2rhel/pull/1151
* [RHELC-1385] Satellite package backup failure fix by @pr-watson in https://github.com/oamg/convert2rhel/pull/1182
* [RHELC-1497, RHELC-1499] Drop internet connection check and its dependencies by @r0x0d in https://github.com/oamg/convert2rhel/pull/1181
* [RHELC-1519] Don't report on skipping dbus check by @bocekm in https://github.com/oamg/convert2rhel/pull/1198
* [RHELC-1276] Modify exit code for conversion when inhibitor is found by @r0x0d in https://github.com/oamg/convert2rhel/pull/1171
* [RHELC-1493] Add RHEL 9 version support up to 9.10 by @pr-watson in https://github.com/oamg/convert2rhel/pull/1204
* [RHELC-1179] Allow converting to RHEL 7 ELS by @pr-watson in https://github.com/oamg/convert2rhel/pull/1146
* [RHELC-1275, RHELC-1516] Exit with 1 when rollback fails by @hosekadam in https://github.com/oamg/convert2rhel/pull/1153
* [RHELC-1528] Fix empty error message in Yum transaction failure by @pr-watson in https://github.com/oamg/convert2rhel/pull/1214
* [RHELC-884] Disable RHEL repos when performing checks by @hosekadam in https://github.com/oamg/convert2rhel/pull/1174
* [HMS-4000] Update the Red Hat package signing key by @bocekm in https://github.com/oamg/convert2rhel/pull/1231
* [RHELC-601] Install subscription-manager using package manager by @r0x0d in https://github.com/oamg/convert2rhel/pull/1164
* [RHELC-1561] Change result of the c2r version check to OVERRIDABLE by @bocekm in https://github.com/oamg/convert2rhel/pull/1238
* [RHELC-1494, RHELC-1289] Restore disabled repos during conversion in rollback by @r0x0d in https://github.com/oamg/convert2rhel/pull/1212
### Bug Fixes 🐛
* [RHELC-1580] Rollback task using "Convert" instead of "Rollback" by @r0x0d in https://github.com/oamg/convert2rhel/pull/1130
* [RHELC-1282] Override yum config exclude list by @r0x0d in https://github.com/oamg/convert2rhel/pull/1030
* [RHELC-1489] Fix an error message referring to a non-existing --organization option by @bocekm in https://github.com/oamg/convert2rhel/pull/1162
* [RHELC-1503] Fix RHSM facts filepath in a log message by @bocekm in https://github.com/oamg/convert2rhel/pull/1183
* [RHELC-1520] Remove leftover reposdir from package updates action by @r0x0d in https://github.com/oamg/convert2rhel/pull/1203
* [RHELC-1532] Require username and password to be specified by @Venefilyn in https://github.com/oamg/convert2rhel/pull/1209
* [RHELC-1521] Fix check for reposdir in RestorablePackage class by @r0x0d in https://github.com/oamg/convert2rhel/pull/1210
* [RHELC-1526] Add the libreport-plugin-mantisbt to excluded list by @hosekadam in https://github.com/oamg/convert2rhel/pull/1222
* [RHELC-1521] Always backup redhat.repo by @hosekadam in https://github.com/oamg/convert2rhel/pull/1220
* [RHELC-1525] Fix cornercase with userpass and keyorg by @Venefilyn in https://github.com/oamg/convert2rhel/pull/1208
* [RHELC-1551] Fix report duplication after analysis by @r0x0d in https://github.com/oamg/convert2rhel/pull/1225
* [RHELC-1547] Fix regression in installing removed packages during rollback by @r0x0d in https://github.com/oamg/convert2rhel/pull/1226
* [RHELC-1583] Check if rollback failed when handling InhibitorFound exception by @hosekadam in https://github.com/oamg/convert2rhel/pull/1224
* [RHELC-1291, RHELC-1292] Skip versionlock file in backup system actions by @bookwar in https://github.com/oamg/convert2rhel/pull/1233
* [RHELC-1540] Fix bug with duplicate packages check when running with Satellite offline by @pr-watson in https://github.com/oamg/convert2rhel/pull/1219
* [RHELC-1556] Raise when RestorablePackage fails to restore by @hosekadam in https://github.com/oamg/convert2rhel/pull/1234
* [RHELC-1581] Return a list instead of string for disablerepo command by @r0x0d in https://github.com/oamg/convert2rhel/pull/1237
### Test Coverage Enhancements 🔧
* [RHELC-1515] Fix the enabled repository check after the conversion by @kokesak in https://github.com/oamg/convert2rhel/pull/1192
* [RHELC-1286, RHELC-1555] Add tests validating the ELS support by @danmyway in https://github.com/oamg/convert2rhel/pull/1228

## New Contributors
* @pholica made their first contribution in https://github.com/oamg/convert2rhel/pull/1189

**Full Changelog**: https://github.com/oamg/convert2rhel/compare/v1.7.1...v2.0.0