### PR TITLE
chore: add concurrent pytest runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ PIP ?= pip3
 VENV ?= .venv3
 PRE_COMMIT ?= pre-commit
 SHOW_CAPTURE ?= no
-PYTEST_ARGS ?= --override-ini=addopts= -p no:cacheprovider
+PYTEST_ARGS ?= -n auto --override-ini=addopts= -p no:cacheprovider
 BUILD_IMAGES ?= 1
 
 ifdef KEEP_TEST_CONTAINER

--- a/requirements/centos7.requirements.txt
+++ b/requirements/centos7.requirements.txt
@@ -2,3 +2,4 @@ pytest==4.6.11
 pathlib2==2.3.7.post1
 mock==3.0.5
 pytest-cov==2.12.1
+pytest-xdist==1.34.0

--- a/requirements/centos8.requirements.txt
+++ b/requirements/centos8.requirements.txt
@@ -1,3 +1,4 @@
 pytest==7.0.1
 pytest-cov==3.0.0
 coverage[toml]
+pytest-xdist==1.34.0

--- a/requirements/centos9.requirements.txt
+++ b/requirements/centos9.requirements.txt
@@ -1,3 +1,4 @@
 pytest==7.0.1
 pytest-cov==3.0.0
 coverage[toml]
+pytest-xdist==1.34.0


### PR DESCRIPTION
This adds concurrent pytest runs through pytest-xdist and automatically
decides how many processes it can start. Overall speeding up the tests
to around the slowest test to execute at the moment rather than having
to wait 10x that amount

Ref: https://pytest-xdist.readthedocs.io/en/stable/distribution.html

Note: the latest release of pytest-xdist that supports py27 is 1.34.0

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
