### PR TITLE
[RHELC-1677] Fix missing repository directory

### DIFF
--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
@@ -15,6 +15,8 @@
 
 __metaclass__ = type
 
+import os
+
 import pytest
 import six
 
@@ -272,3 +274,15 @@ def test_remove_packages_unless_from_redhat(pkgs_to_remove, monkeypatch, caplog)
 
     assert "Removing the following {} packages".format(len(pkgs_to_remove)) in caplog.records[-3].message
     assert "Successfully removed {} packages".format(len(pkgs_to_remove)) in caplog.records[-1].message
+
+
+@pytest.mark.parametrize("dir_exists", (True, False))
+def test_fix_repos_directory(monkeypatch, tmpdir, dir_exists):
+    repo_dir = tmpdir.join("repo")
+    if dir_exists:
+        repo_dir.mkdir()
+    monkeypatch.setattr(handle_packages, "DEFAULT_YUM_REPOFILE_DIR", str(repo_dir))
+
+    handle_packages._fix_repos_directory()
+
+    assert os.path.exists(str(repo_dir))

--- a/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
+++ b/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
@@ -92,14 +92,6 @@ def test_override_inhibitor_os_release_restored(
 
         c2r.expect("'CONVERT2RHEL_INCOMPLETE_ROLLBACK' environment variable detected, continuing conversion.")
 
-        # Apparently the whole "/etc/yum.repos.d" dir is missing when the *-release package gets erased
-        # re-create it, so sub-man is able to refresh the redhat.repo file
-        # TODO remove this part when/if https://issues.redhat.com/browse/RHELC-1677 gets fixed
-        c2r.expect("Ensure kernel modules compatibility with RHEL")
-        missing_dir = "/etc/yum.repos.d"
-        if not os.path.exists(missing_dir):
-            os.mkdir(missing_dir)
-
         c2r.expect("Continue with the system conversion")
         c2r.sendline("n")
     assert c2r.exitstatus == 1


### PR DESCRIPTION
Some packages (e.g. rocky-release or alma-release on EL9) can remove repository directory as their part. Without the directory, sub-man is unable to generate redhat.repo file. This results in inaccessibility of all rhel repositories.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1677](https://issues.redhat.com/browse/RHELC-1677)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
