### PR TITLE
[RHELC-1330] Port list_non_red_hat_pkgs_left to Action framework

### DIFF
--- a/convert2rhel/actions/conversion/list_non_red_hat_pkgs_left.py
+++ b/convert2rhel/actions/conversion/list_non_red_hat_pkgs_left.py
@@ -18,6 +18,8 @@ __metaclass__ = type
 import logging
 
 from convert2rhel import actions, pkghandler
+from convert2rhel.pkghandler import get_installed_pkgs_w_different_fingerprint, print_pkg_info
+from convert2rhel.systeminfo import system_info
 
 
 loggerinst = logging.getLogger(__name__)
@@ -32,4 +34,10 @@ class ListNonRedHatPkgsLeft(actions.Action):
         Red Hat-signed ones during the conversion.
         """
         super(ListNonRedHatPkgsLeft, self).run()
-        pkghandler.list_non_red_hat_pkgs_left()
+        loggerinst.info("Listing packages not signed by Red Hat")
+        non_red_hat_pkgs = get_installed_pkgs_w_different_fingerprint(system_info.fingerprints_rhel)
+        if non_red_hat_pkgs:
+            loggerinst.info("The following packages were left unchanged.\n")
+            print_pkg_info(non_red_hat_pkgs)
+        else:
+            loggerinst.info("All packages are now signed by Red Hat.")

--- a/convert2rhel/actions/conversion/list_non_red_hat_pkgs_left.py
+++ b/convert2rhel/actions/conversion/list_non_red_hat_pkgs_left.py
@@ -17,7 +17,7 @@ __metaclass__ = type
 
 import logging
 
-from convert2rhel import actions, pkghandler
+from convert2rhel import actions
 from convert2rhel.pkghandler import get_installed_pkgs_w_different_fingerprint, print_pkg_info
 from convert2rhel.systeminfo import system_info
 
@@ -27,7 +27,6 @@ loggerinst = logging.getLogger(__name__)
 
 class ListNonRedHatPkgsLeft(actions.Action):
     id = "LIST_NON_RED_HAT_PKGS_LEFT"
-    dependencies = ()  # XXX
 
     def run(self):
         """List all the packages that have not been replaced by the
@@ -36,8 +35,9 @@ class ListNonRedHatPkgsLeft(actions.Action):
         super(ListNonRedHatPkgsLeft, self).run()
         loggerinst.info("Listing packages not signed by Red Hat")
         non_red_hat_pkgs = get_installed_pkgs_w_different_fingerprint(system_info.fingerprints_rhel)
-        if non_red_hat_pkgs:
-            loggerinst.info("The following packages were left unchanged.\n")
-            print_pkg_info(non_red_hat_pkgs)
-        else:
+        if not non_red_hat_pkgs:
             loggerinst.info("All packages are now signed by Red Hat.")
+            return
+
+        loggerinst.info("The following packages were left unchanged.\n")
+        print_pkg_info(non_red_hat_pkgs)

--- a/convert2rhel/actions/conversion/list_non_red_hat_pkgs_left.py
+++ b/convert2rhel/actions/conversion/list_non_red_hat_pkgs_left.py
@@ -1,0 +1,35 @@
+# Copyright(C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import logging
+
+from convert2rhel import actions, pkgmanager
+
+
+loggerinst = logging.getLogger(__name__)
+
+
+class ListNonRedHatPkgsLeft(actions.Action):
+    id = "LIST_NON_RED_HAT_PKGS_LEFT"
+    dependencies = ()  # XXX
+
+    def run(self):
+        """List all the packages that have not been replaced by the
+        Red Hat-signed ones during the conversion.
+        """
+        super(ListNonRedHatPkgsLeft, self).run()
+        pkgmanager.list_non_red_hat_pkgs_left()

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -394,7 +394,6 @@ def post_ponr_changes():
 
 def post_ponr_conversion():
     """Perform main steps for system conversion."""
-    loggerinst.task("Convert: List remaining non-Red Hat packages")
     loggerinst.task("Convert: Configure the bootloader")
     grub.post_ponr_set_efi_configuration()
     loggerinst.task("Convert: Patch yum configuration file")

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -395,7 +395,6 @@ def post_ponr_changes():
 def post_ponr_conversion():
     """Perform main steps for system conversion."""
     loggerinst.task("Convert: List remaining non-Red Hat packages")
-    pkghandler.list_non_red_hat_pkgs_left()
     loggerinst.task("Convert: Configure the bootloader")
     grub.post_ponr_set_efi_configuration()
     loggerinst.task("Convert: Patch yum configuration file")

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -536,19 +536,6 @@ def get_vendor(pkg_obj):
     return pkg_obj.vendor if pkg_obj.vendor else "N/A"
 
 
-def list_non_red_hat_pkgs_left():
-    """List all the packages that have not been replaced by the
-    Red Hat-signed ones during the conversion.
-    """
-    loggerinst.info("Listing packages not signed by Red Hat")
-    non_red_hat_pkgs = get_installed_pkgs_w_different_fingerprint(system_info.fingerprints_rhel)
-    if non_red_hat_pkgs:
-        loggerinst.info("The following packages were left unchanged.\n")
-        print_pkg_info(non_red_hat_pkgs)
-    else:
-        loggerinst.info("All packages are now signed by Red Hat.")
-
-
 def get_pkg_nevras(pkg_objects):
     """Get a list of package NEVRA strings from a list of PackageInformation objects."""
     return [get_pkg_nevra(pkg_obj) for pkg_obj in pkg_objects]

--- a/convert2rhel/unit_tests/actions/conversion/list_non_red_hat_pkgs_left_test.py
+++ b/convert2rhel/unit_tests/actions/conversion/list_non_red_hat_pkgs_left_test.py
@@ -16,20 +16,26 @@
 __metaclass__ = type
 
 import logging
+import os
 
-from convert2rhel import actions, pkghandler
+import pytest
+import six
 
 
-loggerinst = logging.getLogger(__name__)
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
+
+from convert2rhel import pkghandler, unit_tests
+from convert2rhel.actions.conversion import list_non_red_hat_pkgs_left
 
 
-class ListNonRedHatPkgsLeft(actions.Action):
-    id = "LIST_NON_RED_HAT_PKGS_LEFT"
-    dependencies = ()  # XXX
+@pytest.fixture
+def list_non_red_hat_pkgs_left_instance():
+    return list_non_red_hat_pkgs_left.ListNonRedHatPkgsLeft()
 
-    def run(self):
-        """List all the packages that have not been replaced by the
-        Red Hat-signed ones during the conversion.
-        """
-        super(ListNonRedHatPkgsLeft, self).run()
-        pkghandler.list_non_red_hat_pkgs_left()
+
+def test_list_non_red_hat_pkgs_left(list_non_red_hat_pkgs_left_instance, monkeypatch):
+    list_non_red_hat_pkgs_left_mock = mock.Mock()
+    monkeypatch.setattr(pkghandler, "list_non_red_hat_pkgs_left", list_non_red_hat_pkgs_left_mock)
+    list_non_red_hat_pkgs_left_instance.run()
+    assert list_non_red_hat_pkgs_left_mock.call_count == 1

--- a/convert2rhel/unit_tests/actions/conversion/list_non_red_hat_pkgs_left_test.py
+++ b/convert2rhel/unit_tests/actions/conversion/list_non_red_hat_pkgs_left_test.py
@@ -15,8 +15,6 @@
 
 __metaclass__ = type
 
-import logging
-import os
 
 import pytest
 import six
@@ -25,9 +23,8 @@ from convert2rhel.actions.conversion import list_non_red_hat_pkgs_left
 
 
 six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
-from six.moves import mock
 
-from convert2rhel import pkghandler, unit_tests
+from convert2rhel import pkghandler
 from convert2rhel.unit_tests import FormatPkgInfoMocked, GetInstalledPkgInformationMocked
 
 

--- a/convert2rhel/unit_tests/actions/conversion/list_non_red_hat_pkgs_left_test.py
+++ b/convert2rhel/unit_tests/actions/conversion/list_non_red_hat_pkgs_left_test.py
@@ -42,3 +42,13 @@ def test_list_non_red_hat_pkgs_left(list_non_red_hat_pkgs_left_instance, monkeyp
 
     assert len(pkghandler.format_pkg_info.call_args[0][0]) == 1
     assert pkghandler.format_pkg_info.call_args[0][0][0].nevra.name == "pkg2"
+
+
+def test_no_non_red_hat_pkgs_left(list_non_red_hat_pkgs_left_instance, monkeypatch, caplog):
+    monkeypatch.setattr(pkghandler, "format_pkg_info", FormatPkgInfoMocked())
+    monkeypatch.setattr(
+        pkghandler, "get_installed_pkg_information", GetInstalledPkgInformationMocked(pkg_selection="empty")
+    )
+    list_non_red_hat_pkgs_left_instance.run()
+
+    assert "All packages are now signed by Red Hat." in caplog.records[-1].message

--- a/convert2rhel/unit_tests/actions/conversion/list_non_red_hat_pkgs_left_test.py
+++ b/convert2rhel/unit_tests/actions/conversion/list_non_red_hat_pkgs_left_test.py
@@ -21,12 +21,14 @@ import os
 import pytest
 import six
 
+from convert2rhel.actions.conversion import list_non_red_hat_pkgs_left
+
 
 six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
 from six.moves import mock
 
 from convert2rhel import pkghandler, unit_tests
-from convert2rhel.actions.conversion import list_non_red_hat_pkgs_left
+from convert2rhel.unit_tests import FormatPkgInfoMocked, GetInstalledPkgInformationMocked
 
 
 @pytest.fixture
@@ -35,7 +37,11 @@ def list_non_red_hat_pkgs_left_instance():
 
 
 def test_list_non_red_hat_pkgs_left(list_non_red_hat_pkgs_left_instance, monkeypatch):
-    list_non_red_hat_pkgs_left_mock = mock.Mock()
-    monkeypatch.setattr(pkghandler, "list_non_red_hat_pkgs_left", list_non_red_hat_pkgs_left_mock)
+    monkeypatch.setattr(pkghandler, "format_pkg_info", FormatPkgInfoMocked())
+    monkeypatch.setattr(
+        pkghandler, "get_installed_pkg_information", GetInstalledPkgInformationMocked(pkg_selection="fingerprints")
+    )
     list_non_red_hat_pkgs_left_instance.run()
-    assert list_non_red_hat_pkgs_left_mock.call_count == 1
+
+    assert len(pkghandler.format_pkg_info.call_args[0][0]) == 1
+    assert pkghandler.format_pkg_info.call_args[0][0][0].nevra.name == "pkg2"

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -208,11 +208,13 @@ class TestShowEula:
 
 def test_post_ponr_conversion(monkeypatch):
     list_non_red_hat_pkgs_left_mock = mock.Mock()
+    perserve_only_rhel_kernel_mock = mock.Mock()
     post_ponr_set_efi_configuration_mock = mock.Mock()
     yum_conf_patch_mock = mock.Mock()
     lock_releasever_in_rhel_repositories_mock = mock.Mock()
 
     monkeypatch.setattr(pkghandler, "list_non_red_hat_pkgs_left", list_non_red_hat_pkgs_left_mock)
+    monkeypatch.setattr(pkghandler, "preserve_only_rhel_kernel", perserve_only_rhel_kernel_mock)
     monkeypatch.setattr(grub, "post_ponr_set_efi_configuration", post_ponr_set_efi_configuration_mock)
     monkeypatch.setattr(redhatrelease.YumConf, "patch", yum_conf_patch_mock)
     monkeypatch.setattr(subscription, "lock_releasever_in_rhel_repositories", lock_releasever_in_rhel_repositories_mock)
@@ -220,6 +222,7 @@ def test_post_ponr_conversion(monkeypatch):
     main.post_ponr_conversion()
 
     assert list_non_red_hat_pkgs_left_mock.call_count == 1
+    assert perserve_only_rhel_kernel_mock.call_count == 1
     assert post_ponr_set_efi_configuration_mock.call_count == 1
     assert yum_conf_patch_mock.call_count == 1
     assert lock_releasever_in_rhel_repositories_mock.call_count == 1

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -207,22 +207,16 @@ class TestShowEula:
 
 
 def test_post_ponr_conversion(monkeypatch):
-    list_non_red_hat_pkgs_left_mock = mock.Mock()
-    perserve_only_rhel_kernel_mock = mock.Mock()
     post_ponr_set_efi_configuration_mock = mock.Mock()
     yum_conf_patch_mock = mock.Mock()
     lock_releasever_in_rhel_repositories_mock = mock.Mock()
 
-    monkeypatch.setattr(pkghandler, "list_non_red_hat_pkgs_left", list_non_red_hat_pkgs_left_mock)
-    monkeypatch.setattr(pkghandler, "preserve_only_rhel_kernel", perserve_only_rhel_kernel_mock)
     monkeypatch.setattr(grub, "post_ponr_set_efi_configuration", post_ponr_set_efi_configuration_mock)
     monkeypatch.setattr(redhatrelease.YumConf, "patch", yum_conf_patch_mock)
     monkeypatch.setattr(subscription, "lock_releasever_in_rhel_repositories", lock_releasever_in_rhel_repositories_mock)
 
     main.post_ponr_conversion()
 
-    assert list_non_red_hat_pkgs_left_mock.call_count == 1
-    assert perserve_only_rhel_kernel_mock.call_count == 1
     assert post_ponr_set_efi_configuration_mock.call_count == 1
     assert yum_conf_patch_mock.call_count == 1
     assert lock_releasever_in_rhel_repositories_mock.call_count == 1

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -1483,17 +1483,6 @@ def test_get_third_party_pkgs(fingerprint_orig_os, expected_count, expected_pkgs
     assert len(pkgs) == expected_pkgs
 
 
-def test_list_non_red_hat_pkgs_left(monkeypatch):
-    monkeypatch.setattr(pkghandler, "format_pkg_info", FormatPkgInfoMocked())
-    monkeypatch.setattr(
-        pkghandler, "get_installed_pkg_information", GetInstalledPkgInformationMocked(pkg_selection="fingerprints")
-    )
-    pkghandler.list_non_red_hat_pkgs_left()
-
-    assert len(pkghandler.format_pkg_info.call_args[0][0]) == 1
-    assert pkghandler.format_pkg_info.call_args[0][0][0].nevra.name == "pkg2"
-
-
 @pytest.mark.parametrize(
     ("package_name", "subprocess_output", "expected", "expected_command"),
     (


### PR DESCRIPTION
Port list_non_red_hat_pkgs_left to the Action framework

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1330](https://issues.redhat.com/browse/RHELC-1330)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
