### PR TITLE
Use correct docs dependencies in centos9 container

### DIFF
--- a/Containerfiles/centos9.Containerfile
+++ b/Containerfiles/centos9.Containerfile
@@ -5,7 +5,7 @@ ENV PIP pip3
 ENV PYTHONDONTWRITEBYTECODE 1
 
 ENV APP_DEV_DEPS "requirements/centos9.requirements.txt"
-ENV APP_DOCS_DEPS "requirements/centos9.requirements.txt"
+ENV APP_DOCS_DEPS "docs/requirements.txt"
 ENV APP_MAIN_DEPS \
     util-linux \
     python3 \
@@ -23,6 +23,7 @@ RUN dnf update -y && dnf install -y $APP_MAIN_DEPS && dnf clean all
 FROM install_main_deps as install_dev_deps
 RUN curl $URL_GET_PIP | $PYTHON
 COPY $APP_DEV_DEPS $APP_DEV_DEPS
+COPY $APP_DOCS_DEPS $APP_DOCS_DEPS
 RUN $PIP install -r $APP_DEV_DEPS -r $APP_DOCS_DEPS
 
 FROM install_dev_deps as install_application

--- a/requirements/centos7.requirements.txt
+++ b/requirements/centos7.requirements.txt
@@ -2,5 +2,3 @@ pytest==4.6.11
 pathlib2==2.3.7.post1
 mock==3.0.5
 pytest-cov==2.12.1
-sphinx
-sphinx_autodoc_typehints

--- a/requirements/centos8.requirements.txt
+++ b/requirements/centos8.requirements.txt
@@ -1,5 +1,3 @@
 pytest==7.0.1
 pytest-cov==3.0.0
 coverage[toml]
-sphinx
-sphinx_autodoc_typehints

--- a/requirements/centos9.requirements.txt
+++ b/requirements/centos9.requirements.txt
@@ -1,5 +1,3 @@
 pytest==7.0.1
 pytest-cov==3.0.0
 coverage[toml]
-sphinx
-sphinx_autodoc_typehints


### PR DESCRIPTION
Removed the sphinx* dependencies from the development requirements, and updated the centos9.Containerfile to use the requirements that comes from docs/requirements.txt instead.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
