### PR TITLE
Release v2.0.1

### DIFF
--- a/convert2rhel/__init__.py
+++ b/convert2rhel/__init__.py
@@ -1,2 +1,2 @@
 __metaclass__ = type
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -171,7 +171,6 @@ class BackupPackageFiles(actions.Action):
         """Get the output from rpm -Va command from during resolving system info
         to get changes made to package files.
 
-        The dict itself is unique and does not have duplicate entries
 
         :return dict: Return them as a list of dict, for example:
         [{"status":"S5T", "file_type":"c", "path":"/etc/yum.repos.d/CentOS-Linux-AppStream.repo"}]

--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -170,7 +170,10 @@ class BackupPackageFiles(actions.Action):
     def _get_changed_package_files(self):
         """Get the output from rpm -Va command from during resolving system info
         to get changes made to package files.
-        Return them as a list of dict, for example:
+
+        The dict itself is unique and does not have duplicate entries
+
+        :return dict: Return them as a list of dict, for example:
         [{"status":"S5T", "file_type":"c", "path":"/etc/yum.repos.d/CentOS-Linux-AppStream.repo"}]
         """
         data = []
@@ -197,6 +200,7 @@ class BackupPackageFiles(actions.Action):
 
         for line in lines:
             parsed_line = self._parse_line(line.strip())
+            # We first check that it has a path and status, otherwise nothing to backup
             if parsed_line["path"] and parsed_line["status"]:
                 data.append(parsed_line)
 

--- a/convert2rhel/backup/__init__.py
+++ b/convert2rhel/backup/__init__.py
@@ -58,7 +58,7 @@ class BackupController:
     """
 
     def __init__(self):
-        self._restorables = []
+        self._restorables = []  # type: list[RestorableChange]
         self._rollback_failures = []
 
     def push(self, restorable):
@@ -69,6 +69,13 @@ class BackupController:
         """
         if not isinstance(restorable, RestorableChange):
             raise TypeError("`%s` is not a RestorableChange object" % restorable)
+
+        # Check if the restorable is already backed up
+        # if it is, we skip it
+        for r in self._restorables:
+            if r == restorable:
+                loggerinst.debug("Skipping: {} has already been backed up".format(restorable.__class__.__name__))
+                return
 
         restorable.enable()
 
@@ -149,6 +156,9 @@ class BackupController:
         :returns: List of strings containing errors captured during rollback.
         """
         return self._rollback_failures
+
+    def __len__(self):
+        return len(self._restorables)
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/convert2rhel/repo.py
+++ b/convert2rhel/repo.py
@@ -58,16 +58,28 @@ def get_rhel_repoids():
 
 
 def get_rhel_repos_to_disable():
-    """Get the list of repositories which should be disabled when performing pre-conversion checks. Avoid downloading
-    backup and up-to-date checks from them. The output list can looks like:
-    ['rhel*', 'user-provided', 'user-provided1']
+    """Get the list of repositories which should be disabled when performing pre-conversion checks.
+
+    Avoid downloading backup and up-to-date checks from them. The output list can looks like: ["rhel*"]
+
+    .. note::
+        If --enablerepo switch is enabled, we will return a combination of repositories to disable as following:
+
+        >>> # tool_opts.enablerepo comes from the CLI option `--enablerepo`.
+        >>> repos_to_disable = ["rhel*"]
+        >>> repos_to_disable.extend(tool_opts.enablerepo) # returns: ["rhel*", "rhel-7-server-optional-rpms"]
 
     :return: List of repositories to disable when performing checks.
-    :rtype: List[str]
+    :rtype: list[str]
     """
     # RHELC-884 disable the RHEL repos to avoid reaching them when checking original system.
-    # Also disable repositories enabled by the user for the conversion.
-    return ["rhel*"] + tool_opts.enablerepo
+    repos_to_disable = ["rhel*"]
+
+    # In case we want to disable also the custom repositories set by the user in CLI
+    if tool_opts.no_rhsm:
+        repos_to_disable.extend(tool_opts.enablerepo)
+
+    return repos_to_disable
 
 
 def get_rhel_disable_repos_command(disable_repos):

--- a/convert2rhel/repo.py
+++ b/convert2rhel/repo.py
@@ -63,11 +63,11 @@ def get_rhel_repos_to_disable():
     Avoid downloading backup and up-to-date checks from them. The output list can looks like: ["rhel*"]
 
     .. note::
-        If --enablerepo switch is enabled, we will return a combination of repositories to disable as following:
+        If --enablerepo switch is used together with the --no-rhsm, we will return a combination of repositories to disable as following:
 
         >>> # tool_opts.enablerepo comes from the CLI option `--enablerepo`.
         >>> repos_to_disable = ["rhel*"]
-        >>> repos_to_disable.extend(tool_opts.enablerepo) # returns: ["rhel*", "rhel-7-server-optional-rpms"]
+        >>> repos_to_disable.extend(tool_opts.enablerepo) # returns: ["rhel*", "my-rhel-repo-mirror"]
 
     :return: List of repositories to disable when performing checks.
     :rtype: list[str]
@@ -75,7 +75,8 @@ def get_rhel_repos_to_disable():
     # RHELC-884 disable the RHEL repos to avoid reaching them when checking original system.
     repos_to_disable = ["rhel*"]
 
-    # In case we want to disable also the custom repositories set by the user in CLI
+    # this is for the case where the user configures e.g. [my-rhel-repo-mirror] on the system and leaves it enabled
+    # before running convert2rhel - we want to prevent the checks from accessing it as it contains packages for RHEL
     if tool_opts.no_rhsm:
         repos_to_disable.extend(tool_opts.enablerepo)
 

--- a/convert2rhel/unit_tests/__init__.py
+++ b/convert2rhel/unit_tests/__init__.py
@@ -869,6 +869,17 @@ class MinimalRestorable(backup.RestorableChange):
         super(MinimalRestorable, self).restore()
 
 
+class FilePathRestorable(MinimalRestorable):
+    def __init__(self, filepath=None):
+        self.backup_path = filepath
+        super(FilePathRestorable, self).__init__()
+
+    def __eq__(self, value):
+        if self.backup_path:
+            return self.backup_path == value.backup_path
+        return super(FilePathRestorable, self).__eq__(value)
+
+
 class ErrorOnRestoreRestorable(MinimalRestorable):
     def __init__(self, exception=None):
         self.exception = exception or Exception()

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
@@ -286,6 +286,13 @@ class TestBackupSystem:
                 ],
                 (False, True, False, False, True),
             ),
+            (
+                [
+                    "S.5.?..T.     c   {path}/filename",
+                    "S.5.?..T.     c   {path}/filename",
+                ],
+                (True, True),
+            ),
         ),
     )
     def test_backup_package_file_complete(
@@ -297,37 +304,46 @@ class TestBackupSystem:
         backup_package_files_action,
         global_backup_control,
     ):
-        # Prepare the rpm -va ouput to the PRE_RPM_VA_LOG_FILENAME file
+        # Prepare the 'rpm -Va' ouput to the PRE_RPM_VA_LOG_FILENAME file
         rpm_va_output = ""
         rpm_va_path = str(tmpdir)
+        # Prepare 'rpm -Va' output with paths to tmpdir
         for i, line in enumerate(rpm_va_output_lines):
-            status = line.split()[0]
-            # Need to insert tmpdir into the filepath
             rpm_va_output_lines[i] = rpm_va_output_lines[i].format(path=rpm_va_path)
-            # Write some content to the newly created path if the file is present on the system
-            if status != "missing":
-                try:
-                    with open(rpm_va_output_lines[i].split()[-1], mode="w") as f:
-                        # Append the original path to the content
-                        f.write("Content for testing of file %s" % rpm_va_output_lines[i].split()[-1])
-                except (OSError, IOError):
-                    # case with invalid filepath
-                    pass
-            # Prepared rpm -Va output with paths to tmpdir
             rpm_va_output += rpm_va_output_lines[i] + "\n"
-        # Write the data to a file since data from systeminfo are being used
+        # Write the data to a file containing the 'rpm -Va' output since data from systeminfo are being used
         rpm_va_logfile_path = os.path.join(rpm_va_path, PRE_RPM_VA_LOG_FILENAME)
         with open(rpm_va_logfile_path, "w") as f:
             f.write(rpm_va_output)
+
+        # Prepare the files from the 'rpm -Va' output by creating them
+        #
+        # Use only unique paths, since one path can be present multiple times in the output
+        # https://issues.redhat.com/browse/RHELC-1606
+        unique_rpm_va_output_lines = list(set(rpm_va_output_lines))
+        for i, line in enumerate(unique_rpm_va_output_lines):
+            status = line.split()[0]
+            # Write some content to the newly created path if the file is present on the system
+            if status != "missing":
+                try:
+                    path = line.split()[-1]
+                    with open(path, mode="w") as f:
+                        # Append the original path to the content
+                        f.write("Content for testing of file %s" % path)
+                except (OSError, IOError):
+                    # case with invalid filepath
+                    pass
 
         backup_dir = str(tmpdir.mkdir("backup"))
 
         monkeypatch.setattr(files, "BACKUP_DIR", backup_dir)
         monkeypatch.setattr(backup_system, "LOG_DIR", rpm_va_path)
 
+        # Run the function
         backup_package_files_action.run()
 
         # Change the original files (remove, create)
+        removed_paths = []
         for i, line in enumerate(rpm_va_output_lines):
             original_file_path = line.split()[-1]
             status = line.split()[0]
@@ -342,7 +358,16 @@ class TestBackupSystem:
                 # Check if the file exists and contains right content
                 with open(backed_up_file_path, mode="r") as f:
                     assert f.read() == "Content for testing of file %s" % original_file_path
-                os.remove(original_file_path)
+                # Remove the original file
+                try:
+                    os.remove(original_file_path)
+                    removed_paths.append(original_file_path)
+                # FileNotFound on Python 3+, due compatibility with Python 2.7 using OSError
+                except (OSError, IOError):
+                    # If the path is present multiple times in the 'rpm -Va' output
+                    # it's possible, the path was already removed. If not, that's fail.
+                    if original_file_path not in removed_paths:
+                        assert False
             elif status == "missing":
                 with open(original_file_path, mode="w") as f:
                     # Append the original path to the content
@@ -350,9 +375,12 @@ class TestBackupSystem:
             else:
                 assert not os.path.isfile(backed_up_file_path)
 
+        # Restore everything
         global_backup_control.pop_all()
 
-        # Check the existence/nonexistence and content rolled back file
+        assert not global_backup_control.rollback_failures
+
+        # Check the existence/nonexistence and content rolled back files
         for i, line in enumerate(rpm_va_output_lines):
             original_file_path = line.split()[-1]
             status = line.split()[0]

--- a/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
@@ -787,7 +787,6 @@ class TestIsLoadedKernelLatest:
                     "--setopt=exclude=",
                     "--quiet",
                     "--disablerepo=rhel*",
-                    "--disablerepo=test-repo",
                     "--qf",
                     "C2R\\t%{BUILDTIME}\\t%{VERSION}-%{RELEASE}\\t%{REPOID}",
                     "kernel",

--- a/convert2rhel/unit_tests/backup/backup_test.py
+++ b/convert2rhel/unit_tests/backup/backup_test.py
@@ -3,7 +3,7 @@ __metaclass__ = type
 import pytest
 
 from convert2rhel import backup
-from convert2rhel.unit_tests import ErrorOnRestoreRestorable, MinimalRestorable
+from convert2rhel.unit_tests import ErrorOnRestoreRestorable, FilePathRestorable, MinimalRestorable
 
 
 @pytest.fixture
@@ -28,6 +28,23 @@ class TestBackupController:
 
         assert popped_restorable is restorable
         assert restorable.called["restore"] == 1
+
+    def test_backup_same_paths(self, backup_controller):
+        restorable1 = FilePathRestorable("samepath")
+        restorable2 = FilePathRestorable("samepath")
+
+        backup_controller.push(restorable1)
+        backup_controller.push(restorable2)
+
+        # If we backup the same filepath we should ignore the next one
+        assert restorable1.backup_path == restorable2.backup_path
+
+        # Same path on both restorables means only one gets backed up
+        assert len(backup_controller) == 1
+        assert len(backup_controller.pop_all()) == 1
+
+        assert restorable1.called["restore"] == 1
+        assert restorable2.called["restore"] == 0
 
     def test_pop_multiple(self, backup_controller):
         restorable1 = MinimalRestorable()

--- a/convert2rhel/unit_tests/backup/files_test.py
+++ b/convert2rhel/unit_tests/backup/files_test.py
@@ -202,7 +202,7 @@ class TestRestorableFile:
 
         file_backup = RestorableFile(orig_file_path)
         file_backup.enabled = enabled
-        file_backup._backup_path = backedup_file_path
+        file_backup.backup_path = backedup_file_path
         file_backup.restore(rollback=rollback)
 
         # Check if the correct messages printed
@@ -233,7 +233,7 @@ class TestRestorableFile:
 
         file_backup = RestorableFile(orig_file_path)
         file_backup.enabled = True
-        file_backup._backup_path = backedup_file_path
+        file_backup.backup_path = backedup_file_path
 
         # Check if the exception is raised when the file is missing in the backup folder
         with pytest.raises(OSError):
@@ -252,7 +252,7 @@ class TestRestorableFile:
 
         file_backup = RestorableFile(orig_file_path)
         file_backup.enabled = True
-        file_backup._backup_path = backedup_file_path
+        file_backup.backup_path = backedup_file_path
 
         # Check if the exception is raised when the file is missing in the backup folder
         with pytest.raises(IOError):
@@ -306,6 +306,24 @@ class TestRestorableFile:
         result = file._hash_backup_path()
         assert os.path.exists(os.path.dirname(result))
         assert result == expected
+
+    @pytest.mark.parametrize(
+        ("filepath1", "filepath2"),
+        (
+            ("/test.txt", "/test.txt"),
+            ("/another/directory/file.txt", "/test.txt"),
+        ),
+    )
+    def test___eq___works(self, filepath1, filepath2, tmpdir, monkeypatch):
+        backup_dir = str(tmpdir)
+        monkeypatch.setattr(files, "BACKUP_DIR", backup_dir)
+        file1 = RestorableFile(filepath1)
+        file2 = RestorableFile(filepath2)
+
+        if filepath1 == filepath2:
+            assert file1 == file2
+        else:
+            assert file1 != file2
 
 
 class TestMissingFile:

--- a/convert2rhel/unit_tests/repo_test.py
+++ b/convert2rhel/unit_tests/repo_test.py
@@ -80,12 +80,21 @@ def test_get_rhel_repoids_el7(pretend_os, is_els_release, expected, monkeypatch)
     assert repos == expected
 
 
-@pytest.mark.parametrize(("enablerepo", "disablerepos"), (([], ["rhel*"]), (["test-repo"], ["rhel*", "test-repo"])))
-def test_get_rhel_repos_to_disable(monkeypatch, enablerepo, disablerepos):
-    monkeypatch.setattr(repo.tool_opts, "enablerepo", enablerepo)
+@pytest.mark.parametrize(
+    ("no_rhsm", "enablerepo", "disablerepos"),
+    (
+        (False, [], ["rhel*"]),
+        (True, ["test-repo"], ["rhel*", "test-repo"]),
+        (True, [], ["rhel*"]),
+        (False, ["test-repo"], ["rhel*"]),
+    ),
+)
+def test_get_rhel_repos_to_disable(monkeypatch, global_tool_opts, no_rhsm, enablerepo, disablerepos):
+    monkeypatch.setattr(repo, "tool_opts", global_tool_opts)
+    global_tool_opts.enablerepo = enablerepo
+    global_tool_opts.no_rhsm = no_rhsm
 
     repos = repo.get_rhel_repos_to_disable()
-
     assert repos == disablerepos
 
 

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -405,7 +405,7 @@ class TestRegisterSystem:
         os_release_file.enable()
 
         # Remove the file from the backup and orig path, so there will be failure during restoring the file
-        os.remove(os_release_file._backup_path)
+        os.remove(os_release_file.backup_path)
         os.remove(str(os_release_path))
 
         ### Test the register system

--- a/packaging/convert2rhel.spec
+++ b/packaging/convert2rhel.spec
@@ -9,7 +9,7 @@
 %endif
 
 Name:           convert2rhel
-Version:        2.0.0
+Version:        2.0.1
 Release:        1%{?dist}
 Summary:        Automates the conversion of RHEL derivative distributions to RHEL
 
@@ -122,6 +122,10 @@ install -m 0600 config/convert2rhel.ini %{buildroot}%{_sysconfdir}/convert2rhel.
 %attr(0644,root,root) %{_mandir}/man8/%{name}.8*
 
 %changelog
+* Tue Jul 23 2024 Freya Gustavsson <fgustavs@redhat.com> 2.0.1
+- Fix files being backed up multiple times and causing rollback errors
+- Fix conversions failing with third-party repositories
+
 * Mon May 27 2024 Adam Hosek <ahosek@redhat.com> 2.0.0
 - Breaking change: Remove deprecated CLI arguments
 - Breaking change: Remove deprecated latest kernel check env variable


### PR DESCRIPTION
It was possible for multiple packages to depend on the same file. As we
fetch the files for each package that needs to be backed up this caused
issues when rolling back a system as we try to restore it twice.

This fixes that issue by making sure we don't backup to the same path
multiple times

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>