### PR TITLE
Bump to version 2.1.0

### DIFF
--- a/convert2rhel/__init__.py
+++ b/convert2rhel/__init__.py
@@ -1,2 +1,2 @@
 __metaclass__ = type
-__version__ = "2.0.1"
+__version__ = "2.1.0"

--- a/packaging/convert2rhel.spec
+++ b/packaging/convert2rhel.spec
@@ -9,7 +9,7 @@
 %endif
 
 Name:           convert2rhel
-Version:        2.0.1
+Version:        2.1.0
 Release:        1%{?dist}
 Summary:        Automates the conversion of RHEL derivative distributions to RHEL
 
@@ -124,6 +124,35 @@ install -m 0600 config/convert2rhel.ini %{buildroot}%{_sysconfdir}/convert2rhel.
 %attr(0644,root,root) %{_mandir}/man8/%{name}.8*
 
 %changelog
+* Wed Aug 21 2024 Preston Watson <prwatson@redhat.com> 2.1.0
+- Use public CDN instead of paywalled CDN and FTP
+- Remove RuntimeWarning caused by bufsize value of run_subprocess
+- Port ModifiedRPMFilesDiff to Action framework
+- Port preserve_only_rhel_kernel to Action framework
+- Include all reports in post-conversion report
+- Port list_non_red_hat_pkgs_left to Action framework
+- Port post_ponr_set_efi_configuration to Action framework
+- Port PkgManagerConf to Action framework
+- Port lock_releasever_in_rhel_repositories to Action framework
+- Port update_grub_after_conversion to Action framework
+- Port remove_tmp_dir to Action framework
+- Port kernel_boot_files to Action framework
+- Port hostmetering to Action framework
+- Disregard minor version with CentOS Stream
+- Port breadcrumbs.finish_collection to action framework
+- Port update_rhsm_custom_facts to Action framework
+- Remove RHSM repositories enablement fallback
+- Fix CodeQL error uninitialized variable
+- Fix duplicating backups
+- Use no_rhsm to detect if enablerepos should be disabled
+- Add --els to convert2rhel man page and synopsis.
+- Fix of super(run()) call inside action
+- Fix rpm -Va parsing and improve speed
+- Prevent kernel being excluded in repoquery calls
+- Pick correct report results after inhibitors
+- Detect a newer version of RHEL kernel in the main transaction
+- Override exclude option during yumdownloader call
+
 * Tue Jul 23 2024 Freya Gustavsson <fgustavs@redhat.com> 2.0.1
 - Fix files being backed up multiple times and causing rollback errors
 - Fix conversions failing with third-party repositories


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Enhancements 🎉
* [RHELC-1434] Use public CDN instead of paywalled CDN and FTP by @bocekm in https://github.com/oamg/convert2rhel/pull/1123
* [RHELC-1600] Remove RuntimeWarning caused by bufsize value of run_subprocess by @pr-watson in https://github.com/oamg/convert2rhel/pull/1313
* [RHELC-1334] Port ModifiedRPMFilesDiff to Action framework by @hosekadam in https://github.com/oamg/convert2rhel/pull/1266
* [RHELC-1329] Port preserve_only_rhel_kernel to Action framework by @pr-watson in https://github.com/oamg/convert2rhel/pull/1250
* [RHELC-1673] Include all reports in post-conversion report by @hosekadam in https://github.com/oamg/convert2rhel/pull/1336
* [RHELC-1330] Port list_non_red_hat_pkgs_left to Action framework by @jochapma in https://github.com/oamg/convert2rhel/pull/1292
* [RHELC-1331] Port post_ponr_set_efi_configuration to Action framework by @pr-watson in https://github.com/oamg/convert2rhel/pull/1256
* [RHELC-1332] Port PkgManagerConf to Action framework by @pr-watson in https://github.com/oamg/convert2rhel/pull/1321
* [RHELC-1333] Port lock_releasever_in_rhel_repositories to Action framework by @jochapma in https://github.com/oamg/convert2rhel/pull/1326
* [RHELC-1335] Port update_grub_after_conversion to Action framework by @pr-watson in https://github.com/oamg/convert2rhel/pull/1303
* [RHELC-1336] Port remove_tmp_dir to Action framework. by @jochapma in https://github.com/oamg/convert2rhel/pull/1283
* [RHELC-1337] Port kernel_boot_files to Action framework by @pr-watson in https://github.com/oamg/convert2rhel/pull/1301
* [RHELC-1390] Port hostmetering to Action framework by @hosekadam in https://github.com/oamg/convert2rhel/pull/1311
* [RHELC-1650] Disregard minor version with CentOS Stream by @danmyway in https://github.com/oamg/convert2rhel/pull/1296
* [RHELC-1338] Port breadcrumbs.finish_collection to action framework by @hosekadam in https://github.com/oamg/convert2rhel/pull/1305
* [RHELC-1339] Port update_rhsm_custom_facts to Action framework by @Andrew-ang9 in https://github.com/oamg/convert2rhel/pull/1299
* [RHELC-1554] Remove RHSM repositories enablement fallback by @r0x0d in https://github.com/oamg/convert2rhel/pull/1258
### Bug Fixes 🐛
* [RHELC-1284] Fix CodeQL error uninitialized variable by @r0x0d in https://github.com/oamg/convert2rhel/pull/1259
* [RHELC-1606] Fix duplicating backups by @Venefilyn in https://github.com/oamg/convert2rhel/pull/1287
* [RHELC-1626] Use no_rhsm to detect if enablerepos should be disabled by @r0x0d in https://github.com/oamg/convert2rhel/pull/1289
* Add --els to convert2rhel man page and synopsis. by @jeffmcutter in https://github.com/oamg/convert2rhel/pull/1335
* [RHELC-1679] Fix of super(run()) call inside action by @hosekadam in https://github.com/oamg/convert2rhel/pull/1332
* [RHELC-1427] Fix rpm -Va parsing and improve speed by @hosekadam in https://github.com/oamg/convert2rhel/pull/1319
* [RHELC-774] Prevent kernel being excluded in repoquery calls by @r0x0d in https://github.com/oamg/convert2rhel/pull/1255
* [RHELC-1684] Pick correct report results after inhibitors by @r0x0d in https://github.com/oamg/convert2rhel/pull/1339
* [RHELC-1672, RHELC-1707, RHELC-1708] Detect a newer version of RHEL kernel in the main transaction by @danmyway in https://github.com/oamg/convert2rhel/pull/1323
* [RHELC-774] Override exclude option during yumdownloader call by @r0x0d in https://github.com/oamg/convert2rhel/pull/1351
### Test Coverage Enhancements 🔧
* [RHELC-1428, RHELC-1366, RHELC-1594, RHELC-1468] Include 8.10 in tests, introduce CentOS Stream by @danmyway in https://github.com/oamg/convert2rhel/pull/1244

## New Contributors
* @jeffmcutter made their first contribution in https://github.com/oamg/convert2rhel/pull/1335

**Full Changelog**: https://github.com/oamg/convert2rhel/compare/v2.0.0...v2.1.0