### PR TITLE
Remove leftover analysis environment variable

### DIFF
--- a/convert2rhel/toolopts.py
+++ b/convert2rhel/toolopts.py
@@ -336,16 +336,8 @@ class CLI:
         if parsed_opts.debug:
             tool_opts.debug = True
 
-        if hasattr(parsed_opts, "command"):
-            # Once we use a subcommand to set the activity that convert2rhel will perform
-            tool_opts.activity = _COMMAND_TO_ACTIVITY[parsed_opts.command]
-        else:
-            # At first, in tech preview, we use an environment variable to set the activity.
-            experimental_analysis = bool(os.getenv("CONVERT2RHEL_EXPERIMENTAL_ANALYSIS", None))
-            if experimental_analysis:
-                tool_opts.activity = "analysis"
-            else:
-                tool_opts.activity = "conversion"
+        # Once we use a subcommand to set the activity that convert2rhel will perform
+        tool_opts.activity = _COMMAND_TO_ACTIVITY[parsed_opts.command]
 
         # Processing the configuration file
         conf_file_opts = options_from_config_files(parsed_opts.config_file)

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -552,7 +552,6 @@ class TestRollbackFromMain:
             (subscription, "should_subscribe", mock.Mock(side_effect=lambda: True)),
             (subscription, "update_rhsm_custom_facts", mock.Mock()),
             (main, "rollback_changes", mock.Mock()),
-            (os, "environ", {"CONVERT2RHEL_EXPERIMENTAL_ANALYSIS": 1}),
             (report, "summary_as_json", mock.Mock()),
             (report, "summary_as_txt", mock.Mock()),
         )
@@ -618,7 +617,6 @@ class TestRollbackFromMain:
         monkeypatch.setattr(subscription, "should_subscribe", should_subscribe_mock)
         monkeypatch.setattr(subscription, "update_rhsm_custom_facts", update_rhsm_custom_facts_mock)
         monkeypatch.setattr(main, "rollback_changes", rollback_changes_mock)
-        monkeypatch.setattr(os, "environ", {"CONVERT2RHEL_EXPERIMENTAL_ANALYSIS": 1})
         monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
         monkeypatch.setattr(report, "summary_as_txt", summary_as_txt_mock)
         global_tool_opts.activity = "analysis"

--- a/tests/integration/tier0/non-destructive/rollback-handling/main.fmf
+++ b/tests/integration/tier0/non-destructive/rollback-handling/main.fmf
@@ -36,10 +36,6 @@ tag+:
         Get right to the point of no return and end the conversion.
         Verify that the system has been successfully unregistered after the rollback.
         Verify that usermode, rhn-setup and os-release packages are not removed.
-    adjust+:
-        - environment+:
-            CONVERT2RHEL_EXPERIMENTAL_ANALYSIS: 1
-          when: distro == centos-8-latest
     tag+:
         - rhsm-cleanup
     test: |

--- a/tests/integration/tier0/non-destructive/rollback-handling/test_rollback_handling.py
+++ b/tests/integration/tier0/non-destructive/rollback-handling/test_rollback_handling.py
@@ -177,7 +177,7 @@ def test_proper_rhsm_clean_up(shell, convert2rhel):
     packages_to_remove_at_cleanup = install_packages(shell, assign_packages())
 
     with convert2rhel(
-        "--serverurl {} --username {} --password {} --pool {} --debug".format(
+        "analyze --serverurl {} --username {} --password {} --pool {} --debug".format(
             TEST_VARS["RHSM_SERVER_URL"],
             TEST_VARS["RHSM_USERNAME"],
             TEST_VARS["RHSM_PASSWORD"],


### PR DESCRIPTION
In the past, we introduced this environment variable to enable analysis when it was in tech preview. Since we are not in that stage anymore, the variable was left behind in the code after we started to remove all tech preview code.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
