### PR TITLE
[RHELC-1427] Fix rpm -Va parsing and improve speed

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -38,7 +38,7 @@ from convert2rhel.toolopts import PRE_RPM_VA_LOG_FILENAME
 # Match unix path:
 #   [\/\\](?:(?!\.\s+)\S)+(\.)?
 RPM_VA_REGEX = re.compile(
-    r"^(missing|([S\.\?][M\.\?][5\.\?][D\.\?][L\.\?][U\.\?][G\.\?][T\.\?][P\.\?]))\s+[cdlr\s+]\s+[\/\\](?:(?!\.\s+)\S)+(\.)?$"
+    r"^(missing|([S\.\?][M\.\?][5\.\?][D\.\?][L\.\?][U\.\?][G\.\?][T\.\?][P\.\?]))\s+[cdlrg\s+]\s+[\/\\](?:(?!\.\s+)\S)+(\.)?$"
 )
 
 
@@ -153,6 +153,11 @@ class BackupPackageFiles(actions.Action):
         backed_up_paths = ["/etc/yum.repos.d", "/etc/yum/vars", "/etc/dnf/vars"]
 
         for file in package_files_changes:
+            # Ghost files can be skipped since those files are generated during the package run, usually temporary.
+            # We don't need to backup those type of files as was discussed under RHELC-1427
+            if file["file_type"] == "g":
+                continue
+
             if file["status"] == "missing":
                 missing_file = MissingFile(file["path"])
                 backup.backup_control.push(missing_file)

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -390,7 +390,9 @@ class SystemInfo:
             " minutes. It can be disabled by using the"
             " --no-rpm-va option."
         )
-        rpm_va, _ = utils.run_subprocess(["rpm", "-Va"], print_output=False)
+        # Discussed under RHELC-1427, `--nodeps` will skip verification of package dependencies,
+        # avoiding unnecessary packages lookup.
+        rpm_va, _ = utils.run_subprocess(["rpm", "-Va", "--nodeps"], print_output=False)
         output_file = os.path.join(logger.LOG_DIR, log_filename)
         utils.store_content_to_file(output_file, rpm_va)
         self.logger.info("The 'rpm -Va' output has been stored in the %s file." % output_file)

--- a/convert2rhel/unit_tests/systeminfo_test.py
+++ b/convert2rhel/unit_tests/systeminfo_test.py
@@ -54,7 +54,7 @@ class TestGenerateRPMVA:
 
         # Check that rpm -Va is executed (default)
         assert utils.run_subprocess.called
-        assert utils.run_subprocess.call_args_list[0][0][0] == ["rpm", "-Va"]
+        assert utils.run_subprocess.call_args_list[0][0][0] == ["rpm", "-Va", "--nodeps"]
 
         # Check that the output was stored into the specific file.
         assert os.path.isfile(rpmva_output_file)

--- a/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
@@ -294,7 +294,7 @@ def test_analyze_no_rpm_va_option(convert2rhel):
     """
     with convert2rhel("analyze -y --no-rpm-va --debug") as c2r:
         c2r.expect("We will proceed with ignoring the --no-rpm-va option")
-        c2r.expect_exact("Calling command 'rpm -Va'")
+        c2r.expect_exact("Calling command 'rpm -Va --nodeps'")
 
         c2r.sendcontrol("c")
     assert c2r.exitstatus == 1


### PR DESCRIPTION
Fix rpm -Va parsing to accept also ghosts files. Do not generate message
about invalid output of lines related to ghosts files anymore. Those files
aren't backed up as they are temporary.

Extend rpm -Va command by  --nodeps switch. This improves
speed of the command and doesn't generate unimportant info about
unsatisfied dependencies for packages.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues: 

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1427](https://issues.redhat.com/browse/RHELC-1427)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
