### PR TITLE
Remove unused imports from code

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -18,8 +18,6 @@ __metaclass__ = type
 import logging
 import os
 
-from convert2rhel import grub
-from convert2rhel.systeminfo import system_info
 from convert2rhel.utils import run_subprocess
 
 

--- a/convert2rhel/grub.py
+++ b/convert2rhel/grub.py
@@ -20,10 +20,8 @@ __metaclass__ = type
 import logging
 import os
 import re
-import shutil
 
-from convert2rhel import backup, systeminfo, utils
-from convert2rhel.backup.files import RestorableFile
+from convert2rhel import systeminfo, utils
 
 
 logger = logging.getLogger(__name__)

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -20,9 +20,9 @@ __metaclass__ = type
 import logging
 import os
 
-from convert2rhel import actions, applock, backup, breadcrumbs, checks, exceptions
+from convert2rhel import actions, applock, backup, breadcrumbs, exceptions
 from convert2rhel import logger as logger_module
-from convert2rhel import pkghandler, pkgmanager, redhatrelease, subscription, systeminfo, toolopts, utils
+from convert2rhel import pkghandler, pkgmanager, subscription, systeminfo, toolopts, utils
 from convert2rhel.actions import level_for_raw_action_data, report
 
 

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -17,7 +17,6 @@
 
 __metaclass__ = type
 
-import glob
 import logging
 import os
 import os.path

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -17,7 +17,6 @@
 
 __metaclass__ = type
 
-import difflib
 import logging
 import os
 import re
@@ -28,7 +27,7 @@ from collections import namedtuple
 from six.moves import configparser
 
 from convert2rhel import logger, utils
-from convert2rhel.toolopts import POST_RPM_VA_LOG_FILENAME, PRE_RPM_VA_LOG_FILENAME, tool_opts
+from convert2rhel.toolopts import PRE_RPM_VA_LOG_FILENAME, tool_opts
 from convert2rhel.utils import run_subprocess
 
 

--- a/convert2rhel/unit_tests/actions/post_conversion/kernel_boot_files_test.py
+++ b/convert2rhel/unit_tests/actions/post_conversion/kernel_boot_files_test.py
@@ -20,7 +20,7 @@ import os
 import pytest
 import six
 
-from convert2rhel import actions, checks, grub
+from convert2rhel import actions, checks
 from convert2rhel.actions.post_conversion import kernel_boot_files
 from convert2rhel.unit_tests import RunSubprocessMocked
 from convert2rhel.unit_tests.conftest import centos8

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
@@ -22,7 +22,7 @@ import os
 import pytest
 import six
 
-from convert2rhel import subscription, unit_tests
+from convert2rhel import unit_tests
 from convert2rhel.actions.pre_ponr_changes import backup_system
 from convert2rhel.backup import files
 from convert2rhel.backup.files import RestorableFile

--- a/convert2rhel/unit_tests/actions/system_checks/dbus_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/dbus_test.py
@@ -17,7 +17,7 @@ __metaclass__ = type
 
 import pytest
 
-from convert2rhel import actions, subscription, unit_tests
+from convert2rhel import subscription, unit_tests
 from convert2rhel.actions.system_checks import dbus
 
 

--- a/convert2rhel/unit_tests/backup/files_test.py
+++ b/convert2rhel/unit_tests/backup/files_test.py
@@ -2,7 +2,6 @@ __metaclass__ = type
 
 import hashlib
 import os
-import shutil
 
 import pytest
 import six

--- a/convert2rhel/unit_tests/grub_test.py
+++ b/convert2rhel/unit_tests/grub_test.py
@@ -26,7 +26,7 @@ import pytest
 import six
 
 from convert2rhel import grub, utils
-from convert2rhel.unit_tests import EFIBootInfoMocked, RunSubprocessMocked, run_subprocess_side_effect
+from convert2rhel.unit_tests import EFIBootInfoMocked, RunSubprocessMocked
 
 
 six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -27,9 +27,9 @@ import six
 six.add_move(six.MovedModule("mock", "mock", "unittest.mock"))
 from six.moves import mock
 
-from convert2rhel import actions, applock, backup, checks, exceptions
+from convert2rhel import actions, applock, backup, exceptions
 from convert2rhel import logger as logger_module
-from convert2rhel import main, pkghandler, pkgmanager, redhatrelease, subscription, toolopts, utils
+from convert2rhel import main, pkghandler, pkgmanager, subscription, toolopts, utils
 from convert2rhel.actions import report
 from convert2rhel.breadcrumbs import breadcrumbs
 from convert2rhel.systeminfo import system_info

--- a/convert2rhel/unit_tests/pkghandler_test.py
+++ b/convert2rhel/unit_tests/pkghandler_test.py
@@ -37,18 +37,16 @@ from convert2rhel.pkghandler import (
     _get_packages_to_update_yum,
     get_total_packages_to_update,
 )
-from convert2rhel.systeminfo import Version, system_info
+from convert2rhel.systeminfo import system_info
 from convert2rhel.toolopts import tool_opts
 from convert2rhel.unit_tests import (
     CallYumCmdMocked,
     DownloadPkgMocked,
     FormatPkgInfoMocked,
     GetInstalledPkgInformationMocked,
-    GetInstalledPkgsByFingerprintMocked,
     GetInstalledPkgsWDifferentFingerprintMocked,
     RemovePkgsMocked,
     RunSubprocessMocked,
-    StoreContentToFileMocked,
     SysExitCallableObject,
     TestPkgObj,
     create_pkg_information,

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -30,7 +30,7 @@ import six
 
 from convert2rhel import exceptions, pkghandler, pkgmanager, repo, subscription, toolopts, unit_tests, utils
 from convert2rhel.backup import files
-from convert2rhel.systeminfo import Version, system_info
+from convert2rhel.systeminfo import Version
 from convert2rhel.unit_tests import (
     PromptUserMocked,
     RunSubprocessMocked,

--- a/tests/integration/tier0/destructive/single-yum-transaction/install_dependency_packages.py
+++ b/tests/integration/tier0/destructive/single-yum-transaction/install_dependency_packages.py
@@ -1,4 +1,4 @@
-from conftest import SYSTEM_RELEASE_ENV, SystemInformationRelease
+from conftest import SystemInformationRelease
 
 
 def test_install_dependency_packages(shell):


### PR DESCRIPTION
There were some leftovers imports from the past few merges. This patch is intended to remove them.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
