### PR TITLE
[RHELC-1511] Tell users to use config ini instead of env vars

### DIFF
--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -192,7 +192,10 @@ class BackupPackageFiles(actions.Action):
         except IOError as err:
             warn_deprecated_env("CONVERT2RHEL_INCOMPLETE_ROLLBACK")
             if tool_opts.incomplete_rollback:
-                logger.debug("Skipping backup of the package files. CONVERT2RHEL_INCOMPLETE_ROLLBACK detected.")
+                logger.debug(
+                    "You have set the incomplete rollback inhibitor override - skipping backing up of the package"
+                    " files."
+                )
                 # Return empty list results in no backup of the files
                 return data
             else:

--- a/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
+++ b/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
@@ -247,21 +247,21 @@ class EnsureKernelModulesCompatibility(actions.Action):
             rhel_supported_kmods = self._get_rhel_supported_kmods()
             unsupported_kmods = self._get_unsupported_kmods(host_kmods, rhel_supported_kmods)
 
-            # Check if we have the environment variable set, if we do, send a
+            # Check if the user has specified that they allow unavailable kmods and if so, print a
             # warning and return.
             warn_deprecated_env("CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS")
             if tool_opts.allow_unavailable_kmods:
                 logger.warning(
-                    "Detected 'CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS' environment variable."
-                    " We will continue the conversion with the following kernel modules unavailable in RHEL:\n"
+                    "You have set the option to allow unavailable kernel modules."
+                    " The conversion will continue with the following kernel modules unavailable in RHEL:\n"
                     "{kmods}\n".format(kmods="\n".join(unsupported_kmods))
                 )
                 self.add_message(
                     level="WARNING",
                     id="ALLOW_UNAVAILABLE_KERNEL_MODULES",
                     title="Did not perform the ensure kernel modules compatibility check",
-                    description="Detected 'CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS' environment variable.",
-                    diagnosis="We will continue the conversion with the following kernel modules unavailable in RHEL:\n"
+                    diagnosis="You have set the option to allow unavailable kernel modules.",
+                    description="We will continue the conversion with the following kernel modules unavailable in RHEL:\n"
                     "{kmods}\n".format(kmods="\n".join(unsupported_kmods)),
                 )
                 return
@@ -280,8 +280,8 @@ class EnsureKernelModulesCompatibility(actions.Action):
                     "message persists, you can prevent the modules from loading by following {0} and rerun convert2rhel.\n"
                     "Keeping them loaded could cause the system to malfunction after the conversion as they might not work "
                     "properly with the RHEL kernel.\n"
-                    "To circumvent this check and accept the risk you can set environment variable "
-                    "'CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS=1'.".format(LINK_PREVENT_KMODS_FROM_LOADING),
+                    "To circumvent this check and accept the risk, set the allow_unavailable_kmods inhibitor override in the"
+                    "/etc/convert2rhel.ini config file to true.".format(LINK_PREVENT_KMODS_FROM_LOADING),
                 )
                 return
 

--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -179,14 +179,14 @@ class Convert2rhelLatest(actions.Action):
             if tool_opts.allow_older_version:
                 diagnosis = (
                     "You are currently running {} and the latest version of convert2rhel is {}.\n"
-                    "'CONVERT2RHEL_ALLOW_OLDER_VERSION' environment variable detected, continuing conversion".format(
+                    "You have set the option to allow older convert2rhel version, continuing conversion".format(
                         formatted_convert2rhel_version, formatted_available_version
                     )
                 )
                 logger.warning(diagnosis)
                 self.add_message(
                     level="WARNING",
-                    id="ALLOW_OLDER_VERSION_ENVIRONMENT_VARIABLE",
+                    id="ALLOW_OLDER_VERSION_OPTION",
                     title="Outdated convert2rhel version detected",
                     description="An outdated convert2rhel version has been detected",
                     diagnosis=diagnosis,
@@ -224,7 +224,8 @@ class Convert2rhelLatest(actions.Action):
                                 formatted_convert2rhel_version, formatted_available_version
                             )
                         ),
-                        remediations="If you want to disregard this check, then set the environment variable 'CONVERT2RHEL_ALLOW_OLDER_VERSION=1' to continue.",
+                        remediations="If you want to disregard this check, set the allow_older_version inhibitor"
+                        " override in the /etc/convert2rhel.ini config file to true.",
                     )
                     return
 

--- a/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
+++ b/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
@@ -69,20 +69,17 @@ class IsLoadedKernelLatest(actions.Action):
         warn_deprecated_env("CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK")
         if tool_opts.skip_kernel_currency_check:
             logger.warning(
-                "Detected 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip "
-                "the {} comparison.\n"
-                "Beware, this could leave your system in a broken state.".format(package_to_check)
+                "You have set the option to skip the kernel currency check. We will not be checking if the loaded"
+                " kernel is of the latest version available.\nBeware, this could leave your system in a broken state."
             )
 
             self.add_message(
                 level="WARNING",
                 id="UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK_DETECTED",
                 title="Did not perform the kernel currency check",
-                description=(
-                    "Detected 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip "
-                    "the {} comparison.\n"
-                    "Beware, this could leave your system in a broken state.".format(package_to_check)
-                ),
+                description="We will not be checking if the loaded kernel is of the latest version available."
+                "\nBeware, this could leave your system in a broken state.",
+                diagnosis="You have set the option to skip the kernel currency check.",
             )
             return
 
@@ -141,9 +138,9 @@ class IsLoadedKernelLatest(actions.Action):
                     )
                 ),
                 remediations=(
-                    "Please, check if you have any vendor repositories enabled to proceed with the conversion.\n"
-                    "If you wish to disregard this message, set the environment variable "
-                    "'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' to 1."
+                    "Please check if you have any vendor repositories enabled to proceed with the conversion.\n"
+                    "If you wish to disregard this message, set the skip_kernel_currency_check inhibitor override in"
+                    " the /etc/convert2rhel.ini config file to true."
                 ),
             )
             return
@@ -184,8 +181,8 @@ class IsLoadedKernelLatest(actions.Action):
                     "To proceed with the conversion, update the kernel version by executing the following step:\n\n"
                     "1. yum install {}-{} -y\n"
                     "2. reboot\n"
-                    "If you wish to ignore this message, set the environment variable "
-                    "'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' to 1.".format(package_to_check, latest_kernel)
+                    "If you wish to ignore this message, set the skip_kernel_currency_check inhibitor override in"
+                    " the /etc/convert2rhel.ini config file to true.".format(package_to_check, latest_kernel)
                 ),
             )
             return

--- a/convert2rhel/actions/system_checks/tainted_kmods.py
+++ b/convert2rhel/actions/system_checks/tainted_kmods.py
@@ -62,8 +62,9 @@ class TaintedKmods(actions.Action):
                     remediations=(
                         "Prevent the modules from loading by following {0}"
                         " and run convert2rhel again to continue with the conversion."
-                        " Although it is not recommended, you can disregard this message by setting the environment variable"
-                        " 'CONVERT2RHEL_TAINTED_KERNEL_MODULE_CHECK_SKIP' to 1. Overriding this check can be dangerous"
+                        " Although it is not recommended, you can disregard this message by setting the"
+                        " tainted_kernel_module_check_skip inhibitor override in the /etc/convert2rhel.ini"
+                        " config file to true. Overriding this check can be dangerous"
                         " so it is recommended that you do a system backup beforehand."
                         " For information on what a tainted kernel module is, please refer to this documentation {1}".format(
                             LINK_PREVENT_KMODS_FROM_LOADING, LINK_TAINTED_KMOD_DOCS
@@ -76,9 +77,9 @@ class TaintedKmods(actions.Action):
                 level="WARNING",
                 id="SKIP_TAINTED_KERNEL_MODULE_CHECK",
                 title="Skip tainted kernel module check",
+                diagnosis="You have set the option to skip the tainted kernel module check.",
                 description=(
-                    "Detected 'CONVERT2RHEL_TAINTED_KERNEL_MODULE_CHECK_SKIP' environment variable, we will skip "
-                    "the tainted kernel module check.\n"
+                    "We will ignore results of the check that makes sure no tainted kernel modules are loaded.\n"
                     "Beware, this could leave your system in a broken state."
                 ),
             )

--- a/convert2rhel/cli.py
+++ b/convert2rhel/cli.py
@@ -133,10 +133,8 @@ class CLI:
             " stored in log files {} and {}. At the end of the conversion, these logs are compared"
             " to show you what rpm files have been affected by the conversion."
             " Cannot be used with analyze subcommand."
-            " The environment variable CONVERT2RHEL_INCOMPLETE_ROLLBACK"
-            " needs to be set to 1 to use this argument.".format(
-                utils.rpm.PRE_RPM_VA_LOG_FILENAME, utils.rpm.POST_RPM_VA_LOG_FILENAME
-            ),
+            " The incomplete_rollback option needs to be set to true in the /etc/convert2rhel.ini config file to"
+            " use this argument.".format(utils.rpm.PRE_RPM_VA_LOG_FILENAME, utils.rpm.POST_RPM_VA_LOG_FILENAME),
         )
         self._shared_options_parser.add_argument(
             "--eus",

--- a/convert2rhel/toolopts/__init__.py
+++ b/convert2rhel/toolopts/__init__.py
@@ -99,8 +99,8 @@ class ToolOpts:
                 message = (
                     "We need to run the 'rpm -Va' command to be able to perform a complete rollback of changes"
                     " done to the system during the pre-conversion analysis. If you accept the risk of an"
-                    " incomplete rollback, set the CONVERT2RHEL_INCOMPLETE_ROLLBACK=1 environment"
-                    " variable. Otherwise, remove the --no-rpm-va option."
+                    " incomplete rollback, set the incomplete_rollback option in the /etc/convert2rhel.ini"
+                    " config file to true. Otherwise, remove the --no-rpm-va option."
                 )
                 loggerinst.critical(message)
 

--- a/convert2rhel/unit_tests/actions/post_conversion/hostmetering_test.py
+++ b/convert2rhel/unit_tests/actions/post_conversion/hostmetering_test.py
@@ -213,18 +213,16 @@ def test_configure_host_metering(
             (None, 0),
             ("", ""),
             True,
-            set(
-                (
-                    actions.ActionMessage(
-                        level="WARNING",
-                        id="FORCED_CONFIGURE_HOST_METERING",
-                        title="The `force' option has been used for the CONVERT2RHEL_CONFIGURE_HOST_METERING environment variable.",
-                        description="Please note that this option is mainly used for testing and"
-                        " will configure host-metering unconditionally."
-                        " For generic usage please use the 'auto' option.",
-                    ),
-                ),
-            ),
+            {
+                actions.ActionMessage(
+                    level="WARNING",
+                    id="FORCED_CONFIGURE_HOST_METERING",
+                    title="Configuration of host metering set to 'force'",
+                    description="Please note that this option is mainly used for testing and"
+                    " will configure host-metering unconditionally."
+                    " For generic usage please use the 'auto' option.",
+                )
+            },
             actions.ActionResult(level="SUCCESS", id="SUCCESS"),
         ),
         (
@@ -234,17 +232,17 @@ def test_configure_host_metering(
             (None, 0),
             ("", ""),
             None,
-            set(
-                (
-                    actions.ActionMessage(
-                        level="WARNING",
-                        id="UNRECOGNIZED_OPTION_CONFIGURE_HOST_METERING",
-                        title="Unrecognized option in CONVERT2RHEL_CONFIGURE_HOST_METERING environment variable.",
-                        description="Environment variable wrong_env not recognized.",
-                        remediations="Set the option to `auto` value if you want to configure host metering.",
-                    ),
-                ),
-            ),
+            {
+                actions.ActionMessage(
+                    level="WARNING",
+                    id="UNRECOGNIZED_OPTION_CONFIGURE_HOST_METERING",
+                    title="Unexpected value of the host metering setting",
+                    diagnosis="Unexpected value of 'configure_host_metering' in convert2rhel.ini or the"
+                    " CONVERT2RHEL_CONFIGURE_HOST_METERING environment variable: wrong_env",
+                    description="Host metering will not be configured.",
+                    remediations="Set the option to 'auto' or 'force' if you want to configure host metering.",
+                )
+            },
             actions.ActionResult(level="SUCCESS", id="SUCCESS"),
         ),
         (
@@ -383,16 +381,16 @@ def test_configure_host_metering_messages_and_results(
 
 
 def test_configure_host_metering_no_env_var(monkeypatch, hostmetering_instance, global_tool_opts):
-    expected = set(
-        (
-            actions.ActionMessage(
-                level="INFO",
-                id="CONFIGURE_HOST_METERING_SKIP",
-                title="Did not perform host metering configuration.",
-                description="CONVERT2RHEL_CONFIGURE_HOST_METERING was not set.",
-            ),
-        ),
-    )
+    expected = {
+        actions.ActionMessage(
+            level="INFO",
+            id="CONFIGURE_HOST_METERING_SKIP",
+            title="Did not perform host metering configuration.",
+            description="Configuration of host metering has been skipped.",
+            diagnosis="We haven't detected 'configure_host_metering' in the convert2rhel.ini config file nor"
+            " the CONVERT2RHEL_CONFIGURE_HOST_METERING environment variable.",
+        )
+    }
     monkeypatch.setattr(hostmetering, "tool_opts", global_tool_opts)
 
     hostmetering_instance.run()

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
@@ -223,7 +223,7 @@ class TestBackupSystem:
     def test_get_changed_package_files_missing(
         self, caplog, tmpdir, monkeypatch, backup_package_files_action, global_tool_opts
     ):
-        message = "Skipping backup of the package files. CONVERT2RHEL_INCOMPLETE_ROLLBACK detected."
+        message = "You have set the incomplete rollback inhibitor override - skipping backing up of the package files."
         monkeypatch.setattr(backup_system, "LOG_DIR", str(tmpdir))
         monkeypatch.setenv("CONVERT2RHEL_INCOMPLETE_ROLLBACK", "1")
         monkeypatch.setattr(toolopts, "tool_opts", global_tool_opts)

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
@@ -230,8 +230,8 @@ def test_ensure_compatibility_of_kmods_check_env_and_message(
 
     ensure_kernel_modules_compatibility_instance.run()
     should_be_in_logs = (
-        ".*Detected 'CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS' environment variable."
-        " We will continue the conversion with the following kernel modules unavailable in RHEL:.*"
+        ".*You have set the option to allow unavailable kernel modules."
+        " The conversion will continue with the following kernel modules unavailable in RHEL:.*"
     )
     assert re.match(pattern=should_be_in_logs, string=caplog.records[-1].message, flags=re.MULTILINE | re.DOTALL)
     # cannot assert exact action message contents as the kmods arrangement in the message is not static
@@ -239,8 +239,10 @@ def test_ensure_compatibility_of_kmods_check_env_and_message(
     assert STATUS_CODE["WARNING"] == message.level
     assert "ALLOW_UNAVAILABLE_KERNEL_MODULES" == message.id
     assert "Did not perform the ensure kernel modules compatibility check" == message.title
-    assert "Detected 'CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS' environment variable." in message.description
-    assert "We will continue the conversion with the following kernel modules unavailable in RHEL:" in message.diagnosis
+    assert (
+        "We will continue the conversion with the following kernel modules unavailable in RHEL:" in message.description
+    )
+    assert "You have set the option to allow unavailable kernel modules." in message.diagnosis
 
 
 @pytest.mark.parametrize(

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -157,12 +157,12 @@ class TestCheckConvert2rhelLatest:
             level="OVERRIDABLE",
             id="OUT_OF_DATE",
             title="Outdated convert2rhel version detected",
-            description="An outdated convert2rhel version has been detected",
             diagnosis=(
                 "You are currently running {} and the latest version of convert2rhel is {}.\n"
                 "Only the latest version is supported for conversion.".format(running_version, latest_version)
             ),
-            remediations="If you want to disregard this check, then set the environment variable 'CONVERT2RHEL_ALLOW_OLDER_VERSION=1' to continue.",
+            remediations="If you want to disregard this check, set the allow_older_version inhibitor"
+            " override in the /etc/convert2rhel.ini config file to true.",
         )
 
     @pytest.mark.parametrize(
@@ -337,7 +337,7 @@ class TestCheckConvert2rhelLatest:
 
         log_msg = (
             "You are currently running {} and the latest version of convert2rhel is {}.\n"
-            "'CONVERT2RHEL_ALLOW_OLDER_VERSION' environment variable detected, continuing conversion".format(
+            "You have set the option to allow older convert2rhel version, continuing conversion".format(
                 running_version, latest_version
             )
         )
@@ -769,7 +769,8 @@ class TestCheckConvert2rhelLatest:
                 "You are currently running {} and the latest version of convert2rhel is {}.\n"
                 "Only the latest version is supported for conversion.".format(running_version, latest_version)
             ),
-            remediations="If you want to disregard this check, then set the environment variable 'CONVERT2RHEL_ALLOW_OLDER_VERSION=1' to continue.",
+            remediations="If you want to disregard this check, set the allow_older_version inhibitor"
+            " override in the /etc/convert2rhel.ini config file to true.",
         )
 
     def test_convert2rhel_latest_unable_to_get_c2r_repofile(

--- a/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
@@ -372,12 +372,10 @@ class TestIsLoadedKernelLatest:
                 "WARNING",
                 "UNSUPPORTED_SKIP_KERNEL_CURRENCY_CHECK_DETECTED",
                 "Did not perform the kernel currency check",
-                (
-                    "Detected 'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' environment variable, we will skip the kernel-core comparison.\nBeware, this could leave your system in a broken state."
-                ),
+                "We will not be checking if the loaded kernel is of the latest version available."
+                "\nBeware, this could leave your system in a broken state.",
+                "You have set the option to skip the kernel currency check.",
                 None,
-                None,
-                id="Unsupported skip with environment var set to 1",
             ),
         ),
     )
@@ -554,9 +552,9 @@ class TestIsLoadedKernelLatest:
                 "Please refer to the diagnosis for further information",
                 "Could not find any {0} from repositories to compare against the loaded kernel.",
                 (
-                    "Please, check if you have any vendor repositories enabled to proceed with the conversion.\n"
-                    "If you wish to disregard this message, set the environment variable "
-                    "'CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK' to 1."
+                    "Please check if you have any vendor repositories enabled to proceed with the conversion.\n"
+                    "If you wish to disregard this message, set the skip_kernel_currency_check inhibitor override in"
+                    " the /etc/convert2rhel.ini config file to true."
                 ),
                 id="Repoquery failure without environment var",
             ),

--- a/convert2rhel/unit_tests/actions/system_checks/tainted_kmods_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/tainted_kmods_test.py
@@ -80,8 +80,9 @@ def test_check_tainted_kmods(monkeypatch, command_return, is_error, tainted_kmod
             remediations=(
                 "Prevent the modules from loading by following {0}"
                 " and run convert2rhel again to continue with the conversion."
-                " Although it is not recommended, you can disregard this message by setting the environment variable"
-                " 'CONVERT2RHEL_TAINTED_KERNEL_MODULE_CHECK_SKIP' to 1. Overriding this check can be dangerous"
+                " Although it is not recommended, you can disregard this message by setting the"
+                " tainted_kernel_module_check_skip inhibitor override in the /etc/convert2rhel.ini"
+                " config file to true. Overriding this check can be dangerous"
                 " so it is recommended that you do a system backup beforehand."
                 " For information on what a tainted kernel module is, please refer to this documentation {1}".format(
                     LINK_PREVENT_KMODS_FROM_LOADING, LINK_TAINTED_KMOD_DOCS
@@ -145,9 +146,9 @@ def test_check_tainted_kmods_skip(monkeypatch, command_return, is_error, tainted
                     level="WARNING",
                     id="SKIP_TAINTED_KERNEL_MODULE_CHECK",
                     title="Skip tainted kernel module check",
+                    diagnosis="You have set the option to skip the tainted kernel module check.",
                     description=(
-                        "Detected 'CONVERT2RHEL_TAINTED_KERNEL_MODULE_CHECK_SKIP' environment variable, we will skip "
-                        "the tainted kernel module check.\n"
+                        "We will ignore results of the check that makes sure no tainted kernel modules are loaded.\n"
                         "Beware, this could leave your system in a broken state."
                     ),
                 ),

--- a/convert2rhel/unit_tests/cli_test.py
+++ b/convert2rhel/unit_tests/cli_test.py
@@ -543,7 +543,10 @@ def test_critical_exit_no_rpm_va_setting(monkeypatch, global_tool_opts, tmpdir):
     monkeypatch.setattr(sys, "argv", mock_cli_arguments(["--no-rpm-va"]))
     with pytest.raises(
         SystemExit,
-        match="We need to run the 'rpm -Va' command to be able to perform a complete rollback of changes done to the system during the pre-conversion analysis. If you accept the risk of an incomplete rollback, set the CONVERT2RHEL_INCOMPLETE_ROLLBACK=1 environment variable. Otherwise, remove the --no-rpm-va option.",
+        match="We need to run the 'rpm -Va' command to be able to perform a complete rollback of changes"
+        " done to the system during the pre-conversion analysis. If you accept the risk of an"
+        " incomplete rollback, set the incomplete_rollback option in the /etc/convert2rhel.ini"
+        " config file to true. Otherwise, remove the --no-rpm-va option.",
     ):
         cli.CLI()
 

--- a/convert2rhel/unit_tests/toolopts/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts/toolopts_test.py
@@ -333,8 +333,8 @@ def test_handle_config_conflicts_system_exit(config_sources):
         match=(
             "We need to run the 'rpm -Va' command to be able to perform a complete rollback of changes"
             " done to the system during the pre-conversion analysis. If you accept the risk of an"
-            " incomplete rollback, set the CONVERT2RHEL_INCOMPLETE_ROLLBACK=1 environment"
-            " variable. Otherwise, remove the --no-rpm-va option."
+            " incomplete rollback, set the incomplete_rollback option in the /etc/convert2rhel.ini"
+            " config file to true. Otherwise, remove the --no-rpm-va option."
         ),
     ):
         tool_opts.initialize(config_sources)

--- a/convert2rhel/utils/__init__.py
+++ b/convert2rhel/utils/__init__.py
@@ -783,25 +783,24 @@ def report_on_a_download_error(output, pkg):
     # (4) Making the choices here mean that when used inside of the Action
     #     framework, we are limited to returning a FAILURE for the Action
     #     plugin whereas returning SKIP would be more accurate.
-    from convert2rhel import toolopts
     from convert2rhel.systeminfo import system_info
 
-    if toolopts.tool_opts.activity == "conversion":
-        if "CONVERT2RHEL_INCOMPLETE_ROLLBACK" not in os.environ:
+    if tool_opts.activity == "conversion":
+        warn_deprecated_env("CONVERT2RHEL_INCOMPLETE_ROLLBACK")
+        if not tool_opts.incomplete_rollback:
             logger.critical(
                 "Couldn't download the {} package. This means we will not be able to do a"
                 " complete rollback and may put the system in a broken state.\n"
                 "Check to make sure that the {} repositories are enabled"
                 " and the package is updated to its latest version.\n"
-                "If you would rather disregard this check set the environment variable"
-                " 'CONVERT2RHEL_INCOMPLETE_ROLLBACK=1'.".format(pkg, system_info.name)
+                "If you would rather disregard this check set the incomplete_rollback option in the"
+                " /etc/convert2rhel.ini config file to true.".format(pkg, system_info.name)
             )
         else:
-            warn_deprecated_env("CONVERT2RHEL_INCOMPLETE_ROLLBACK")
             logger.warning(
                 "Couldn't download the {} package. This means we will not be able to do a"
                 " complete rollback and may put the system in a broken state.\n"
-                "'CONVERT2RHEL_INCOMPLETE_ROLLBACK' environment variable detected, continuing"
+                "You have set the incomplete rollback inhibitor override, continuing"
                 " conversion.".format(pkg)
             )
     else:
@@ -810,7 +809,7 @@ def report_on_a_download_error(output, pkg):
             " Check to make sure that the {} repositories are enabled and the package is"
             " updated to its latest version.\n"
             "Note that you can choose to disregard this check when running a conversion by"
-            " setting the environment variable 'CONVERT2RHEL_INCOMPLETE_ROLLBACK=1'"
+            " setting the incomplete_rollback option in the /etc/convert2rhel.ini config file to true,"
             " but not during a pre-conversion analysis.".format(pkg, system_info.name)
         )
 

--- a/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
@@ -165,7 +165,7 @@ def test_c2r_version_latest_override_inhibitor(convert2rhel, c2r_version, versio
         assert c2r.expect("You are currently running 0.01.0", timeout=300) == 0
         assert (
             c2r.expect(
-                "'CONVERT2RHEL_ALLOW_OLDER_VERSION' environment variable detected, continuing conversion",
+                "You have set the option to allow older convert2rhel version, continuing conversion",
                 timeout=300,
             )
             == 0
@@ -279,7 +279,8 @@ def test_analyze_incomplete_rollback(remove_repositories, convert2rhel):
         # Verify the user is informed to not use the envar during the analysis
         assert (
             c2r.expect(
-                "setting the environment variable 'CONVERT2RHEL_INCOMPLETE_ROLLBACK=1' but not during a pre-conversion analysis",
+                "setting the incomplete_rollback option in the /etc/convert2rhel.ini config file to true,"
+                " but not during a pre-conversion analysis",
                 timeout=300,
             )
             == 0
@@ -295,7 +296,7 @@ def test_analyze_incomplete_rollback(remove_repositories, convert2rhel):
         c2r.sendline("y")
         assert (
             c2r.expect(
-                "'CONVERT2RHEL_INCOMPLETE_ROLLBACK' environment variable detected, continuing conversion.",
+                "You have set the incomplete rollback inhibitor override, continuing conversion.",
                 timeout=300,
             )
             == 0

--- a/tests/integration/tier0/non-destructive/kernel-modules/test_unsupported_kmod.py
+++ b/tests/integration/tier0/non-destructive/kernel-modules/test_unsupported_kmod.py
@@ -70,8 +70,8 @@ def test_override_inhibitor_with_unavailable_kmod_loaded(
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("y")
 
-        c2r.expect("Detected 'CONVERT2RHEL_ALLOW_UNAVAILABLE_KMODS' environment variable")
-        c2r.expect("We will continue the conversion with the following kernel modules")
+        c2r.expect("You have set the option to allow unavailable kernel modules.")
+        c2r.expect("The conversion will continue with the following kernel modules unavailable in RHEL")
 
         c2r.sendcontrol("c")
 
@@ -191,7 +191,8 @@ def test_inhibitor_with_custom_built_tainted_kmod(custom_kmod, convert2rhel):
     ) as c2r:
         c2r.expect("Tainted kernel modules detected")
         c2r.expect(
-            "disregard this message by setting the environment variable 'CONVERT2RHEL_TAINTED_KERNEL_MODULE_CHECK_SKIP'"
+            "disregard this message by setting the tainted_kernel_module_check_skip inhibitor override in the"
+            " /etc/convert2rhel.ini config file"
         )
         c2r.sendcontrol("c")
 

--- a/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
+++ b/tests/integration/tier0/non-destructive/system-release-backup/test_system_release_backup.py
@@ -60,7 +60,7 @@ def test_inhibitor_os_release_restored(shell, convert2rhel, fixture_satellite, r
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("y")
 
-        c2r.expect_exact("set the environment variable 'CONVERT2RHEL_INCOMPLETE_ROLLBACK", timeout=600)
+        c2r.expect_exact("set the incomplete_rollback option in the /etc/convert2rhel.ini config file", timeout=600)
     # We expect the return code to be 2, given an error is raised
     assert c2r.exitstatus == 2
 
@@ -96,7 +96,7 @@ def test_override_inhibitor_os_release_restored(
         c2r.expect("Continue with the system conversion?")
         c2r.sendline("y")
 
-        c2r.expect("'CONVERT2RHEL_INCOMPLETE_ROLLBACK' environment variable detected, continuing conversion.")
+        c2r.expect("You have set the incomplete rollback inhibitor override, continuing conversion.")
 
         c2r.expect("Continue with the system conversion")
         c2r.sendline("n")

--- a/tests/integration/tier1/destructive/kernel-check-skip/test_latest_kernel_check_skip.py
+++ b/tests/integration/tier1/destructive/kernel-check-skip/test_latest_kernel_check_skip.py
@@ -47,7 +47,7 @@ def test_latest_kernel_check_skip(shell, convert2rhel, backup_directory):
         # Make sure the kernel comparison is skipped
         c2r_expect_index = c2r.expect(
             [
-                "we will skip the kernel comparison.",
+                "We will not be checking if the loaded kernel is of the latest version available",
                 "Could not find any kernel packages in repositories to compare against the loaded kernel.",
             ]
         )


### PR DESCRIPTION
Env vars have been deprecated in favor of the ini config file (e.g. /etc/convert2rhel.ini). We should be telling users to use the config file instead of the deprecated env vars.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

- [RHELC-1511](https://issues.redhat.com/browse/RHELC-1511)

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Label depicting the kind of PR it is <!-- kind/breaking kind/feature kind/bug-fix kind/security kind/tests etc. -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
