### PR TITLE
chore: include type comments recommendation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,14 +219,24 @@ linters/formatters that are run directly from
 Don't worry, most of the code formatting and styleguide is handled by
 [black](https://github.com/psf/black), an awesome formatter for python code.
 
-### Python documentation styleguide
+#### Documenting the code
 
-The documentation for our python code should follow the [PEP 8 -- Documentation
+##### Docstrings for classes, functions, and variables
+Code should be self-documenting, but it does not take into consideration how
+the functions should be used, what the scope of the classes are, or what the variable
+is to be used for. We follow [PEP 8 -- Documentation
 Strings](https://www.python.org/dev/peps/pep-0008/#toc-entry-20) or more
 precisely the [PEP 257 -- Docstring
 Conventions](https://www.python.org/dev/peps/pep-0257/) and preferably all
 functions should contain at least a minimum docstring to identify what that
 function is used for.
+
+When writing the docstrings, imagine onboarding a new person to the codebase half
+a year down the line and what they need to know to understand the function and
+any edge-cases.
+
+##### Type comments
+We make use of type comments where possible to get type hinting, since we cannot use type hints due to having to support python 2.7. You can find the type comments style in [PEP-0484#type-comments](https://peps.python.org/pep-0484/#type-comments)
 
 ## Additional information
 
@@ -234,7 +244,6 @@ Additional technical information is located [on the
 wiki](https://github.com/oamg/convert2rhel/wiki).  When you add a new feature that others might need
 to plug into or affects how their code should be written in the future, please add a new page there
 and link it to the toplevel [Topics section](https://github.com/oamg/convert2rhel/wiki#topics).
-
 
 ### Building rpms locally
 


### PR DESCRIPTION
This adds the type comments section from the type hints PEP as a
recommendation within the CONTRIBUTING.md. In particular this will help
us with IDE and editor suggestions and warnings

https://peps.python.org/pep-0484/#type-comments

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
