### PR TITLE
chore(Renovate): ignore deps from specific files

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,11 +26,17 @@
       "matchPackageNames": [
         "Sphinx"
       ],
+      "matchFiles": [
+        "docs/requirements.txt"
+      ],
       "allowedVersions": "<=7.4.7"
     },
     {
       "matchPackageNames": [
         "sphinx_autodoc_typehints"
+      ],
+      "matchFiles": [
+        "docs/requirements.txt"
       ],
       "allowedVersions": "<=2.3.0"
     }


### PR DESCRIPTION
Previous attempt didn't work, likely we need to add the files to ignore dependencies in for it to successfully ignore them.
