### PR TITLE
chore:Disable the tier0 a and tier1 plans for Stream 9

### DIFF
--- a/plans/tier0.fmf
+++ b/plans/tier0.fmf
@@ -6,7 +6,7 @@ description+: |
 
 adjust+:
   - enabled: false
-    when: distro == stream-8-latest
+    when: distro == stream-8-latest, stream-9-latest
     because: We have a separate plan for CentOS Stream
 
 /sanity:

--- a/plans/tier1.fmf
+++ b/plans/tier1.fmf
@@ -7,7 +7,7 @@ description+: |
 
 adjust+:
   - enabled: false
-    when: distro == stream-8-latest
+    when: distro == stream-8-latest, stream-9-latest
     because: We have a separate plan for CentOS Stream
 
 /non-destructive:


### PR DESCRIPTION
* CentOS Stream has a separate plan, disable the original plans for both Stream 8 and 9

