### PR TITLE
[RHELC-1672, RHELC-1707, RHELC-1708] Detect a newer version of RHEL kernel in the main transaction

### DIFF
--- a/convert2rhel/actions/conversion/preserve_only_rhel_kernel.py
+++ b/convert2rhel/actions/conversion/preserve_only_rhel_kernel.py
@@ -50,34 +50,63 @@ class InstallRhelKernel(actions.Action):
             )
             return
 
-        # Check if kernel with same version is already installed.
+        # Check which of the kernel versions are already installed.
         # Example output from yum and dnf:
         #  "Package kernel-4.18.0-193.el8.x86_64 is already installed."
-        already_installed = re.search(r" (.*?)(?: is)? already installed", output, re.MULTILINE)
-        if already_installed:
-            rhel_kernel_nevra = already_installed.group(1)
-            non_rhel_kernels = pkghandler.get_installed_pkgs_w_different_fingerprint(
-                system_info.fingerprints_rhel, "kernel"
+        # When calling install, yum/dnf essentially reports all the already installed versions.
+        already_installed = re.findall(r" (.*?)(?: is)? already installed", output, re.MULTILINE)
+        # Get list of kernel pkgs not signed by Red Hat
+        non_rhel_kernels_pkg_info = pkghandler.get_installed_pkgs_w_different_fingerprint(
+            system_info.fingerprints_rhel, "kernel"
+        )
+        # Extract the NEVRA from the package object to a list
+        non_rhel_kernels = [pkghandler.get_pkg_nevra(kernel) for kernel in non_rhel_kernels_pkg_info]
+        rhel_kernels = [kernel for kernel in already_installed if kernel not in non_rhel_kernels]
+
+        # There is no RHEL kernel installed on the system at this point.
+        # Generally that would mean, that there is either only one kernel
+        # package installed on the system by the time of the conversion.
+        # Or none of the kernel packages installed is possible to be handled
+        # during the main transaction.
+        if not rhel_kernels:
+            info_message = "Conflict of kernels: The running kernel has the same version as the latest RHEL kernel."
+            loggerinst.info("\n%s" % info_message)
+            self.add_message(
+                level="INFO",
+                id="CONFLICT_OF_KERNELS",
+                title="Conflict of installed kernel versions",
+                description=info_message,
             )
-            for non_rhel_kernel in non_rhel_kernels:
-                # We're comparing to NEVRA since that's what yum/dnf prints out
-                if rhel_kernel_nevra == pkghandler.get_pkg_nevra(non_rhel_kernel):
-                    # If the installed kernel is from a third party (non-RHEL) and has the same NEVRA as the one available
-                    # from RHEL repos, it's necessary to install an older version RHEL kernel and the third party one will
-                    # be removed later in the conversion process. It's because yum/dnf is unable to reinstall a kernel.
-                    info_message = (
-                        "Conflict of kernels: One of the installed kernels"
-                        " has the same version as the latest RHEL kernel."
-                    )
-                    loggerinst.info("\n%s" % info_message)
-                    self.add_message(
-                        level="INFO",
-                        id="CONFLICT_OF_KERNELS",
-                        title="Conflict of installed kernel versions",
-                        description=info_message,
-                    )
-                    pkghandler.handle_no_newer_rhel_kernel_available()
-                    kernel_update_needed = True
+            pkghandler.handle_no_newer_rhel_kernel_available()
+            kernel_update_needed = True
+
+        # In this case all kernel packages were already replaced during the main transaction
+        elif not non_rhel_kernels:
+            return
+
+        # At this point we need to decide if the highest package version in the rhel_kernels list
+        # is higher than the highest package version in the non_rhel_kernels list
+        else:
+            latest_installed_non_rhel_kernel = pkghandler.get_highest_package_version(
+                ("non-RHEL kernel", non_rhel_kernels)
+            )
+            latest_installed_rhel_kernel = pkghandler.get_highest_package_version(("RHEL kernel", rhel_kernels))
+            is_rhel_kernel_higher = pkghandler.compare_package_versions(
+                latest_installed_rhel_kernel, latest_installed_non_rhel_kernel
+            )
+
+            # If the highest version of the RHEL kernel package installed at this point is indeed
+            # higher than any non-RHEL package, we don't need to do anything else.
+            if is_rhel_kernel_higher == 1:
+                return
+
+            # This also contains a scenario, where the running non-RHEL kernel is of a higher version
+            # than the latest one available in the RHEL repositories.
+            # That might happen and happened before, when the original vendor patches the package
+            # with a higher release number.
+            else:
+                pkghandler.handle_no_newer_rhel_kernel_available()
+                kernel_update_needed = True
 
         if kernel_update_needed:
             pkghandler.update_rhel_kernel()

--- a/convert2rhel/actions/conversion/preserve_only_rhel_kernel.py
+++ b/convert2rhel/actions/conversion/preserve_only_rhel_kernel.py
@@ -69,7 +69,12 @@ class InstallRhelKernel(actions.Action):
         # Or none of the kernel packages installed is possible to be handled
         # during the main transaction.
         if not rhel_kernels:
-            info_message = "Conflict of kernels: The running kernel has the same version as the latest RHEL kernel."
+            info_message = (
+                "Conflict of kernels: The running kernel has the same version as the latest RHEL kernel. "
+                "The kernel package could not be replaced during the main transaction. "
+                "We will try to install a lower version of the package, "
+                "remove the conflicting kernel and then update to the latest security patched version."
+            )
             loggerinst.info("\n%s" % info_message)
             self.add_message(
                 level="INFO",

--- a/convert2rhel/actions/conversion/preserve_only_rhel_kernel.py
+++ b/convert2rhel/actions/conversion/preserve_only_rhel_kernel.py
@@ -86,7 +86,7 @@ class InstallRhelKernel(actions.Action):
             kernel_update_needed = True
 
         # In this case all kernel packages were already replaced during the main transaction
-        elif not non_rhel_kernels:
+        if not non_rhel_kernels:
             return
 
         # At this point we need to decide if the highest package version in the rhel_kernels list
@@ -109,9 +109,8 @@ class InstallRhelKernel(actions.Action):
             # than the latest one available in the RHEL repositories.
             # That might happen and happened before, when the original vendor patches the package
             # with a higher release number.
-            else:
-                pkghandler.handle_no_newer_rhel_kernel_available()
-                kernel_update_needed = True
+            pkghandler.handle_no_newer_rhel_kernel_available()
+            kernel_update_needed = True
 
         if kernel_update_needed:
             pkghandler.update_rhel_kernel()

--- a/convert2rhel/actions/conversion/preserve_only_rhel_kernel.py
+++ b/convert2rhel/actions/conversion/preserve_only_rhel_kernel.py
@@ -70,9 +70,9 @@ class InstallRhelKernel(actions.Action):
         # during the main transaction.
         if not rhel_kernels:
             info_message = (
-                "Conflict of kernels: The running kernel has the same version as the latest RHEL kernel. "
-                "The kernel package could not be replaced during the main transaction. "
-                "We will try to install a lower version of the package, "
+                "Conflict of kernels: The running kernel has the same version as the latest RHEL kernel.\n"
+                "The kernel package could not be replaced during the main transaction.\n"
+                "We will try to install a lower version of the package,\n"
                 "remove the conflicting kernel and then update to the latest security patched version."
             )
             loggerinst.info("\n%s" % info_message)
@@ -85,8 +85,10 @@ class InstallRhelKernel(actions.Action):
             pkghandler.handle_no_newer_rhel_kernel_available()
             kernel_update_needed = True
 
-        # In this case all kernel packages were already replaced during the main transaction
-        if not non_rhel_kernels:
+        # In this case all kernel packages were already replaced during the main transaction.
+        # Having elif here to prevent breaking the action. Otherwise, when the first condition applies,
+        # and the pkghandler.handle_no_newer_rhel_kernel_available() we can assume the Action finished.
+        elif not non_rhel_kernels:
             return
 
         # At this point we need to decide if the highest package version in the rhel_kernels list
@@ -95,7 +97,11 @@ class InstallRhelKernel(actions.Action):
             latest_installed_non_rhel_kernel = pkghandler.get_highest_package_version(
                 ("non-RHEL kernel", non_rhel_kernels)
             )
+            loggerinst.debug(
+                "Latest installed kernel version from the original vendor: %s" % latest_installed_non_rhel_kernel
+            )
             latest_installed_rhel_kernel = pkghandler.get_highest_package_version(("RHEL kernel", rhel_kernels))
+            loggerinst.debug("Latest installed RHEL kernel version: %s" % latest_installed_rhel_kernel)
             is_rhel_kernel_higher = pkghandler.compare_package_versions(
                 latest_installed_rhel_kernel, latest_installed_non_rhel_kernel
             )
@@ -178,12 +184,12 @@ class FixInvalidGrub2Entries(actions.Action):
                 loggerinst.debug("Removing boot entry %s" % entry)
                 os.remove(entry)
 
-        # Removing a boot entry that used to be the default makes grubby to choose a different entry as default, but we will
-        # call grub --set-default to set the new default on all the proper places, e.g. for grub2-editenv
+        # Removing a boot entry that used to be the default makes grubby to choose a different entry as default,
+        # but we will call grub --set-default to set the new default on all the proper places, e.g. for grub2-editenv
         output, ret_code = utils.run_subprocess(["/usr/sbin/grubby", "--default-kernel"], print_output=False)
         if ret_code:
-            # Not setting the default entry shouldn't be a deal breaker and the reason to stop the conversions, grub should
-            # pick one entry in any case.
+            # Not setting the default entry shouldn't be a deal breaker and the reason to stop the conversions,
+            # grub should pick one entry in any case.
             description = "Couldn't get the default GRUB2 boot loader entry:\n%s" % output
             loggerinst.warning(description)
             self.add_message(

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -1056,3 +1056,20 @@ def _parse_pkg_with_dnf(pkg):
 
     pkg_ver_components = (name, epoch, version, release, arch)
     return pkg_ver_components
+
+
+def get_highest_package_version(pkgs):
+    """
+    Get the highest version from the provided list of packages.
+    :param pkgs: A tuple containing the name of the package list (as a string) and the list of package versions (as a list of strings).
+    :type pkgs: tuple(str,list[str])
+    :return: Return a single package with the highest version.
+    :rtype: str
+
+    :raises ValueError: If the list is empty, raise a ValueError.
+    """
+    try:
+        return max(pkgs[1])
+    except ValueError:
+        loggerinst.debug("The list of %s packages is empty." % pkgs[0])
+        return None

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -1072,4 +1072,4 @@ def get_highest_package_version(pkgs):
         return max(pkgs[1])
     except ValueError:
         loggerinst.debug("The list of %s packages is empty." % pkgs[0])
-        return None
+        raise

--- a/convert2rhel/unit_tests/actions/conversion/preserve_only_rhel_kernel_test.py
+++ b/convert2rhel/unit_tests/actions/conversion/preserve_only_rhel_kernel_test.py
@@ -153,13 +153,19 @@ class TestInstallRhelKernel:
             GetInstalledPkgsWDifferentFingerprintMocked(pkg_selection="kernels"),
         )
         install_rhel_kernel_instance.run()
+        info_message = (
+            "Conflict of kernels: The running kernel has the same version as the latest RHEL kernel. "
+            "The kernel package could not be replaced during the main transaction. "
+            "We will try to install a lower version of the package, "
+            "remove the conflicting kernel and then update to the latest security patched version."
+        )
         expected = set(
             (
                 actions.ActionMessage(
                     level="INFO",
                     id="CONFLICT_OF_KERNELS",
                     title="Conflict of installed kernel versions",
-                    description="Conflict of kernels: One of the installed kernels has the same version as the latest RHEL kernel.",
+                    description=info_message,
                     diagnosis=None,
                     remediations=None,
                 ),

--- a/convert2rhel/unit_tests/actions/conversion/preserve_only_rhel_kernel_test.py
+++ b/convert2rhel/unit_tests/actions/conversion/preserve_only_rhel_kernel_test.py
@@ -105,9 +105,9 @@ class TestInstallRhelKernel:
                             level="INFO",
                             id="CONFLICT_OF_KERNELS",
                             title="Conflict of installed kernel versions",
-                            description="Conflict of kernels: The running kernel has the same version as the latest RHEL kernel. "
-                            "The kernel package could not be replaced during the main transaction. "
-                            "We will try to install a lower version of the package, "
+                            description="Conflict of kernels: The running kernel has the same version as the latest RHEL kernel.\n"
+                            "The kernel package could not be replaced during the main transaction.\n"
+                            "We will try to install a lower version of the package,\n"
                             "remove the conflicting kernel and then update to the latest security patched version.",
                         ),
                     ),

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -1797,3 +1797,54 @@ def test_get_package_repositories_repoquery_failure(pretend_os, monkeypatch, cap
     for package, repo in result.items():
         assert package in packages
         assert repo == "N/A"
+
+
+@pytest.mark.parametrize(
+    (
+        "packages",
+        "expected",
+    ),
+    [
+        (
+            (
+                "kernels",
+                [
+                    "kernel-0:6.10.5-500.fc40.x86_64",
+                    "kernel-0:6.8.5-301.fc40.x86_64",
+                    "kernel-0:6.8.6-301.fc40.x86_64",
+                    "kernel-0:6.10.6-200.fc40.x86_64",
+                ],
+            ),
+            "kernel-0:6.10.6-200.fc40.x86_64",
+        ),
+        (
+            (
+                "kernels",
+                [
+                    "kernel-0:6.8.5-301.fc40.x86_64",
+                ],
+            ),
+            "kernel-0:6.8.5-301.fc40.x86_64",
+        ),
+        (
+            (
+                "kernels",
+                [
+                    "kernel-0:12.8.5-301.fc40.x86_64",
+                    "kernel-1:1.1.5-101.fc40.x86_64",
+                ],
+            ),
+            "kernel-1:1.1.5-101.fc40.x86_64",
+        ),
+    ],
+)
+def test_get_highest_package_version(packages, expected):
+    result = pkghandler.get_highest_package_version(pkgs=packages)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize("packages", ("void", []))
+def test_get_highest_package_version_value_err(packages):
+    with pytest.raises(ValueError):
+        pkghandler.get_highest_package_version(pkgs=packages)

--- a/tests/integration/common/checks-after-conversion/main.fmf
+++ b/tests/integration/common/checks-after-conversion/main.fmf
@@ -161,6 +161,8 @@ order: 52
 /yum_check_update:
     summary+: |
       Run yum check-update
-    description+:
+    description+: |
       After the conversion verify yum check-update does not return outdated package.
+      Validated packages:
+        - kernel*
     test: pytest -m test_yum_check_update

--- a/tests/integration/common/checks-after-conversion/main.fmf
+++ b/tests/integration/common/checks-after-conversion/main.fmf
@@ -148,7 +148,7 @@ order: 52
     summary+: |
         Run yum check
     description+: |
-        After conversion check verifying yum check is able to finis without any issues.
+        After conversion verify that yum check is able to finish without any issues.
     test: pytest -m test_yum_check
 
 /check_firewalld_errors:
@@ -157,3 +157,10 @@ order: 52
     description+: |
         Verify that firewalld is not reporting any issues in the logs.
     test: pytest -m test_check_firewalld_errors
+
+/yum_check_update:
+    summary+: |
+      Run yum check-update
+    description+:
+      After the conversion verify yum check-update does not return outdated package.
+    test: pytest -m test_yum_check_update

--- a/tests/integration/common/checks-after-conversion/test_yum_check_update.py
+++ b/tests/integration/common/checks-after-conversion/test_yum_check_update.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.mark.parametrize("package", ["kernel"])
+def test_yum_check_update(shell, package):
+    """
+    After the conversion verify yum check-update does not return outdated package.
+    """
+    assert package not in shell(f"yum check-update {package}").output

--- a/tests/integration/common/checks-after-conversion/test_yum_check_update.py
+++ b/tests/integration/common/checks-after-conversion/test_yum_check_update.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.parametrize("package", ["kernel"])
+@pytest.mark.parametrize("package", ["kernel*"])
 def test_yum_check_update(shell, package):
     """
     After the conversion verify yum check-update does not return outdated package.


### PR DESCRIPTION
In this PR we try to detect, if a RHEL kernel was installed during the main transaction.
We compare which of the installed kernel packages has a higher version. 
* If the installed RHEL kernel has a higher version than the original vendor kernel, we do not perform any further action and set such kernel as default.
* If there is no non-RHEL kernel detected, we assume that the main transaction handled the whole kernel replacement by itself.
* If the latest available RHEL kernel package is the same version as the currently running non-RHEL kernel, we fall back to the original procedure of trying to install an older version and subsequently updating it.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-1672](https://issues.redhat.com/browse/RHELC-1672) -->
- [RHELC-1672](https://issues.redhat.com/browse/RHELC-1672)
- [RHELC-1708](https://issues.redhat.com/browse/RHELC-1708)
- [RHELC-1707](https://issues.redhat.com/browse/RHELC-1707)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [x] When merged: Jira issue has been updated to `Release Pending` if relevant
