### PR TITLE
[RHELC-1684] Pick correct report results after inhibitors

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -204,7 +204,8 @@ def main_locked():
         return ConversionExitCodes.SUCCESSFUL
     except _InhibitorsFound as err:
         loggerinst.critical_no_exit(str(err))
-        _handle_main_exceptions(process_phase, pre_conversion_results)
+        results = _pick_conversion_results(process_phase, pre_conversion_results, post_conversion_results)
+        _handle_main_exceptions(process_phase, results)
 
         return _handle_inhibitors_found_exception()
     except exceptions.CriticalError as err:


### PR DESCRIPTION
There are two places where we raise the _InhibitorsFound exception, and while this works correctly, we actually are reporting the wrong type of data in one of them. We always assume that the type of data that will be shown to the user is for pre-conversion, but in a further case down the road of conversion, we could also show post conversion results.

This commit patches this bug and tries to correctly show the appropriate result depending on the conversion state.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-1684](https://issues.redhat.com/browse/RHELC-1684) -->
- [RHELC-1684](https://issues.redhat.com/browse/RHELC-1684) 

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
