### PR TITLE
[RHELC-774] Override exclude option during yumdownloader call

### DIFF
--- a/convert2rhel/unit_tests/utils_test.py
+++ b/convert2rhel/unit_tests/utils_test.py
@@ -488,6 +488,7 @@ class TestDownload_pkg:
         assert [
             "yumdownloader",
             "-v",
+            "--setopt=exclude=",
             "--destdir=%s" % dest,
             "--setopt=reposdir=%s" % reposdir,
             "--disablerepo=*",

--- a/convert2rhel/utils/__init__.py
+++ b/convert2rhel/utils/__init__.py
@@ -642,7 +642,7 @@ def download_pkg(
     loggerinst.debug("Downloading the %s package." % pkg)
 
     # On RHEL 7, it's necessary to invoke yumdownloader with -v, otherwise there's no output to stdout.
-    cmd = ["yumdownloader", "-v", "--destdir=%s" % dest]
+    cmd = ["yumdownloader", "-v", "--setopt=exclude=", "--destdir=%s" % dest]
     if reposdir:
         cmd.append("--setopt=reposdir=%s" % reposdir)
 


### PR DESCRIPTION
As pointed out by QE, we forgot to override the exclude option during yumdownloader calls. This patch is fixing the command to also ignore it during the yumdownloader.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-774](https://issues.redhat.com/browse/RHELC-774) -->
- [RHELC-774](https://issues.redhat.com/browse/RHELC-774)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
