### PR TITLE
[RHELC-1554] Remove RHSM repositories enablement fallback

### DIFF
--- a/tests/integration/tier0/non-destructive/els/main.fmf
+++ b/tests/integration/tier0/non-destructive/els/main.fmf
@@ -28,11 +28,6 @@ adjust+:
       pytest -m test_els_enablement
 
 /non_els_account:
-    # We expect this test to fail given a missing logic in the convert2rhel code,
-    # see https://issues.redhat.com/browse/RHELC-1554
-    # this is a safety measure to enable the test when the issue gets fixed
-    result: xfail
-
     description: |
         Verify that Convert2RHEL is working properly when ELS repositories are not available for conversions
         (the account does not have the ELS SKU available) to RHEL ELS version (7.9)

--- a/tests/integration/tier0/non-destructive/els/test_els_enablement.py
+++ b/tests/integration/tier0/non-destructive/els/test_els_enablement.py
@@ -107,6 +107,5 @@ def test_rhsm_non_els_account(convert2rhel):
     ) as c2r:
         c2r.expect_exact(ELS_REPOID_MSG)
         c2r.expect_exact("Error: 'rhel-7-server-els-rpms' does not match a valid repository ID.")
-        c2r.expect_exact("The RHEL ELS repositories are not possible to enable.")
-        c2r.expect_exact("Trying to enable standard RHEL repositories as a fallback.")
+        c2r.expect_exact("SUBSCRIBE_SYSTEM::FAILED_TO_ENABLE_RHSM_REPOSITORIES")
     assert c2r.exitstatus == 0

--- a/tests/integration/tier0/non-destructive/eus/test_eus_enablement.py
+++ b/tests/integration/tier0/non-destructive/eus/test_eus_enablement.py
@@ -102,7 +102,8 @@ def test_eus_enablement(
             # If is_eus is True, expect a corresponding EUS message displayed
             if is_eus:
                 c2r.expect_exact(
-                    "The system version corresponds to a RHEL Extended Update Support (EUS) release.",
+                    "Trying to enable the following RHEL repositories: "
+                    "rhel-8-for-x86_64-baseos-eus-rpms, rhel-8-for-x86_64-appstream-eus-rpms",
                     timeout=120,
                 )
             c2r.expect("Repositories enabled through subscription-manager", timeout=120)
@@ -125,6 +126,5 @@ def test_rhsm_non_eus_account(convert2rhel):
     ) as c2r:
         c2r.expect_exact("Error: 'rhel-8-for-x86_64-baseos-eus-rpms' does not match a valid repository ID.")
         c2r.expect_exact("Error: 'rhel-8-for-x86_64-appstream-eus-rpms' does not match a valid repository ID.")
-        c2r.expect_exact("The RHEL EUS repositories are not possible to enable.")
-        c2r.expect_exact("Trying to enable standard RHEL repositories as a fallback.")
+        c2r.expect_exact("SUBSCRIBE_SYSTEM::FAILED_TO_ENABLE_RHSM_REPOSITORIES")
     assert c2r.exitstatus == 0


### PR DESCRIPTION
In case of repositories not being able to be enabled, we won't fallback to the normal RHSM repoids anymore. Instead, we want to throw an error and tell the user what was the reason on why we couldn't enable the repository.

This simplify the function that handles the enablement, making it much more simpler now.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1554](https://issues.redhat.com/browse/RHELC-1554)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
