### PR TITLE
chore: update CentOS Linux 7 mirror to vault

### DIFF
--- a/.devcontainer/centos7/centos7-development.Containerfile
+++ b/.devcontainer/centos7/centos7-development.Containerfile
@@ -22,6 +22,9 @@ WORKDIR /workspaces/convert2rhel
 
 FROM base as install_main_deps
 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
 RUN yum update -y && yum install -y $APP_MAIN_DEPS && yum clean all
 
 FROM install_main_deps as install_dev_deps

--- a/Containerfiles/centos7.Containerfile
+++ b/Containerfiles/centos7.Containerfile
@@ -14,6 +14,10 @@ ENV APP_MAIN_DEPS \
 WORKDIR /data
 
 FROM base as install_main_deps
+
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
 RUN yum update -y && yum install -y $APP_MAIN_DEPS && yum clean all
 
 FROM install_main_deps as install_dev_deps

--- a/Containerfiles/rpmbuild.centos7.Containerfile
+++ b/Containerfiles/rpmbuild.centos7.Containerfile
@@ -1,5 +1,8 @@
 FROM centos:7 as base
 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
 RUN yum update -y && yum clean all
 
 ENV APP_MAIN_DEPS \


### PR DESCRIPTION
With CentOS Linux 7 now being unsupported the packages were moved to the
vault as it is no longer recommended to use

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
