### PR TITLE
[RHELC-1508] Add deprecation notice about environment variables

### DIFF
--- a/convert2rhel/actions/post_conversion/hostmetering.py
+++ b/convert2rhel/actions/post_conversion/hostmetering.py
@@ -23,7 +23,7 @@ from convert2rhel.logger import root_logger
 from convert2rhel.pkgmanager import call_yum_cmd
 from convert2rhel.subscription import get_rhsm_facts
 from convert2rhel.systeminfo import system_info
-from convert2rhel.utils import run_subprocess
+from convert2rhel.utils import run_subprocess, warn_deprecated_env
 
 
 logger = root_logger.getChild(__name__)
@@ -55,7 +55,7 @@ class ConfigureHostMetering(actions.Action):
 
         super(ConfigureHostMetering, self).run()
 
-        self.env_var = os.environ.get("CONVERT2RHEL_CONFIGURE_HOST_METERING", None)
+        self.env_var = warn_deprecated_env("CONVERT2RHEL_CONFIGURE_HOST_METERING")
         if not self._check_env_var():
             return False
 

--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -26,6 +26,7 @@ from convert2rhel.pkghandler import VERSIONLOCK_FILE_PATH
 from convert2rhel.redhatrelease import os_release_file, system_release_file
 from convert2rhel.repo import DEFAULT_DNF_VARS_DIR, DEFAULT_YUM_REPOFILE_DIR, DEFAULT_YUM_VARS_DIR
 from convert2rhel.systeminfo import system_info
+from convert2rhel.utils import warn_deprecated_env
 from convert2rhel.utils.rpm import PRE_RPM_VA_LOG_FILENAME
 
 
@@ -188,7 +189,7 @@ class BackupPackageFiles(actions.Action):
                 output = f.read()
         # Catch the IOError due Python 2 compatibility
         except IOError as err:
-            if os.environ.get("CONVERT2RHEL_INCOMPLETE_ROLLBACK", None):
+            if warn_deprecated_env("CONVERT2RHEL_INCOMPLETE_ROLLBACK"):
                 logger.debug("Skipping backup of the package files. CONVERT2RHEL_INCOMPLETE_ROLLBACK detected.")
                 # Return empty list results in no backup of the files
                 return data

--- a/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
+++ b/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
@@ -24,7 +24,7 @@ from functools import cmp_to_key
 from convert2rhel import actions, pkghandler
 from convert2rhel.logger import root_logger
 from convert2rhel.systeminfo import system_info
-from convert2rhel.utils import run_subprocess
+from convert2rhel.utils import run_subprocess, warn_deprecated_env
 
 
 logger = root_logger.getChild(__name__)
@@ -247,7 +247,7 @@ class EnsureKernelModulesCompatibility(actions.Action):
 
             # Check if we have the environment variable set, if we do, send a
             # warning and return.
-            if "CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS" in os.environ:
+            if warn_deprecated_env("CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS"):
                 logger.warning(
                     "Detected 'CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS' environment variable."
                     " We will continue the conversion with the following kernel modules unavailable in RHEL:\n"

--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -26,6 +26,7 @@ from convert2rhel import actions, exceptions, repo, utils
 from convert2rhel.logger import root_logger
 from convert2rhel.pkghandler import parse_pkg_string
 from convert2rhel.systeminfo import system_info
+from convert2rhel.utils import warn_deprecated_env
 
 
 logger = root_logger.getChild(__name__)
@@ -170,7 +171,7 @@ class Convert2rhelLatest(actions.Action):
         formatted_available_version = _format_EVR(*precise_available_version)
 
         if ver_compare < 0:
-            if "CONVERT2RHEL_ALLOW_OLDER_VERSION" in os.environ:
+            if warn_deprecated_env("CONVERT2RHEL_ALLOW_OLDER_VERSION"):
                 diagnosis = (
                     "You are currently running %s and the latest version of convert2rhel is %s.\n"
                     "'CONVERT2RHEL_ALLOW_OLDER_VERSION' environment variable detected, continuing conversion"

--- a/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
+++ b/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
@@ -22,7 +22,7 @@ from convert2rhel import actions, repo
 from convert2rhel.logger import root_logger
 from convert2rhel.pkghandler import compare_package_versions
 from convert2rhel.systeminfo import system_info
-from convert2rhel.utils import run_subprocess
+from convert2rhel.utils import run_subprocess, warn_deprecated_env
 
 
 logger = root_logger.getChild(__name__)
@@ -67,7 +67,7 @@ class IsLoadedKernelLatest(actions.Action):
         # Repoquery failed to detected any kernel or kernel-core packages in it's repositories
         # we allow the user to provide a environment variable to override the functionality and proceed
         # with the conversion, otherwise, we just throw a critical logging to them.
-        if "CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK" in os.environ:
+        if warn_deprecated_env("CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK"):
             logger.warning(
                 "Detected 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip "
                 "the %s comparison.\n"

--- a/convert2rhel/actions/system_checks/package_updates.py
+++ b/convert2rhel/actions/system_checks/package_updates.py
@@ -22,6 +22,7 @@ from convert2rhel import actions, pkgmanager, utils
 from convert2rhel.logger import root_logger
 from convert2rhel.pkghandler import get_total_packages_to_update
 from convert2rhel.systeminfo import system_info
+from convert2rhel.utils import warn_deprecated_env
 
 
 logger = root_logger.getChild(__name__)
@@ -79,7 +80,7 @@ class PackageUpdates(actions.Action):
             return
 
         if len(packages_to_update) > 0:
-            package_not_up_to_date_skip = os.environ.get("CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP", None)
+            package_not_up_to_date_skip = warn_deprecated_env("CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP")
             package_not_up_to_date_error_message = (
                 "The system has %s package(s) not updated based on repositories defined in the system repositories.\n"
                 "List of packages to update: %s.\n\n"

--- a/convert2rhel/actions/system_checks/tainted_kmods.py
+++ b/convert2rhel/actions/system_checks/tainted_kmods.py
@@ -20,7 +20,7 @@ import os
 
 from convert2rhel import actions
 from convert2rhel.logger import root_logger
-from convert2rhel.utils import run_subprocess
+from convert2rhel.utils import run_subprocess, warn_deprecated_env
 
 
 logger = root_logger.getChild(__name__)
@@ -46,7 +46,7 @@ class TaintedKmods(actions.Action):
         logger.task("Prepare: Check if loaded kernel modules are not tainted")
         unsigned_modules, _ = run_subprocess(["grep", "(", "/proc/modules"])
         module_names = "\n  ".join([mod.split(" ")[0] for mod in unsigned_modules.splitlines()])
-        tainted_kmods_skip = os.environ.get("CONVERT2RHEL_TAINTED_KERNEL_MODULE_CHECK_SKIP", None)
+        tainted_kmods_skip = warn_deprecated_env("CONVERT2RHEL_TAINTED_KERNEL_MODULE_CHECK_SKIP")
         diagnosis = (
             "Tainted kernel modules detected:\n  {0}\n"
             "Third-party components are not supported per our "

--- a/convert2rhel/toolopts/__init__.py
+++ b/convert2rhel/toolopts/__init__.py
@@ -17,6 +17,7 @@
 __metaclass__ = type
 
 import logging
+import os
 
 from convert2rhel.utils.subscription import setup_rhsm_parts
 

--- a/convert2rhel/utils/__init__.py
+++ b/convert2rhel/utils/__init__.py
@@ -1129,11 +1129,10 @@ def warn_deprecated_env(env_name):
     """
     if env_name not in os.environ:
         # Nothing to do here.
-        return
+        return None
 
     root_logger.warning(
-        "The environment variable {} is deprecated and is set to be removed on Convert2RHEL 2.4.0.\n"
-        "Please, use the configuration file instead."
+        "The environment variable {} is deprecated in favor of using a configuration file and will be removed in version Convert2RHEL 2.4.0."
     )
 
     return os.getenv(env_name, None)

--- a/convert2rhel/utils/__init__.py
+++ b/convert2rhel/utils/__init__.py
@@ -797,6 +797,7 @@ def report_on_a_download_error(output, pkg):
                 " 'CONVERT2RHEL_INCOMPLETE_ROLLBACK=1'." % (pkg, system_info.name)
             )
         else:
+            warn_deprecated_env("CONVERT2RHEL_INCOMPLETE_ROLLBACK")
             logger.warning(
                 "Couldn't download the %s package. This means we will not be able to do a"
                 " complete rollback and may put the system in a broken state.\n"
@@ -1115,3 +1116,24 @@ def write_json_object_to_file(path, data, mode=0o600):
     with open(path, mode="w") as handler:
         os.chmod(path, mode)
         json.dump(data, handler, indent=4)
+
+
+def warn_deprecated_env(env_name):
+    """Warn the user that the environment variable is deprecated.
+
+    .. note::
+        This will be removed after we finalize switching all env vars to toolopts.
+
+    :param env_name: The name of the environment variable that is deprecated.
+    :type env_name: str
+    """
+    if env_name not in os.environ:
+        # Nothing to do here.
+        return
+
+    root_logger.warning(
+        "The environment variable {} is deprecated and is set to be removed on Convert2RHEL 2.4.0.\n"
+        "Please, use the configuration file instead."
+    )
+
+    return os.getenv(env_name, None)


### PR DESCRIPTION
With the most recent work to migrate all environment variables to the configuration file, we need now to warn the user that the variables will be deprecated in order to use configuration file as our main place to track configuarations.

This patch is introducing a very lightweight change to make sure that we will be able modify the code in the future to remove all environment variables.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-1508](https://issues.redhat.com/browse/RHELC-1508-) -->
- [RHELC-1508](https://issues.redhat.com/browse/RHELC-1508-)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
