### PR TITLE
[RHELC-1760] Make post-conversion analysis summary clearer

### DIFF
--- a/convert2rhel/actions/__init__.py
+++ b/convert2rhel/actions/__init__.py
@@ -81,8 +81,8 @@ _STATUS_NAME_FROM_CODE = dict((value, key) for key, value in STATUS_CODE.items()
 #: When we print a report for the user to view, we want some explanation of
 #: what the results mean
 STATUS_HEADER = {
-    0: "Success (No changes needed)",
-    25: "Info (No changes needed)",
+    0: "Success (No action required)",
+    25: "Info (No action required)",
     51: "Warning (Review and fix if needed)",
     101: "Skip (Could not be checked due to other failures)",
     152: "Overridable (Review and either fix or ignore the failure)",

--- a/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
+++ b/tests/integration/tier0/non-destructive/assessment-report/test_assessment_report.py
@@ -68,10 +68,10 @@ def test_failures_and_skips_in_report(convert2rhel):
         # Verify the ordering and contents
         # of the skip and error header
         # Success header first
-        c2r.expect_exact("Success (No changes needed)")
+        c2r.expect_exact("Success (No action required)")
 
         # Info header
-        c2r.expect_exact("Info (No changes needed)")
+        c2r.expect_exact("Info (No action required)")
 
         # Warning header
         c2r.expect_exact("Warning (Review and fix if needed)")
@@ -119,7 +119,7 @@ def test_successful_report(convert2rhel):
 
         # Verify that only success header printed out, assert if error or skip header appears
         c2r_report_header_index = c2r.expect(
-            ["No changes needed", "Must fix before conversion", "Could not be checked due to other failures"],
+            ["No action required", "Must fix before conversion", "Could not be checked due to other failures"],
             timeout=300,
         )
         if c2r_report_header_index == 0:
@@ -168,7 +168,7 @@ def test_convert_method_successful_report(convert2rhel):
 
         # Verify that none of the headers is present, assert if it is present
         c2r_report_header_index = c2r.expect(
-            [EOF, "No changes needed", "Must fix before conversion", "Could not be checked due to other failures"],
+            [EOF, "No action required", "Must fix before conversion", "Could not be checked due to other failures"],
             timeout=300,
         )
         if c2r_report_header_index == 0:


### PR DESCRIPTION
I was not sure what "No changes needed" means (changes to do by the tool or myself?).
IMHO "No action required" is clearer.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1760](https://issues.redhat.com/browse/RHELC-1760)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Label depicting the kind of PR it is <!-- kind/breaking kind/feature kind/bug-fix kind/security kind/tests etc. -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
