### PR TITLE
[RHELC-1650] Disregard minor version with CentOS Stream

### DIFF
--- a/convert2rhel/data/9/x86_64/configs/centos-9-x86_64.cfg
+++ b/convert2rhel/data/9/x86_64/configs/centos-9-x86_64.cfg
@@ -1,0 +1,55 @@
+[system_info]
+
+# Fingerprints of GPG keys used for signing packages of the OS to be converted.
+# The GPG keys are available at https://www.centos.org/keys/
+# Delimited by whitespace(s).
+gpg_fingerprints = 05b555b38483c65d
+
+# List of packages to be removed before the system conversion starts.
+# Delimited by any whitespace(s).
+excluded_pkgs =
+  centos-obsolete-packages
+  centos-gpg-keys
+
+# Mapping of packages that need to be swapped during the transaction
+swap_pkgs =
+  centos-logos | redhat-logos
+  centos-logos-httpd | redhat-logos-httpd
+  centos-logos-ipa | redhat-logos-ipa
+  centos-indexhtml | redhat-indexhtml
+  centos-backgrounds | redhat-backgrounds
+
+# List of packages that either contain repofiles or affect variables in the repofiles (e.g. $releasever).
+# Delimited by any whitespace(s).
+repofile_pkgs =
+  centos-release*
+  centos-repos
+  centos-linux-repos
+  centos-stream-repos
+  centos-linux-release
+  centos-stream-release
+
+# List of repoids to enable through subscription-manager when the --enablerepo option is not used.
+# Delimited by any whitespace(s).
+default_rhsm_repoids =
+  rhel-9-for-x86_64-baseos-rpms
+  rhel-9-for-x86_64-appstream-rpms
+
+# List of Extended Update Support (EUS) repoids to enable through subscription-manager when the --enablerepo option is
+# not used. Delimited by any whitespace(s).
+eus_rhsm_repoids =
+  rhel-9-for-x86_64-baseos-eus-rpms
+  rhel-9-for-x86_64-appstream-eus-rpms
+
+# List of Extended Lifecycle Support (ELS) repoids to enable through subscription-manager when the --enablerepo option is
+# not used. Delimited by any whitespace(s).
+els_rhsm_repoids =
+
+# If defined, it overrides the default releasever defined by RELEASE_VER_MAPPING.
+# The value is passed to the yum calls through the --releasever option when accessing RHEL repos. Its purpose is to
+# substitute the $releasever variable in a repository baseurl.
+releasever=
+
+# Some kernel modules move from kernel modules to kernel core. Instead of inhibiting the conversion with a message
+# that such a module is not available in RHEL and thus is unsupported, we ignore it.
+kmods_to_ignore =

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -75,14 +75,12 @@ class Version(namedtuple("Version", ["major", "minor"])):
     Example:
     >>> ver1 = Version(7, 9)
     >>> ver2 = Version(8, None)
-    >>> repr(ver1)
-    '7.9'
+    >>> ver1
+    7.9
     >>> repr(ver2)
     '8'
     >>> print(ver1.major, ver1.minor)
     7 9
-    >>> print(ver2)
-    Version(8, None)
     """
 
     def __repr__(self):
@@ -96,9 +94,9 @@ class Version(namedtuple("Version", ["major", "minor"])):
         :rtype: str
         """
         if self.minor:
-            return "%s.%s" % (self.major, self.minor)
+            return "{major}.{minor}".format(major=self.major, minor=self.minor)
 
-        return "%s" % self.major
+        return "{major}".format(major=self.major)
 
 
 class SystemInfo:
@@ -186,7 +184,7 @@ class SystemInfo:
     def print_system_information(self):
         """Print system related information."""
         self.logger.info("%-20s %s" % ("Name:", self.name))
-        self.logger.info("%-20s %s" % ("OS version:", repr(self.version)))
+        self.logger.info("%-20s %s" % ("OS version:", self.version))
         self.logger.info("%-20s %s" % ("Architecture:", self.arch))
         self.logger.info("%-20s %s" % ("Config filename:", self.cfg_filename))
 
@@ -390,12 +388,9 @@ class SystemInfo:
             return releasever_cfg or RELEASE_VER_MAPPING[repr(self.version)]
         except KeyError:
             self.logger.critical(
-                "%s of version %s is not allowed for conversion.\n"
-                "Allowed versions are: %s"
-                % (
-                    self.name,
-                    repr(self.version),
-                    list(RELEASE_VER_MAPPING.keys()),
+                "{os_name} of version {current_version} is not allowed for conversion.\n"
+                "Allowed versions are: {allowed_versions}".format(
+                    os_name=self.name, current_version=self.version, allowed_versions=list(RELEASE_VER_MAPPING.keys())
                 )
             )
 

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -170,41 +170,43 @@ def test_get_dbus_status_in_progress(monkeypatch, states, expected):
 
 
 @pytest.mark.parametrize(
-    ("version_str", "expected"),
+    ("major", "minor", "expected"),
     (
-        ("7.9", False),
-        ("8", False),
-        ("8.5", False),
-        ("8.6", False),
-        ("8.7", False),
-        ("8.8", True),
-        ("8.9", False),
-        ("9", False),
+        (7, 9, False),
+        (8, None, False),
+        (8, 5, False),
+        (8, 6, False),
+        (8, 7, False),
+        (8, 8, True),
+        (8, 9, False),
+        (9, None, False),
     ),
 )
-def test_corresponds_to_rhel_eus_release(version_str, expected, monkeypatch, global_tool_opts):
+def test_corresponds_to_rhel_eus_release(major, minor, expected, monkeypatch, global_tool_opts):
+    version = Version(major, minor)
     global_tool_opts.eus = True
     monkeypatch.setattr(tool_opts, "eus", global_tool_opts)
-    monkeypatch.setattr(system_info, "version_str", version_str)
+    monkeypatch.setattr(system_info, "version", version)
 
     assert system_info.corresponds_to_rhel_eus_release() == expected
 
 
 @pytest.mark.parametrize(
-    ("version_str", "expected"),
+    ("major", "minor", "expected"),
     (
-        ("7.9", False),
-        ("8", False),
-        ("8.5", False),
-        ("8.6", False),
-        ("8.7", False),
-        ("8.8", True),
-        ("8.9", False),
-        ("9", False),
+        (7, 9, False),
+        (8, None, False),
+        (8, 5, False),
+        (8, 6, False),
+        (8, 7, False),
+        (8, 8, True),
+        (8, 9, False),
+        (9, None, False),
     ),
 )
-def test_corresponds_to_rhel_eus_release_eus_override(version_str, expected, monkeypatch, global_tool_opts):
-    monkeypatch.setattr(system_info, "version_str", version_str)
+def test_corresponds_to_rhel_eus_release_eus_override(major, minor, expected, monkeypatch, global_tool_opts):
+    version = Version(major, minor)
+    monkeypatch.setattr(system_info, "version", version)
     monkeypatch.setattr(systeminfo, "tool_opts", global_tool_opts)
     global_tool_opts.eus = True
     assert system_info.corresponds_to_rhel_eus_release() == expected
@@ -221,9 +223,6 @@ def test_corresponds_to_rhel_eus_release_eus_override(version_str, expected, mon
         ("CentOS Stream release 8", "version", Version(8, None)),
         ("Red Hat Enterprise Linux release 8.10 Beta (Ootpa)", "version", Version(8, 10)),
         ("CentOS Stream release 9", "version", Version(9, None)),
-        ("CentOS Linux release 8.1.1911 (Core)", "version_str", "8.1"),
-        ("CentOS Stream release 8", "version_str", "8"),
-        ("Red Hat Enterprise Linux release 8.10 Beta (Ootpa)", "version_str", "8.10"),
     ),
 )
 def test_parse_system_release_content_from_string(system_release_content, key, value):
@@ -341,3 +340,22 @@ def test_get_swap_pkgs(monkeypatch, file_content, tmpdir, expected, message, cap
         assert message in caplog.text
     else:
         assert "" == caplog.text
+
+
+@pytest.mark.parametrize(
+    ("major", "minor", "expected"),
+    (
+        (7, 9, "7.9"),
+        (8, None, "8"),
+        (8, 5, "8.5"),
+        (8, 6, "8.6"),
+        (8, 7, "8.7"),
+        (8, 8, "8.8"),
+        (8, 9, "8.9"),
+        (9, None, "9"),
+    ),
+)
+def test_get_version_repr(major, minor, expected, monkeypatch):
+    version = Version(major, minor)
+    monkeypatch.setattr(system_info, "version", version)
+    assert repr(system_info.version) == expected

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -170,32 +170,41 @@ def test_get_dbus_status_in_progress(monkeypatch, states, expected):
 
 
 @pytest.mark.parametrize(
-    ("major", "minor", "expected"),
+    ("version_str", "expected"),
     (
-        (7, 9, False),
-        (8, 5, False),
-        (8, 6, False),
-        (8, 7, False),
-        (8, 8, True),
-        (8, 9, False),
+        ("7.9", False),
+        ("8", False),
+        ("8.5", False),
+        ("8.6", False),
+        ("8.7", False),
+        ("8.8", True),
+        ("8.9", False),
+        ("9", False),
     ),
 )
-def test_corresponds_to_rhel_eus_release(major, minor, expected, monkeypatch, global_tool_opts):
-    version = Version(major, minor)
+def test_corresponds_to_rhel_eus_release(version_str, expected, monkeypatch, global_tool_opts):
     global_tool_opts.eus = True
     monkeypatch.setattr(tool_opts, "eus", global_tool_opts)
-    monkeypatch.setattr(system_info, "version", version)
+    monkeypatch.setattr(system_info, "version_str", version_str)
 
     assert system_info.corresponds_to_rhel_eus_release() == expected
 
 
 @pytest.mark.parametrize(
-    ("major", "minor", "expected"),
-    ((7, 9, False), (8, 5, False), (8, 6, False), (8, 7, False), (8, 8, True), (8, 9, False)),
+    ("version_str", "expected"),
+    (
+        ("7.9", False),
+        ("8", False),
+        ("8.5", False),
+        ("8.6", False),
+        ("8.7", False),
+        ("8.8", True),
+        ("8.9", False),
+        ("9", False),
+    ),
 )
-def test_corresponds_to_rhel_eus_release_eus_override(major, minor, expected, monkeypatch, global_tool_opts):
-    version = Version(major, minor)
-    monkeypatch.setattr(system_info, "version", version)
+def test_corresponds_to_rhel_eus_release_eus_override(version_str, expected, monkeypatch, global_tool_opts):
+    monkeypatch.setattr(system_info, "version_str", version_str)
     monkeypatch.setattr(systeminfo, "tool_opts", global_tool_opts)
     global_tool_opts.eus = True
     assert system_info.corresponds_to_rhel_eus_release() == expected
@@ -209,8 +218,12 @@ def test_corresponds_to_rhel_eus_release_eus_override(major, minor, expected, mo
         ("Oracle Linux Server release 7.8", "distribution_id", None),
         ("CentOS Stream release 8", "id", "centos"),
         ("CentOS Linux release 8.1.1911 (Core)", "version", Version(8, 1)),
-        ("CentOS Stream release 8", "version", Version(8, 10)),
+        ("CentOS Stream release 8", "version", Version(8, None)),
         ("Red Hat Enterprise Linux release 8.10 Beta (Ootpa)", "version", Version(8, 10)),
+        ("CentOS Stream release 9", "version", Version(9, None)),
+        ("CentOS Linux release 8.1.1911 (Core)", "version_str", "8.1"),
+        ("CentOS Stream release 8", "version_str", "8"),
+        ("Red Hat Enterprise Linux release 8.10 Beta (Ootpa)", "version_str", "8.10"),
     ),
 )
 def test_parse_system_release_content_from_string(system_release_content, key, value):

--- a/tests/integration/common/checks-after-conversion/test_release_version.py
+++ b/tests/integration/common/checks-after-conversion/test_release_version.py
@@ -23,7 +23,7 @@ DISTRO_CONVERSION_MAPPING = {
     ),
     "Red Hat Enterprise Linux release 8.10 (Ootpa)": (
         {"id": "null", "name": "Oracle Linux Server", "version": "8.10"},
-        {"id": "null", "name": "CentOS Stream", "version": "8.10"},
+        {"id": "null", "name": "CentOS Stream", "version": "8"},
         {"id": "Cerulean Leopard", "name": "AlmaLinux", "version": "8.10"},
         {"id": "Green Obsidian", "name": "Rocky Linux", "version": "8.10"},
     ),


### PR DESCRIPTION
* if the matched regex of the system-release file does not return a minor version (the full_version group lenght is one character only) disregard the minor version completely
* point the target releaseversion to major only, assuming the rhelX/X/ repository namespace mirrors the latest available rhelX/X.Y/ namespace

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1650](https://issues.redhat.com/browse/RHELC-1650)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [x] When merged: Jira issue has been updated to `Release Pending` if relevant
