### PR TITLE
chore: Added CODEOWNERS to the repo for approvals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+
+# If you would like to be the owner of something and you
+# are either a member or well-known contributor. Just
+# submit a PR to add yourself
+
+# Convert2RHEL codebase itself
+convert2rhel/             @oamg/convert2rhel-developers
+
+# Integration tests
+tests/integration         @danmyway @kokesak @SerCantus
+
+# Packaging
+packaging/                @Venefilyn @bocekm @pr-watson @r0x0d @bookwar
+
+# Containers
+.devcontainer/            @Venefilyn @r0x0d
+*.Containerfile           @Venefilyn @r0x0d


### PR DESCRIPTION
This adds CODEOWNERS so that we can have specific tags for who is the
primary owner of that section of the codebase

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
