### PR TITLE
chore: set Renovate to ignore Sphinx deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,6 +21,18 @@
         "requirements/centos8.requirements.txt"
       ],
       "allowedVersions": "<=7.0"
+    },
+    {
+      "matchPackageNames": [
+        "Sphinx"
+      ],
+      "allowedVersions": "<=7.4.7"
+    },
+    {
+      "matchPackageNames": [
+        "sphinx_autodoc_typehints"
+      ],
+      "allowedVersions": "<=2.3.0"
     }
   ],
   "dockerfile": {


### PR DESCRIPTION
We need to hardcode Sphinx atm due to issues with py3.9 being dropped
for the packages and we haven't setup the container with it yet