### PR TITLE
[RHELC-1587] Fix failing artifact installation on Alma 8.8

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -186,7 +186,11 @@ jobs:
     use_internal_tf: True
     # For some targets we use official AWS marketplace images, those do not support root ssh login as default,
     # therefore we need to pass post-install-script to enable root login on the host
-    tf_post_install_script: '#!/bin/bash\nsudo sed -i "s/^.*ssh-rsa/ssh-rsa/" /root/.ssh/authorized_keys'
+    # Additionally on Alma 8.8 there is an issue with installing convert2rhel testing artifact due to
+    # messed up GPG keys, when the artifact is installed the repositories are not pinned to 8.8
+    # thus the dependencies are installed from the latest release, the new GPG key needed for installation
+    # of new packages is not imported at that point, we need to install them manually
+    tf_post_install_script: '#!/bin/bash\nsudo sed -i "s/^.*ssh-rsa/ssh-rsa/" /root/.ssh/authorized_keys; rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux'
     targets:
       epel-8-x86_64:
         distros: ["AlmaLinux OS 8.8.20230524 x86_64"]


### PR DESCRIPTION
* the new gpg key is messing with convert2rhel installation
* import the key as a part of the tf_post_install_script

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1587](https://issues.redhat.com/browse/RHELC-1587) 

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [x] When merged: Jira issue has been updated to `Release Pending` if relevant
