### PR TITLE
[RHELC-1717] Fix the latest RHEL kernel not being set as default when converting from CentOS Stream 9

### DIFF
--- a/convert2rhel/actions/conversion/list_non_red_hat_pkgs_left.py
+++ b/convert2rhel/actions/conversion/list_non_red_hat_pkgs_left.py
@@ -25,7 +25,7 @@ loggerinst = logger.root_logger.getChild(__name__)
 
 class ListNonRedHatPkgsLeft(actions.Action):
     id = "LIST_NON_RED_HAT_PKGS_LEFT"
-    dependencies = ("KERNEL_PACKAGES_INSTALLATION",)
+    dependencies = ("REMOVE_NON_RHEL_KERNELS",)
 
     def run(self):
         """List all the packages that have not been replaced by the

--- a/convert2rhel/actions/conversion/preserve_only_rhel_kernel.py
+++ b/convert2rhel/actions/conversion/preserve_only_rhel_kernel.py
@@ -17,7 +17,6 @@ __metaclass__ = type
 
 import glob
 import os
-import re
 
 from convert2rhel import actions, logger, pkghandler, pkgmanager, utils
 from convert2rhel.systeminfo import system_info
@@ -37,6 +36,14 @@ class InstallRhelKernel(actions.Action):
         super(InstallRhelKernel, self).run()
         loggerinst.task("Prepare kernel")
 
+        rhel_kernels = pkghandler.get_installed_pkgs_by_key_id(system_info.key_ids_rhel, name="kernel")
+
+        if not rhel_kernels:
+            # install the rhel kernel when any isn't installed
+            loggerinst.debug("handle_no_newer_rhel_kernel_available")
+            pkghandler.handle_no_newer_rhel_kernel_available()
+
+        """
         # Solution for RHELC-1707
         # Update is needed in the UpdateKernel action
         global _kernel_update_needed
@@ -54,6 +61,56 @@ class InstallRhelKernel(actions.Action):
                 remediations="Please check that you can access the repositories that provide the RHEL kernel.",
             )
             return
+
+        ## new code
+
+        # installed_kernel, available_kernel = pkghandler.get_kernel_availability()
+
+        # TODO check statement bellow
+        # at this moment we should have access only to rhel content, any original vendor repos available at this moment
+        # this should return latest available kernel installed
+        cmd = ["repoquery", "kernel"]
+        target_kernel = utils.run_subprocess(cmd)
+
+        # Get list of kernel pkgs not signed by Red Hat
+        non_rhel_kernels_pkg_info = pkghandler.get_installed_pkgs_w_different_key_id(system_info.key_ids_rhel, "kernel")
+        non_rhel_kernels = [pkghandler.get_pkg_nevra(kernel) for kernel in non_rhel_kernels_pkg_info]
+
+        # Get the latest installed rhel kernel
+        #already_installed = re.findall(r" (.*?)(?: is)? already installed", output, re.MULTILINE)
+        rhel_kernels = pkghandler.get_installed_pkgs_by_key_id(system_info.key_ids_rhel, name="kernel")
+
+        if not rhel_kernels:
+            # install the rhel kernel if any unavailable
+            pkghandler.handle_no_newer_rhel_kernel_available()
+            # get installed rhel kernel again
+            rhel_kernels = pkghandler.get_installed_pkgs_by_key_id(system_info.key_ids_rhel, name="kernel")
+        elif not non_rhel_kernels:
+            return
+
+        latest_installed_rhel_kernel = pkghandler.get_highest_package_version(("RHEL kernel", rhel_kernels))
+        is_target_higher_than_rhel = pkghandler.compare_package_versions(target_kernel, latest_installed_rhel_kernel)
+
+        if is_target_higher_than_rhel == 0:
+            # latest rhel kernel is already installed, any other action needed
+            return
+
+        latest_installed_non_rhel_kernel = pkghandler.get_highest_package_version(("NON-RHEL kernel", non_rhel_kernels))
+        is_target_higher_than_nonrhel = pkghandler.compare_package_versions(target_kernel, latest_installed_non_rhel_kernel)
+
+
+        if is_target_higher_than_nonrhel == 1:
+            # target rhel kernel is higher then the original
+            return
+        elif is_target_higher_than_nonrhel == 0:
+            # versions are the same
+            # replace the rhel kernel
+            pkghandler.handle_no_newer_rhel_kernel_available()
+        elif is_target_higher_than_nonrhel == -1:
+            # target kernel is older then the kernel from original vendor
+            pkghandler.handle_no_newer_rhel_kernel_available()
+
+        ## end of new code
 
         # Check which of the kernel versions are already installed.
         # Example output from yum and dnf:
@@ -121,6 +178,7 @@ class InstallRhelKernel(actions.Action):
             # with a higher release number.
             pkghandler.handle_no_newer_rhel_kernel_available()
             _kernel_update_needed = True
+        """
 
 
 class VerifyRhelKernelInstalled(actions.Action):
@@ -302,8 +360,25 @@ class UpdateKernel(actions.Action):
         # This variable is set in the InstallRhelKernel action
         global _kernel_update_needed
 
-        if _kernel_update_needed:
-            # Note: Info message is in the function
+        pkghandler.update_rhel_kernel()
+        """
+        cmd = ["repoquery", "kernel", "--envra"]
+        # extract the nvra from the envra, format epoch:name-version-release.architecture
+        target_kernel, _ = utils.run_subprocess(cmd)
+
+        target_kernel = target_kernel.split(":")[1]
+
+        rhel_kernels = pkghandler.get_installed_pkgs_by_key_id(system_info.key_ids_rhel, name="kernel")
+
+        loggerinst.debug("RHEL Kernels: {}".format(rhel_kernels))
+
+        latest_installed_rhel_kernel = pkghandler.get_highest_package_version(("RHEL kernel", rhel_kernels))
+
+        loggerinst.debug("Latest RHEL Kernel: {}".format(latest_installed_rhel_kernel))
+        is_target_higher_than_rhel = pkghandler.compare_package_versions(target_kernel, latest_installed_rhel_kernel)
+
+        if is_target_higher_than_rhel == 1:
             pkghandler.update_rhel_kernel()
         else:
             loggerinst.info("RHEL kernel already present in latest version. Update not needed.\n")
+        """

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -594,19 +594,19 @@ def install_gpg_keys():
 
 
 def handle_no_newer_rhel_kernel_available():
-    """Handle cases when the installed third party (non-RHEL) kernel has the
-    same version as (or newer than) the RHEL one available in the RHEL repo(s).
+    """Handle cases when the installed non-RHEL kernel has the
+    same version as (or newer than) the latest RHEL kernel available in the RHEL repo(s).
     """
-    installed, available = get_kernel_availability()
-    to_install = [kernel for kernel in available if kernel not in installed]
+    installed, all_available = get_kernel_availability()
+    available_to_install = [kernel for kernel in all_available if kernel not in installed]
 
-    if not to_install:
-        # All the available RHEL kernel versions are already installed
+    if not available_to_install:
+        # All the available RHEL kernels are already installed
         if len(installed) > 1:
             # There's more than one installed non-RHEL kernel. We'll remove one
             # of them - the one that has the same version as the available RHEL
             # kernel
-            older = available[-1]
+            older = all_available[-1]
             utils.remove_pkgs(pkgs_to_remove=["kernel-{}".format(older)])
             pkgmanager.call_yum_cmd(command="install", args=["kernel-{}".format(older)])
         else:
@@ -615,7 +615,7 @@ def handle_no_newer_rhel_kernel_available():
         return
 
     # Install the latest out of the available non-clashing RHEL kernels
-    pkgmanager.call_yum_cmd(command="install", args=["kernel-{}".format(to_install[-1])])
+    pkgmanager.call_yum_cmd(command="install", args=["kernel-{}".format(available_to_install[-1])])
 
 
 def get_kernel_availability():

--- a/convert2rhel/unit_tests/actions/conversion/preserve_only_rhel_kernel_test.py
+++ b/convert2rhel/unit_tests/actions/conversion/preserve_only_rhel_kernel_test.py
@@ -79,105 +79,31 @@ def apply_global_tool_opts(monkeypatch, global_tool_opts):
 class TestInstallRhelKernel:
     @pytest.mark.parametrize(
         (
-            "subprocess_output",
-            "pkgs_w_diff_key_id",
+            "pkgs_w_rhel_key_id",
             "no_newer_kernel_call",
-            "update_kernel",
             "action_message",
             "action_result",
         ),
         (
             (
-                # Info about installed kernel from yum contains the same version as is listed in the different key_id pkgs
-                # The latest installed kernel is from CentOS
-                "Package kernel-4.18.0-193.el8.x86_64 is already installed.",
-                [
-                    create_pkg_information(
-                        name="kernel",
-                        version="4.18.0",
-                        release="193.el8",
-                        arch="x86_64",
-                        packager="CentOS",
-                    ),
-                    create_pkg_information(
-                        name="kernel",
-                        version="4.18.0",
-                        release="183.el8",
-                        arch="x86_64",
-                        packager="CentOS",
-                    ),
-                ],
-                1,
-                True,
-                set(()),
-                actions.ActionResult(level="SUCCESS", id="SUCCESS"),
-            ),
-            (
-                # Output from yum contains different version than is listed in different key_id
-                # Rhel kernel already installed with centos kernels
-                "Package kernel-4.18.0-205.el8.x86_64 is already installed.",
-                [
-                    create_pkg_information(
-                        name="kernel",
-                        version="4.18.0",
-                        release="193.el8",
-                        arch="x86_64",
-                        packager="CentOS",
-                    ),
-                    create_pkg_information(
-                        name="kernel",
-                        version="4.18.0",
-                        release="183.el8",
-                        arch="x86_64",
-                        packager="CentOS",
-                    ),
-                ],
-                0,
-                False,
-                set(()),
-                actions.ActionResult(level="SUCCESS", id="SUCCESS"),
-            ),
-            (
-                # Only rhel kernel already installed
-                "Package kernel-4.18.0-205.el8.x86_64 is already installed.",
+                # rhel kernel not installed
                 [],
-                0,
-                False,
-                set(()),
-                actions.ActionResult(level="SUCCESS", id="SUCCESS"),
-            ),
-            (
-                # Output from yum contains different version than is listed in different key_id
-                # Rhel kernel already installed in older versin than centos kernel
-                "Package kernel-4.18.0-183.el8.x86_64 is already installed.",
-                [
-                    create_pkg_information(
-                        name="kernel",
-                        version="4.18.0",
-                        release="193.el8",
-                        arch="x86_64",
-                        packager="CentOS",
-                    ),
-                ],
                 1,
-                True,
                 set(()),
                 actions.ActionResult(level="SUCCESS", id="SUCCESS"),
             ),
             (
-                # Output from yum contains info about installing some package - corner case
-                "Installing kernel-4.18.0-183.el8.x86_64",
+                # rhel kernel already installed
                 [
                     create_pkg_information(
                         name="kernel",
                         version="4.18.0",
-                        release="193.el8",
+                        release="183.el8",
                         arch="x86_64",
-                        packager="CentOS",
+                        packager="Red Hat",
                     ),
                 ],
                 0,
-                False,
                 set(()),
                 actions.ActionResult(level="SUCCESS", id="SUCCESS"),
             ),
@@ -187,11 +113,9 @@ class TestInstallRhelKernel:
     def test_install_rhel_kernel(
         self,
         monkeypatch,
-        subprocess_output,
-        pkgs_w_diff_key_id,
+        pkgs_w_rhel_key_id,
         install_rhel_kernel_instance,
         no_newer_kernel_call,
-        update_kernel,
         pretend_os,
         action_message,
         action_result,
@@ -199,58 +123,14 @@ class TestInstallRhelKernel:
         """Test the logic of kernel installation&update"""
         handle_no_newer_rhel_kernel_available = mock.Mock()
 
-        monkeypatch.setattr(
-            utils, "run_subprocess", RunSubprocessMocked(return_string=subprocess_output, return_code=0)
-        )
-        monkeypatch.setattr(
-            pkghandler,
-            "get_installed_pkgs_w_different_key_id",
-            GetInstalledPkgsWDifferentKeyIdMocked(return_value=pkgs_w_diff_key_id),
-        )
         monkeypatch.setattr(pkghandler, "handle_no_newer_rhel_kernel_available", handle_no_newer_rhel_kernel_available)
+        monkeypatch.setattr(
+            pkghandler, "get_installed_pkgs_by_key_id", GetInstalledPkgsByKeyIdMocked(return_value=pkgs_w_rhel_key_id)
+        )
 
         install_rhel_kernel_instance.run()
 
         assert handle_no_newer_rhel_kernel_available.call_count == no_newer_kernel_call
-        assert preserve_only_rhel_kernel._kernel_update_needed == update_kernel
-        assert action_message.issuperset(install_rhel_kernel_instance.messages)
-        assert action_message.issubset(install_rhel_kernel_instance.messages)
-        assert action_result == install_rhel_kernel_instance.result
-
-    @pytest.mark.parametrize(
-        ("subprocess_output", "subprocess_return", "action_message", "action_result"),
-        (
-            (
-                "yum command failed",
-                1,
-                set(()),
-                actions.ActionResult(
-                    level="ERROR",
-                    id="FAILED_TO_INSTALL_RHEL_KERNEL",
-                    title="Failed to install RHEL kernel",
-                    description="There was an error while attempting to install the RHEL kernel from yum.",
-                    remediations="Please check that you can access the repositories that provide the RHEL kernel.",
-                ),
-            ),
-        ),
-    )
-    @centos8
-    def test_install_rhel_kernel_yum_fail(
-        self,
-        monkeypatch,
-        subprocess_output,
-        subprocess_return,
-        action_message,
-        action_result,
-        install_rhel_kernel_instance,
-        pretend_os,
-    ):
-        monkeypatch.setattr(
-            utils, "run_subprocess", RunSubprocessMocked(return_string=subprocess_output, return_code=subprocess_return)
-        )
-
-        install_rhel_kernel_instance.run()
-
         assert action_message.issuperset(install_rhel_kernel_instance.messages)
         assert action_message.issubset(install_rhel_kernel_instance.messages)
         assert action_result == install_rhel_kernel_instance.result
@@ -615,14 +495,10 @@ class TestFixDefaultKernel:
 class TestUpdateKernel:
     @pytest.mark.parametrize(
         ("update_kernel"),
-        (
-            (True),
-            (False),
-        ),
+        ((True),),
     )
     @centos8
     def test_update_kernel(self, monkeypatch, update_kernel_instance, update_kernel, pretend_os):
-        preserve_only_rhel_kernel._kernel_update_needed = update_kernel
         update_rhel_kernel = mock.Mock()
         monkeypatch.setattr(pkghandler, "update_rhel_kernel", update_rhel_kernel)
 

--- a/tests/integration/common/checks-after-conversion/main.fmf
+++ b/tests/integration/common/checks-after-conversion/main.fmf
@@ -34,12 +34,6 @@ order: 52
         test: pytest -m test_correct_distro
 
     /grub_default:
-        adjust+:
-          enabled: false
-          when: distro == stream-9-latest
-          because: |
-            The versions of latest RHEL kernel < latest Stream kernel, which is not handled very well in the code.
-            Related issue: https://issues.redhat.com/browse/RHELC-1717
         summary+: |
             Grub default
         description+: |


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

* simplify the kernel (re-)installation 
* check if any RHEL kernel got installed during the main transaction, if not, handle the same version conflict
* try to update the installed kernel in every case

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-1717](https://issues.redhat.com/browse/RHELC-1717) -->
- [RHELC-1717](https://issues.redhat.com/browse/RHELC-1717)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] GitHub label has been added to help with Release notes <!-- enhancement, bug-fix, no-changelog, security-hardening, breaking-change, test-coverage-enhancement -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
