### PR TITLE
[RHELC-1338] Port breadcrumbs.finish_collection to action framework

### DIFF
--- a/convert2rhel/actions/post_conversion/breadcrumbs_finish_collection.py
+++ b/convert2rhel/actions/post_conversion/breadcrumbs_finish_collection.py
@@ -1,0 +1,37 @@
+# Copyright(C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import logging
+
+from convert2rhel import actions, breadcrumbs
+
+
+logger = logging.getLogger(__name__)
+
+
+class BreadcumbsFinishCollection(actions.Action):
+    id = "BREADCRUMBS_FINISH_COLLECTION"
+    dependencies = (
+        "KERNEL_BOOT_FILES",
+        "UPDATE_GRUB",
+    )
+
+    def run(self):
+        super(BreadcumbsFinishCollection, self).run()
+
+        logger.task("Final: Update breadcrumbs")
+        breadcrumbs.breadcrumbs.finish_collection(success=True)

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -372,9 +372,6 @@ def prepare_system():
 
 def post_ponr_changes():
     """Start the conversion itself"""
-    loggerinst.task("Final: Update breadcrumbs")
-    breadcrumbs.breadcrumbs.finish_collection(success=True)
-
     loggerinst.task("Final: Update RHSM custom facts")
     subscription.update_rhsm_custom_facts()
 

--- a/convert2rhel/unit_tests/actions/post_conversion/breadcrumbs_finish_collection_test.py
+++ b/convert2rhel/unit_tests/actions/post_conversion/breadcrumbs_finish_collection_test.py
@@ -1,0 +1,40 @@
+# Copyright(C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import pytest
+import six
+
+from convert2rhel.actions.post_conversion import breadcrumbs_finish_collection
+
+
+six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
+from six.moves import mock
+
+
+@pytest.fixture
+def breadcrumbs_finish_collection_instance():
+    return breadcrumbs_finish_collection.BreadcumbsFinishCollection()
+
+
+def test_breadcrumbs_finish_collection(monkeypatch, caplog, breadcrumbs_finish_collection_instance):
+    finish_collection = mock.Mock()
+    monkeypatch.setattr(breadcrumbs_finish_collection.breadcrumbs.breadcrumbs, "finish_collection", finish_collection)
+
+    breadcrumbs_finish_collection_instance.run()
+
+    assert "Final: Update breadcrumbs" in caplog.records[-1].message
+    assert finish_collection.call_count == 1

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -242,7 +242,6 @@ def test_main(monkeypatch, tmp_path):
     clear_versionlock_mock = mock.Mock()
     ask_to_continue_mock = mock.Mock()
     restart_system_mock = mock.Mock()
-    finish_collection_mock = mock.Mock()
     update_rhsm_custom_facts_mock = mock.Mock()
     summary_as_json_mock = mock.Mock()
     summary_as_txt_mock = mock.Mock()
@@ -264,7 +263,6 @@ def test_main(monkeypatch, tmp_path):
     monkeypatch.setattr(report, "_summary", report_summary_mock)
     monkeypatch.setattr(utils, "ask_to_continue", ask_to_continue_mock)
     monkeypatch.setattr(utils, "restart_system", restart_system_mock)
-    monkeypatch.setattr(breadcrumbs, "finish_collection", finish_collection_mock)
     monkeypatch.setattr(subscription, "update_rhsm_custom_facts", update_rhsm_custom_facts_mock)
     monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
     monkeypatch.setattr(report, "summary_as_txt", summary_as_txt_mock)
@@ -285,7 +283,6 @@ def test_main(monkeypatch, tmp_path):
     assert clear_versionlock_mock.call_count == 1
     assert ask_to_continue_mock.call_count == 1
     assert restart_system_mock.call_count == 1
-    assert finish_collection_mock.call_count == 1
     assert update_rhsm_custom_facts_mock.call_count == 1
     assert summary_as_json_mock.call_count == 1
     assert summary_as_txt_mock.call_count == 1


### PR DESCRIPTION
Port one of the final steps of conversion to be called by action framework.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of  -->
- [RHELC-1338](https://issues.redhat.com/browse/RHELC-1338)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
