### PR TITLE
[RHELC-1675] Add handling for rhel9 systems in duplicate package check

### DIFF
--- a/convert2rhel/actions/system_checks/duplicate_packages.py
+++ b/convert2rhel/actions/system_checks/duplicate_packages.py
@@ -42,7 +42,7 @@ class DuplicatePackages(actions.Action):
             self.duplicate_packages_failure()
             return
         # For el8 machines we can depend on just the return code being 1 to know the check failed
-        if system_info.version.major == 8 and ret_code == 1:
+        if system_info.version.major >= 8 and ret_code == 1:
             self.duplicate_packages_failure()
             return
         duplicate_packages = filter(None, output.split("\n"))

--- a/convert2rhel/actions/system_checks/duplicate_packages.py
+++ b/convert2rhel/actions/system_checks/duplicate_packages.py
@@ -41,7 +41,7 @@ class DuplicatePackages(actions.Action):
         if system_info.version.major == 7 and "name or service not known" in output.lower():
             self.duplicate_packages_failure()
             return
-        # For el8 machines we can depend on just the return code being 1 to know the check failed
+        # For el8+ machines we can depend on just the return code being 1 to know the check failed
         if system_info.version.major >= 8 and ret_code == 1:
             self.duplicate_packages_failure()
             return

--- a/convert2rhel/unit_tests/actions/system_checks/duplicate_packages_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/duplicate_packages_test.py
@@ -55,6 +55,16 @@ def duplicate_packages_action():
             "package1.x86_64\npackage1.i686\npackage1.s390x\npackage2.x86_64\npackage2.ppc64le\n",
             ["package1.x86_64", "package1.i686", "package1.s390x", "package2.x86_64", "package2.ppc64le"],
         ),
+        (
+            Version(9, 4),
+            "package1.x86_64\npackage1.s390x\npackage2.x86_64\npackage2.ppc64le\n",
+            ["package1.x86_64", "package1.s390x", "package2.x86_64", "package2.ppc64le"],
+        ),
+        (
+            Version(9, 4),
+            "package1.x86_64\npackage1.i686\npackage1.s390x\npackage2.x86_64\npackage2.ppc64le\n",
+            ["package1.x86_64", "package1.i686", "package1.s390x", "package2.x86_64", "package2.ppc64le"],
+        ),
     ),
 )
 def test_duplicate_packages_error(


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
This PR modifies the condition to handle duplicate package error results to also work when run on an el9 system. New unit tests have been added for the el9 scenarios. 
<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-1675) -->
- [RHELC-1675](https://issues.redhat.com/browse/RHELC-1675)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
