### PR TITLE
Update Red Hat GPG Key URL to new location

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -105,7 +105,7 @@ class SubscriptionManager:
             "curl --create-dirs -ko /etc/rhsm/ca/redhat-uep.pem https://cdn-public.redhat.com/content/public/repofiles/redhat-uep.pem"
         )
         self.shell(
-            "curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release https://www.redhat.com/security/data/fd431d51.txt"
+            "curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release https://security.access.redhat.com/data/fd431d51.txt"
         )
 
     def add_client_tools_repo(self):

--- a/tests/integration/tier1/destructive/proxy-conversion/test_proxy_conversion.py
+++ b/tests/integration/tier1/destructive/proxy-conversion/test_proxy_conversion.py
@@ -85,7 +85,7 @@ def setup_rhsm(shell):
 
     assert (
         shell(
-            f"curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release https://www.redhat.com/security/data/fd431d51.txt \
+            f"curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release https://security.access.redhat.com/data/fd431d51.txt \
                   --proxy http://{TEST_VARS['PROXY_SERVER']}:{TEST_VARS['PROXY_PORT']}",
             silent=True,
         ).returncode


### PR DESCRIPTION
Since September 3rd the location of the GPG Key has changed. This patch is to introduce the new URL in order to keep the tests working consistenly in the future.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
