### PR TITLE
[RHELC-1578] Change out of date packages overridable inhibitor to warning

### DIFF
--- a/config/convert2rhel.ini
+++ b/config/convert2rhel.ini
@@ -19,7 +19,6 @@
 [inhibitor_overrides]
 # incomplete_rollback              = false
 # tainted_kernel_module_check_skip = false
-# outdated_package_check_skip      = false
 # allow_older_version              = false
 # allow_unavailable_kmods          = false
 # skip_kernel_currency_check       = false

--- a/convert2rhel/actions/system_checks/package_updates.py
+++ b/convert2rhel/actions/system_checks/package_updates.py
@@ -98,6 +98,6 @@ class PackageUpdates(actions.Action):
                 diagnosis=package_not_up_to_date_error_message,
                 remediations="Run yum update to update all the packages on the system.",
             )
+            return
 
-        else:
-            logger.info("System is up-to-date.")
+        logger.info("System is up-to-date.")

--- a/convert2rhel/actions/system_checks/package_updates.py
+++ b/convert2rhel/actions/system_checks/package_updates.py
@@ -98,7 +98,6 @@ class PackageUpdates(actions.Action):
                 diagnosis=package_not_up_to_date_error_message,
                 remediations="Run yum update to update all the packages on the system.",
             )
-            return
 
         else:
             logger.info("System is up-to-date.")

--- a/convert2rhel/actions/system_checks/package_updates.py
+++ b/convert2rhel/actions/system_checks/package_updates.py
@@ -16,13 +16,10 @@
 __metaclass__ = type
 
 
-import os
-
 from convert2rhel import actions, pkgmanager, utils
 from convert2rhel.logger import root_logger
 from convert2rhel.pkghandler import get_total_packages_to_update
 from convert2rhel.systeminfo import system_info
-from convert2rhel.utils import warn_deprecated_env
 
 
 logger = root_logger.getChild(__name__)
@@ -80,7 +77,6 @@ class PackageUpdates(actions.Action):
             return
 
         if len(packages_to_update) > 0:
-
             package_not_up_to_date_error_message = (
                 "The system has {} package(s) not updated based on repositories defined in the system repositories.\n"
                 "List of packages to update: {}.\n\n"

--- a/convert2rhel/actions/system_checks/package_updates.py
+++ b/convert2rhel/actions/system_checks/package_updates.py
@@ -16,11 +16,12 @@
 __metaclass__ = type
 
 
+import os
+
 from convert2rhel import actions, pkgmanager, utils
 from convert2rhel.logger import root_logger
 from convert2rhel.pkghandler import get_total_packages_to_update
 from convert2rhel.systeminfo import system_info
-from convert2rhel.toolopts import tool_opts
 from convert2rhel.utils import warn_deprecated_env
 
 
@@ -79,7 +80,7 @@ class PackageUpdates(actions.Action):
             return
 
         if len(packages_to_update) > 0:
-            warn_deprecated_env("CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP")
+
             package_not_up_to_date_error_message = (
                 "The system has {} package(s) not updated based on repositories defined in the system repositories.\n"
                 "List of packages to update: {}.\n\n"
@@ -88,40 +89,16 @@ class PackageUpdates(actions.Action):
                     len(packages_to_update), " ".join(packages_to_update)
                 )
             )
-            if not tool_opts.outdated_package_check_skip:
-                logger.warning(package_not_up_to_date_error_message)
-                self.set_result(
-                    level="OVERRIDABLE",
-                    id="OUT_OF_DATE_PACKAGES",
-                    title="Outdated packages detected",
-                    description="Please refer to the diagnosis for further information",
-                    diagnosis=package_not_up_to_date_error_message,
-                    remediations="If you wish to ignore this message, set the environment variable "
-                    "'CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP' to 1.",
-                )
-                return
-
-            skip_package_not_up_to_date_message = (
-                "Detected 'CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP' environment variable, we will skip "
-                "the package up-to-date check.\n"
-                "Beware, this could leave your system in a broken state."
-            )
-            logger.warning(skip_package_not_up_to_date_message)
-            self.add_message(
-                level="WARNING",
-                id="SKIP_OUTDATED_PACKAGE_CHECK",
-                title="Skip package not up to date check",
-                description=skip_package_not_up_to_date_message,
-            )
-
             logger.warning(package_not_up_to_date_error_message)
             self.add_message(
                 level="WARNING",
-                id="OUTDATED_PACKAGE_MESSAGE",
+                id="OUT_OF_DATE_PACKAGES",
                 title="Outdated packages detected",
                 description="Please refer to the diagnosis for further information",
                 diagnosis=package_not_up_to_date_error_message,
                 remediations="Run yum update to update all the packages on the system.",
             )
+            return
+
         else:
             logger.info("System is up-to-date.")

--- a/convert2rhel/toolopts/config.py
+++ b/convert2rhel/toolopts/config.py
@@ -45,7 +45,6 @@ CONFIG_FILE_MAPPING_OPTIONS = {
     "inhibitor_overrides": [
         "incomplete_rollback",
         "tainted_kernel_module_check_skip",
-        "outdated_package_check_skip",
         "allow_older_version",
         "allow_unavailable_kmods",
         "configure_host_metering",

--- a/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
@@ -87,61 +87,20 @@ def test_check_package_updates_not_up_to_date(
     monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=lambda: packages)
 
     package_updates_action.run()
-    unit_tests.assert_actions_result(
-        package_updates_action,
-        level="OVERRIDABLE",
-        id="OUT_OF_DATE_PACKAGES",
-        title="Outdated packages detected",
-        description="Please refer to the diagnosis for further information",
-        diagnosis=diagnosis,
-        remediations=(
-            "If you wish to ignore this message, set the environment variable "
-            "'CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP' to 1."
-        ),
-    )
-
-    assert diagnosis in caplog.records[-1].message
-
-
-@centos8
-def test_check_package_updates_not_up_to_date_skip(pretend_os, monkeypatch, package_updates_action):
-    packages = ["package-2", "package-1"]
-    diagnosis = (
-        "The system has 2 package(s) not updated based on repositories defined in the system repositories.\n"
-        "List of packages to update: package-1 package-2.\n\n"
-        "Not updating the packages may cause the conversion to fail.\n"
-        "Consider updating the packages before proceeding with the conversion."
-    )
-    monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=lambda: packages)
-    monkeypatch.setattr(
-        os,
-        "environ",
-        {"CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP": 1},
-    )
-
     expected = set(
         (
             actions.ActionMessage(
                 level="WARNING",
-                id="SKIP_OUTDATED_PACKAGE_CHECK",
-                title="Skip package not up to date check",
-                description=(
-                    "Detected 'CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP' environment variable, we will skip "
-                    "the package up-to-date check.\n"
-                    "Beware, this could leave your system in a broken state."
-                ),
-            ),
-            actions.ActionMessage(
-                level="WARNING",
-                id="OUTDATED_PACKAGE_MESSAGE",
+                id="OUT_OF_DATE_PACKAGES",
                 title="Outdated packages detected",
                 description="Please refer to the diagnosis for further information",
                 diagnosis=diagnosis,
                 remediations="Run yum update to update all the packages on the system.",
+                variables={},
             ),
         )
     )
-    package_updates_action.run()
+
     assert expected.issuperset(package_updates_action.messages)
     assert expected.issubset(package_updates_action.messages)
 

--- a/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
@@ -17,12 +17,11 @@
 
 __metaclass__ = type
 
-import os
 
 import pytest
 import six
 
-from convert2rhel import actions, pkgmanager, unit_tests
+from convert2rhel import actions, pkgmanager
 from convert2rhel.actions.system_checks import package_updates
 from convert2rhel.unit_tests.conftest import centos8, oracle8
 
@@ -65,7 +64,6 @@ def test_check_package_updates_skip_on_not_latest_ol(pretend_os, caplog, package
 
 @centos8
 def test_check_package_updates(pretend_os, monkeypatch, caplog, package_updates_action, global_tool_opts):
-    monkeypatch.setattr(package_updates, "tool_opts", global_tool_opts)
     monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=lambda: [])
 
     package_updates_action.run()
@@ -76,7 +74,6 @@ def test_check_package_updates(pretend_os, monkeypatch, caplog, package_updates_
 def test_check_package_updates_not_up_to_date(
     pretend_os, monkeypatch, package_updates_action, caplog, global_tool_opts
 ):
-    monkeypatch.setattr(package_updates, "tool_opts", global_tool_opts)
     packages = ["package-2", "package-1"]
     diagnosis = (
         "The system has 2 package(s) not updated based on repositories defined in the system repositories.\n"

--- a/convert2rhel/unit_tests/toolopts/config_test.py
+++ b/convert2rhel/unit_tests/toolopts/config_test.py
@@ -134,7 +134,6 @@ incomplete_rollback = false
 [inhibitor_overrides]
 incomplete_rollback = false
 tainted_kernel_module_check_skip = false
-outdated_package_check_skip = false
 allow_older_version = false
 allow_unavailable_kmods = false
 configure_host_metering = false
@@ -143,7 +142,6 @@ skip_kernel_currency_check = false
                 {
                     "incomplete_rollback": False,
                     "tainted_kernel_module_check_skip": False,
-                    "outdated_package_check_skip": False,
                     "allow_older_version": False,
                     "allow_unavailable_kmods": False,
                     "configure_host_metering": False,

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -142,11 +142,6 @@ adjust+:
                 # Bypass the kernel check, since the installed kernel is an older version
                 CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK: 1
 
-                # We need to set envar to override the out of date packages check
-                # to perform the full conversion
-                # The packages are outdated because the repoquery check is done
-                # against the rhel-7-server-rpms repository, not CentOS'.
-                CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP: 1
 
                 # Since we are removing all the repositories other than rhel-7-server-rpms
                 # we need pass CONVERT2RHEL_INCOMPLETE_ROLLBACK due to the inability

--- a/tests/integration/tier1/destructive/system-not-up-to-date/main.fmf
+++ b/tests/integration/tier1/destructive/system-not-up-to-date/main.fmf
@@ -4,7 +4,6 @@ description: |
     Verify that the conversion emits a warning if there are packages which are not updated to the latest.
     Verify that the conversion emits a warning if the yum versionlock plugin is being used.
     Verify the conversion succeeds anyway.
-    Verify that CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP overrides the out of date pkg check.
 
 /system_not_updated:
     test: pytest -m test_system_not_updated

--- a/tests/integration/tier1/destructive/system-not-up-to-date/test_system_not_up_to_date.py
+++ b/tests/integration/tier1/destructive/system-not-up-to-date/test_system_not_up_to_date.py
@@ -1,4 +1,3 @@
-import os
 import re
 
 import pytest

--- a/tests/integration/tier1/destructive/system-not-up-to-date/test_system_not_up_to_date.py
+++ b/tests/integration/tier1/destructive/system-not-up-to-date/test_system_not_up_to_date.py
@@ -46,9 +46,6 @@ def test_system_not_updated(shell, convert2rhel, downgrade_and_versionlock):
     the latest version. The c2r has to display a warning message
     about that. Also, not updated package has its version locked.
     Display a warning about used version lock.
-    Since the introduction of overridables, we need to use
-    CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP to override out of date
-    packages.
     """
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --debug".format(
@@ -63,10 +60,6 @@ def test_system_not_updated(shell, convert2rhel, downgrade_and_versionlock):
 
     assert c2r.exitstatus == 2
 
-    # We need to set envar to override the out of date packages check
-    # to perform the full conversion
-    os.environ["CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP"] = "1"
-
     # Run utility until the reboot
     with convert2rhel(
         "-y --serverurl {} --username {} --password {} --debug".format(
@@ -76,6 +69,5 @@ def test_system_not_updated(shell, convert2rhel, downgrade_and_versionlock):
         )
     ) as c2r:
         c2r.expect("WARNING - YUM/DNF versionlock plugin is in use. It may cause the conversion to fail.")
-        c2r.expect_exact("Detected 'CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP' environment variable")
         c2r.expect(r"WARNING - The system has \d+ package\(s\) not updated")
     assert c2r.exitstatus == 0


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
This PR changes the overridable inhibitor result `OUT_OF_DATE_PACKAGES` to a warning. Relevant unit tests have been updated.

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1578](https://issues.redhat.com/browse/RHELC-1578)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
