### PR TITLE
[RHELC-1598] Add EL9 repofile url to convert2rhel latest check

### DIFF
--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -33,6 +33,7 @@ logger = root_logger.getChild(__name__)
 C2R_REPOFILE_URLS = {
     7: "https://cdn-public.redhat.com/content/public/addon/dist/convert2rhel/server/7/7Server/x86_64/files/repofile.repo",
     8: "https://cdn-public.redhat.com/content/public/addon/dist/convert2rhel8/8/x86_64/files/repofile.repo",
+    9: "https://cdn-public.redhat.com/content/public/repofiles/convert2rhel-for-rhel-9-x86_64.repo",
 }
 
 

--- a/convert2rhel/repo.py
+++ b/convert2rhel/repo.py
@@ -129,7 +129,8 @@ def download_repofile(repofile_url):
         raise exceptions.CriticalError(
             id_="DOWNLOAD_REPOSITORY_FILE_FAILED",
             title="Failed to download a repository file",
-            description="Failed to download a repository file from {}.\n" "Reason: {}".format(repofile_url, err.reason),
+            description="Failed to download a repository file from {}.".format(repofile_url),
+            diagnosis="Reason: {}.".format(err.reason),
         )
 
 


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
This PR adds the new CDN repo for publishing convert2rhel on EL9. A correction to the diagnosis field in one of the repo.py results was also made. 
<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-1598](https://issues.redhat.com/browse/RHELC-1598) -->
- [RHELC-1598](https://issues.redhat.com/browse/RHELC-1598)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
