### PR TITLE
[RHELC-1600] Update the bufsize value of run_subprocess

### DIFF
--- a/convert2rhel/utils/__init__.py
+++ b/convert2rhel/utils/__init__.py
@@ -350,7 +350,7 @@ def run_subprocess(cmd, print_cmd=True, print_output=True):
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        bufsize=1,
+        bufsize=-1,
     )
     output = ""
     for line in iter(process.stdout.readline, b""):


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
This PR updates the bufsize value for our run_subprocess function from 1 to -1 to avoid the RuntimeWarning introduced in python 3.8. The bufsize value of -1 is the new default value because it is compatible with most code according to the python docs - https://docs.python.org/3/library/subprocess.html .
<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-1652) -->
- [RHELC-1600](https://issues.redhat.com/browse/RHELC-1600)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
