### PR TITLE
Remove info message from InstallRhelKernel

### DIFF
--- a/convert2rhel/actions/conversion/preserve_only_rhel_kernel.py
+++ b/convert2rhel/actions/conversion/preserve_only_rhel_kernel.py
@@ -89,12 +89,6 @@ class InstallRhelKernel(actions.Action):
                 "remove the conflicting kernel and then update to the latest security patched version."
             )
             loggerinst.info("\n%s" % info_message)
-            self.add_message(
-                level="INFO",
-                id="CONFLICT_OF_KERNELS",
-                title="Conflict of installed kernel versions",
-                description=info_message,
-            )
             pkghandler.handle_no_newer_rhel_kernel_available()
             _kernel_update_needed = True
 

--- a/convert2rhel/unit_tests/actions/conversion/preserve_only_rhel_kernel_test.py
+++ b/convert2rhel/unit_tests/actions/conversion/preserve_only_rhel_kernel_test.py
@@ -104,19 +104,7 @@ class TestInstallRhelKernel:
                 ],
                 1,
                 True,
-                set(
-                    (
-                        actions.ActionMessage(
-                            level="INFO",
-                            id="CONFLICT_OF_KERNELS",
-                            title="Conflict of installed kernel versions",
-                            description="Conflict of kernels: The running kernel has the same version as the latest RHEL kernel.\n"
-                            "The kernel package could not be replaced during the main transaction.\n"
-                            "We will try to install a lower version of the package,\n"
-                            "remove the conflicting kernel and then update to the latest security patched version.",
-                        ),
-                    ),
-                ),
+                set(()),
                 actions.ActionResult(level="SUCCESS", id="SUCCESS"),
             ),
             (


### PR DESCRIPTION
Info message about conflicting kerne from InstallRhelKernell was removed because it can be confusing for users to see this in the post-conversion report. The conflict was already solved in next action steps.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
