### PR TITLE
chore: Update image builds with new tags

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -42,6 +42,6 @@ jobs:
           push: true
           context: .
           file: ./Containerfiles/${{ matrix.el.distro }}${{ matrix.el.ver }}.Containerfile
-          tags: ghcr.io/${{ github.repository_owner }}/convert2rhel-${{ matrix.el.distro }}${{ matrix.el.ver }}:latest
+          tags: ghcr.io/${{ github.repository_owner }}/convert2rhel-${{ matrix.el.distro }}:${{ matrix.el.ver }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/convert2rhel-${{ matrix.el.distro }}${{ matrix.el.ver }}:latest
           cache-to: type=inline


### PR DESCRIPTION
We used to use :latest tags like this
- ghcr.io/oamg/convert2rhel-centos7:latest
- ghcr.io/oamg/convert2rhel-centos8:latest
- ghcr.io/oamg/convert2rhel-centos9:latest

but now we unify them with
- ghcr.io/oamg/convert2rhel-centos:7
- ghcr.io/oamg/convert2rhel-centos:8
- ghcr.io/oamg/convert2rhel-centos:9

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
