### PR TITLE
[RHELC-1736] Fix different exit codes

### DIFF
--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -192,6 +192,9 @@ def main_locked():
         if backup.backup_control.rollback_failed:
             return ConversionExitCodes.FAILURE
 
+        if _get_failed_actions(pre_conversion_results):
+            return ConversionExitCodes.INHIBITORS_FOUND
+
         return ConversionExitCodes.SUCCESSFUL
     except _InhibitorsFound as err:
         loggerinst.critical_no_exit(str(err))
@@ -229,6 +232,10 @@ def main_locked():
     return ConversionExitCodes.SUCCESSFUL
 
 
+def _get_failed_actions(results):
+    return actions.find_actions_of_severity(results, "SKIP", level_for_raw_action_data)
+
+
 def _raise_for_skipped_failures(results):
     """Analyze the action results for failures
 
@@ -237,7 +244,7 @@ def _raise_for_skipped_failures(results):
     :raises SystemExit: In case we detect any actions that has level of `SKIP`
         or above.
     """
-    failures = actions.find_actions_of_severity(results, "SKIP", level_for_raw_action_data)
+    failures = _get_failed_actions(results)
     if failures:
         # The report will be handled in the error handler, after rollback.
         message = (

--- a/convert2rhel/unit_tests/main_test.py
+++ b/convert2rhel/unit_tests/main_test.py
@@ -528,6 +528,7 @@ class TestRollbackFromMain:
             (main, "rollback_changes", mock.Mock()),
             (report, "summary_as_json", mock.Mock()),
             (report, "summary_as_txt", mock.Mock()),
+            (actions, "find_actions_of_severity", mock.Mock(return_value=[])),
         )
         global_tool_opts.activity = "analysis"
         for module, function, value in mocks:
@@ -569,6 +570,7 @@ class TestRollbackFromMain:
         ask_to_continue_mock = mock.Mock(return_value=True)
         summary_as_json_mock = mock.Mock()
         summary_as_txt_mock = mock.Mock()
+        find_actions_of_severity = mock.Mock(return_value=[])
 
         # Mock the rollback calls
         finish_collection_mock = mock.Mock()
@@ -596,6 +598,7 @@ class TestRollbackFromMain:
         monkeypatch.setattr(main, "rollback_changes", rollback_changes_mock)
         monkeypatch.setattr(report, "summary_as_json", summary_as_json_mock)
         monkeypatch.setattr(report, "summary_as_txt", summary_as_txt_mock)
+        monkeypatch.setattr(actions, "find_actions_of_severity", find_actions_of_severity)
         global_tool_opts.activity = "analysis"
 
         assert main.main() == 0
@@ -683,6 +686,47 @@ class TestRollbackFromMain:
         assert summary_as_txt_mock.call_count == 1
         assert "The system is left in an undetermined state that Convert2RHEL cannot fix." in caplog.records[-3].message
         assert update_rhsm_custom_facts_mock.call_count == 1
+
+    @pytest.mark.parametrize(
+        ("activity", "inhibitor", "rc"),
+        (
+            ("analysis", True, 2),
+            ("analysis", False, 0),
+            ("convert", True, 2),
+            ("convert", False, 0),
+        ),
+    )
+    def test_main_inhibitor_return_code(self, monkeypatch, activity, inhibitor, rc, tmp_path, global_tool_opts):
+        mocks = (
+            (applock, "_DEFAULT_LOCK_DIR", str(tmp_path)),
+            (utils, "require_root", mock.Mock()),
+            (main, "initialize_file_logging", mock.Mock()),
+            (cli, "CLI", mock.Mock()),
+            (main, "show_eula", mock.Mock()),
+            (breadcrumbs, "print_data_collection", mock.Mock()),
+            (system_info, "resolve_system_info", mock.Mock()),
+            (system_info, "print_system_information", mock.Mock()),
+            (breadcrumbs, "collect_early_data", mock.Mock()),
+            (pkghandler, "clear_versionlock", mock.Mock()),
+            (pkgmanager, "clean_yum_metadata", mock.Mock()),
+            (actions, "run_pre_actions", mock.Mock()),
+            (actions, "find_actions_of_severity", mock.Mock(return_value=inhibitor)),
+            (report, "_summary", mock.Mock()),
+            (breadcrumbs, "finish_collection", mock.Mock()),
+            (subscription, "should_subscribe", mock.Mock(side_effect=lambda: True)),
+            (subscription, "update_rhsm_custom_facts", mock.Mock()),
+            (main, "rollback_changes", mock.Mock()),
+            (report, "summary_as_json", mock.Mock()),
+            (report, "summary_as_txt", mock.Mock()),
+            (utils, "ask_to_continue", mock.Mock()),
+            (actions, "run_post_actions", mock.Mock()),
+            (utils, "restart_system", mock.Mock()),
+        )
+        global_tool_opts.activity = activity
+        for module, function, value in mocks:
+            monkeypatch.setattr(module, function, value)
+
+        assert main.main() == rc
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
+++ b/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
@@ -86,7 +86,7 @@ def test_failures_and_skips_in_report(convert2rhel):
         c2r.expect("SUBSCRIBE_SYSTEM::FAILED_TO_SUBSCRIBE_SYSTEM")
         c2r.expect("Diagnosis: System registration failed with error")
 
-    assert c2r.exitstatus == 0
+    assert c2r.exitstatus == 2
 
     _validate_report()
 

--- a/tests/integration/tier0/non-destructive/basic-sanity-checks/main.fmf
+++ b/tests/integration/tier0/non-destructive/basic-sanity-checks/main.fmf
@@ -61,10 +61,6 @@ tag+:
 
 
 /convert2rhel_version:
-    adjust+:
-        result: xfail
-        when: distro == alma-9, oracle-9, rocky-9, stream-9
-        because: We're unable to validate the version of convert2rhel, as there is no build GA for EL9 yet
     summary+: |
         convert2rhel version check
     /c2r_is_latest_with_mocked_newer_version:

--- a/tests/integration/tier0/non-destructive/duplicate-pkgs/test_duplicate_pkgs.py
+++ b/tests/integration/tier0/non-destructive/duplicate-pkgs/test_duplicate_pkgs.py
@@ -62,5 +62,5 @@ def test_duplicate_packages_installed(convert2rhel, install_duplicate_pkg):
         c2r.expect("Pre-conversion analysis report", timeout=600)
         c2r.expect_exact("(ERROR) DUPLICATE_PACKAGES::DUPLICATE_PACKAGES_FOUND")
 
-    # The analysis should exit with 0, if it finishes successfully
-    assert c2r.exitstatus == 0
+    # The analysis should exit with 2, if inhibitor is found
+    assert c2r.exitstatus == 2

--- a/tests/integration/tier0/non-destructive/els/test_els_enablement.py
+++ b/tests/integration/tier0/non-destructive/els/test_els_enablement.py
@@ -110,4 +110,4 @@ def test_rhsm_non_els_account(convert2rhel):
         c2r.expect_exact(ELS_REPOID_MSG)
         c2r.expect_exact("Error: 'rhel-7-server-els-rpms' does not match a valid repository ID.")
         c2r.expect_exact("SUBSCRIBE_SYSTEM::FAILED_TO_ENABLE_RHSM_REPOSITORIES")
-    assert c2r.exitstatus == 0
+    assert c2r.exitstatus == 2

--- a/tests/integration/tier0/non-destructive/eus/test_eus_enablement.py
+++ b/tests/integration/tier0/non-destructive/eus/test_eus_enablement.py
@@ -132,4 +132,4 @@ def test_rhsm_non_eus_account(convert2rhel):
         c2r.expect_exact("Error: 'rhel-8-for-x86_64-baseos-eus-rpms' does not match a valid repository ID.")
         c2r.expect_exact("Error: 'rhel-8-for-x86_64-appstream-eus-rpms' does not match a valid repository ID.")
         c2r.expect_exact("SUBSCRIBE_SYSTEM::FAILED_TO_ENABLE_RHSM_REPOSITORIES")
-    assert c2r.exitstatus == 0
+    assert c2r.exitstatus == 2

--- a/tests/integration/tier0/non-destructive/file-backup/test_file_backup.py
+++ b/tests/integration/tier0/non-destructive/file-backup/test_file_backup.py
@@ -144,4 +144,4 @@ def test_file_backup(convert2rhel, shell, file_action_fixture, request):
         # Verify the rollback starts and analysis report is printed out
         c2r.expect("Abnormal exit! Performing rollback")
         c2r.expect("Pre-conversion analysis report")
-    assert c2r.exitstatus == 0
+    assert c2r.exitstatus == 2

--- a/tests/integration/tier0/non-destructive/grub/test_invalid_changed_to_grub.py
+++ b/tests/integration/tier0/non-destructive/grub/test_invalid_changed_to_grub.py
@@ -56,4 +56,4 @@ def test_invalid_changes_to_grub_file(convert2rhel, grub_file_invalid):
             c2r.expect_exact("ERROR - (ERROR) GRUB_VALIDITY::INVALID_GRUB_FILE - Grub boot entry file is invalid") == 0
         )
 
-    assert c2r.exitstatus == 0
+    assert c2r.exitstatus == 2

--- a/tests/integration/tier0/non-destructive/modified-releasever/test_modified_releasever.py
+++ b/tests/integration/tier0/non-destructive/modified-releasever/test_modified_releasever.py
@@ -53,7 +53,8 @@ def test_releasever_modified_in_c2r_config(backup_files, convert2rhel, shell):
         c2r.expect("--releasever=420")
         c2r.expect_exact("ERROR - (ERROR) ENSURE_KERNEL_MODULES_COMPATIBILITY::PROBLEM_WITH_PACKAGE_REPO")
 
-    assert c2r.exitstatus == 0
+    # Inhibitor expected
+    assert c2r.exitstatus == 2
 
 
 @pytest.mark.parametrize("backup_files", ["/etc/system-release"], indirect=True)

--- a/tests/integration/tier0/non-destructive/rollback-handling/test_rollback_handling.py
+++ b/tests/integration/tier0/non-destructive/rollback-handling/test_rollback_handling.py
@@ -154,7 +154,6 @@ def test_polluted_yumdownloader_output_by_yum_plugin_local(shell, convert2rhel, 
         with convert2rhel("analyze --debug -y") as c2r:
             c2r.expect("Rollback: Install removed packages")
             c2r.expect("Pre-conversion analysis report", timeout=600)
-        assert c2r.exitstatus == 0
 
         is_installed_post_rollback(shell, assign_packages())
 

--- a/tests/integration/tier0/non-destructive/system-release-backup/main.fmf
+++ b/tests/integration/tier0/non-destructive/system-release-backup/main.fmf
@@ -25,7 +25,7 @@ tag+:
             os-release restored without CONVERT2RHEL_INCOMPLETE_ROLLBACK
         description+: |
             In this scenario the variable `CONVERT2RHEL_INCOMPLETE_ROLLBACK` is not set, therefore
-            using analyze we expect convert2rhel to raise an error and return code 1.
+            using analyze we expect convert2rhel to raise an error and return code 2.
         environment+:
             CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK: 1
         tag+:

--- a/tests/integration/tier1/non-destructive/httpd-package-transaction-error/test_httpd_package_transaction_error.py
+++ b/tests/integration/tier1/non-destructive/httpd-package-transaction-error/test_httpd_package_transaction_error.py
@@ -76,4 +76,5 @@ def test_httpd_package_transaction_error(shell, convert2rhel, handle_packages):
         assert index == 0, "The analysis found an error. Probably related to the transaction check."
         assert c2r.expect_exact("VALIDATE_PACKAGE_MANAGER_TRANSACTION has succeeded") == 0
 
-    assert c2r.exitstatus == 2
+    # Correct handling of the httpd package dependencies is expected
+    assert c2r.exitstatus == 0

--- a/tests/integration/tier1/non-destructive/httpd-package-transaction-error/test_httpd_package_transaction_error.py
+++ b/tests/integration/tier1/non-destructive/httpd-package-transaction-error/test_httpd_package_transaction_error.py
@@ -76,4 +76,4 @@ def test_httpd_package_transaction_error(shell, convert2rhel, handle_packages):
         assert index == 0, "The analysis found an error. Probably related to the transaction check."
         assert c2r.expect_exact("VALIDATE_PACKAGE_MANAGER_TRANSACTION has succeeded") == 0
 
-    assert c2r.exitstatus == 0
+    assert c2r.exitstatus == 2


### PR DESCRIPTION
The convert2rhel finished with different exit codes when inhibitor was found and different subcommands were used.

In the code was missing part for handling the inhibitors during analysis exit.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1736](https://issues.redhat.com/browse/RHELC-1736)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
