### PR TITLE
[RHELC-1740] Load inhibitor override env vars into the toolopts structure

### DIFF
--- a/convert2rhel/actions/post_conversion/hostmetering.py
+++ b/convert2rhel/actions/post_conversion/hostmetering.py
@@ -152,7 +152,7 @@ class ConfigureHostMetering(actions.Action):
             return False
 
         if tool_opts.configure_host_metering not in ("force", "auto"):
-            logger.debug("Value for environment variable not recognized: %s" % tool_opts.configure_host_metering)
+            logger.debug("Value for environment variable not recognized: {}".format(tool_opts.configure_host_metering))
             self.add_message(
                 level="WARNING",
                 id="UNRECOGNIZED_OPTION_CONFIGURE_HOST_METERING",

--- a/convert2rhel/actions/post_conversion/hostmetering.py
+++ b/convert2rhel/actions/post_conversion/hostmetering.py
@@ -15,12 +15,12 @@
 
 __metaclass__ = type
 
-
 from convert2rhel import actions, systeminfo
 from convert2rhel.logger import root_logger
 from convert2rhel.pkgmanager import call_yum_cmd
 from convert2rhel.subscription import get_rhsm_facts
 from convert2rhel.systeminfo import system_info
+from convert2rhel.toolopts import tool_opts
 from convert2rhel.utils import run_subprocess, warn_deprecated_env
 
 
@@ -35,7 +35,6 @@ class ConfigureHostMetering(actions.Action):
     """
 
     id = "CONFIGURE_HOST_METERING_IF_NEEDED"
-    env_var = None  # type: str|None
 
     def run(self):
         """
@@ -53,11 +52,11 @@ class ConfigureHostMetering(actions.Action):
 
         super(ConfigureHostMetering, self).run()
 
-        self.env_var = warn_deprecated_env("CONVERT2RHEL_CONFIGURE_HOST_METERING")
+        warn_deprecated_env("CONVERT2RHEL_CONFIGURE_HOST_METERING")
         if not self._check_env_var():
             return False
 
-        if system_info.version.major != 7 and self.env_var == "auto":
+        if system_info.version.major != 7 and tool_opts.configure_host_metering == "auto":
             logger.info("Did not perform host metering configuration. Only supported for RHEL 7.")
             self.add_message(
                 level="INFO",
@@ -69,7 +68,7 @@ class ConfigureHostMetering(actions.Action):
 
         is_hyperscaler = self.is_running_on_hyperscaler()
 
-        if not is_hyperscaler and self.env_var == "auto":
+        if not is_hyperscaler and tool_opts.configure_host_metering == "auto":
             logger.info("Did not perform host-metering configuration.")
             self.add_message(
                 level="INFO",
@@ -142,7 +141,7 @@ class ConfigureHostMetering(actions.Action):
         :return: Return True if the value is equal to auto|force, otherwise False
         :rtype: bool
         """
-        if self.env_var is None:
+        if tool_opts.configure_host_metering is None:
             logger.debug("CONVERT2RHEL_CONFIGURE_HOST_METERING was not set. Skipping it.")
             self.add_message(
                 level="INFO",
@@ -152,18 +151,20 @@ class ConfigureHostMetering(actions.Action):
             )
             return False
 
-        if self.env_var not in ("force", "auto"):
-            logger.debug("Value for environment variable not recognized: {}".format(self.env_var))
+        if tool_opts.configure_host_metering not in ("force", "auto"):
+            logger.debug("Value for environment variable not recognized: %s" % tool_opts.configure_host_metering)
             self.add_message(
                 level="WARNING",
                 id="UNRECOGNIZED_OPTION_CONFIGURE_HOST_METERING",
                 title="Unrecognized option in CONVERT2RHEL_CONFIGURE_HOST_METERING environment variable.",
-                description="Environment variable {env_var} not recognized.".format(env_var=self.env_var),
+                description="Environment variable {env_var} not recognized.".format(
+                    env_var=tool_opts.configure_host_metering
+                ),
                 remediations="Set the option to `auto` value if you want to configure host metering.",
             )
             return False
 
-        if self.env_var == "force":
+        if tool_opts.configure_host_metering == "force":
             logger.warning(
                 "The `force' option has been used for the CONVERT2RHEL_CONFIGURE_HOST_METERING environment variable."
                 " Please note that this option is mainly used for testing and will configure host-metering unconditionally. "
@@ -177,7 +178,7 @@ class ConfigureHostMetering(actions.Action):
                 " will configure host-metering unconditionally."
                 " For generic usage please use the 'auto' option.",
             )
-        elif self.env_var == "auto":
+        elif tool_opts.configure_host_metering == "auto":
             logger.debug("Automatic detection of host hyperscaler and configuration.")
 
         return True

--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -26,6 +26,7 @@ from convert2rhel.pkghandler import VERSIONLOCK_FILE_PATH
 from convert2rhel.redhatrelease import os_release_file, system_release_file
 from convert2rhel.repo import DEFAULT_DNF_VARS_DIR, DEFAULT_YUM_REPOFILE_DIR, DEFAULT_YUM_VARS_DIR
 from convert2rhel.systeminfo import system_info
+from convert2rhel.toolopts import tool_opts
 from convert2rhel.utils import warn_deprecated_env
 from convert2rhel.utils.rpm import PRE_RPM_VA_LOG_FILENAME
 
@@ -189,7 +190,8 @@ class BackupPackageFiles(actions.Action):
                 output = f.read()
         # Catch the IOError due Python 2 compatibility
         except IOError as err:
-            if warn_deprecated_env("CONVERT2RHEL_INCOMPLETE_ROLLBACK"):
+            warn_deprecated_env("CONVERT2RHEL_INCOMPLETE_ROLLBACK")
+            if tool_opts.incomplete_rollback:
                 logger.debug("Skipping backup of the package files. CONVERT2RHEL_INCOMPLETE_ROLLBACK detected.")
                 # Return empty list results in no backup of the files
                 return data

--- a/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
+++ b/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
@@ -23,6 +23,7 @@ from functools import cmp_to_key
 from convert2rhel import actions, pkghandler
 from convert2rhel.logger import root_logger
 from convert2rhel.systeminfo import system_info
+from convert2rhel.toolopts import tool_opts
 from convert2rhel.utils import run_subprocess, warn_deprecated_env
 
 
@@ -248,7 +249,8 @@ class EnsureKernelModulesCompatibility(actions.Action):
 
             # Check if we have the environment variable set, if we do, send a
             # warning and return.
-            if warn_deprecated_env("CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS"):
+            warn_deprecated_env("CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS")
+            if tool_opts.allow_unavailable_kmods:
                 logger.warning(
                     "Detected 'CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS' environment variable."
                     " We will continue the conversion with the following kernel modules unavailable in RHEL:\n"

--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -26,6 +26,7 @@ from convert2rhel import actions, exceptions, repo, utils
 from convert2rhel.logger import root_logger
 from convert2rhel.pkghandler import parse_pkg_string
 from convert2rhel.systeminfo import system_info
+from convert2rhel.toolopts import tool_opts
 from convert2rhel.utils import warn_deprecated_env
 
 
@@ -174,7 +175,8 @@ class Convert2rhelLatest(actions.Action):
         formatted_available_version = _format_EVR(*precise_available_version)
 
         if ver_compare < 0:
-            if warn_deprecated_env("CONVERT2RHEL_ALLOW_OLDER_VERSION"):
+            warn_deprecated_env("CONVERT2RHEL_ALLOW_OLDER_VERSION")
+            if tool_opts.allow_older_version:
                 diagnosis = (
                     "You are currently running {} and the latest version of convert2rhel is {}.\n"
                     "'CONVERT2RHEL_ALLOW_OLDER_VERSION' environment variable detected, continuing conversion".format(

--- a/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
+++ b/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
@@ -20,6 +20,7 @@ from convert2rhel import actions, repo
 from convert2rhel.logger import root_logger
 from convert2rhel.pkghandler import compare_package_versions
 from convert2rhel.systeminfo import system_info
+from convert2rhel.toolopts import tool_opts
 from convert2rhel.utils import run_subprocess, warn_deprecated_env
 
 
@@ -65,7 +66,8 @@ class IsLoadedKernelLatest(actions.Action):
         # Repoquery failed to detected any kernel or kernel-core packages in it's repositories
         # we allow the user to provide a environment variable to override the functionality and proceed
         # with the conversion, otherwise, we just throw a critical logging to them.
-        if warn_deprecated_env("CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK"):
+        warn_deprecated_env("CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK")
+        if tool_opts.skip_kernel_currency_check:
             logger.warning(
                 "Detected 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip "
                 "the {} comparison.\n"

--- a/convert2rhel/actions/system_checks/package_updates.py
+++ b/convert2rhel/actions/system_checks/package_updates.py
@@ -20,6 +20,7 @@ from convert2rhel import actions, pkgmanager, utils
 from convert2rhel.logger import root_logger
 from convert2rhel.pkghandler import get_total_packages_to_update
 from convert2rhel.systeminfo import system_info
+from convert2rhel.toolopts import tool_opts
 from convert2rhel.utils import warn_deprecated_env
 
 
@@ -78,7 +79,7 @@ class PackageUpdates(actions.Action):
             return
 
         if len(packages_to_update) > 0:
-            package_not_up_to_date_skip = warn_deprecated_env("CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP")
+            warn_deprecated_env("CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP")
             package_not_up_to_date_error_message = (
                 "The system has {} package(s) not updated based on repositories defined in the system repositories.\n"
                 "List of packages to update: {}.\n\n"
@@ -87,7 +88,7 @@ class PackageUpdates(actions.Action):
                     len(packages_to_update), " ".join(packages_to_update)
                 )
             )
-            if not package_not_up_to_date_skip:
+            if not tool_opts.outdated_package_check_skip:
                 logger.warning(package_not_up_to_date_error_message)
                 self.set_result(
                     level="OVERRIDABLE",

--- a/convert2rhel/actions/system_checks/tainted_kmods.py
+++ b/convert2rhel/actions/system_checks/tainted_kmods.py
@@ -15,9 +15,9 @@
 
 __metaclass__ = type
 
-
 from convert2rhel import actions
 from convert2rhel.logger import root_logger
+from convert2rhel.toolopts import tool_opts
 from convert2rhel.utils import run_subprocess, warn_deprecated_env
 
 
@@ -44,7 +44,7 @@ class TaintedKmods(actions.Action):
         logger.task("Prepare: Check if loaded kernel modules are not tainted")
         unsigned_modules, _ = run_subprocess(["grep", "(", "/proc/modules"])
         module_names = "\n  ".join([mod.split(" ")[0] for mod in unsigned_modules.splitlines()])
-        tainted_kmods_skip = warn_deprecated_env("CONVERT2RHEL_TAINTED_KERNEL_MODULE_CHECK_SKIP")
+        warn_deprecated_env("CONVERT2RHEL_TAINTED_KERNEL_MODULE_CHECK_SKIP")
         diagnosis = (
             "Tainted kernel modules detected:\n  {0}\n"
             "Third-party components are not supported per our "
@@ -52,7 +52,7 @@ class TaintedKmods(actions.Action):
         )
 
         if unsigned_modules:
-            if not tainted_kmods_skip:
+            if not tool_opts.tainted_kernel_module_check_skip:
                 self.set_result(
                     level="OVERRIDABLE",
                     id="TAINTED_KMODS_DETECTED",

--- a/convert2rhel/toolopts/__init__.py
+++ b/convert2rhel/toolopts/__init__.py
@@ -17,6 +17,7 @@
 __metaclass__ = type
 
 import logging
+import os
 
 from convert2rhel.utils.subscription import setup_rhsm_parts
 
@@ -115,6 +116,17 @@ class ToolOpts:
         current_attribute_value = getattr(self, key)
 
         if value and not current_attribute_value:
+            setattr(self, key, value)
+
+    def update_opts(self, key, value):
+        """Update a given option in toolopts.
+
+        :param key:
+        :type key: str
+        :param value:
+        :type value: str
+        """
+        if key and value:
             setattr(self, key, value)
 
     def _handle_rhsm_parts(self):

--- a/convert2rhel/toolopts/__init__.py
+++ b/convert2rhel/toolopts/__init__.py
@@ -17,7 +17,6 @@
 __metaclass__ = type
 
 import logging
-import os
 
 from convert2rhel.utils.subscription import setup_rhsm_parts
 
@@ -27,7 +26,10 @@ loggerinst = logging.getLogger(__name__)
 
 class ToolOpts:
     def _handle_config_conflict(self, config_sources):
-        file_config = next((config for config in config_sources if config.SOURCE == "configuration file"), None)
+        file_config = next(
+            (config for config in config_sources if config.SOURCE == "configuration file"),
+            None,
+        )
         # No file config detected, let's just bail out.
         if not file_config:
             return

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
@@ -104,6 +104,7 @@ def test_ensure_compatibility_of_kmods(
     caplog,
     host_kmods,
     should_be_in_logs,
+    global_tool_opts,
 ):
     monkeypatch.setattr(
         ensure_kernel_modules_compatibility_instance, "_get_loaded_kmods", mock.Mock(return_value=host_kmods)
@@ -121,6 +122,7 @@ def test_ensure_compatibility_of_kmods(
         "run_subprocess",
         value=run_subprocess_mock,
     )
+    monkeypatch.setattr(kernel_modules, "tool_opts", global_tool_opts)
 
     ensure_kernel_modules_compatibility_instance.run()
     assert_actions_result(ensure_kernel_modules_compatibility_instance, level="SUCCESS")
@@ -172,12 +174,12 @@ def test_ensure_compatibility_of_kmods_failure(
     ensure_kernel_modules_compatibility_instance,
     monkeypatch,
     pretend_os,
-    caplog,
     host_kmods,
     repo_kmod_pkgs,
     makecache_output,
     error_id,
     level,
+    global_tool_opts,
 ):
     monkeypatch.setattr(
         ensure_kernel_modules_compatibility_instance, "_get_loaded_kmods", mock.Mock(return_value=host_kmods)
@@ -195,6 +197,7 @@ def test_ensure_compatibility_of_kmods_failure(
         "run_subprocess",
         value=run_subprocess_mock,
     )
+    monkeypatch.setattr(kernel_modules, "tool_opts", global_tool_opts)
 
     ensure_kernel_modules_compatibility_instance.run()
     assert_actions_result(ensure_kernel_modules_compatibility_instance, level=level, id=error_id)
@@ -273,6 +276,7 @@ def test_ensure_compatibility_of_kmods_excluded(
     msg_in_logs,
     msg_not_in_logs,
     exception,
+    global_tool_opts,
 ):
     monkeypatch.setattr(
         ensure_kernel_modules_compatibility_instance,
@@ -300,6 +304,7 @@ def test_ensure_compatibility_of_kmods_excluded(
         "_get_unsupported_kmods",
         value=get_unsupported_kmods_mocked,
     )
+    monkeypatch.setattr(kernel_modules, "tool_opts", global_tool_opts)
 
     if exception:
         ensure_kernel_modules_compatibility_instance.run()

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -144,9 +144,10 @@ class TestCheckConvert2rhelLatest:
         indirect=True,
     )
     def test_convert2rhel_latest_outdated_version_inhibitor(
-        self, convert2rhel_latest_action_instance, prepare_convert2rhel_latest_action
+        self, convert2rhel_latest_action_instance, prepare_convert2rhel_latest_action, monkeypatch, global_tool_opts
     ):
         """When runnnig on a supported major version, we issue an error = inhibitor."""
+        monkeypatch.setattr(convert2rhel_latest, "tool_opts", global_tool_opts)
         convert2rhel_latest_action_instance.run()
 
         running_version, latest_version = prepare_convert2rhel_latest_action
@@ -231,9 +232,10 @@ class TestCheckConvert2rhelLatest:
         indirect=True,
     )
     def test_convert2rhel_latest_outdated_version_warning(
-        self, convert2rhel_latest_action_instance, prepare_convert2rhel_latest_action
+        self, convert2rhel_latest_action_instance, prepare_convert2rhel_latest_action, monkeypatch, global_tool_opts
     ):
         """When runnnig on an older unsupported major version, we issue just a warning instead of an inhibitor."""
+        monkeypatch.setattr(convert2rhel_latest, "tool_opts", global_tool_opts)
         convert2rhel_latest_action_instance.run()
 
         running_version, latest_version = prepare_convert2rhel_latest_action
@@ -738,10 +740,12 @@ class TestCheckConvert2rhelLatest:
         ),
         indirect=True,
     )
-    def test_convert2rhel_latest_bad_NEVRA_to_parse_pkg_string(
+    def test_convert2rhel_latest_bad_nevra_to_parse_pkg_string(
         self,
+        monkeypatch,
         convert2rhel_latest_action_instance,
         prepare_convert2rhel_latest_action,
+        global_tool_opts,
     ):
         generator = extract_convert2rhel_versions_generator()
 
@@ -750,6 +754,7 @@ class TestCheckConvert2rhelLatest:
             "convert2rhel_latest._extract_convert2rhel_versions",
             side_effect=generator,
         )
+        monkeypatch.setattr(convert2rhel_latest, "tool_opts", global_tool_opts)
         convert2rhel_latest_action_instance.run()
 
         running_version, latest_version = prepare_convert2rhel_latest_action

--- a/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
@@ -83,6 +83,7 @@ class TestIsLoadedKernelLatest:
         package_name,
         monkeypatch,
         is_loaded_kernel_latest_action,
+        global_tool_opts,
     ):
         run_subprocess_mocked = mock.Mock(
             spec=run_subprocess,
@@ -110,7 +111,7 @@ class TestIsLoadedKernelLatest:
             "run_subprocess",
             value=run_subprocess_mocked,
         )
-
+        monkeypatch.setattr(is_loaded_kernel_latest, "tool_opts", global_tool_opts)
         is_loaded_kernel_latest_action.run()
 
         unit_tests.assert_actions_result(
@@ -172,6 +173,7 @@ class TestIsLoadedKernelLatest:
         remediations,
         monkeypatch,
         is_loaded_kernel_latest_action,
+        global_tool_opts,
     ):
         run_subprocess_mocked = mock.Mock(
             spec=run_subprocess,
@@ -200,6 +202,7 @@ class TestIsLoadedKernelLatest:
             value=run_subprocess_mocked,
         )
 
+        monkeypatch.setattr(is_loaded_kernel_latest, "tool_opts", global_tool_opts)
         is_loaded_kernel_latest_action.run()
         expected = set(
             (
@@ -266,6 +269,7 @@ class TestIsLoadedKernelLatest:
         remediations,
         monkeypatch,
         is_loaded_kernel_latest_action,
+        global_tool_opts,
     ):
         run_subprocess_mocked = mock.Mock(
             spec=run_subprocess,
@@ -293,7 +297,7 @@ class TestIsLoadedKernelLatest:
             "run_subprocess",
             value=run_subprocess_mocked,
         )
-
+        monkeypatch.setattr(is_loaded_kernel_latest, "tool_opts", global_tool_opts)
         is_loaded_kernel_latest_action.run()
 
         expected = set(
@@ -313,7 +317,9 @@ class TestIsLoadedKernelLatest:
         assert expected.issubset(is_loaded_kernel_latest_action.messages)
 
     @centos8
-    def test_is_loaded_kernel_latest_eus_system(self, pretend_os, monkeypatch, caplog, is_loaded_kernel_latest_action):
+    def test_is_loaded_kernel_latest_eus_system(
+        self, pretend_os, monkeypatch, caplog, is_loaded_kernel_latest_action, global_tool_opts
+    ):
         run_subprocess_mocked = mock.Mock(
             spec=run_subprocess,
             side_effect=run_subprocess_side_effect(
@@ -341,6 +347,7 @@ class TestIsLoadedKernelLatest:
             value=run_subprocess_mocked,
         )
 
+        monkeypatch.setattr(is_loaded_kernel_latest, "tool_opts", global_tool_opts)
         is_loaded_kernel_latest_action.run()
         assert "The currently loaded kernel is at the latest version." in caplog.records[-1].message
 
@@ -481,6 +488,7 @@ class TestIsLoadedKernelLatest:
         monkeypatch,
         caplog,
         is_loaded_kernel_latest_action,
+        global_tool_opts,
     ):
         run_subprocess_mocked = mock.Mock(
             spec=run_subprocess,
@@ -507,6 +515,7 @@ class TestIsLoadedKernelLatest:
             "run_subprocess",
             value=run_subprocess_mocked,
         )
+        monkeypatch.setattr(is_loaded_kernel_latest, "tool_opts", global_tool_opts)
 
         expected_set = set(
             (
@@ -565,6 +574,7 @@ class TestIsLoadedKernelLatest:
         diagnosis,
         monkeypatch,
         is_loaded_kernel_latest_action,
+        global_tool_opts,
     ):
         run_subprocess_mocked = mock.Mock(
             spec=run_subprocess,
@@ -591,6 +601,7 @@ class TestIsLoadedKernelLatest:
             "run_subprocess",
             value=run_subprocess_mocked,
         )
+        monkeypatch.setattr(is_loaded_kernel_latest, "tool_opts", global_tool_opts)
         is_loaded_kernel_latest_action.run()
         diagnosis = diagnosis.format(package_name)
         unit_tests.assert_actions_result(
@@ -671,6 +682,7 @@ class TestIsLoadedKernelLatest:
         monkeypatch,
         caplog,
         is_loaded_kernel_latest_action,
+        global_tool_opts,
     ):
         # Using the minor version as 99, so the tests should never fail because of a
         # constraint in the code, since we don't mind the minor version number (for
@@ -705,6 +717,7 @@ class TestIsLoadedKernelLatest:
                 (("uname", "-r"), (uname_version, return_code)),
             ),
         )
+        monkeypatch.setattr(is_loaded_kernel_latest, "tool_opts", global_tool_opts)
         monkeypatch.setattr(
             is_loaded_kernel_latest,
             "run_subprocess",
@@ -714,7 +727,7 @@ class TestIsLoadedKernelLatest:
         is_loaded_kernel_latest_action.run()
         assert expected_message in caplog.records[-1].message
 
-    def test_is_loaded_kernel_latest_system_exit(self, monkeypatch, is_loaded_kernel_latest_action, tmpdir):
+    def test_is_loaded_kernel_latest_system_exit(self, monkeypatch, is_loaded_kernel_latest_action, global_tool_opts):
         repoquery_version = "C2R\t1634146676\t3.10.0-1160.45.1.el7\tbaseos"
         uname_version = "3.10.0-1160.42.2.el7.x86_64"
 
@@ -756,6 +769,7 @@ class TestIsLoadedKernelLatest:
             "run_subprocess",
             value=run_subprocess_mocked,
         )
+        monkeypatch.setattr(is_loaded_kernel_latest, "tool_opts", global_tool_opts)
 
         is_loaded_kernel_latest_action.run()
         unit_tests.assert_actions_result(
@@ -799,7 +813,13 @@ class TestIsLoadedKernelLatest:
         ),
     )
     def test_is_loaded_kernel_latest_disable_repos(
-        self, monkeypatch, enablerepos, expected_cmd, is_loaded_kernel_latest_action, pretend_os
+        self,
+        monkeypatch,
+        enablerepos,
+        expected_cmd,
+        is_loaded_kernel_latest_action,
+        pretend_os,
+        global_tool_opts,
     ):
         """Test if the --disablerepo part of the command is built propertly."""
         run_subprocess = mock.Mock(return_value=[None, None])
@@ -808,8 +828,9 @@ class TestIsLoadedKernelLatest:
             "run_subprocess",
             run_subprocess,
         )
-
-        monkeypatch.setattr(repo.tool_opts, "enablerepo", enablerepos)
+        global_tool_opts.enablerepos = enablerepos
+        monkeypatch.setattr(is_loaded_kernel_latest, "tool_opts", global_tool_opts)
+        monkeypatch.setattr(repo, "tool_opts", global_tool_opts)
 
         is_loaded_kernel_latest_action.run()
 

--- a/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
@@ -64,7 +64,8 @@ def test_check_package_updates_skip_on_not_latest_ol(pretend_os, caplog, package
 
 
 @centos8
-def test_check_package_updates(pretend_os, monkeypatch, caplog, package_updates_action):
+def test_check_package_updates(pretend_os, monkeypatch, caplog, package_updates_action, global_tool_opts):
+    monkeypatch.setattr(package_updates, "tool_opts", global_tool_opts)
     monkeypatch.setattr(package_updates, "get_total_packages_to_update", value=lambda: [])
 
     package_updates_action.run()
@@ -72,7 +73,10 @@ def test_check_package_updates(pretend_os, monkeypatch, caplog, package_updates_
 
 
 @centos8
-def test_check_package_updates_not_up_to_date(pretend_os, monkeypatch, package_updates_action, caplog):
+def test_check_package_updates_not_up_to_date(
+    pretend_os, monkeypatch, package_updates_action, caplog, global_tool_opts
+):
+    monkeypatch.setattr(package_updates, "tool_opts", global_tool_opts)
     packages = ["package-2", "package-1"]
     diagnosis = (
         "The system has 2 package(s) not updated based on repositories defined in the system repositories.\n"

--- a/convert2rhel/unit_tests/actions/system_checks/tainted_kmods_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/tainted_kmods_test.py
@@ -54,13 +54,15 @@ def tainted_kmods_action():
         ),
     ),
 )
-def test_check_tainted_kmods(monkeypatch, command_return, is_error, tainted_kmods_action):
+def test_check_tainted_kmods(monkeypatch, command_return, is_error, tainted_kmods_action, global_tool_opts):
     run_subprocess_mock = mock.Mock(return_value=command_return)
     monkeypatch.setattr(
         tainted_kmods,
         "run_subprocess",
         value=run_subprocess_mock,
     )
+    monkeypatch.setattr(tainted_kmods, "tool_opts", global_tool_opts)
+
     tainted_kmods_action.run()
 
     if is_error:
@@ -151,7 +153,5 @@ def test_check_tainted_kmods_skip(monkeypatch, command_return, is_error, tainted
                 ),
             )
         )
-        print(expected)
-        print(tainted_kmods_action.messages)
         assert expected.issuperset(tainted_kmods_action.messages)
         assert expected.issubset(tainted_kmods_action.messages)

--- a/convert2rhel/unit_tests/conftest.py
+++ b/convert2rhel/unit_tests/conftest.py
@@ -138,10 +138,31 @@ class CliConfigMock:
         pass
 
 
+class FileConfigMock:
+    SOURCE = "configuration file"
+
+    def __init__(self):
+        self.configure_host_metering = None
+        self.incomplete_rollback = None
+        self.tainted_kernel_module_check_skip = None
+        self.outdated_package_check_skip = None
+        self.allow_older_version = None
+        self.allow_unavailable_kmods = None
+        self.skip_kernel_currency_check = None
+
+        self.username = None
+        self.password = None
+        self.org = None
+        self.activation_key = None
+
+    def run(self):
+        pass
+
+
 @pytest.fixture
 def global_tool_opts(monkeypatch):
     local_tool_opts = toolopts.ToolOpts()
-    local_tool_opts.initialize(config_sources=[CliConfigMock()])
+    local_tool_opts.initialize(config_sources=[CliConfigMock(), FileConfigMock()])
     monkeypatch.setattr(toolopts, "tool_opts", local_tool_opts)
     return local_tool_opts
 

--- a/convert2rhel/utils/__init__.py
+++ b/convert2rhel/utils/__init__.py
@@ -1129,6 +1129,16 @@ def warn_deprecated_env(env_name):
     :param env_name: The name of the environment variable that is deprecated.
     :type env_name: str
     """
+    env_var_to_toolopts_map = {
+        "CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP": "outdated_package_check_skip",
+        "CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK": "skip_kernel_currency_check",
+        "CONVERT2RHEL_INCOMPLETE_ROLLBACK": "incomplete_rollback",
+        "CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS": "allow_unavailable_kmods",
+        "CONVERT2RHEL_ALLOW_OLDER_VERSION": "allow_older_version",
+        "CONVERT2RHEL_CONFIGURE_HOST_METERING": "configure_host_metering",
+        "CONVERT2RHEL_TAINTED_KERNEL_MODULE_CHECK_SKIP": "tainted_kernel_module_check_skip",
+    }
+
     if env_name not in os.environ:
         # Nothing to do here.
         return None
@@ -1136,5 +1146,7 @@ def warn_deprecated_env(env_name):
     root_logger.warning(
         "The environment variable {} is deprecated in favor of using a configuration file and will be removed in version Convert2RHEL 2.4.0."
     )
-
-    return os.getenv(env_name, None)
+    key = env_var_to_toolopts_map[env_name]
+    value = os.getenv(env_name, None)
+    print(vars(tool_opts))
+    tool_opts.update_opts(key, value)

--- a/convert2rhel/utils/__init__.py
+++ b/convert2rhel/utils/__init__.py
@@ -1144,9 +1144,9 @@ def warn_deprecated_env(env_name):
         return None
 
     root_logger.warning(
-        "The environment variable {} is deprecated in favor of using a configuration file and will be removed in version Convert2RHEL 2.4.0."
+        "The environment variable {} is deprecated and is set to be removed on Convert2RHEL 2.4.0.\n"
+        "Please, use the configuration file instead.".format(env_name)
     )
     key = env_var_to_toolopts_map[env_name]
     value = os.getenv(env_name, None)
-    print(vars(tool_opts))
     tool_opts.update_opts(key, value)


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
Following the strategy of moving all the environment variables to be inside the configuration file, this patch introduces the ability of converting the env_var to their toolopts counterpart. This will help in the deprecation later down the road when all users are comfortable enough using the config file.

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-1740](https://issues.redhat.com/browse/RHELC-1740-) -->
- [RHELC-1740](https://issues.redhat.com/browse/RHELC-1740-) 

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
