### PR TITLE
[RHELC-1601] Add preconversion check for invalid grub file

### DIFF
--- a/convert2rhel/actions/system_checks/grub_validity.py
+++ b/convert2rhel/actions/system_checks/grub_validity.py
@@ -39,9 +39,9 @@ class GrubValidity(actions.Action):
                 level="ERROR",
                 id="INVALID_GRUB_FILE",
                 title="Grub boot entry file is invalid",
-                description="The grub file seems to be invalid leaving the system in a" \
-                    " non-clean state and must be fixed before continuing the conversion" \
-                    " to ensure a smooth process.",
+                description="The grub file seems to be invalid leaving the system in a"
+                " non-clean state and must be fixed before continuing the conversion"
+                " to ensure a smooth process.",
                 remediations="Check the grub file inside `/etc/default` directory and remove any "
-                    "misconfigurations, then re-run the conversion.",
+                "misconfigurations, then re-run the conversion.",
             )

--- a/convert2rhel/actions/system_checks/grub_validity.py
+++ b/convert2rhel/actions/system_checks/grub_validity.py
@@ -1,0 +1,47 @@
+# Copyright(C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import logging
+
+from convert2rhel import actions, utils
+
+
+logger = logging.getLogger(__name__)
+
+
+class GrubValidity(actions.Action):
+    id = "GRUB_VALIDITY"
+
+    def run(self):
+        """
+        Execute grub2-mkconfig and report an error if it fails to execute. A failure means that the grub file
+        is invalid.
+        """
+        super(GrubValidity, self).run()
+        logger.task("Prepare: Check if the grub file is valid")
+        output, ret_code = utils.run_subprocess(["grub2-mkconfig"], print_output=False)
+
+        if ret_code != 0:
+            self.set_result(
+                level="ERROR",
+                id="INVALID_GRUB_FILE",
+                title="The grub file on the system is invalid",
+                description="The grub file has been determined to be invalid, therefore the system is in a "
+                "non-clean state and must be fixed before continuing the conversion.",
+                remediations="Check the grub file inside the 'etc/default' directory and remove any "
+                "misconfigurations, then re-run the conversion.",
+            )

--- a/convert2rhel/actions/system_checks/grub_validity.py
+++ b/convert2rhel/actions/system_checks/grub_validity.py
@@ -15,12 +15,11 @@
 
 __metaclass__ = type
 
-import logging
-
 from convert2rhel import actions, utils
+from convert2rhel.logger import root_logger
 
 
-logger = logging.getLogger(__name__)
+logger = root_logger.getChild(__name__)
 
 
 class GrubValidity(actions.Action):
@@ -39,9 +38,10 @@ class GrubValidity(actions.Action):
             self.set_result(
                 level="ERROR",
                 id="INVALID_GRUB_FILE",
-                title="The grub file on the system is invalid",
-                description="The grub file has been determined to be invalid, therefore the system is in a "
-                "non-clean state and must be fixed before continuing the conversion.",
-                remediations="Check the grub file inside the 'etc/default' directory and remove any "
-                "misconfigurations, then re-run the conversion.",
+                title="Grub boot entry file is invalid",
+                description="The grub file seems to be invalid leaving the system in a" \
+                    " non-clean state and must be fixed before continuing the conversion" \
+                    " to ensure a smooth process.",
+                remediations="Check the grub file inside `/etc/default` directory and remove any "
+                    "misconfigurations, then re-run the conversion.",
             )

--- a/convert2rhel/unit_tests/actions/system_checks/grub_validity_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/grub_validity_test.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright(C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+
+import pytest
+
+from convert2rhel import unit_tests, utils
+from convert2rhel.actions.system_checks import grub_validity
+from convert2rhel.unit_tests import RunSubprocessMocked
+
+
+@pytest.fixture
+def grub_validity_instance():
+    return grub_validity.GrubValidity()
+
+
+def test_grub_validity_error(grub_validity_instance, monkeypatch):
+
+    monkeypatch.setattr(utils, "run_subprocess", RunSubprocessMocked(return_value=("output", 127)))
+    grub_validity_instance.run()
+    unit_tests.assert_actions_result(
+        grub_validity_instance,
+        level="ERROR",
+        id="INVALID_GRUB_FILE",
+        title="The grub file on the system is invalid",
+        description="The grub file has been determined to be invalid, therefore the system is in a "
+        "non-clean state and must be fixed before continuing the conversion.",
+        diagnosis=None,
+        remediations="Check the grub file inside the 'etc/default' directory and remove any "
+        "misconfigurations, then re-run the conversion.",
+    )

--- a/convert2rhel/unit_tests/actions/system_checks/grub_validity_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/grub_validity_test.py
@@ -38,10 +38,10 @@ def test_grub_validity_error(grub_validity_instance, monkeypatch):
         grub_validity_instance,
         level="ERROR",
         id="INVALID_GRUB_FILE",
-        title="The grub file on the system is invalid",
-        description="The grub file has been determined to be invalid, therefore the system is in a "
-        "non-clean state and must be fixed before continuing the conversion.",
-        diagnosis=None,
-        remediations="Check the grub file inside the 'etc/default' directory and remove any "
+        title="Grub boot entry file is invalid",
+        description="The grub file seems to be invalid leaving the system in a"
+        " non-clean state and must be fixed before continuing the conversion"
+        " to ensure a smooth process.",
+        remediations="Check the grub file inside `/etc/default` directory and remove any "
         "misconfigurations, then re-run the conversion.",
     )


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
This PR adds a preconversion analysis check that runs `grub2-mkconfig` to determine if the systems grub file is valid. If a non-zero return code is found then we raise an error telling the customer that their grub file is misconfigured and they need to fix it before rerunning the conversion. 

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1601](https://issues.redhat.com/browse/RHELC-1601)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
