### PR TITLE
[RHELC-1670] Add control of lowest message level in summary

### DIFF
--- a/convert2rhel/actions/report.py
+++ b/convert2rhel/actions/report.py
@@ -179,10 +179,11 @@ def post_conversion_report(results, include_all_reports=False, disable_colors=Fa
     :type include_all_reports: bool
     """
     logger.task("Post-conversion report")
-    _summary(results, include_all_reports, disable_colors)
+    # In the post conversion report we want to print also INFO messages in the final report
+    _summary(results, include_all_reports, disable_colors, lowest_message_level="INFO")
 
 
-def _summary(results, include_all_reports, disable_colors):
+def _summary(results, include_all_reports, disable_colors, lowest_message_level="WARNING"):
     """Output a summary regarding the actions execution.
 
     This summary is intended to be used to inform the user about the results
@@ -220,10 +221,10 @@ def _summary(results, include_all_reports, disable_colors):
                 for the user.
         * Some action_id have results that are not successes (warnings, errors...)
             * For those cases, we only want to print whatever is higher than
-                STATUS_CODE['WARNING']
+                specified in `lowest_message_level`, default is STATUS_CODE['WARNING']
 
         The order of the message is from the highest priority (ERROR) to the
-        lowest priority (WARNING).
+        lowest priority (specified / default - WARNING).
 
         Message example's::
             * (ERROR) SubscribeSystem.ERROR: Error message
@@ -234,7 +235,8 @@ def _summary(results, include_all_reports, disable_colors):
         default message will be used::
             * (ERROR) SubscribeSystem.ERROR: N/A
 
-        In case of all actions executed without warnings or errors, the
+        In case of all actions executed without specified the lowest error for logging
+        (in case of the default `WARNING` warnings or errors would be printed), the
         following message is used::
             * No problems detected during the analysis!
 
@@ -245,6 +247,9 @@ def _summary(results, include_all_reports, disable_colors):
     :keyword include_all_reports: If all reports should be logged instead of the
         highest ones.
     :type include_all_reports: bool
+    :param lowest_message_level: The lowest level from which are message printed. Default is "WARNING".
+        Possible values are INFO and WARNING.
+    :type lowest_message_level: str
     """
     report = []
 
@@ -255,7 +260,7 @@ def _summary(results, include_all_reports, disable_colors):
 
     else:
         combined_results_and_message = find_actions_of_severity(
-            combined_results_and_message, "WARNING", level_for_combined_action_data
+            combined_results_and_message, lowest_message_level, level_for_combined_action_data
         )
 
     terminal_size = utils.get_terminal_size()

--- a/convert2rhel/unit_tests/actions/report_test.py
+++ b/convert2rhel/unit_tests/actions/report_test.py
@@ -514,6 +514,101 @@ def test_summary(results, expected_results, include_all_reports, caplog):
 
 
 @pytest.mark.parametrize(
+    ("results", "include_all_reports", "lowest_message_level", "expected_results"),
+    (
+        # Test controlling of lowest reporting level of message. From INFO:
+        (
+            {
+                "PreSubscription": {
+                    "messages": [
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediations": "move on",
+                            "variables": {},
+                        },
+                        {
+                            "level": STATUS_CODE["INFO"],
+                            "id": "INFO_ID",
+                            "title": "Info",
+                            "description": "Action info",
+                            "diagnosis": "User info",
+                            "remediations": "move on",
+                            "variables": {},
+                        },
+                    ],
+                    "result": {
+                        "level": STATUS_CODE["SUCCESS"],
+                        "id": "SUCCESS",
+                        "title": "",
+                        "description": "",
+                        "diagnosis": "",
+                        "remediations": "",
+                        "variables": {},
+                    },
+                }
+            },
+            False,
+            "INFO",
+            [
+                "(WARNING) PreSubscription::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediations: move on",
+                "(INFO) PreSubscription::INFO_ID - Info\n     Description: Action info\n     Diagnosis: User info\n     Remediations: move on",
+            ],
+        ),
+        # Test controlling of lowest reporting level of message. From WARNING.
+        (
+            {
+                "PreSubscription": {
+                    "messages": [
+                        {
+                            "level": STATUS_CODE["WARNING"],
+                            "id": "WARNING_ID",
+                            "title": "Warning",
+                            "description": "Action warning",
+                            "diagnosis": "User warning",
+                            "remediations": "move on",
+                            "variables": {},
+                        },
+                        {
+                            "level": STATUS_CODE["INFO"],
+                            "id": "INFO_ID",
+                            "title": "Info",
+                            "description": "Action info",
+                            "diagnosis": "User info",
+                            "remediations": "move on",
+                            "variables": {},
+                        },
+                    ],
+                    "result": {
+                        "level": STATUS_CODE["SUCCESS"],
+                        "id": "SUCCESS",
+                        "title": "",
+                        "description": "",
+                        "diagnosis": "",
+                        "remediations": "",
+                        "variables": {},
+                    },
+                }
+            },
+            False,
+            "WARNING",
+            [
+                "(WARNING) PreSubscription::WARNING_ID - Warning\n     Description: Action warning\n     Diagnosis: User warning\n     Remediations: move on",
+            ],
+        ),
+    ),
+)
+def test_summary_lowest_message_level(results, expected_results, include_all_reports, caplog, lowest_message_level):
+    report._summary(results, include_all_reports, disable_colors=True, lowest_message_level=lowest_message_level)
+
+    for expected in expected_results:
+        assert expected in caplog.records[-1].message
+
+
+@pytest.mark.parametrize(
     ("long_message"),
     (
         (_LONG_MESSAGE),


### PR DESCRIPTION
Add controlling of the lowest message level printed in the report summary.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1670](https://issues.redhat.com/browse/RHELC-1670)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
