### PR TITLE
[RHELC-1617] Update ELS start date to match correct date

### DIFF
--- a/convert2rhel/actions/system_checks/els.py
+++ b/convert2rhel/actions/system_checks/els.py
@@ -19,7 +19,7 @@ import datetime
 import logging
 
 from convert2rhel import actions
-from convert2rhel.systeminfo import ELS_RELEASE_DATE, system_info
+from convert2rhel.systeminfo import ELS_START_DATE, system_info
 from convert2rhel.toolopts import tool_opts
 
 
@@ -35,16 +35,19 @@ class ElsSystemCheck(actions.Action):
 
         if system_info.version.major == 7:
             current_datetime = datetime.date.today()
-            # Turn ELS_RELEASE_DATE into a datetime object
-            els_release_date = datetime.datetime.strptime(ELS_RELEASE_DATE, "%Y-%m-%d").date()
+            # Turn ELS_START_DATE into a datetime object
+            els_start_date = datetime.datetime.strptime(ELS_START_DATE, "%Y-%m-%d").date()
 
             # warning message if the els release date is past and the --els option is not set
-            if not tool_opts.els and current_datetime > els_release_date:
+            if not tool_opts.els and current_datetime > els_start_date:
                 self.add_message(
                     level="WARNING",
                     id="ELS_COMMAND_LINE_OPTION_UNUSED",
                     title="The --els command line option is unused",
-                    description="Current system version is under Extended Lifecycle Support (ELS). You may want to consider using the --els"
-                    " command line option to land on a system patched with the latest security errata.",
+                    description=(
+                        "Current system version is under Extended Lifecycle Support (ELS). You may want to "
+                        "consider using the --els command line option to land on a system patched with the latest "
+                        "security errata.",
+                    ),
                 )
         return

--- a/convert2rhel/actions/system_checks/els.py
+++ b/convert2rhel/actions/system_checks/els.py
@@ -19,11 +19,13 @@ import datetime
 import logging
 
 from convert2rhel import actions
-from convert2rhel.systeminfo import ELS_START_DATE, system_info
+from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts
 
 
 logger = logging.getLogger(__name__)
+
+ELS_START_DATE = "2024-07-01"
 
 
 class ElsSystemCheck(actions.Action):
@@ -38,6 +40,7 @@ class ElsSystemCheck(actions.Action):
             # Turn ELS_START_DATE into a datetime object
             els_start_date = datetime.datetime.strptime(ELS_START_DATE, "%Y-%m-%d").date()
 
+            print(current_datetime > els_start_date)
             # warning message if the els release date is past and the --els option is not set
             if not tool_opts.els and current_datetime > els_start_date:
                 self.add_message(

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -62,7 +62,7 @@ RELEASE_VER_MAPPING = {
 # Dictionary of EUS minor versions supported and their EUS period start date
 EUS_MINOR_VERSIONS = {"8.8": "2023-11-14"}
 
-ELS_RELEASE_DATE = "2024-06-12"
+ELS_START_DATE = "2024-07-01"
 
 Version = namedtuple("Version", ["major", "minor"])
 

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -62,8 +62,6 @@ RELEASE_VER_MAPPING = {
 # Dictionary of EUS minor versions supported and their EUS period start date
 EUS_MINOR_VERSIONS = {"8.8": "2023-11-14"}
 
-ELS_START_DATE = "2024-07-01"
-
 Version = namedtuple("Version", ["major", "minor"])
 
 

--- a/convert2rhel/unit_tests/actions/system_checks/els_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/els_test.py
@@ -32,7 +32,7 @@ def els_action():
 class DateMock(datetime.date):
     @classmethod
     def today(cls):
-        return cls(2024, 6, 13)
+        return cls(2024, 7, 2)
 
 
 class TestEus:
@@ -58,8 +58,11 @@ class TestEus:
                     level="WARNING",
                     id="ELS_COMMAND_LINE_OPTION_UNUSED",
                     title="The --els command line option is unused",
-                    description="Current system version is under Extended Lifecycle Support (ELS). You may want to consider using the --els"
-                    " command line option to land on a system patched with the latest security errata.",
+                    description=(
+                        "Current system version is under Extended Lifecycle Support (ELS). You may want to "
+                        "consider using the --els command line option to land on a system patched with the latest "
+                        "security errata.",
+                    ),
                 ),
             )
         )

--- a/tests/integration/tier0/non-destructive/els/main.fmf
+++ b/tests/integration/tier0/non-destructive/els/main.fmf
@@ -14,7 +14,7 @@ adjust+:
 /els_support:
     description: |
         Test verifying correct behavior when converting ELS candidates.
-        ELS_RELEASE_DATE in convert2rhel/systeminfo.py is modified to mock the different scenarios.
+        ELS_START_DATE in convert2rhel/systeminfo.py is modified to mock the different scenarios.
         Verified scenarios (handled by pytest parametrization):
         1/ The system is considered as a non-ELS. This is done by modifying the major system version
             in the els.py file.

--- a/tests/integration/tier0/non-destructive/els/test_els_support.py
+++ b/tests/integration/tier0/non-destructive/els/test_els_support.py
@@ -9,7 +9,7 @@ from conftest import TEST_VARS
 def els_mock(shell, backup_directory):
     """
     Fixture to mock different scenarios while handling the ELS candidates.
-    Backs up the convert2rhel/systeminfo.py and modifies the ELS_RELEASE_DATE variable.
+    Backs up the convert2rhel/systeminfo.py and modifies the ELS_START_DATE variable.
     Restores the original version after the test is done.
     """
     systeminfo_file = shell("find /usr -path '*/convert2rhel/systeminfo.py'").output.strip()
@@ -66,7 +66,7 @@ def test_els_support(
 ):
     """
     Test verifying correct behavior when converting ELS candidates.
-    ELS_RELEASE_DATE in convert2rhel/systeminfo.py is modified to mock the different scenarios.
+    ELS_START_DATE in convert2rhel/systeminfo.py is modified to mock the different scenarios.
     Verified scenarios (handled by pytest parametrization):
     1/ The system is considered as a non-ELS. This is done by modifying the major system version
         in the els.py file.


### PR DESCRIPTION
The ELS start date was set to a month early incorrectly. This patch is fixing the date for 2024-07-01 to fix it. We are also renaming it from ELS_RELEASE_DATA to ELS_START_DATE

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1617](https://issues.redhat.com/browse/RHELC-1617)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
