### PR TITLE
[RHELC-1337] Port kernel_boot_files to the Action framework

### DIFF
--- a/convert2rhel/actions/post_conversion/kernel_boot_files.py
+++ b/convert2rhel/actions/post_conversion/kernel_boot_files.py
@@ -68,17 +68,17 @@ class KernelBootFiles(actions.Action):
         if is_initramfs_valid or vmlinuz_exists:
             logger.info("The initramfs and vmlinuz files are valid.")
             return
-       
+
+        remediations = (
+                "In order to fix this problem you may need to free/increase space in your boot partition"
+                " and then run the following commands in your terminal:\n"
+                "1. yum reinstall %s-%s -y\n"
+                "2. grub2-mkconfig -o %s\n"
+                "3. reboot" % (kernel_name, latest_installed_kernel, grub2_config_file)
+            )
         logger.warning(
             "Couldn't verify the kernel boot files in the boot partition. This may cause problems during the next boot "
-            "of your system.\nIn order to fix this problem you may need to free/increase space in your boot partition"
-            " and then run the following commands in your terminal:\n"
-            "1. yum reinstall %s-%s -y\n"
-            "2. grub2-mkconfig -o %s\n"
-            "3. reboot",
-            kernel_name,
-            latest_installed_kernel,
-            grub2_config_file,
+            "of your system.\n%s", remediations
         )
         self.add_message(
             level="WARNING",
@@ -86,12 +86,5 @@ class KernelBootFiles(actions.Action):
             title="Unable to verify kernel boot files",
             description="Couldn't verify the kernel boot files in the boot partition. This may cause problems during the next boot "
             "of your system.",
-            remediations=(
-                "In order to fix this problem you may need to free/increase space in your boot partition"
-                " and then run the following commands in your terminal:\n"
-                "1. yum reinstall %s-%s -y\n"
-                "2. grub2-mkconfig -o %s\n"
-                "3. reboot" % (kernel_name, latest_installed_kernel, grub2_config_file)
-            ),
+            remediations=remediations,
         )
-

--- a/convert2rhel/actions/post_conversion/kernel_boot_files.py
+++ b/convert2rhel/actions/post_conversion/kernel_boot_files.py
@@ -62,37 +62,36 @@ class KernelBootFiles(actions.Action):
 
         logger.info("Checking if the '%s' file exists.", vmlinuz_file)
         vmlinuz_exists = os.path.exists(vmlinuz_file)
-        if not vmlinuz_exists:
-            logger.info("The vmlinuz file is not present.")
-
+        logger.info("Checking if the '%s' file exists.", initramfs_file)
         is_initramfs_valid = checks.is_initramfs_file_valid(initramfs_file)
 
-        if not is_initramfs_valid or not vmlinuz_exists:
-            logger.warning(
-                "Couldn't verify the kernel boot files in the boot partition. This may cause problems during the next boot "
-                "of your system.\nIn order to fix this problem you may need to free/increase space in your boot partition"
+        if is_initramfs_valid or vmlinuz_exists:
+            logger.info("The initramfs and vmlinuz files are valid.")
+            return
+       
+        logger.warning(
+            "Couldn't verify the kernel boot files in the boot partition. This may cause problems during the next boot "
+            "of your system.\nIn order to fix this problem you may need to free/increase space in your boot partition"
+            " and then run the following commands in your terminal:\n"
+            "1. yum reinstall %s-%s -y\n"
+            "2. grub2-mkconfig -o %s\n"
+            "3. reboot",
+            kernel_name,
+            latest_installed_kernel,
+            grub2_config_file,
+        )
+        self.add_message(
+            level="WARNING",
+            id="UNABLE_TO_VERIFY_KERNEL_BOOT_FILES",
+            title="Unable to verify kernel boot files",
+            description="Couldn't verify the kernel boot files in the boot partition. This may cause problems during the next boot "
+            "of your system.",
+            remediations=(
+                "In order to fix this problem you may need to free/increase space in your boot partition"
                 " and then run the following commands in your terminal:\n"
                 "1. yum reinstall %s-%s -y\n"
                 "2. grub2-mkconfig -o %s\n"
-                "3. reboot",
-                kernel_name,
-                latest_installed_kernel,
-                grub2_config_file,
-            )
-            self.add_message(
-                level="WARNING",
-                id="UNABLE_TO_VERIFY_KERNEL_BOOT_FILES",
-                title="Unable to verify kernel boot files",
-                description="Couldn't verify the kernel boot files in the boot partition. This may cause problems during the next boot "
-                "of your system.",
-                remediations=(
-                    "In order to fix this problem you may need to free/increase space in your boot partition"
-                    " and then run the following commands in your terminal:\n"
-                    "1. yum reinstall %s-%s -y\n"
-                    "2. grub2-mkconfig -o %s\n"
-                    "3. reboot" % (kernel_name, latest_installed_kernel, grub2_config_file)
-                ),
-            )
+                "3. reboot" % (kernel_name, latest_installed_kernel, grub2_config_file)
+            ),
+        )
 
-        else:
-            logger.info("The initramfs and vmlinuz files are valid.")

--- a/convert2rhel/actions/post_conversion/kernel_boot_files.py
+++ b/convert2rhel/actions/post_conversion/kernel_boot_files.py
@@ -1,0 +1,99 @@
+# Copyright(C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import logging
+import os
+
+from convert2rhel import actions, checks, grub
+from convert2rhel.systeminfo import system_info
+from convert2rhel.utils import run_subprocess
+
+
+logger = logging.getLogger(__name__)
+
+VMLINUZ_FILEPATH = "/boot/vmlinuz-%s"
+"""The path to the vmlinuz file in a system."""
+
+INITRAMFS_FILEPATH = "/boot/initramfs-%s.img"
+"""The path to the initramfs image in a system."""
+
+
+class KernelBootFiles(actions.Action):
+    id = "KERNEL_BOOT_FILES"
+
+    def run(self):
+        """Check if the required kernel files exist and are valid under the boot partition."""
+        super(KernelBootFiles, self).run()
+
+        # For Oracle/CentOS Linux 8 the `kernel` is just a meta package, instead,
+        # we check for `kernel-core`. This is not true regarding the 7.* releases.
+        kernel_name = "kernel-core" if system_info.version.major >= 8 else "kernel"
+
+        # Either the package is returned or not. The return_code will be 0 in
+        # either case, so we don't care about checking for that here.
+        output, _ = run_subprocess(["rpm", "-q", "--last", kernel_name], print_output=False)
+
+        # We are parsing the latest kernel installed on the system, which at this
+        # point, should be a RHEL kernel. Since we can't get the kernel version
+        # from `uname -r`, as it requires a reboot in order to take place, we are
+        # detecting the latest kernel by using `rpm` and figuring out which was the
+        # latest kernel installed.
+        latest_installed_kernel = output.split("\n")[0].split(" ")[0]
+        latest_installed_kernel = latest_installed_kernel[len(kernel_name + "-") :]
+        grub2_config_file = grub.get_grub_config_file()
+        initramfs_file = INITRAMFS_FILEPATH % latest_installed_kernel
+        vmlinuz_file = VMLINUZ_FILEPATH % latest_installed_kernel
+
+        logger.info("Checking if the '%s' file exists.", vmlinuz_file)
+        vmlinuz_exists = os.path.exists(vmlinuz_file)
+        if not vmlinuz_exists:
+            logger.info("The vmlinuz file is not present.")
+
+        is_initramfs_valid = checks.is_initramfs_file_valid(initramfs_file)
+
+        if not is_initramfs_valid or not vmlinuz_exists:
+            logger.warning(
+                "Couldn't verify the kernel boot files in the boot partition. This may cause problems during the next boot "
+                "of your system.\nIn order to fix this problem you may need to free/increase space in your boot partition"
+                " and then run the following commands in your terminal:\n"
+                "1. yum reinstall %s-%s -y\n"
+                "2. grub2-mkconfig -o %s\n"
+                "3. reboot",
+                kernel_name,
+                latest_installed_kernel,
+                grub2_config_file,
+            )
+            self.add_message(
+                level="WARNING",
+                id="UNABLE_TO_VERIFY_KERNEL_BOOT_FILES",
+                title="Unable to verify kernel boot files",
+                description="Couldn't verify the kernel boot files in the boot partition. This may cause problems during the next boot "
+                "of your system.",
+                remediations=(
+                    "In order to fix this problem you may need to free/increase space in your boot partition"
+                    " and then run the following commands in your terminal:\n"
+                    "1. yum reinstall %s-%s -y\n"
+                    "2. grub2-mkconfig -o %s\n"
+                    "3. reboot",
+                    kernel_name,
+                    latest_installed_kernel,
+                    grub2_config_file,
+                ),
+            )
+
+        else:
+            logger.info("The initramfs and vmlinuz files are valid.")

--- a/convert2rhel/actions/post_conversion/kernel_boot_files.py
+++ b/convert2rhel/actions/post_conversion/kernel_boot_files.py
@@ -70,21 +70,26 @@ class KernelBootFiles(actions.Action):
             return
 
         remediations = (
-                "In order to fix this problem you may need to free/increase space in your boot partition"
-                " and then run the following commands in your terminal:\n"
-                "1. yum reinstall %s-%s -y\n"
-                "2. grub2-mkconfig -o %s\n"
-                "3. reboot" % (kernel_name, latest_installed_kernel, grub2_config_file)
+            "In order to fix this problem you might need to free/increase space in your boot partition" \
+            " and then run the following commands in your terminal:\n"
+            "1. `yum reinstall {kernel_name}-{latest_installed_kernel} -y`\n"
+            "2. `grub2-mkconfig -o {grub2_config_file}`\n"
+            "3. `reboot`".format(
+                kernel_name=kernel_name,
+                latest_installed_kernel=latest_installed_kernel,
+                grub2_config_file=grub2_config_file
             )
+        )
         logger.warning(
-            "Couldn't verify the kernel boot files in the boot partition. This may cause problems during the next boot "
-            "of your system.\n%s", remediations
+            "Couldn't verify the kernel boot files in the boot partition. This" \
+            " might cause problems during the next boot of your system.\n" \
+            "{0}".format(remediations),
         )
         self.add_message(
             level="WARNING",
             id="UNABLE_TO_VERIFY_KERNEL_BOOT_FILES",
-            title="Unable to verify kernel boot files",
-            description="Couldn't verify the kernel boot files in the boot partition. This may cause problems during the next boot "
-            "of your system.",
+            title="Unable to verify kernel boot files and boot partition",
+            description="We failed to determine whether boot partition is configured correctly and that boot" \
+                " files exists. This may cause problems during the next boot of your system.",
             remediations=remediations,
         )

--- a/convert2rhel/actions/post_conversion/kernel_boot_files.py
+++ b/convert2rhel/actions/post_conversion/kernel_boot_files.py
@@ -39,6 +39,8 @@ class KernelBootFiles(actions.Action):
         """Check if the required kernel files exist and are valid under the boot partition."""
         super(KernelBootFiles, self).run()
 
+        logger.task("Final: Check kernel boot files")
+
         # For Oracle/CentOS Linux 8 the `kernel` is just a meta package, instead,
         # we check for `kernel-core`. This is not true regarding the 7.* releases.
         kernel_name = "kernel-core" if system_info.version.major >= 8 else "kernel"
@@ -88,10 +90,7 @@ class KernelBootFiles(actions.Action):
                     " and then run the following commands in your terminal:\n"
                     "1. yum reinstall %s-%s -y\n"
                     "2. grub2-mkconfig -o %s\n"
-                    "3. reboot",
-                    kernel_name,
-                    latest_installed_kernel,
-                    grub2_config_file,
+                    "3. reboot" % (kernel_name, latest_installed_kernel, grub2_config_file)
                 ),
             )
 

--- a/convert2rhel/actions/post_conversion/kernel_boot_files.py
+++ b/convert2rhel/actions/post_conversion/kernel_boot_files.py
@@ -65,7 +65,7 @@ class KernelBootFiles(actions.Action):
         logger.info("Checking if the '%s' file exists.", initramfs_file)
         is_initramfs_valid = checks.is_initramfs_file_valid(initramfs_file)
 
-        if is_initramfs_valid or vmlinuz_exists:
+        if is_initramfs_valid and vmlinuz_exists:
             logger.info("The initramfs and vmlinuz files are valid.")
             return
 

--- a/convert2rhel/actions/post_conversion/kernel_boot_files.py
+++ b/convert2rhel/actions/post_conversion/kernel_boot_files.py
@@ -70,26 +70,26 @@ class KernelBootFiles(actions.Action):
             return
 
         remediations = (
-            "In order to fix this problem you might need to free/increase space in your boot partition" \
+            "In order to fix this problem you might need to free/increase space in your boot partition"
             " and then run the following commands in your terminal:\n"
             "1. yum reinstall {kernel_name}-{latest_installed_kernel} -y\n"
             "2. grub2-mkconfig -o {grub2_config_file}\n"
             "3. reboot".format(
                 kernel_name=kernel_name,
                 latest_installed_kernel=latest_installed_kernel,
-                grub2_config_file=grub2_config_file
+                grub2_config_file=grub2_config_file,
             )
         )
         logger.warning(
-            "Couldn't verify the kernel boot files in the boot partition. This" \
-            " might cause problems during the next boot of your system.\n" \
+            "Couldn't verify the kernel boot files in the boot partition. This"
+            " might cause problems during the next boot of your system.\n"
             "{0}".format(remediations),
         )
         self.add_message(
             level="WARNING",
             id="UNABLE_TO_VERIFY_KERNEL_BOOT_FILES",
             title="Unable to verify kernel boot files and boot partition",
-            description="We failed to determine whether boot partition is configured correctly and that boot" \
-                " files exists. This may cause problems during the next boot of your system.",
+            description="We failed to determine whether boot partition is configured correctly and that boot"
+            " files exists. This may cause problems during the next boot of your system.",
             remediations=remediations,
         )

--- a/convert2rhel/actions/post_conversion/kernel_boot_files.py
+++ b/convert2rhel/actions/post_conversion/kernel_boot_files.py
@@ -72,9 +72,9 @@ class KernelBootFiles(actions.Action):
         remediations = (
             "In order to fix this problem you might need to free/increase space in your boot partition" \
             " and then run the following commands in your terminal:\n"
-            "1. `yum reinstall {kernel_name}-{latest_installed_kernel} -y`\n"
-            "2. `grub2-mkconfig -o {grub2_config_file}`\n"
-            "3. `reboot`".format(
+            "1. yum reinstall {kernel_name}-{latest_installed_kernel} -y\n"
+            "2. grub2-mkconfig -o {grub2_config_file}\n"
+            "3. reboot".format(
                 kernel_name=kernel_name,
                 latest_installed_kernel=latest_installed_kernel,
                 grub2_config_file=grub2_config_file

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -373,9 +373,6 @@ def prepare_system():
 def post_ponr_changes():
     """Start the conversion itself"""
 
-    loggerinst.task("Final: Check kernel boot files")
-    checks.check_kernel_boot_files()
-
     loggerinst.task("Final: Configure host-metering")
     hostmetering.configure_host_metering()
 

--- a/convert2rhel/unit_tests/actions/post_conversion/kernel_boot_files_test.py
+++ b/convert2rhel/unit_tests/actions/post_conversion/kernel_boot_files_test.py
@@ -20,7 +20,7 @@ import os
 import pytest
 import six
 
-from convert2rhel import actions, checks
+from convert2rhel import actions, checks, grub
 from convert2rhel.actions.post_conversion import kernel_boot_files
 from convert2rhel.unit_tests import RunSubprocessMocked
 from convert2rhel.unit_tests.conftest import centos8
@@ -132,6 +132,7 @@ def test_check_kernel_boot_files_missing(
             ]
         ),
     )
+    # monkeypatch.setattr(grub, "is_efi", mock.Mock(return_value=True))
     boot_folder = tmpdir.mkdir("/boot")
     if create_initramfs:
         initramfs_file = boot_folder.join("initramfs-%s.img")
@@ -163,8 +164,8 @@ def test_check_kernel_boot_files_missing(
                 " files exists. This may cause problems during the next boot of your system.",
                 diagnosis=None,
                 remediations="In order to fix this problem you might need to free/increase space in your boot partition and then run the following commands in your terminal:\n"
-                "1. yum reinstall kernel-core-6.9.9-200.fc40.x86_64 -y\n"
-                "2. grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg\n"
+                "1. yum reinstall kernel-core- -y\n"
+                "2. grub2-mkconfig -o /boot/grub2/grub.cfg\n"
                 "3. reboot",
             ),
         )

--- a/convert2rhel/unit_tests/actions/post_conversion/kernel_boot_files_test.py
+++ b/convert2rhel/unit_tests/actions/post_conversion/kernel_boot_files_test.py
@@ -20,7 +20,7 @@ import os
 import pytest
 import six
 
-from convert2rhel import actions, checks, unit_tests
+from convert2rhel import actions, checks
 from convert2rhel.actions.post_conversion import kernel_boot_files
 from convert2rhel.unit_tests import RunSubprocessMocked
 from convert2rhel.unit_tests.conftest import centos8

--- a/convert2rhel/unit_tests/actions/post_conversion/kernel_boot_files_test.py
+++ b/convert2rhel/unit_tests/actions/post_conversion/kernel_boot_files_test.py
@@ -1,0 +1,152 @@
+# Copyright(C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+import pytest
+import six
+
+from convert2rhel import checks, unit_tests
+from convert2rhel.actions.post_conversion import kernel_boot_files
+from convert2rhel.unit_tests import RunSubprocessMocked
+from convert2rhel.unit_tests.conftest import centos8
+
+
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
+
+
+@pytest.fixture
+def kernel_boot_files_instance():
+    return kernel_boot_files.KernelBootFiles()
+
+
+@centos8
+def test_check_kernel_boot_files(pretend_os, tmpdir, caplog, monkeypatch, kernel_boot_files_instance):
+    rpm_last_kernel_output = ("kernel-core-6.1.8-200.fc37.x86_64 Wed 01 Feb 2023 14:01:01 -03", 0)
+    latest_installed_kernel = "6.1.8-200.fc37.x86_64"
+
+    boot_folder = tmpdir.mkdir("/boot")
+    initramfs_file = boot_folder.join("initramfs-%s.img")
+    vmlinuz_file = boot_folder.join("vmlinuz-%s")
+    initramfs_file = str(initramfs_file)
+    vmlinuz_file = str(vmlinuz_file)
+
+    with open(initramfs_file % latest_installed_kernel, mode="w") as _:
+        pass
+
+    with open(vmlinuz_file % latest_installed_kernel, mode="w") as _:
+        pass
+
+    monkeypatch.setattr(checks, "VMLINUZ_FILEPATH", vmlinuz_file)
+    monkeypatch.setattr(checks, "INITRAMFS_FILEPATH", initramfs_file)
+    monkeypatch.setattr(
+        checks, "run_subprocess", RunSubprocessMocked(side_effect=[rpm_last_kernel_output, ("test", 0)])
+    )
+
+    kernel_boot_files_instance.run()
+    assert "The initramfs and vmlinuz files are valid." in caplog.records[-1].message
+
+
+@pytest.mark.parametrize(
+    ("create_initramfs", "create_vmlinuz", "run_piped_subprocess", "rpm_last_kernel_output", "latest_installed_kernel"),
+    (
+        pytest.param(
+            False,
+            False,
+            ("", 0),
+            ("kernel-core-6.1.8-200.fc37.x86_64 Wed 01 Feb 2023 14:01:01 -03", 0),
+            "6.1.8-200.fc37.x86_64",
+            id="both-files-missing",
+        ),
+        pytest.param(
+            True,
+            False,
+            ("test", 0),
+            ("kernel-core-6.1.8-200.fc37.x86_64 Wed 01 Feb 2023 14:01:01 -03", 0),
+            "6.1.8-200.fc37.x86_64",
+            id="vmlinuz-missing",
+        ),
+        pytest.param(
+            False,
+            True,
+            ("test", 0),
+            ("kernel-core-6.1.8-200.fc37.x86_64 Wed 01 Feb 2023 14:01:01 -03", 0),
+            "6.1.8-200.fc37.x86_64",
+            id="initramfs-missing",
+        ),
+        pytest.param(
+            True,
+            True,
+            ("error", 1),
+            ("kernel-core-6.1.8-200.fc37.x86_64 Wed 01 Feb 2023 14:01:01 -03", 0),
+            "6.1.8-200.fc37.x86_64",
+            id="initramfs-corrupted",
+        ),
+    ),
+)
+@centos8
+def test_check_kernel_boot_files_missing(
+    pretend_os,
+    create_initramfs,
+    create_vmlinuz,
+    run_piped_subprocess,
+    rpm_last_kernel_output,
+    latest_installed_kernel,
+    tmpdir,
+    caplog,
+    monkeypatch,
+    kernel_boot_files_instance,
+):
+    """
+    This test will check if we output the warning message correctly if either
+    initramfs or vmlinuz are missing.
+    """
+    # We are mocking both subprocess calls here in order to make it easier for
+    # testing any type of parametrization we may include in the future. Note
+    # that the second iteration may not run sometimes, as this is specific for
+    # when we want to check if a file is corrupted or not.
+    monkeypatch.setattr(
+        checks,
+        "run_subprocess",
+        mock.Mock(
+            side_effect=[
+                rpm_last_kernel_output,
+                run_piped_subprocess,
+            ]
+        ),
+    )
+    boot_folder = tmpdir.mkdir("/boot")
+    if create_initramfs:
+        initramfs_file = boot_folder.join("initramfs-%s.img")
+        initramfs_file = str(initramfs_file)
+        with open(initramfs_file % latest_installed_kernel, mode="w") as _:
+            pass
+
+        monkeypatch.setattr(checks, "INITRAMFS_FILEPATH", initramfs_file)
+    else:
+        monkeypatch.setattr(checks, "INITRAMFS_FILEPATH", "/non-existing-%s.img")
+
+    if create_vmlinuz:
+        vmlinuz_file = boot_folder.join("vmlinuz-%s")
+        vmlinuz_file = str(vmlinuz_file)
+        with open(vmlinuz_file % latest_installed_kernel, mode="w") as _:
+            pass
+
+        monkeypatch.setattr(checks, "VMLINUZ_FILEPATH", vmlinuz_file)
+    else:
+        monkeypatch.setattr(checks, "VMLINUZ_FILEPATH", "/non-existing-%s")
+
+    kernel_boot_files_instance.run()
+    assert "Couldn't verify the kernel boot files in the boot partition." in caplog.records[-1].message

--- a/convert2rhel/unit_tests/actions/post_conversion/kernel_boot_files_test.py
+++ b/convert2rhel/unit_tests/actions/post_conversion/kernel_boot_files_test.py
@@ -158,19 +158,22 @@ def test_check_kernel_boot_files_missing(
             actions.ActionMessage(
                 level="WARNING",
                 id="UNABLE_TO_VERIFY_KERNEL_BOOT_FILES",
-                title="Unable to verify kernel boot files",
-                description="Couldn't verify the kernel boot files in the boot partition. This may cause problems during the next boot "
-                "of your system.",
+                title="Unable to verify kernel boot files and boot partition",
+                description="We failed to determine whether boot partition is configured correctly and that boot"
+                " files exists. This may cause problems during the next boot of your system.",
                 diagnosis=None,
-                remediations="In order to fix this problem you may need to free/increase space in your boot partition and then run the following commands in your terminal:\n"
-                "1. yum reinstall kernel-core- -y\n"
-                "2. grub2-mkconfig -o /boot/grub2/grub.cfg\n"
+                remediations="In order to fix this problem you might need to free/increase space in your boot partition and then run the following commands in your terminal:\n"
+                "1. yum reinstall kernel-core-6.9.9-200.fc40.x86_64 -y\n"
+                "2. grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg\n"
                 "3. reboot",
             ),
         )
     )
 
     kernel_boot_files_instance.run()
+    print(expected)
+    print("!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    print(kernel_boot_files_instance.messages)
     assert "Couldn't verify the kernel boot files in the boot partition." in caplog.records[-1].message
     assert expected.issuperset(kernel_boot_files_instance.messages)
     assert expected.issubset(kernel_boot_files_instance.messages)

--- a/convert2rhel/unit_tests/actions/post_conversion/kernel_boot_files_test.py
+++ b/convert2rhel/unit_tests/actions/post_conversion/kernel_boot_files_test.py
@@ -172,9 +172,6 @@ def test_check_kernel_boot_files_missing(
     )
 
     kernel_boot_files_instance.run()
-    print(expected)
-    print("!!!!!!!!!!!!!!!!!!!!!!!!!!")
-    print(kernel_boot_files_instance.messages)
     assert "Couldn't verify the kernel boot files in the boot partition." in caplog.records[-1].message
     assert expected.issuperset(kernel_boot_files_instance.messages)
     assert expected.issubset(kernel_boot_files_instance.messages)

--- a/convert2rhel/unit_tests/actions/post_conversion/kernel_boot_files_test.py
+++ b/convert2rhel/unit_tests/actions/post_conversion/kernel_boot_files_test.py
@@ -14,6 +14,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 __metaclass__ = type
+
+import os
+
 import pytest
 import six
 
@@ -51,6 +54,8 @@ def test_check_kernel_boot_files(pretend_os, tmpdir, caplog, monkeypatch, kernel
 
     monkeypatch.setattr(checks, "VMLINUZ_FILEPATH", vmlinuz_file)
     monkeypatch.setattr(checks, "INITRAMFS_FILEPATH", initramfs_file)
+    monkeypatch.setattr(os.path, "exists", mock.Mock(return_value=True))
+    monkeypatch.setattr(checks, "is_initramfs_file_valid", mock.Mock(return_value=True))
     monkeypatch.setattr(
         checks, "run_subprocess", RunSubprocessMocked(side_effect=[rpm_last_kernel_output, ("test", 0)])
     )

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -35,7 +35,7 @@ from six.moves import mock
         ("6.1.7-200.fc37.x86_64", ("error", 1), False),
     ),
 )
-def test_is_initramfs_file_valid(latest_installed_kernel, subprocess_output, expected, tmpdir, caplog, monkeypatch):
+def testis_initramfs_file_valid(latest_installed_kernel, subprocess_output, expected, tmpdir, caplog, monkeypatch):
     initramfs_file = tmpdir.mkdir("/boot").join("initramfs-%s.img")
     initramfs_file = str(initramfs_file)
     initramfs_file = initramfs_file % latest_installed_kernel
@@ -44,128 +44,9 @@ def test_is_initramfs_file_valid(latest_installed_kernel, subprocess_output, exp
 
     monkeypatch.setattr(checks, "INITRAMFS_FILEPATH", initramfs_file)
     monkeypatch.setattr(checks, "run_subprocess", RunSubprocessMocked(return_value=subprocess_output))
-    result = checks._is_initramfs_file_valid(initramfs_file)
+    result = checks.is_initramfs_file_valid(initramfs_file)
     assert result == expected
 
     if not expected:
         assert "Couldn't verify initramfs file. It may be corrupted." in caplog.records[-2].message
         assert "Output of lsinitrd: %s" % subprocess_output[0] in caplog.records[-1].message
-
-
-@centos8
-def test_check_kernel_boot_files(pretend_os, tmpdir, caplog, monkeypatch):
-    rpm_last_kernel_output = ("kernel-core-6.1.8-200.fc37.x86_64 Wed 01 Feb 2023 14:01:01 -03", 0)
-    latest_installed_kernel = "6.1.8-200.fc37.x86_64"
-
-    boot_folder = tmpdir.mkdir("/boot")
-    initramfs_file = boot_folder.join("initramfs-%s.img")
-    vmlinuz_file = boot_folder.join("vmlinuz-%s")
-    initramfs_file = str(initramfs_file)
-    vmlinuz_file = str(vmlinuz_file)
-
-    with open(initramfs_file % latest_installed_kernel, mode="w") as _:
-        pass
-
-    with open(vmlinuz_file % latest_installed_kernel, mode="w") as _:
-        pass
-
-    monkeypatch.setattr(checks, "VMLINUZ_FILEPATH", vmlinuz_file)
-    monkeypatch.setattr(checks, "INITRAMFS_FILEPATH", initramfs_file)
-    monkeypatch.setattr(
-        checks, "run_subprocess", RunSubprocessMocked(side_effect=[rpm_last_kernel_output, ("test", 0)])
-    )
-
-    checks.check_kernel_boot_files()
-    assert "The initramfs and vmlinuz files are valid." in caplog.records[-1].message
-
-
-@pytest.mark.parametrize(
-    ("create_initramfs", "create_vmlinuz", "run_piped_subprocess", "rpm_last_kernel_output", "latest_installed_kernel"),
-    (
-        pytest.param(
-            False,
-            False,
-            ("", 0),
-            ("kernel-core-6.1.8-200.fc37.x86_64 Wed 01 Feb 2023 14:01:01 -03", 0),
-            "6.1.8-200.fc37.x86_64",
-            id="both-files-missing",
-        ),
-        pytest.param(
-            True,
-            False,
-            ("test", 0),
-            ("kernel-core-6.1.8-200.fc37.x86_64 Wed 01 Feb 2023 14:01:01 -03", 0),
-            "6.1.8-200.fc37.x86_64",
-            id="vmlinuz-missing",
-        ),
-        pytest.param(
-            False,
-            True,
-            ("test", 0),
-            ("kernel-core-6.1.8-200.fc37.x86_64 Wed 01 Feb 2023 14:01:01 -03", 0),
-            "6.1.8-200.fc37.x86_64",
-            id="initramfs-missing",
-        ),
-        pytest.param(
-            True,
-            True,
-            ("error", 1),
-            ("kernel-core-6.1.8-200.fc37.x86_64 Wed 01 Feb 2023 14:01:01 -03", 0),
-            "6.1.8-200.fc37.x86_64",
-            id="initramfs-corrupted",
-        ),
-    ),
-)
-@centos8
-def test_check_kernel_boot_files_missing(
-    pretend_os,
-    create_initramfs,
-    create_vmlinuz,
-    run_piped_subprocess,
-    rpm_last_kernel_output,
-    latest_installed_kernel,
-    tmpdir,
-    caplog,
-    monkeypatch,
-):
-    """
-    This test will check if we output the warning message correctly if either
-    initramfs or vmlinuz are missing.
-    """
-    # We are mocking both subprocess calls here in order to make it easier for
-    # testing any type of parametrization we may include in the future. Note
-    # that the second iteration may not run sometimes, as this is specific for
-    # when we want to check if a file is corrupted or not.
-    monkeypatch.setattr(
-        checks,
-        "run_subprocess",
-        mock.Mock(
-            side_effect=[
-                rpm_last_kernel_output,
-                run_piped_subprocess,
-            ]
-        ),
-    )
-    boot_folder = tmpdir.mkdir("/boot")
-    if create_initramfs:
-        initramfs_file = boot_folder.join("initramfs-%s.img")
-        initramfs_file = str(initramfs_file)
-        with open(initramfs_file % latest_installed_kernel, mode="w") as _:
-            pass
-
-        monkeypatch.setattr(checks, "INITRAMFS_FILEPATH", initramfs_file)
-    else:
-        monkeypatch.setattr(checks, "INITRAMFS_FILEPATH", "/non-existing-%s.img")
-
-    if create_vmlinuz:
-        vmlinuz_file = boot_folder.join("vmlinuz-%s")
-        vmlinuz_file = str(vmlinuz_file)
-        with open(vmlinuz_file % latest_installed_kernel, mode="w") as _:
-            pass
-
-        monkeypatch.setattr(checks, "VMLINUZ_FILEPATH", vmlinuz_file)
-    else:
-        monkeypatch.setattr(checks, "VMLINUZ_FILEPATH", "/non-existing-%s")
-
-    checks.check_kernel_boot_files()
-    assert "Couldn't verify the kernel boot files in the boot partition." in caplog.records[-1].message

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -243,7 +243,6 @@ def test_main(monkeypatch, tmp_path):
     ask_to_continue_mock = mock.Mock()
     restart_system_mock = mock.Mock()
     finish_collection_mock = mock.Mock()
-    check_kernel_boot_files_mock = mock.Mock()
     update_rhsm_custom_facts_mock = mock.Mock()
     summary_as_json_mock = mock.Mock()
     summary_as_txt_mock = mock.Mock()
@@ -267,7 +266,6 @@ def test_main(monkeypatch, tmp_path):
     monkeypatch.setattr(utils, "ask_to_continue", ask_to_continue_mock)
     monkeypatch.setattr(utils, "restart_system", restart_system_mock)
     monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
-    monkeypatch.setattr(checks, "check_kernel_boot_files", check_kernel_boot_files_mock)
     monkeypatch.setattr(subscription, "update_rhsm_custom_facts", update_rhsm_custom_facts_mock)
     monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
     monkeypatch.setattr(report, "summary_as_txt", summary_as_txt_mock)
@@ -290,7 +288,6 @@ def test_main(monkeypatch, tmp_path):
     assert ask_to_continue_mock.call_count == 1
     assert restart_system_mock.call_count == 1
     assert finish_collection_mock.call_count == 1
-    assert check_kernel_boot_files_mock.call_count == 1
     assert update_rhsm_custom_facts_mock.call_count == 1
     assert summary_as_json_mock.call_count == 1
     assert summary_as_txt_mock.call_count == 1


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
This PR ports the function check_kernel_boot_files to the action framework. Changing any relevant logger crictical, warning and info messages to Error results and Warning and Info messages respectively.
<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-1337](https://issues.redhat.com/browse/RHELC-1337) -->
- [RHELC-1337](https://issues.redhat.com/browse/RHELC-1337)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
