### PR TITLE
[RHELC-1672] Fix edge case of kernel meta package not the on system

### DIFF
--- a/convert2rhel/actions/conversion/preserve_only_rhel_kernel.py
+++ b/convert2rhel/actions/conversion/preserve_only_rhel_kernel.py
@@ -61,6 +61,13 @@ class InstallRhelKernel(actions.Action):
         #  "Package kernel-4.18.0-193.el8.x86_64 is already installed."
         # When calling install, yum/dnf essentially reports all the already installed versions.
         already_installed = re.findall(r" (.*?)(?: is)? already installed", output, re.MULTILINE)
+
+        # Mitigates an edge case, when the kernel meta-package might not be installed prior to the conversion
+        # with only kernel-core being on the system.
+        # During that scenario the kernel meta package gets actually installed leaving the already_installed unmatched
+        if not already_installed:
+            return
+
         # Get list of kernel pkgs not signed by Red Hat
         non_rhel_kernels_pkg_info = pkghandler.get_installed_pkgs_w_different_fingerprint(
             system_info.fingerprints_rhel, "kernel"

--- a/convert2rhel/unit_tests/actions/conversion/preserve_only_rhel_kernel_test.py
+++ b/convert2rhel/unit_tests/actions/conversion/preserve_only_rhel_kernel_test.py
@@ -171,6 +171,23 @@ class TestInstallRhelKernel:
                 set(()),
                 actions.ActionResult(level="SUCCESS", id="SUCCESS"),
             ),
+            (
+                # Output from yum contains info about installing some package - corner case
+                "Installing kernel-4.18.0-183.el8.x86_64",
+                [
+                    create_pkg_information(
+                        name="kernel",
+                        version="4.18.0",
+                        release="193.el8",
+                        arch="x86_64",
+                        packager="CentOS",
+                    ),
+                ],
+                0,
+                False,
+                set(()),
+                actions.ActionResult(level="SUCCESS", id="SUCCESS"),
+            ),
         ),
     )
     @centos8

--- a/tests/integration/common/checks-after-conversion/main.fmf
+++ b/tests/integration/common/checks-after-conversion/main.fmf
@@ -159,6 +159,8 @@ order: 52
     test: pytest -m test_check_firewalld_errors
 
 /yum_check_update:
+    # This needs to run before the system gets unregistered
+    order: 51
     summary+: |
       Run yum check-update
     description+: |


### PR DESCRIPTION
* when there is just the kernel-core package on the system and the meta kernel package is removed, the yum call to install kernel actually installs the meta-package and leaves already_installed variable unmatched

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1672](https://issues.redhat.com/browse/RHELC-1672) 

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [x] When merged: Jira issue has been updated to `Release Pending` if relevant
