### PR TITLE
[RHELC-1630] Improve reliability of the Isolated system conversion test

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -44,9 +44,6 @@ prepare+:
     - name: main preparation step
       how: ansible
       playbook: tests/ansible_collections/main.yml
-    - name: reboot system after update
-      how: ansible
-      playbook: tests/ansible_collections/roles/reboot/main.yml
 
     # We need to remove all the repositories that were used to install c2r package.
     # The updated packages check may find that installed c2r is not latest and it then

--- a/plans/stream.fmf
+++ b/plans/stream.fmf
@@ -108,6 +108,9 @@ adjust+:
                           script: pytest --setup-show -svv tests/integration/*/destructive/single-yum-transaction/install_multilib_packages.py
             /yum_distro_sync:
                 prepare+:
+                    - name: enable CentOS' extras repo
+                      how: ansible
+                      playbook: tests/integration/tier0/destructive/yum-distro-sync/add-extras-repo/main.yml
                     - name: Install problematic package
                       how: shell
                       script: pytest --setup-show -svv tests/integration/*/destructive/yum-distro-sync/install_problematic_package.py

--- a/plans/stream.fmf
+++ b/plans/stream.fmf
@@ -61,10 +61,16 @@ adjust+:
                     exclude:
                         - checks-after-conversion/rhel_subman
             /isolated_system_conversion:
+                adjust+:
+                  - environment+:
+                      TESTS_DONT_UPDATE_SYSTEM: 1
                 prepare+:
                     - name: Allow access to Satellite only
                       how: shell
                       script: pytest --setup-show -svv tests/integration/*/destructive/isolated-system-conversion/prepare_system.py
+                    - name: Reboot the system
+                      how: ansible
+                      playbook: tests/ansible_collections/roles/reboot/main.yml
                 discover+:
                     test+<:
                         - isolated-system-conversion/isolated_system_conversion

--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -184,10 +184,16 @@ adjust+:
 
 
         /isolated_system_conversion:
+            adjust+:
+                - environment+:
+                    TESTS_DONT_UPDATE_SYSTEM: 1
             prepare+:
                 - name: Allow access to Satellite only
                   how: shell
                   script: pytest --setup-show -svv tests/integration/*/destructive/isolated-system-conversion/prepare_system.py
+                - name: Reboot the system
+                  how: ansible
+                  playbook: tests/ansible_collections/roles/reboot/main.yml
             discover+:
                 test+<:
                     - isolated-system-conversion/isolated_system_conversion

--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -175,6 +175,9 @@ adjust+:
 
             /yum_distro_sync:
                 prepare+:
+                      - name: enable CentOS' extras repo
+                        how: ansible
+                        playbook: tests/integration/tier0/destructive/yum-distro-sync/add-extras-repo/main.yml
                       - name: Install problematic package
                         how: shell
                         script: pytest --setup-show -svv tests/integration/*/destructive/yum-distro-sync/install_problematic_package.py

--- a/tests/ansible_collections/main.yml
+++ b/tests/ansible_collections/main.yml
@@ -10,6 +10,7 @@
     - role: remove-tf-artifact-leftovers
 
     - role: update-system
+      when: lookup('env', 'TESTS_DONT_UPDATE_SYSTEM') != "1"
 
     - role: oracle-linux-specific
       when: ansible_facts['distribution'] == "OracleLinux"
@@ -21,3 +22,6 @@
     - role: get-test-vars
 
     - role: update-ca-trust
+
+- import_playbook: roles/reboot/main.yml
+  when: lookup('env', 'TESTS_DONT_UPDATE_SYSTEM') != "1"

--- a/tests/integration/tier0/destructive/isolated-system-conversion/prepare_system.py
+++ b/tests/integration/tier0/destructive/isolated-system-conversion/prepare_system.py
@@ -49,3 +49,9 @@ def test_prepare_system(shell, satellite_registration):
     configure_connection()
 
     assert shell("systemctl enable dnsmasq && systemctl restart dnsmasq").returncode == 0
+
+    # We need to update the system at this point instead of relying on the ansible playbook
+    # run with the host set up.
+    # At this point we actually update the system from the repositories synced to the Satellite
+    # dogfood server, not the system ones.
+    assert shell("yum update -y")

--- a/tests/integration/tier0/destructive/isolated-system-conversion/prepare_system.py
+++ b/tests/integration/tier0/destructive/isolated-system-conversion/prepare_system.py
@@ -3,7 +3,7 @@ import socket
 
 import pytest
 
-from conftest import TEST_VARS
+from conftest import TEST_VARS, SystemInformationRelease
 
 
 def configure_connection():
@@ -32,19 +32,11 @@ def test_prepare_system(shell, satellite_registration):
     """
     Perform all the steps to make the system appear to be offline.
     Register to the Satellite server.
-    Remove all the repositories before the Satellite subscription,
+    Remove all the repositories before the Satellite registration,
     so there is only the redhat.repo created by subscription-manager.
     The original system repositories are then used from the synced Satellite server.
     """
     assert shell("yum install dnsmasq -y").returncode == 0
-
-    repos_dir = "/etc/yum.repos.d"
-    # Remove all repofiles except the redhat.repo
-    for file in os.listdir(repos_dir):
-        if not file.endswith("redhat.repo"):
-            os.remove(os.path.join(repos_dir, file))
-
-    assert os.path.isfile("/etc/yum.repos.d/redhat.repo")
 
     configure_connection()
 
@@ -52,6 +44,19 @@ def test_prepare_system(shell, satellite_registration):
 
     # We need to update the system at this point instead of relying on the ansible playbook
     # run with the host set up.
-    # At this point we actually update the system from the repositories synced to the Satellite
-    # dogfood server, not the system ones.
-    assert shell("yum update -y")
+    # We could remove all the system repositories before the update, but in case
+    # there is also an update of the <system>-release package the repositories would get restored.
+    # Therefore, we update the system with all repositories disabled enabling only the Satellite.
+    assert shell("yum update -y --disablerepo=* --enablerepo=Satellite_Engineering*")
+
+    repos_dir = "/etc/yum.repos.d"
+    # At this point we can safely remove all the repofiles except the redhat.repo
+    for file in os.listdir(repos_dir):
+        os.remove(os.path.join(repos_dir, file))
+        assert not os.path.isfile(os.path.join(repos_dir, file))
+
+    # Clean the package manager metadata and the cache directory
+    pkgmanager = "yum"
+    if SystemInformationRelease.version.major >= 8:
+        pkgmanager = "dnf"
+    shell(f"{pkgmanager} clean all && rm -rf /var/cache/{pkgmanager}/*")

--- a/tests/integration/tier0/destructive/yum-distro-sync/add-extras-repo/centos7_extras.yml
+++ b/tests/integration/tier0/destructive/yum-distro-sync/add-extras-repo/centos7_extras.yml
@@ -1,0 +1,10 @@
+- hosts: all
+  tasks:
+    - name: Add CentOS extras repo
+      yum_repository:
+        name: centos7-extras
+        description: CentOS extras for $basearch
+        baseurl: https://vault.centos.org/centos/7/extras/$basearch/
+        gpgcheck: no
+        enabled: yes
+        file: centos7-extras

--- a/tests/integration/tier0/destructive/yum-distro-sync/add-extras-repo/centos8_extras.yml
+++ b/tests/integration/tier0/destructive/yum-distro-sync/add-extras-repo/centos8_extras.yml
@@ -1,0 +1,10 @@
+- hosts: all
+  tasks:
+    - name: Add CentOS extras repo
+      yum_repository:
+        name: centos8-extras
+        description: CentOS extras for $basearch
+        baseurl: https://vault.centos.org/centos/8/extras/$basearch/os/
+        gpgcheck: no
+        enabled: yes
+        file: centos8-extras

--- a/tests/integration/tier0/destructive/yum-distro-sync/add-extras-repo/main.yml
+++ b/tests/integration/tier0/destructive/yum-distro-sync/add-extras-repo/main.yml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  gather_facts: yes
+  become: false
+- import_playbook: centos7_extras.yml
+  when: ansible_facts['distribution_major_version'] == "7"
+- import_playbook: centos8_extras.yml
+  when: ansible_facts['distribution_major_version'] == "8"


### PR DESCRIPTION
* condition the update-system and the subsequent reboot roles not to be used for the isolated system conversion
* system will be updated during the test preparation phase when it's registered to consume the satellite content
* move the reboot role to the main yaml out of the fmf

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1630](https://issues.redhat.com/browse/RHELC-1630)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [x] When merged: Jira issue has been updated to `Release Pending` if relevant
