### PR TITLE
[RHELC-1626] Use no_rhsm to detect if enablerepos should be disabled

### DIFF
--- a/convert2rhel/repo.py
+++ b/convert2rhel/repo.py
@@ -58,16 +58,28 @@ def get_rhel_repoids():
 
 
 def get_rhel_repos_to_disable():
-    """Get the list of repositories which should be disabled when performing pre-conversion checks. Avoid downloading
-    backup and up-to-date checks from them. The output list can looks like:
-    ['rhel*', 'user-provided', 'user-provided1']
+    """Get the list of repositories which should be disabled when performing pre-conversion checks.
+
+    Avoid downloading backup and up-to-date checks from them. The output list can looks like: ["rhel*"]
+
+    .. note::
+        If --enablerepo switch is enabled, we will return a combination of repositories to disable as following:
+
+        >>> # tool_opts.enablerepo comes from the CLI option `--enablerepo`.
+        >>> repos_to_disable = ["rhel*"]
+        >>> repos_to_disable.extend(tool_opts.enablerepo) # returns: ["rhel*", "rhel-7-server-optional-rpms"]
 
     :return: List of repositories to disable when performing checks.
-    :rtype: List[str]
+    :rtype: list[str]
     """
     # RHELC-884 disable the RHEL repos to avoid reaching them when checking original system.
-    # Also disable repositories enabled by the user for the conversion.
-    return ["rhel*"] + tool_opts.enablerepo
+    repos_to_disable = ["rhel*"]
+
+    # In case we want to disable also the custom repositories set by the user in CLI
+    if tool_opts.no_rhsm:
+        repos_to_disable.extend(tool_opts.enablerepo)
+
+    return repos_to_disable
 
 
 def get_rhel_disable_repos_command(disable_repos):

--- a/convert2rhel/repo.py
+++ b/convert2rhel/repo.py
@@ -63,11 +63,11 @@ def get_rhel_repos_to_disable():
     Avoid downloading backup and up-to-date checks from them. The output list can looks like: ["rhel*"]
 
     .. note::
-        If --enablerepo switch is enabled, we will return a combination of repositories to disable as following:
+        If --enablerepo switch is used together with the --no-rhsm, we will return a combination of repositories to disable as following:
 
         >>> # tool_opts.enablerepo comes from the CLI option `--enablerepo`.
         >>> repos_to_disable = ["rhel*"]
-        >>> repos_to_disable.extend(tool_opts.enablerepo) # returns: ["rhel*", "rhel-7-server-optional-rpms"]
+        >>> repos_to_disable.extend(tool_opts.enablerepo) # returns: ["rhel*", "my-rhel-repo-mirror"]
 
     :return: List of repositories to disable when performing checks.
     :rtype: list[str]
@@ -75,7 +75,8 @@ def get_rhel_repos_to_disable():
     # RHELC-884 disable the RHEL repos to avoid reaching them when checking original system.
     repos_to_disable = ["rhel*"]
 
-    # In case we want to disable also the custom repositories set by the user in CLI
+    # this is for the case where the user configures e.g. [my-rhel-repo-mirror] on the system and leaves it enabled
+    # before running convert2rhel - we want to prevent the checks from accessing it as it contains packages for RHEL
     if tool_opts.no_rhsm:
         repos_to_disable.extend(tool_opts.enablerepo)
 

--- a/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
@@ -787,7 +787,6 @@ class TestIsLoadedKernelLatest:
                     "--setopt=exclude=",
                     "--quiet",
                     "--disablerepo=rhel*",
-                    "--disablerepo=test-repo",
                     "--qf",
                     "C2R\\t%{BUILDTIME}\\t%{VERSION}-%{RELEASE}\\t%{REPOID}",
                     "kernel",

--- a/convert2rhel/unit_tests/repo_test.py
+++ b/convert2rhel/unit_tests/repo_test.py
@@ -80,12 +80,21 @@ def test_get_rhel_repoids_el7(pretend_os, is_els_release, expected, monkeypatch)
     assert repos == expected
 
 
-@pytest.mark.parametrize(("enablerepo", "disablerepos"), (([], ["rhel*"]), (["test-repo"], ["rhel*", "test-repo"])))
-def test_get_rhel_repos_to_disable(monkeypatch, enablerepo, disablerepos):
-    monkeypatch.setattr(repo.tool_opts, "enablerepo", enablerepo)
+@pytest.mark.parametrize(
+    ("no_rhsm", "enablerepo", "disablerepos"),
+    (
+        (False, [], ["rhel*"]),
+        (True, ["test-repo"], ["rhel*", "test-repo"]),
+        (True, [], ["rhel*"]),
+        (False, ["test-repo"], ["rhel*"]),
+    ),
+)
+def test_get_rhel_repos_to_disable(monkeypatch, global_tool_opts, no_rhsm, enablerepo, disablerepos):
+    monkeypatch.setattr(repo, "tool_opts", global_tool_opts)
+    global_tool_opts.enablerepo = enablerepo
+    global_tool_opts.no_rhsm = no_rhsm
 
     repos = repo.get_rhel_repos_to_disable()
-
     assert repos == disablerepos
 
 


### PR DESCRIPTION
We have a special function that returns a list of repositories that needs to be disabled during various command calls, and that list is returning always the user enablerepos command line switch in it. This patch only add the enablerepos option to the list when the --no-rhsm switch is also applied.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1626](https://issues.redhat.com/browse/RHELC-1626)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
