### PR TITLE
[RHELC-1622] Require yum on RHEL 8+ based systems

### DIFF
--- a/packaging/convert2rhel.spec
+++ b/packaging/convert2rhel.spec
@@ -44,6 +44,8 @@ Requires:       python%{python_pkgversion}-setuptools
 Requires:       python%{python_pkgversion}-six
 %if 0%{?rhel} && 0%{?rhel} >= 8
 Requires:       dnf
+# The yum rpm mainly takes care of creating symlinks to dnf. We need it since we call yum in convert2rhel.
+Requires:       yum
 # dnf-utils includes yumdownloader and package-cleanup we use
 Requires:       dnf-utils
 Requires:       grubby


### PR DESCRIPTION
The package manager on RHEL 8+ is dnf but for a backwards compatibility reason a yum rpm is available to create symlinks pointing to dnf.

If the yum package is missing, convert2rhel fails because it calls yum.

Having yum as a dependency of convert2rhel on RHEL 8+ based systems will ensure that yum will be available (unless someone intentionally removes yum after the convert2rhel installation but then ¯\_(ツ)_/¯).

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1622](https://issues.redhat.com/browse/RHELC-1622)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
