### PR TITLE
chore: Remove forceful cleanup of all containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,13 +151,10 @@ tests9: image9
 	$(PODMAN) build -f Containerfiles/rpmbuild.centos9.Containerfile -t $(IMAGE_ORG)/$(IMAGE_PREFIX)-centos9rpmbuild .
 	$(PODMAN) cp $$($(PODMAN) create $(IMAGE_ORG)/$(IMAGE_PREFIX)-centos9rpmbuild):/data/.rpms .
 
-.rpm-container-cleanup:
-	$(PODMAN) rm $$($(PODMAN) ps -aq) -f
-
-rpms: .rpm7 .rpm8 .rpm9 .rpm-container-cleanup
-rpm7: .rpm7 .rpm-container-cleanup
-rpm8: .rpm8 .rpm-container-cleanup
-rpm9: .rpm9 .rpm-container-cleanup
+rpms: .rpm7 .rpm8 .rpm9
+rpm7: .rpm7
+rpm8: .rpm8
+rpm9: .rpm9
 
 copr-build: rpms
 	mkdir -p .srpms
@@ -165,5 +162,4 @@ copr-build: rpms
 	$(PODMAN) cp $$($(PODMAN) create $(IMAGE_ORG)/$(IMAGE_PREFIX)-centos9rpmbuild):/data/.srpms .
 	$(PODMAN) cp $$($(PODMAN) create $(IMAGE_ORG)/$(IMAGE_PREFIX)-centos8rpmbuild):/data/.srpms .
 	$(PODMAN) cp $$($(PODMAN) create $(IMAGE_ORG)/$(IMAGE_PREFIX)-centos7rpmbuild):/data/.srpms .
-	$(PODMAN) rm $$($(PODMAN) ps -aq) -f
 	copr-cli --config .copr.conf build --nowait @oamg/convert2rhel .srpms/*


### PR DESCRIPTION
A while back it was introduced to cleanup the containers due to caching
issue. This also cleans up your own containers and should not be ran
locally whatsoever as it forcefully removes all containers.

This is just a removal for now. It is better to have to run the command
twice than have to deal with the aftermath of all your own containers
suddenly being gone.

Introduced in #295

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
