### PR TITLE
chore(workflows): Autotag to upload rpms

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,11 @@
     "**/*centos7*Containerfile",
     ".devcontainer/centos7/**"
   ],
-  "labels": ["skip/changelog", "tests/skip"],
+  "labels": [
+    "kind/dependencies",
+    "skip/changelog",
+    "tests/skip"
+  ],
   "packageRules": [
     {
       "matchPackageNames": [

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -2,6 +2,10 @@
 name: Build release RPMs
 
 on:
+  workflow_run:
+    workflows: [Auto Tag]
+    types:
+      - completed
   push:
     tags:
       - v*

--- a/.github/workflows/jira-links.yml
+++ b/.github/workflows/jira-links.yml
@@ -1,5 +1,5 @@
 ---
-name: Build release RPMs & Handle release
+name: Handle release
 
 on:
   release:


### PR DESCRIPTION
Auto tag workflow didn't trigger a follow-up RPM build and attach to the
tag which means no tags get the rpms attached. This defeats the point of
our autotagging as we want to have RPMs to test against.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Label depicting the kind of PR it is <!-- kind/breaking kind/feature kind/bug-fix kind/security kind/tests etc. -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
