### PR TITLE
[RHELC-1606] Fix of multiple backup of one file

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -162,6 +162,7 @@ class BackupPackageFiles(actions.Action):
                     # If the MD5 checksum differs, the content of the file differs
                     restorable_file = RestorableFile(file["path"])
                     backup.backup_control.push(restorable_file)
+                    backed_up_files.append(file["path"])
                 else:
                     loggerinst.debug(
                         "File {filepath} already backed up - not backing up again".format(filepath=file["path"])


### PR DESCRIPTION
File can be present multiple times in the output of 'rpm -Va' command. The file is backed up only once.

Also, the unit test was updated to handle this situation.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1606](https://issues.redhat.com/browse/RHELC-1606)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
