### PR TITLE
[RHELC-1753] Fix reaching unaccessible repos from enablerepo 

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/handle_packages.py
+++ b/convert2rhel/actions/pre_ponr_changes/handle_packages.py
@@ -43,10 +43,9 @@ class ListThirdPartyPackages(actions.Action):
         if third_party_pkgs:
             # RHELC-884 disable the RHEL repos to avoid reaching them when checking original system.
             # There is needed for avoid reaching out RHEL repositories while requesting info about pkgs.
-            disable_repos_ints = repo.DisableReposDuringAnalysis()
-            disable_repos = disable_repos_ints.repos_to_disable
+            repos_to_disable = repo.DisableReposDuringAnalysis().get_rhel_repos_to_disable()
             pkg_list = pkghandler.format_pkg_info(
-                sorted(third_party_pkgs, key=self.extract_packages), disable_repos=disable_repos
+                sorted(third_party_pkgs, key=self.extract_packages), disable_repos=repos_to_disable
             )
             warning_message = (
                 "Only packages signed by {} are to be"
@@ -131,9 +130,8 @@ class RemoveSpecialPackages(actions.Action):
 
             # RHELC-884 disable the RHEL repos to avoid reaching them when checking original system.
             # There is needed for avoid reaching out RHEL repositories while requesting info about pkgs.
-            disable_repos_ints = repo.DisableReposDuringAnalysis()
-            disable_repos = disable_repos_ints.repos_to_disable
-            pkgs_removed = _remove_packages_unless_from_redhat(pkgs_list=all_pkgs, disable_repos=disable_repos)
+            repos_to_disable = repo.DisableReposDuringAnalysis().get_rhel_repos_to_disable()
+            pkgs_removed = _remove_packages_unless_from_redhat(pkgs_list=all_pkgs, disable_repos=repos_to_disable)
 
             # https://issues.redhat.com/browse/RHELC-1677
             # In some cases the {system}-release package takes ownership of the /etc/yum.repos.d/ directory,

--- a/convert2rhel/actions/pre_ponr_changes/handle_packages.py
+++ b/convert2rhel/actions/pre_ponr_changes/handle_packages.py
@@ -43,7 +43,8 @@ class ListThirdPartyPackages(actions.Action):
         if third_party_pkgs:
             # RHELC-884 disable the RHEL repos to avoid reaching them when checking original system.
             # There is needed for avoid reaching out RHEL repositories while requesting info about pkgs.
-            disable_repos = repo.get_rhel_repos_to_disable()
+            disable_repos_ints = repo.DisableReposDuringAnalysis()
+            disable_repos = disable_repos_ints.repos_to_disable
             pkg_list = pkghandler.format_pkg_info(
                 sorted(third_party_pkgs, key=self.extract_packages), disable_repos=disable_repos
             )
@@ -130,7 +131,8 @@ class RemoveSpecialPackages(actions.Action):
 
             # RHELC-884 disable the RHEL repos to avoid reaching them when checking original system.
             # There is needed for avoid reaching out RHEL repositories while requesting info about pkgs.
-            disable_repos = repo.get_rhel_repos_to_disable()
+            disable_repos_ints = repo.DisableReposDuringAnalysis()
+            disable_repos = disable_repos_ints.repos_to_disable
             pkgs_removed = _remove_packages_unless_from_redhat(pkgs_list=all_pkgs, disable_repos=disable_repos)
 
             # https://issues.redhat.com/browse/RHELC-1677

--- a/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
+++ b/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
@@ -45,8 +45,8 @@ class IsLoadedKernelLatest(actions.Action):
             return
 
         # RHELC-884 disable the RHEL repos to avoid reaching them when checking original system.
-        disable_repos_ints = repo.DisableReposDuringAnalysis()
-        disable_repo_command = repo.get_rhel_disable_repos_command(disable_repos_ints.repos_to_disable)
+        repos_to_disable = repo.DisableReposDuringAnalysis().get_rhel_repos_to_disable()
+        disable_repo_command = repo.get_rhel_disable_repos_command(repos_to_disable)
 
         cmd = [
             "repoquery",

--- a/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
+++ b/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
@@ -45,7 +45,8 @@ class IsLoadedKernelLatest(actions.Action):
             return
 
         # RHELC-884 disable the RHEL repos to avoid reaching them when checking original system.
-        disable_repo_command = repo.get_rhel_disable_repos_command(repo.get_rhel_repos_to_disable())
+        disable_repos_ints = repo.DisableReposDuringAnalysis()
+        disable_repo_command = repo.get_rhel_disable_repos_command(disable_repos_ints.repos_to_disable)
 
         cmd = [
             "repoquery",

--- a/convert2rhel/backup/packages.py
+++ b/convert2rhel/backup/packages.py
@@ -60,8 +60,7 @@ class RestorablePackage(RestorableChange):
         self.varsdir = varsdir
 
         # RHELC-884 disable the RHEL repos to avoid downloading pkg from them.
-        disable_repos_ints = repo.DisableReposDuringAnalysis()
-        self.disable_repos = disable_repos or disable_repos_ints.repos_to_disable
+        self.disable_repos = disable_repos or repo.DisableReposDuringAnalysis().get_rhel_repos_to_disable()
 
         self._backedup_pkgs_paths = []
 

--- a/convert2rhel/backup/packages.py
+++ b/convert2rhel/backup/packages.py
@@ -60,7 +60,8 @@ class RestorablePackage(RestorableChange):
         self.varsdir = varsdir
 
         # RHELC-884 disable the RHEL repos to avoid downloading pkg from them.
-        self.disable_repos = disable_repos or repo.get_rhel_repos_to_disable()
+        disable_repos_ints = repo.DisableReposDuringAnalysis()
+        self.disable_repos = disable_repos or disable_repos_ints.repos_to_disable
 
         self._backedup_pkgs_paths = []
 

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -734,13 +734,12 @@ def get_total_packages_to_update():
     # RHEL repositories needs to be disabled when checking if the packages are up to date.
     # When user specifies rhel repos to use during conversion, disabling them is also needed.
     # Note: Do not depend on the --no-rhsm option, enable repos can be specified without it.
-    disable_repos_ints = repo.DisableReposDuringAnalysis()
-    disable_repos = disable_repos_ints.repos_to_disable
+    repos_to_disable = repo.DisableReposDuringAnalysis().get_rhel_repos_to_disable()
 
     if pkgmanager.TYPE == "yum":
-        packages = _get_packages_to_update_yum(disable_repos=disable_repos)
+        packages = _get_packages_to_update_yum(disable_repos=repos_to_disable)
     elif pkgmanager.TYPE == "dnf":
-        packages = _get_packages_to_update_dnf(disable_repos=disable_repos)
+        packages = _get_packages_to_update_dnf(disable_repos=repos_to_disable)
 
     return set(packages)
 

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -734,7 +734,8 @@ def get_total_packages_to_update():
     # RHEL repositories needs to be disabled when checking if the packages are up to date.
     # When user specifies rhel repos to use during conversion, disabling them is also needed.
     # Note: Do not depend on the --no-rhsm option, enable repos can be specified without it.
-    disable_repos = repo.get_rhel_repos_to_disable()
+    disable_repos_ints = repo.DisableReposDuringAnalysis()
+    disable_repos = disable_repos_ints.repos_to_disable
 
     if pkgmanager.TYPE == "yum":
         packages = _get_packages_to_update_yum(disable_repos=disable_repos)

--- a/convert2rhel/pkgmanager/__init__.py
+++ b/convert2rhel/pkgmanager/__init__.py
@@ -243,6 +243,7 @@ def call_yum_cmd(
         # When using subscription-manager for the conversion, use those repos for the yum call that have been enabled
         # through subscription-manager
         repos_to_enable = system_info.get_enabled_rhel_repos()
+        logger.debug("Custom epos in yum cmd: {repos_to_enable}".format(repos_to_enable=repos_to_enable))
 
     for repo in repos_to_enable:
         cmd.append("--enablerepo={}".format(repo))

--- a/convert2rhel/unit_tests/repo_test.py
+++ b/convert2rhel/unit_tests/repo_test.py
@@ -179,14 +179,14 @@ class TestDisableReposDuringAnalysis:
         # Force remove the singleton instance
         repo.DisableReposDuringAnalysis._instance = None
 
-        get_rhel_repos_to_disable = mock.Mock()
-        monkeypatch.setattr(repo.DisableReposDuringAnalysis, "_set_rhel_repos_to_disable", get_rhel_repos_to_disable)
+        set_rhel_repos_to_disable = mock.Mock()
+        monkeypatch.setattr(repo.DisableReposDuringAnalysis, "_set_rhel_repos_to_disable", set_rhel_repos_to_disable)
 
         singleton1 = repo.DisableReposDuringAnalysis()
         singleton2 = repo.DisableReposDuringAnalysis()
 
         assert singleton1 is singleton2
-        assert get_rhel_repos_to_disable.call_count == 1
+        assert set_rhel_repos_to_disable.call_count == 1
 
         # Force remove the singleton instance
         repo.DisableReposDuringAnalysis._instance = None
@@ -247,7 +247,7 @@ class TestDisableReposDuringAnalysis:
         global_tool_opts.enablerepo = enablerepo
         global_tool_opts.no_rhsm = no_rhsm
 
-        repos = repo.DisableReposDuringAnalysis().repos_to_disable
+        repos = repo.DisableReposDuringAnalysis().get_rhel_repos_to_disable()
         assert repos == disablerepos
 
         # Force remove the singleton instance
@@ -276,7 +276,7 @@ class TestDisableReposDuringAnalysis:
         global_tool_opts.enablerepo = enablerepo
         global_tool_opts.no_rhsm = no_rhsm
 
-        repos = repo.DisableReposDuringAnalysis().repos_to_disable
+        repos = repo.DisableReposDuringAnalysis().get_rhel_repos_to_disable()
         assert repos == disablerepos
 
         # Force remove the singleton instance

--- a/tests/integration/tier0/non-destructive/custom-repository/test_custom_repository.py
+++ b/tests/integration/tier0/non-destructive/custom-repository/test_custom_repository.py
@@ -44,7 +44,9 @@ def test_custom_invalid_repo_without_rhsm(shell, convert2rhel):
     with invalid repository passed.
     Make sure that after failed repo check there is a kernel installed.
     """
-    with convert2rhel("-y --no-rhsm --enablerepo fake-rhel-8-for-x86_64-baseos-rpms --debug", unregister=True) as c2r:
+    with convert2rhel(
+        "-y --no-rhsm --enablerepo fake-rhel-repo-1 --enablerepo fake-rhel-repo-2 --debug", unregister=True
+    ) as c2r:
         c2r.expect("CUSTOM_REPOSITORIES_ARE_VALID::UNABLE_TO_ACCESS_REPOSITORIES")
 
     assert c2r.exitstatus == 2


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
Avoid reaching unaccessible repositories provided by user using
--enablerepo argument. Those repos are manually disabled during
analysis, but when user provides unreachable repo the analysis would
fail.

This change adds check if provided repos are accessible - if not, those
unaccessible ones are removed from the list for manual disable during
analysis.


<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1753](https://issues.redhat.com/browse/RHELC-1753)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Label depicting the kind of PR it is <!-- kind/breaking kind/feature kind/bug-fix kind/security kind/tests etc. -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
