### PR TITLE
chore: add HMS to release notes workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Checklist
 
 - [ ] PR has been tested manually in a VM (either author or reviewer)
 - [ ] Jira issue has been made public if possible
-- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
+- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
 - [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
 - [ ] PR title explains the change from the user's point of view
 - [ ] Code and tests are documented properly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,10 @@ jobs:
 
           #  RegEx explained
           # (?<!\/) Negative lookbehind of / to avoid grabbing URLs
-          # (RHELC?-\d+) Get RHEL or RHELC keys, add to a group
+          # ((?:RHELC?|HMS)-\d+) Get HMS, RHEL or RHELC keys, add to a group
           # \b Word boundary to indicate this should be the end of the match
           # (?!\]\() Negative lookahead of ]( to prevent Jira keys in markdown links
-          regex=re.compile(r"(?<!\/)(RHELC?-\d+)\b(?!\]\()", re.MULTILINE)
+          regex=re.compile(r"(?<!\/)((?:RHELC?|HMS)-\d+)\b(?!\]\()", re.MULTILINE)
           with open("releaseBody.txt", 'r+') as f:
             data = f.read()
             f.seek(0)


### PR DESCRIPTION
This expands the RegEx for capturing and linking Jira issues to also
include HMS instead of just RHEL and RHELC

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
