### PR TITLE
[RHELC-774] Add exclude setopt to remaining repoquery calls

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
+++ b/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
@@ -71,10 +71,7 @@ class EnsureKernelModulesCompatibility(actions.Action):
             "--releasever=%s" % system_info.releasever,
             "--setopt=*.skip_if_unavailable=False",
         ]
-        basecmd = [
-            "repoquery",
-            "--releasever=%s" % system_info.releasever,
-        ]
+        basecmd = ["repoquery", "--releasever=%s" % system_info.releasever, "--setopt=exclude="]
 
         if system_info.version.major >= 8:
             basecmd.append("--setopt=module_platform_id=platform:el" + str(system_info.version.major))

--- a/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
+++ b/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
@@ -71,6 +71,9 @@ class EnsureKernelModulesCompatibility(actions.Action):
             "--releasever=%s" % system_info.releasever,
             "--setopt=*.skip_if_unavailable=False",
         ]
+        # Clearing the exclude field with setopt to prevent kernel being
+        # excluded in the config.
+        # https://issues.redhat.com/browse/RHELC-774
         basecmd = ["repoquery", "--releasever=%s" % system_info.releasever, "--setopt=exclude="]
 
         if system_info.version.major >= 8:

--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -52,6 +52,7 @@ class Convert2rhelLatest(actions.Action):
             "repoquery",
             "--releasever=%s" % system_info.version.major,
             "--setopt=reposdir=%s" % os.path.dirname(repofile_path),
+            "--setopt=exclude=",
             "--qf",
             "C2R %{NAME}-%{EPOCH}:%{VERSION}-%{RELEASE}.%{ARCH}",
             "convert2rhel",

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -402,7 +402,7 @@ def _get_package_repositories(pkgs, disable_repos=None):
     # If needed, disable some repos for the repoquery
     disable_repo_command = repo.get_rhel_disable_repos_command(disable_repos)
 
-    cmd = ["repoquery", "--quiet", "-q"]
+    cmd = ["repoquery", "--quiet", "-q", "--setopt=exclude="]
     cmd.extend(disable_repo_command)
     cmd.extend(pkgs)
     cmd.extend(["--qf", query_format])

--- a/convert2rhel/pkgmanager/__init__.py
+++ b/convert2rhel/pkgmanager/__init__.py
@@ -211,7 +211,7 @@ def call_yum_cmd(
     args = args or []
     setopts = setopts or []
 
-    cmd = ["yum", command, "-y"]
+    cmd = ["yum", command, "--setopt=exclude=", "-y"]
 
     # The --disablerepo yum option must be added before --enablerepo,
     #   otherwise the enabled repo gets disabled if --disablerepo="*" is used

--- a/convert2rhel/pkgmanager/handlers/dnf/__init__.py
+++ b/convert2rhel/pkgmanager/handlers/dnf/__init__.py
@@ -86,6 +86,10 @@ class DnfTransactionHandler(TransactionHandlerBase):
         # going in with the packages in the transaction.
         self._base._ds_callback = DependencySolverProgressIndicatorCallback()
 
+        # Override the exclude option that is loaded from the config and set it
+        # to empty.
+        self._base.conf.substitutions["exclude"] = []
+
     def _enable_repos(self):
         """Enable a list of required repositories."""
         self._base.read_all_repos()

--- a/convert2rhel/pkgmanager/handlers/dnf/__init__.py
+++ b/convert2rhel/pkgmanager/handlers/dnf/__init__.py
@@ -86,9 +86,10 @@ class DnfTransactionHandler(TransactionHandlerBase):
         # going in with the packages in the transaction.
         self._base._ds_callback = DependencySolverProgressIndicatorCallback()
 
-        # Override the exclude option that is loaded from the config and set it
-        # to empty.
-        self._base.conf.substitutions["exclude"] = []
+        # Override the exclude option that is loaded from the config and set it to empty.
+        # NOTE(r0x0d): In DNF they have exclude to be `py:excludepkgs`. It is fine to use `exclude` for now as it is
+        # compatible with yum.
+        self._base.conf.exclude = []
 
     def _enable_repos(self):
         """Enable a list of required repositories."""

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -231,36 +231,6 @@ class TestGetRpmHeader:
             pkghandler.get_rpm_header(unknown_pkg)
 
 
-class TestPreserveOnlyRHELKernel:
-    @centos7
-    def test_preserve_only_rhel_kernel(self, pretend_os, monkeypatch):
-        monkeypatch.setattr(pkghandler, "install_rhel_kernel", lambda: True)
-        monkeypatch.setattr(pkghandler, "fix_invalid_grub2_entries", lambda: None)
-        monkeypatch.setattr(pkghandler, "remove_non_rhel_kernels", mock.Mock(return_value=[]))
-        monkeypatch.setattr(pkghandler, "install_gpg_keys", mock.Mock())
-        monkeypatch.setattr(utils, "run_subprocess", RunSubprocessMocked())
-        monkeypatch.setattr(
-            pkghandler,
-            "get_installed_pkgs_by_fingerprint",
-            GetInstalledPkgsByFingerprintMocked(return_value=[create_pkg_information(name="kernel")]),
-        )
-        monkeypatch.setattr(system_info, "name", "CentOS7")
-        monkeypatch.setattr(system_info, "arch", "x86_64")
-        monkeypatch.setattr(utils, "store_content_to_file", StoreContentToFileMocked())
-
-        pkghandler.preserve_only_rhel_kernel()
-
-        assert utils.run_subprocess.cmd == [
-            "yum",
-            "update",
-            "--setopt=exclude=",
-            "-y",
-            "--releasever=7Server",
-            "kernel",
-        ]
-        assert pkghandler.get_installed_pkgs_by_fingerprint.call_count == 1
-
-
 class TestGetKernelAvailability:
     @pytest.mark.parametrize(
         ("subprocess_output", "expected_installed", "expected_available"),

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -231,6 +231,36 @@ class TestGetRpmHeader:
             pkghandler.get_rpm_header(unknown_pkg)
 
 
+class TestPreserveOnlyRHELKernel:
+    @centos7
+    def test_preserve_only_rhel_kernel(self, pretend_os, monkeypatch):
+        monkeypatch.setattr(pkghandler, "install_rhel_kernel", lambda: True)
+        monkeypatch.setattr(pkghandler, "fix_invalid_grub2_entries", lambda: None)
+        monkeypatch.setattr(pkghandler, "remove_non_rhel_kernels", mock.Mock(return_value=[]))
+        monkeypatch.setattr(pkghandler, "install_gpg_keys", mock.Mock())
+        monkeypatch.setattr(utils, "run_subprocess", RunSubprocessMocked())
+        monkeypatch.setattr(
+            pkghandler,
+            "get_installed_pkgs_by_fingerprint",
+            GetInstalledPkgsByFingerprintMocked(return_value=[create_pkg_information(name="kernel")]),
+        )
+        monkeypatch.setattr(system_info, "name", "CentOS7")
+        monkeypatch.setattr(system_info, "arch", "x86_64")
+        monkeypatch.setattr(utils, "store_content_to_file", StoreContentToFileMocked())
+
+        pkghandler.preserve_only_rhel_kernel()
+
+        assert utils.run_subprocess.cmd == [
+            "yum",
+            "update",
+            "--setopt=exclude=",
+            "-y",
+            "--releasever=7Server",
+            "kernel",
+        ]
+        assert pkghandler.get_installed_pkgs_by_fingerprint.call_count == 1
+
+
 class TestGetKernelAvailability:
     @pytest.mark.parametrize(
         ("subprocess_output", "expected_installed", "expected_available"),
@@ -267,7 +297,14 @@ class TestHandleNoNewerRHELKernelAvailable:
 
         pkghandler.handle_no_newer_rhel_kernel_available()
 
-        assert utils.run_subprocess.cmd == ["yum", "install", "-y", "--releasever=7Server", "kernel-4.7.2-201.fc24"]
+        assert utils.run_subprocess.cmd == [
+            "yum",
+            "install",
+            "--setopt=exclude=",
+            "-y",
+            "--releasever=7Server",
+            "kernel-4.7.2-201.fc24",
+        ]
 
     @centos7
     def test_handle_older_rhel_kernel_not_available(self, pretend_os, monkeypatch):
@@ -294,7 +331,14 @@ class TestHandleNoNewerRHELKernelAvailable:
 
         assert len(utils.remove_pkgs.pkgs) == 1
         assert utils.remove_pkgs.pkgs[0] == "kernel-4.7.4-200.fc24"
-        assert utils.run_subprocess.cmd == ["yum", "install", "-y", "--releasever=7Server", "kernel-4.7.4-200.fc24"]
+        assert utils.run_subprocess.cmd == [
+            "yum",
+            "install",
+            "--setopt=exclude=",
+            "-y",
+            "--releasever=7Server",
+            "kernel-4.7.4-200.fc24",
+        ]
 
 
 class TestReplaceNonRHELInstalledKernel:

--- a/convert2rhel/unit_tests/pkgmanager/pkgmanager_test.py
+++ b/convert2rhel/unit_tests/pkgmanager/pkgmanager_test.py
@@ -99,6 +99,7 @@ class TestCallYumCmd:
         assert utils.run_subprocess.cmd == [
             "yum",
             "install",
+            "--setopt=exclude=",
             "-y",
             "--releasever=8",
             "--setopt=module_platform_id=platform:el8",
@@ -110,7 +111,7 @@ class TestCallYumCmd:
 
         pkgmanager.call_yum_cmd("install", set_releasever=False)
 
-        assert utils.run_subprocess.cmd == ["yum", "install", "-y"]
+        assert utils.run_subprocess.cmd == ["yum", "install", "--setopt=exclude=", "-y"]
 
     @centos7
     def test_call_yum_cmd_with_disablerepo_and_enablerepo(self, pretend_os, monkeypatch):
@@ -124,6 +125,7 @@ class TestCallYumCmd:
         assert utils.run_subprocess.cmd == [
             "yum",
             "install",
+            "--setopt=exclude=",
             "-y",
             "--disablerepo=*",
             "--releasever=7Server",
@@ -141,6 +143,7 @@ class TestCallYumCmd:
         assert utils.run_subprocess.cmd == [
             "yum",
             "install",
+            "--setopt=exclude=",
             "-y",
             "--releasever=7Server",
             "--enablerepo=rhel-7-extras-rpm",
@@ -154,7 +157,7 @@ class TestCallYumCmd:
 
         pkgmanager.call_yum_cmd("install", ["pkg"], enable_repos=[], disable_repos=[])
 
-        assert utils.run_subprocess.cmd == ["yum", "install", "-y", "--releasever=7Server", "pkg"]
+        assert utils.run_subprocess.cmd == ["yum", "install", "--setopt=exclude=", "-y", "--releasever=7Server", "pkg"]
 
         pkgmanager.call_yum_cmd(
             "install",
@@ -166,6 +169,7 @@ class TestCallYumCmd:
         assert utils.run_subprocess.cmd == [
             "yum",
             "install",
+            "--setopt=exclude=",
             "-y",
             "--disablerepo=disable-repo",
             "--releasever=7Server",
@@ -185,6 +189,7 @@ class TestCallYumCmd:
         assert utils.run_subprocess.cmd == [
             "yum",
             "install",
+            "--setopt=exclude=",
             "-y",
             "--releasever=8.5",
             "--setopt=module_platform_id=platform:el8",
@@ -206,6 +211,7 @@ class TestCallYumCmd:
         assert utils.run_subprocess.cmd == [
             "yum",
             "install",
+            "--setopt=exclude=",
             "-y",
             "--releasever=8",
             "--setopt=module_platform_id=platform:el8",
@@ -245,6 +251,7 @@ class TestCallYumCmd:
         expected_cmd = [
             "yum",
             "install",
+            "--setopt=exclude=",
             "-y",
             "--setopt=module_platform_id=platform:el8",
         ]


### PR DESCRIPTION
We need to exclude any packages set in the /etc/yum.conf set by the user so we can make sure that when we run repoquery, we are really gathering all the data we want from the command. This patch introduces the overridable --setopt=exclude= in the remaining repoquery calls.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of  -->
- [RHELC-774](https://issues.redhat.com/browse/RHELC-774)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
