### PR TITLE
chore: Improve autotag and build rpm again

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -27,7 +27,5 @@ jobs:
           git tag ${{ steps.determine_tag.outputs.tag  }}
           git push origin ${{ steps.determine_tag.outputs.tag }}
 
-      - name: Call build RPM workflow
-        uses: oamg/convert2rhel/.github/workflows/build-rpm.yml@main
-        with:
-          tag: ${{ steps.determine_tag.outputs.tag  }}
+  call-build-rpms:
+    uses: oamg/convert2rhel/.github/workflows/build-rpm.yml@main

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -2,12 +2,10 @@
 name: Build release RPMs
 
 on:
-  workflow_call:
-    inputs:
-      tag:
-        required: false
-        type: string
-        default: "v0.0.0"
+  workflow_run:
+    workflows: [Auto Tag]
+    types:
+      - completed
   push:
     tags:
       - v*
@@ -33,16 +31,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Get tag
-        if: startsWith(github.event.ref, 'refs/tags/')
+      - name: Determine tag
         id: tag
-        uses: devops-actions/action-get-tag@v1.0.3
-        with:
-          strip_v: true # Optional: Remove 'v' character from version
-          default: ${{ inputs.tag }} # Optional: Default version when tag not found
+        run: |
+          echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
 
       - name: Update specfile to match tag
-        if: startsWith(github.event.ref, 'refs/tags/') && ${{ steps.tag.outputs.tag != '0.0.0' }}
+        if: startsWith(github.event.ref, 'refs/tags/')
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           include: "packaging/convert2rhel.spec"
@@ -50,7 +45,7 @@ jobs:
           replace: "${1}${{steps.tag.outputs.tag}}"
 
       - name: Update convert2rhel version to match tag
-        if: startsWith(github.event.ref, 'refs/tags/') && ${{ steps.tag.outputs.tag != '0.0.0' }}
+        if: startsWith(github.event.ref, 'refs/tags/')
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           include: "convert2rhel/__init__.py"


### PR DESCRIPTION
This should hopefully tag and have all the variables accessible without
issue.<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Label depicting the kind of PR it is <!-- kind/breaking kind/feature kind/bug-fix kind/security kind/tests etc. -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
