### PR TITLE
[RHELC-1711] Except UnicodeDecodeError when parsing initramfs

### DIFF
--- a/convert2rhel/checks.py
+++ b/convert2rhel/checks.py
@@ -51,10 +51,14 @@ def is_initramfs_file_valid(filepath):
         return False
 
     logger.debug("Checking if the '%s' file is not corrupted.", filepath)
-    out, return_code = run_subprocess(
-        cmd=["/usr/bin/lsinitrd", filepath],
-        print_output=False,
-    )
+    try:
+        out, return_code = run_subprocess(
+            cmd=["/usr/bin/lsinitrd", filepath],
+            print_output=False,
+        )
+    except UnicodeDecodeError as e:
+        out = e
+        return_code = 99  # Having this a high number to not mess with the actual process return codes.
 
     if return_code != 0:
         logger.info("Couldn't verify initramfs file. It may be corrupted.")

--- a/convert2rhel/unit_tests/checks_test.py
+++ b/convert2rhel/unit_tests/checks_test.py
@@ -44,3 +44,26 @@ def testis_initramfs_file_valid(latest_installed_kernel, subprocess_output, expe
     if not expected:
         assert "Couldn't verify initramfs file. It may be corrupted." in caplog.records[-2].message
         assert "Output of lsinitrd: {}".format(subprocess_output[0]) in caplog.records[-1].message
+
+
+@pytest.mark.parametrize(
+    ("latest_installed_kernel", "subprocess_output", "expected", "file_content"),
+    (("6.1.7-200.fc37.x86_64", ("can't decode byte", 99), False, b"\xF8\x88\x80\x80\x80"),),
+)
+def test_is_initramfs_file_valid_unicodedecodeerror(
+    latest_installed_kernel, subprocess_output, expected, file_content, tmpdir, caplog, monkeypatch
+):
+    initramfs_file = tmpdir.mkdir("/boot").join("initramfs-%s.img")
+    initramfs_file = str(initramfs_file)
+    initramfs_file = initramfs_file % latest_installed_kernel
+    with open(initramfs_file, mode="wb") as f:
+        f.write(file_content)
+
+    monkeypatch.setattr(checks, "INITRAMFS_FILEPATH", initramfs_file)
+    monkeypatch.setattr(checks, "run_subprocess", RunSubprocessMocked(return_value=subprocess_output))
+    result = checks.is_initramfs_file_valid(initramfs_file)
+    assert result == expected
+
+    if not expected:
+        assert "Couldn't verify initramfs file. It may be corrupted." in caplog.records[-2].message
+        assert "Output of lsinitrd: %s" % subprocess_output[0] in caplog.records[-1].message

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -217,12 +217,6 @@ adjust+:
                     - kernel-boot-files/missing_kernel_boot_files
 
         /corrupted_initramfs_file:
-            adjust+:
-              - enabled: false
-                when: distro == alma-8-latest, alma-9-latest, rocky-8.8
-                because: |
-                  An unhandled UnicodeDecodeError breaks the conversion.
-                  Reference https://issues.redhat.com/browse/RHELC-1711
             discover+:
                 test+<:
                     - kernel-boot-files/corrupted_initramfs_file


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
* Except the UnicodeDecodeError exception when the initramfs file is badly miscofigured

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1711](https://issues.redhat.com/browse/RHELC-1711)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [x] When merged: Jira issue has been updated to `Release Pending` if relevant
