### PR TITLE
[RHELC-1395] Drop the python3-syspurpose workaround

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -631,24 +631,6 @@ def environment_variables(request):
     return _unset_env_var
 
 
-# TODO remove when https://issues.redhat.com/browse/RHELC-1389 resolved
-@pytest.fixture(autouse=True, scope="function")
-def remediation_out_of_date_packages(shell):
-    """
-    Remediation fixture.
-    There is an open issue https://issues.redhat.com/browse/RHELC-1389
-    The python3-syspurpose package is left outdated on the system in some cases,
-    causing subsequent tests to fail.
-    Update the package at the end of each test function if needed.
-    """
-    problematic_packages = ["python3-syspurpose"]
-
-    yield
-
-    for package in problematic_packages:
-        shell(f"yum update -y {package}")
-
-
 def _create_old_repo(distro: str, repo_name: str):
     """
     Create a repo on system with content that is older than the latest released version.


### PR DESCRIPTION
* to test validate the fix from RHELC-1389, drop the automatic installation of python3-syspurpose after every test run

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-1395](https://issues.redhat.com/browse/RHELC-1395]) -->
- [RHELC-1395](https://issues.redhat.com/browse/RHELC-1395])

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
