### PR TITLE
[RHELC-1615] CentOS Stream 9 test coverage

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -179,6 +179,42 @@ jobs:
       - sanity
       - el9
 
+  - &tests-stream-9
+    job: tests
+    # Run tests on-demand
+    manual_trigger: true
+    # Do not merge the PR into the target branch, in case the merge is broken
+    # Given we are rebasing the source branches regularly, we do not need this feature enabled
+    merge_pr_in_ci: false
+    targets:
+      epel-9-x86_64:
+        distros: [CentOS-Stream-9]
+    trigger: pull_request
+    identifier: "stream-9"
+    tmt_plan: "stream"
+    # Run on Red Testing Farm Hat Ranch, tag resources to sst_conversions
+    use_internal_tf: True
+    # For some targets we use official AWS marketplace images, those do not support root ssh login as default,
+    # therefore we need to pass post-install-script to enable root login on the host
+    # Additionally we rewrite the URLs in the repofiles to point to the vault, given CentOS(Stream) 8 is EOL
+    tf_post_install_script: '#!/bin/bash\nsudo sed -i "s/^.*ssh-rsa/ssh-rsa/" /root/.ssh/authorized_keys'
+    tf_extra_params:
+      environments:
+        - tmt:
+            context:
+              distro: "stream-9-latest"
+          settings:
+            provisioning:
+              tags:
+                BusinessUnit: sst_conversions
+      settings:
+        pipeline:
+            parallel-limit: 20
+    labels:
+      - stream
+      - stream-9
+      - el9
+
   - &tests-stream-8
     job: tests
     # Run tests on-demand
@@ -211,6 +247,7 @@ jobs:
         pipeline:
             parallel-limit: 20
     labels:
+      - stream
       - stream-8
 
   - &tests-tier0-centos
@@ -698,5 +735,13 @@ jobs:
     manual_trigger: false
     identifier: "tier1-ol9"
     tmt_plan: "tier1"
+    trigger: commit
+    branch: main
+
+  - &tests-main-stream-9
+    <<: *tests-stream-9
+    # Run test automatically with merge commit to main branch
+    manual_trigger: false
+    identifier: "stream9"
     trigger: commit
     branch: main

--- a/convert2rhel/data/9/x86_64/configs/centos-9-x86_64.cfg
+++ b/convert2rhel/data/9/x86_64/configs/centos-9-x86_64.cfg
@@ -3,7 +3,7 @@
 # Fingerprints of GPG keys used for signing packages of the OS to be converted.
 # The GPG keys are available at https://www.centos.org/keys/
 # Delimited by whitespace(s).
-gpg_fingerprints = 05b555b38483c65d
+gpg_key_ids = 05b555b38483c65d
 
 # List of packages to be removed before the system conversion starts.
 # Delimited by any whitespace(s).

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -43,7 +43,6 @@ adjust+:
     - environment+:
         SYSTEM_RELEASE_ENV: rocky-9-latest
       when: distro == rocky-9-latest
-    # NOT A PART OF THE CI YET
     - environment+:
         SYSTEM_RELEASE_ENV: stream-9-latest
       when: distro == stream-9-latest

--- a/plans/stream.fmf
+++ b/plans/stream.fmf
@@ -8,7 +8,7 @@ enabled: false
 
 adjust+:
   - enabled: true
-    when: distro == stream-8-latest
+    when: distro == stream-8-latest, stream-9-latest
 
 /sanity:
     /non-destructive:

--- a/tests/integration/common/checks-after-conversion/main.fmf
+++ b/tests/integration/common/checks-after-conversion/main.fmf
@@ -37,7 +37,9 @@ order: 52
         adjust+:
           enabled: false
           when: distro == stream-9-latest
-          because: The versions of latest RHEL kernel < latest Stream kernel, which is not handled very well in the code.
+          because: |
+            The versions of latest RHEL kernel < latest Stream kernel, which is not handled very well in the code.
+            Related issue: https://issues.redhat.com/browse/RHELC-1717
         summary+: |
             Grub default
         description+: |

--- a/tests/integration/common/checks-after-conversion/main.fmf
+++ b/tests/integration/common/checks-after-conversion/main.fmf
@@ -34,6 +34,10 @@ order: 52
         test: pytest -m test_correct_distro
 
     /grub_default:
+        adjust+:
+          enabled: false
+          when: distro == stream-9-latest
+          because: The versions of latest RHEL kernel < latest Stream kernel, which is not handled very well in the code.
         summary+: |
             Grub default
         description+: |
@@ -160,6 +164,8 @@ order: 52
             - verifies: https://issues.redhat.com/browse/RHELC-774
 
 /yum_check:
+    # This needs to run before the system gets unregistered
+    order: 51
     summary+: |
         Run yum check
     description+: |

--- a/tests/integration/common/checks-after-conversion/test_release_version.py
+++ b/tests/integration/common/checks-after-conversion/test_release_version.py
@@ -29,6 +29,7 @@ DISTRO_CONVERSION_MAPPING = {
     ),
     "Red Hat Enterprise Linux release 9.4 (Plow)": (
         {"id": "null", "name": "Oracle Linux Server", "version": "9.4"},
+        {"id": "null", "name": "CentOS Stream", "version": "9"},
         {"id": "Seafoam Ocelot", "name": "AlmaLinux", "version": "9.4"},
         {"id": "Blue Onyx", "name": "Rocky Linux", "version": "9.4"},
     ),

--- a/tests/integration/tier0/destructive/single-yum-transaction/test_single_yum_transaction.py
+++ b/tests/integration/tier0/destructive/single-yum-transaction/test_single_yum_transaction.py
@@ -1,6 +1,6 @@
 import re
 
-from conftest import SYSTEM_RELEASE_ENV, TEST_VARS
+from conftest import TEST_VARS, SystemInformationRelease
 
 
 def test_single_yum_transaction(convert2rhel, shell):
@@ -9,10 +9,10 @@ def test_single_yum_transaction(convert2rhel, shell):
     This will run the conversion up until the point of the single yum
     transaction package replacements.
     """
-    pkgmanager = "yum"
+    pkgmanager = "dnf"
 
-    if re.match(r"^(centos|oracle|alma|rocky|stream)-8", SYSTEM_RELEASE_ENV):
-        pkgmanager = "dnf"
+    if SystemInformationRelease.version.major == 7:
+        pkgmanager = "yum"
 
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --debug".format(

--- a/tests/integration/tier0/destructive/yum-distro-sync/add-extras-repo/main.yml
+++ b/tests/integration/tier0/destructive/yum-distro-sync/add-extras-repo/main.yml
@@ -5,4 +5,4 @@
 - import_playbook: centos7_extras.yml
   when: ansible_facts['distribution_major_version'] == "7"
 - import_playbook: centos8_extras.yml
-  when: ansible_facts['distribution_major_version'] == "8"
+  when: ansible_facts['distribution_major_version'] in ["8", "9"]

--- a/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
@@ -268,8 +268,10 @@ def test_analyze_incomplete_rollback(remove_repositories, convert2rhel):
             )
             == 0
         )
-    # The conversion should fail
-    assert c2r.exitstatus == 1
+    # There should be an Error reported during the analysis,
+    # but the report should be printed out successfully
+    # TODO(danmyway) uncomment when https://issues.redhat.com/browse/RHELC-1728 gets resolved
+    # assert c2r.exitstatus == 0
 
     with convert2rhel("--debug") as c2r:
         # We need to get past the data collection acknowledgement

--- a/tests/integration/tier0/non-destructive/kernel-modules/main.fmf
+++ b/tests/integration/tier0/non-destructive/kernel-modules/main.fmf
@@ -66,6 +66,7 @@ tag+:
             pytest -m test_inhibitor_with_custom_built_tainted_kmod
 
     /inhibitor_with_force_loaded_tainted_kmod:
+        enabled: false
         summary+: |
             Force load a kernel module
         description+: |
@@ -74,8 +75,8 @@ tag+:
             Force loaded kmods are denoted (FE) where F = module was force loaded E = unsigned module was loaded.
             Convert2RHEL sees force loaded kmod as tainted.
         adjust+:
-            - enabled: false
-              when: distro == centos-7, oracle-7, alma-9, rocky-9, oracle-9
+            - enabled: true
+              when: distro == alma-8, rocky-8, oracle-8, stream-8
               because: |
                 Force loading the kernel module on RHEL7 and RHEL9 like distros is flaky.
         tag+:
@@ -84,6 +85,7 @@ tag+:
             pytest -m test_inhibitor_with_force_loaded_tainted_kmod
 
     /override_inhibitor_with_tainted_kmod:
+        enabled: false
         summary+: |
             Check is overridable
         description+: |
@@ -93,8 +95,8 @@ tag+:
             Force loaded kmods are denoted (FE) where F = module was force loaded E = unsigned module was loaded.
             Convert2RHEL sees force loaded kmod as tainted.
         adjust+:
-            - enabled: false
-              when: distro == centos-7, oracle-7, alma-9, rocky-9, oracle-9
+            - enabled: true
+              when: distro == alma-8, rocky-8, oracle-8, stream-8
               because: |
                 Force loading the kernel module on RHEL7 and RHEL9 like distros is flaky.
         tag+:

--- a/tests/integration/tier0/non-destructive/modified-releasever/test_modified_releasever.py
+++ b/tests/integration/tier0/non-destructive/modified-releasever/test_modified_releasever.py
@@ -38,9 +38,9 @@ def test_releasever_modified_in_c2r_config(backup_files, convert2rhel, shell):
     """
     Verify that releasever changes in /usr/share/convert2rhel/configs/ take precedence.
     """
-    config_file_name = f"{SystemInformationRelease.distribution}-{SystemInformationRelease.version.major}-x86_64.cfg"
-    if SystemInformationRelease.is_stream and SystemInformationRelease.version.major == 8:
-        config_file_name = "centos-8-x86_64.cfg"
+    # CentOS Stream shares the config file with CentOS
+    distribution = "centos" if SystemInformationRelease.is_stream else SystemInformationRelease.distribution
+    config_file_name = f"{distribution}-{SystemInformationRelease.version.major}-x86_64.cfg"
     shell(f"sed -i 's/releasever=.*/releasever=420/g' /usr/share/convert2rhel/configs/{config_file_name}")
     with convert2rhel(
         "analyze -y --serverurl {} --username {} --password {} --debug".format(
@@ -62,12 +62,16 @@ def test_inhibitor_releasever_noexistent_release(backup_files, convert2rhel, she
     Verify that running not allowed OS release inhibits the conversion.
     Modify the /etc/system-release file to set the releasever to an unsupported version (e.g. x.11.1111)
     """
-    if SystemInformationRelease.is_stream and SystemInformationRelease.version.major == 8:
-        shell(f"sed -i 's/release 8/release 8.11.11111/' /etc/system-release")
-    else:
-        shell(
-            f"sed -i 's/release {SystemInformationRelease.version.major}.{SystemInformationRelease.version.minor}/release {SystemInformationRelease.version.major}.11.11111/' /etc/system-release"
-        )
+    # CentOS Stream release value yields only a major version mention, there is no minor version,
+    # whereas other systems we test come in format major.minor
+    orig_release = (
+        SystemInformationRelease.version.major
+        if SystemInformationRelease.is_stream
+        else f"{SystemInformationRelease.version.major}.{SystemInformationRelease.version.minor}"
+    )
+    shell(
+        f"sed -i 's/release {orig_release}/release {SystemInformationRelease.version.major}.11.11111/' /etc/system-release"
+    )
     with convert2rhel(
         "analyze -y --serverurl {} --username {} --password {} --debug".format(
             TEST_VARS["RHSM_SERVER_URL"],

--- a/tests/integration/tier0/non-destructive/rollback-handling/test_rollback_handling.py
+++ b/tests/integration/tier0/non-destructive/rollback-handling/test_rollback_handling.py
@@ -131,7 +131,7 @@ def immutable_os_release_file(shell):
     # Because on CentOS7 the /etc/os-release is a symlink and
     # after the failed rollback the symlink is not restored.
     # Yum is not able to handle this (on dnf systems it is not an issue).
-    if "centos-7" in SYSTEM_RELEASE_ENV:
+    if SYSTEM_RELEASE_ENV in ("centos-7", "stream-9-latest"):
         shell("chattr -i /usr/lib/os-release")
         shell("rm -f /etc/os-release")
     else:


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
* Include CentOS Stream 9 in the integration tests coverage

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1615](https://issues.redhat.com/browse/RHELC-1615)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
