### PR TITLE
Add dependency for non redhat pkgs listing

### DIFF
--- a/convert2rhel/actions/conversion/list_non_red_hat_pkgs_left.py
+++ b/convert2rhel/actions/conversion/list_non_red_hat_pkgs_left.py
@@ -27,6 +27,7 @@ loggerinst = logging.getLogger(__name__)
 
 class ListNonRedHatPkgsLeft(actions.Action):
     id = "LIST_NON_RED_HAT_PKGS_LEFT"
+    dependencies = ("KERNEL_PACKAGES_INSTALLATION",)
 
     def run(self):
         """List all the packages that have not been replaced by the


### PR DESCRIPTION
Without this dependency, the action can run before the package conversion in the system. Ideally, we want this to run after the `KERNEL_PACKAGES_INSTALLATION`, as it is no use to have this run before the package replacement.

Pointed out by @hosekadam in https://github.com/oamg/convert2rhel/pull/1256#discussion_r1718100982

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
