### PR TITLE
[RHELC-1761] Format messages for consistency

### DIFF
--- a/convert2rhel/actions/__init__.py
+++ b/convert2rhel/actions/__init__.py
@@ -559,7 +559,7 @@ class Stage:
                     title="Skipped action",
                     description="This action was skipped due to another action failing.",
                     diagnosis=diagnosis,
-                    remediations="Please ensure that the {} check passes so that this Action can evaluate your system".format(
+                    remediations="Ensure that the {} check passes so that this Action can evaluate your system".format(
                         utils.format_sequence_as_message(failed_deps)
                     ),
                 )
@@ -586,7 +586,7 @@ class Stage:
 
             # Categorize the results
             if action.result.level <= STATUS_CODE["WARNING"]:
-                logger.info("{} has succeeded".format(action.id))
+                logger.info("The {} action has succeeded.".format(action.id))
                 successes.append(action)
 
             if action.result.level > STATUS_CODE["WARNING"]:
@@ -742,7 +742,7 @@ def run_pre_actions():
     # When we call check_dependencies() or run() on the first Stage
     # (system_checks), it will operate on the first Stage and then recursively
     # call check_dependencies() or run() on the next_stage.
-    pre_ponr_changes = Stage("pre_ponr_changes", "Making recoverable changes")
+    pre_ponr_changes = Stage("pre_ponr_changes", "Make recoverable changes")
     system_checks = Stage("system_checks", "Check whether system is ready for conversion", next_stage=pre_ponr_changes)
 
     try:

--- a/convert2rhel/actions/conversion/list_non_red_hat_pkgs_left.py
+++ b/convert2rhel/actions/conversion/list_non_red_hat_pkgs_left.py
@@ -34,7 +34,7 @@ class ListNonRedHatPkgsLeft(actions.Action):
         super(ListNonRedHatPkgsLeft, self).run()
         loggerinst.task("List remaining non-Red Hat packages")
 
-        loggerinst.info("Listing packages not signed by Red Hat")
+        loggerinst.info("Listing packages not signed by Red Hat.")
         non_red_hat_pkgs = get_installed_pkgs_w_different_key_id(system_info.key_ids_rhel)
         if not non_red_hat_pkgs:
             loggerinst.info("All packages are now signed by Red Hat.")

--- a/convert2rhel/actions/conversion/preserve_only_rhel_kernel.py
+++ b/convert2rhel/actions/conversion/preserve_only_rhel_kernel.py
@@ -36,7 +36,7 @@ class InstallRhelKernel(actions.Action):
         non-RHEL kernel(s) conflicted with the available RHEL kernels.
         """
         super(InstallRhelKernel, self).run()
-        loggerinst.info("Verifying that RHEL kernel has been installed")
+        loggerinst.task("Verify RHEL kernel installation")
 
         rhel_kernels = pkghandler.get_installed_pkgs_by_key_id(system_info.key_ids_rhel, name="kernel")
 
@@ -68,8 +68,8 @@ class FixInvalidGrub2Entries(actions.Action):
 
     def run(self):
         """
-        On systems derived from RHEL 8 and later, /etc/machine-id is being used to identify grub2 boot loader entries per
-        the Boot Loader Specification.
+        On systems derived from RHEL 8 and later, /etc/machine-id is being used to identify grub2 bootloader entries per
+        the bootloader Specification.
         However, at the time of executing convert2rhel, the current machine-id can be different from the machine-id from the
         time when the kernels were installed. If that happens:
         - convert2rhel installs the RHEL kernel, but it's not set as default
@@ -79,18 +79,18 @@ class FixInvalidGrub2Entries(actions.Action):
         """
         super(FixInvalidGrub2Entries, self).run()
 
+        loggerinst.task("Fix GRUB2 bootloader entries")
         if system_info.version.major < 8:
             # Applicable only on systems derived from RHEL 8 and later, and systems using GRUB2 (s390x uses zipl)
+            loggerinst.info("Skipped. Only relevant to RHEL 8 and newer.")
             return
-
-        loggerinst.info("Fixing GRUB boot loader entries.")
 
         machine_id = utils.get_file_content("/etc/machine-id").strip()
         boot_entries = glob.glob("/boot/loader/entries/*.conf")
         for entry in boot_entries:
-            # The boot loader entries in /boot/loader/entries/<machine-id>-<kernel-version>.conf
+            # The bootloader entries in /boot/loader/entries/<machine-id>-<kernel-version>.conf
             if machine_id not in os.path.basename(entry):
-                loggerinst.debug("Removing boot entry {}".format(entry))
+                loggerinst.debug("Removing boot entry {}.".format(entry))
                 os.remove(entry)
 
         # Removing a boot entry that used to be the default makes grubby to choose a different entry as default,
@@ -99,24 +99,24 @@ class FixInvalidGrub2Entries(actions.Action):
         if ret_code:
             # Not setting the default entry shouldn't be a deal breaker and the reason to stop the conversions,
             # grub should pick one entry in any case.
-            description = "Couldn't get the default GRUB2 boot loader entry:\n{}".format(output)
+            description = "Couldn't get the default GRUB2 bootloader entry:\n{}".format(output)
             loggerinst.warning(description)
             self.add_message(
                 level="WARNING",
                 id="UNABLE_TO_GET_GRUB2_BOOT_LOADER_ENTRY",
-                title="Unable to get the GRUB2 boot loader entry",
+                title="Unable to get the GRUB2 bootloader entry",
                 description=description,
             )
             return
-        loggerinst.debug("Setting RHEL kernel {} as the default boot loader entry.".format(output.strip()))
+        loggerinst.debug("Setting RHEL kernel {} as the default bootloader entry.".format(output.strip()))
         output, ret_code = utils.run_subprocess(["/usr/sbin/grubby", "--set-default", output.strip()])
         if ret_code:
-            description = "Couldn't set the default GRUB2 boot loader entry:\n{}".format(output)
+            description = "Couldn't set the default GRUB2 bootloader entry:\n{}".format(output)
             loggerinst.warning(description)
             self.add_message(
                 level="WARNING",
                 id="UNABLE_TO_SET_GRUB2_BOOT_LOADER_ENTRY",
-                title="Unable to set the GRUB2 boot loader entry",
+                title="Unable to set the GRUB2 bootloader entry",
                 description=description,
             )
 
@@ -165,7 +165,7 @@ class FixDefaultKernel(actions.Action):
             utils.store_content_to_file(self.KERNEL_SYSCONFIG_PATH, content)
             return
 
-        loggerinst.info("Checking for incorrect boot kernel")
+        loggerinst.task("Check for default boot kernel in /etc/sysconfig/kernel")
         kernel_sys_cfg = utils.get_file_content(self.KERNEL_SYSCONFIG_PATH)
 
         possible_kernels = ["kernel-uek", "kernel-plus"]
@@ -174,21 +174,28 @@ class FixDefaultKernel(actions.Action):
             None,
         )
         if kernel_to_change:
-            description = "Detected leftover boot kernel, changing to RHEL kernel"
-            loggerinst.warning(description)
+            diagnosis = "Detected default boot kernel {} in /etc/sysconfig/kernel.".format(kernel_to_change)
+            new_kernel_str = "DEFAULTKERNEL=" + default_kernel
+            loggerinst.warning(diagnosis)
             self.add_message(
                 level="WARNING",
                 id="LEFTOVER_BOOT_KERNEL_DETECTED",
-                title="Leftover boot kernel detected",
-                description=description,
+                title="Leftover default boot kernel detected",
+                diagnosis=diagnosis,
+                description="Some systems have the default boot kernel in /etc/sysconfig/kernel set to a distribution"
+                " specific kernel even after such a kernel is uninstalled. We have changed it to {}.".format(
+                    new_kernel_str
+                ),
             )
-            new_kernel_str = "DEFAULTKERNEL=" + default_kernel
-
             kernel_sys_cfg = kernel_sys_cfg.replace("DEFAULTKERNEL=" + kernel_to_change, new_kernel_str)
             utils.store_content_to_file(self.KERNEL_SYSCONFIG_PATH, kernel_sys_cfg)
-            loggerinst.info("Boot kernel {} was changed to {}".format(kernel_to_change, new_kernel_str))
+            loggerinst.info(
+                "Default boot kernel {} was changed to {} in /etc/sysconfig/kernel.".format(
+                    kernel_to_change, new_kernel_str
+                )
+            )
         else:
-            loggerinst.debug("Boot kernel validated.")
+            loggerinst.debug("The default boot kernel is correct.")
 
 
 class KernelPkgsInstall(actions.Action):
@@ -199,18 +206,20 @@ class KernelPkgsInstall(actions.Action):
         """Remove non-RHEL kernels."""
         super(KernelPkgsInstall, self).run()
 
+        loggerinst.task("Remove non-RHEL kernels")
+
         kernel_pkgs_to_install = self.remove_non_rhel_kernels()
         if kernel_pkgs_to_install:
             self.install_additional_rhel_kernel_pkgs(kernel_pkgs_to_install)
 
     def remove_non_rhel_kernels(self):
-        loggerinst.info("Searching for non-RHEL kernels ...")
+        loggerinst.info("Searching for non-RHEL kernels.")
         non_rhel_kernels = pkghandler.get_installed_pkgs_w_different_key_id(system_info.key_ids_rhel, "kernel*")
         if not non_rhel_kernels:
             loggerinst.info("None found.")
             return None
 
-        loggerinst.info("Removing non-RHEL kernels\n")
+        loggerinst.info("Removing detected non-RHEL kernels.\n")
         pkghandler.print_pkg_info(non_rhel_kernels)
         pkgs_to_remove = [pkghandler.get_pkg_nvra(pkg) for pkg in non_rhel_kernels]
         utils.remove_pkgs(pkgs_to_remove)
@@ -228,7 +237,7 @@ class KernelPkgsInstall(actions.Action):
         pkg_names = [p.nevra.name.replace(ol_kernel_ext, "", 1) for p in additional_pkgs]
         for name in set(pkg_names):
             if name != "kernel":
-                loggerinst.info("Installing RHEL {}".format(name))
+                loggerinst.info("Installing RHEL {}.".format(name))
                 pkgmanager.call_yum_cmd("install", args=[name])
 
 
@@ -247,4 +256,5 @@ class UpdateKernel(actions.Action):
         """
         super(UpdateKernel, self).run()
 
+        loggerinst.task("Update RHEL kernel")
         pkghandler.update_rhel_kernel()

--- a/convert2rhel/actions/conversion/set_efi_config.py
+++ b/convert2rhel/actions/conversion/set_efi_config.py
@@ -169,7 +169,7 @@ class MoveGrubFiles(actions.Action):
                 )
                 continue
 
-            logger.info("Moving '{}' to '{}'".format(src_file, dst_file))
+            logger.info("Moving '{}' to '{}'.".format(src_file, dst_file))
 
             try:
                 shutil.move(src_file, dst_file)

--- a/convert2rhel/actions/post_conversion/hostmetering.py
+++ b/convert2rhel/actions/post_conversion/hostmetering.py
@@ -74,8 +74,8 @@ class ConfigureHostMetering(actions.Action):
             self.add_message(
                 level="WARNING",
                 id="INSTALL_HOST_METERING_FAILURE",
-                title="Failed to install host metering package.",
-                description="When installing host metering package an error occurred meaning we can't"
+                title="Failed to install the host-metering package",
+                description="When installing the host-metering package an error occurred meaning we can't"
                 " enable host metering on the system.",
                 diagnosis="`yum install host-metering` command returned {ret_install} with message {output}".format(
                     ret_install=ret_install, output=output
@@ -94,9 +94,9 @@ class ConfigureHostMetering(actions.Action):
             self.add_message(
                 level="WARNING",
                 id="CONFIGURE_HOST_METERING_FAILURE",
-                title="Failed to enable and start host metering service.",
+                title="Failed to enable and start the host metering service",
                 description="The host metering service failed to start"
-                " successfully and won't be able to keep track.",
+                " successfully and won't be able to report on the use of the system for the billing purposes.",
                 diagnosis="Command {command} failed with {error_message}".format(
                     command=command, error_message=error_message
                 ),
@@ -114,7 +114,7 @@ class ConfigureHostMetering(actions.Action):
             self.set_result(
                 level="ERROR",
                 id="HOST_METERING_NOT_RUNNING",
-                title="Host metering service is not running.",
+                title="Host metering service is not running",
                 description="host-metering.service is not running.",
                 remediations="You can try to start the service manually"
                 " by running following command:\n"
@@ -131,7 +131,7 @@ class ConfigureHostMetering(actions.Action):
         :rtype: bool
         """
         if tool_opts.configure_host_metering is None:
-            logger.debug("You have not enabled configuration of host metering. Skipping it.")
+            logger.info("You have not enabled configuration of host metering. Skipping it.")
             return False
 
         if tool_opts.configure_host_metering not in ("force", "auto"):
@@ -157,19 +157,22 @@ class ConfigureHostMetering(actions.Action):
         if tool_opts.configure_host_metering == "force":
             logger.warning(
                 "You've set the host metering setting to 'force'."
-                " Please note that this option is mainly used for testing and will configure host-metering unconditionally. "
-                " For generic usage please use the 'auto' option."
+                " Note that this option is mainly used for testing and will configure host-metering unconditionally. "
+                " For generic usage use the 'auto' option."
             )
             self.add_message(
                 level="WARNING",
                 id="FORCED_CONFIGURE_HOST_METERING",
                 title="Configuration of host metering set to 'force'",
-                description="Please note that this option is mainly used for testing and"
+                description="Note that this option is mainly used for testing and"
                 " will configure host-metering unconditionally."
-                " For generic usage please use the 'auto' option.",
+                " For generic usage use the 'auto' option.",
             )
         elif tool_opts.configure_host_metering == "auto":
-            logger.debug("Automatic detection of host hyperscaler and configuration.")
+            logger.debug(
+                "Configuration of host metering set to 'auto' - host-metering will be enabled based on"
+                " a detected hyperscaler."
+            )
 
         return True
 

--- a/convert2rhel/actions/post_conversion/modified_rpm_files_diff.py
+++ b/convert2rhel/actions/post_conversion/modified_rpm_files_diff.py
@@ -46,7 +46,7 @@ class ModifiedRPMFilesDiff(actions.Action):
             self.add_message(
                 level="INFO",
                 id="SKIPPED_MODIFIED_RPM_FILES_DIFF",
-                title="Skipped comparison of 'rpm -Va' output from before and after the conversion.",
+                title="Skipped comparison of 'rpm -Va' output from before and after the conversion",
                 description="Comparison of 'rpm -Va' output was not performed due to missing output "
                 "of the 'rpm -Va' run before the conversion.",
                 diagnosis="This is caused mainly by using '--no-rpm-va' argument for convert2rhel.",
@@ -76,8 +76,8 @@ class ModifiedRPMFilesDiff(actions.Action):
             self.add_message(
                 level="INFO",
                 id="FOUND_MODIFIED_RPM_FILES",
-                title="Modified rpm files from before and after the conversion were found.",
-                description="Comparison of modified rpm files from before and after " "the conversion: \n{}".format(
+                title="Modified rpm files from before and after the conversion were found",
+                description="Comparison of modified rpm files from before and after the conversion: \n{}".format(
                     modified_rpm_files_diff
                 ),
             )

--- a/convert2rhel/actions/post_conversion/remove_tmp_dir.py
+++ b/convert2rhel/actions/post_conversion/remove_tmp_dir.py
@@ -45,7 +45,7 @@ class RemoveTmpDir(actions.Action):
 
         try:
             shutil.rmtree(self.tmp_dir)
-            loggerinst.info("Temporary folder {} removed".format(self.tmp_dir))
+            loggerinst.info("Temporary folder {} removed.".format(self.tmp_dir))
         except OSError as exc:
             # We want run() to be idempotent, so do nothing silently if
             # the path doesn't exist.
@@ -61,6 +61,6 @@ class RemoveTmpDir(actions.Action):
             self.add_message(
                 level="WARNING",
                 id="UNSUCCESSFUL_REMOVE_TMP_DIR",
-                title="Temporary folder {tmp_dir} wasn't removed.".format(tmp_dir=self.tmp_dir),
+                title="Temporary folder {tmp_dir} wasn't removed".format(tmp_dir=self.tmp_dir),
                 description=warning_message,
             )

--- a/convert2rhel/actions/post_conversion/update_grub.py
+++ b/convert2rhel/actions/post_conversion/update_grub.py
@@ -132,7 +132,7 @@ class UpdateGrub(actions.Action):
                     level="ERROR",
                     id="FAILED_TO_IDENTIFY_GRUB2_BLOCK_DEVICE",
                     title="Failed to identify GRUB2 block device",
-                    description="The block device could not be identified, please look at the diagnosis "
+                    description="The block device could not be identified. Look at the diagnosis "
                     "for more information.",
                     diagnosis=str(e),
                 )

--- a/convert2rhel/actions/pre_ponr_changes/backup_system.py
+++ b/convert2rhel/actions/pre_ponr_changes/backup_system.py
@@ -50,8 +50,8 @@ class BackupRedhatRelease(actions.Action):
     id = "BACKUP_REDHAT_RELEASE"
 
     def run(self):
-        """Backup redhat release file before starting conversion process"""
-        logger.task("Backup Redhat Release Files")
+        """Back up redhat release file before starting conversion process"""
+        logger.task("Back up redhat-release files")
 
         super(BackupRedhatRelease, self).run()
 
@@ -78,7 +78,7 @@ class BackupRepository(actions.Action):
 
     def run(self):
         """Backup .repo files in /etc/yum.repos.d/ so the repositories can be restored on rollback."""
-        logger.task("Backup Repository Files")
+        logger.task("Back up repository files")
 
         super(BackupRepository, self).run()
 
@@ -111,7 +111,7 @@ class BackupPackageFiles(actions.Action):
         """Backup changed package files"""
         super(BackupPackageFiles, self).run()
 
-        logger.task("Backup package files")
+        logger.task("Back up package files")
 
         package_files_changes = self._get_changed_package_files()
 
@@ -143,7 +143,6 @@ class BackupPackageFiles(actions.Action):
         """Get the output from rpm -Va command from during resolving system info
         to get changes made to package files.
 
-
         :return dict: Return them as a list of dict, for example:
         [{"status":"S5T", "file_type":"c", "path":"/etc/yum.repos.d/CentOS-Linux-AppStream.repo"}]
         """
@@ -164,10 +163,9 @@ class BackupPackageFiles(actions.Action):
                 # Return empty list results in no backup of the files
                 return data
             else:
-                # The file should be there
-                # If missing conversion is in unknown state
+                # The file should be there. If missing, the conversion is in an unknown state.
                 logger.warning("Error({}): {}".format(err.errno, err.strerror))
-                logger.critical("Missing file {rpm_va_output} in it's location".format(rpm_va_output=path))
+                logger.critical("The file {rpm_va_output} is missing.".format(rpm_va_output=path))
 
         lines = output.strip().split("\n")
         for line in lines:
@@ -185,7 +183,7 @@ class BackupPackageFiles(actions.Action):
         if not match:  # line not matching the regex
             if line.strip() != "":
                 # Line is not empty string
-                logger.debug("Skipping invalid output {}".format(line))
+                logger.debug("Skipping invalid output: {}".format(line))
             return {"status": None, "file_type": None, "path": None}
 
         line = line.split()

--- a/convert2rhel/actions/pre_ponr_changes/custom_repos_are_valid.py
+++ b/convert2rhel/actions/pre_ponr_changes/custom_repos_are_valid.py
@@ -39,7 +39,10 @@ class CustomReposAreValid(actions.Action):
         logger.task("Check if --enablerepo repositories are accessible")
 
         if not tool_opts.enablerepo:
-            logger.info("Did not perform the check of repositories due to the use of RHSM for the conversion.")
+            logger.info(
+                "No repositories passed through --enablerepo. Skipping the check verifying the"
+                " accessibility of the repositories."
+            )
             return
 
         output, ret_code = call_yum_cmd(
@@ -53,7 +56,7 @@ class CustomReposAreValid(actions.Action):
                 id="UNABLE_TO_ACCESS_REPOSITORIES",
                 title="Unable to access repositories",
                 description="Access could not be made to the custom repositories.",
-                diagnosis="Unable to access the repositories passed through the --enablerepo option.",
+                diagnosis="Unable to access repositories passed through the --enablerepo option.",
                 remediations="For more details, see YUM/DNF output:\n{0}".format(output),
             )
             return

--- a/convert2rhel/actions/pre_ponr_changes/handle_packages.py
+++ b/convert2rhel/actions/pre_ponr_changes/handle_packages.py
@@ -102,17 +102,18 @@ class RemoveSpecialPackages(actions.Action):
         all_pkgs = []
         pkgs_removed = []
         try:
-            logger.task("Searching for the following excluded packages")
+            logger.task("Remove special packages")
+            logger.info("Searching for the following excluded packages.")
             excluded_pkgs = sorted(pkghandler.get_packages_to_remove(system_info.excluded_pkgs))
 
-            logger.task("Searching for packages containing .repo files or affecting variables in the .repo files")
+            logger.info("Searching for packages containing .repo files or affecting variables in the .repo files.")
             repofile_pkgs = sorted(pkghandler.get_packages_to_remove(system_info.repofile_pkgs))
 
             logger.info("\n")
 
             all_pkgs = excluded_pkgs + repofile_pkgs
             if not all_pkgs:
-                logger.info("No packages to backup and remove.")
+                logger.info("No packages to back up and remove.")
                 return
 
             # We're using the backed up yum repositories to prevent the following:
@@ -149,8 +150,8 @@ class RemoveSpecialPackages(actions.Action):
             self.set_result(
                 level="ERROR",
                 id="SPECIAL_PACKAGE_REMOVAL_FAILED",
-                title="Failed to remove some packages necessary for the conversion.",
-                description="The cause of this error is unknown, please look at the diagnosis for more information.",
+                title="Failed to remove some packages necessary for the conversion",
+                description="The cause of this error is unknown. Look at the diagnosis for more information.",
                 diagnosis=str(e),
             )
             return
@@ -209,7 +210,7 @@ def _remove_packages_unless_from_redhat(pkgs_list, disable_repos=None):
     pkghandler.print_pkg_info(pkgs_list, disable_repos)
 
     pkgs_removed = utils.remove_pkgs(pkghandler.get_pkg_nevras(pkgs_list))
-    logger.debug("Successfully removed {} packages".format(len(pkgs_list)))
+    logger.debug("Successfully removed {} packages.".format(len(pkgs_list)))
 
     return pkgs_removed
 

--- a/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
+++ b/convert2rhel/actions/pre_ponr_changes/kernel_modules.py
@@ -273,7 +273,7 @@ class EnsureKernelModulesCompatibility(actions.Action):
                 self.add_message(
                     level="WARNING",
                     id="ALLOW_UNAVAILABLE_KERNEL_MODULES",
-                    title="Did not perform the ensure kernel modules compatibility check",
+                    title="Ignoring the check ensuring kernel module availability in RHEL",
                     diagnosis="You have set the option to allow unavailable kernel modules.",
                     description="We will continue the conversion with the following kernel modules unavailable in RHEL:\n"
                     "{kmods}\n".format(kmods="\n".join(unsupported_kmods)),
@@ -286,7 +286,7 @@ class EnsureKernelModulesCompatibility(actions.Action):
                     level="OVERRIDABLE",
                     id="UNSUPPORTED_KERNEL_MODULES",
                     title="Unsupported kernel modules",
-                    description="Unsupported kernel modules were found",
+                    description="Unsupported kernel modules were found.",
                     diagnosis="The following loaded kernel modules are not available in RHEL:\n{0}\n".format(
                         "\n".join(unsupported_kmods)
                     ),

--- a/convert2rhel/actions/pre_ponr_changes/subscription.py
+++ b/convert2rhel/actions/pre_ponr_changes/subscription.py
@@ -100,7 +100,7 @@ class PreSubscription(actions.Action):
             logger.task("Subscription Manager - Check for installed packages")
             subscription_manager_pkgs = subscription.needed_subscription_manager_pkgs()
             if not subscription_manager_pkgs:
-                logger.info("Subscription Manager is already present")
+                logger.info("Subscription Manager is already present.")
             else:
                 logger.task("Subscription Manager - Install packages")
                 subscription.install_rhel_subscription_manager(subscription_manager_pkgs)
@@ -118,7 +118,7 @@ class PreSubscription(actions.Action):
                 level="ERROR",
                 id="UNKNOWN_ERROR",
                 title="Unknown error",
-                description="The cause of this error is unknown, please look at the diagnosis for more information.",
+                description="The cause of this error is unknown. Look at the diagnosis for more information.",
                 diagnosis=str(e),
             )
         except exceptions.CriticalError as e:
@@ -177,7 +177,7 @@ class SubscribeSystem(actions.Action):
                         level="ERROR",
                         id="SYSTEM_NOT_REGISTERED",
                         title="Not registered with RHSM",
-                        description="This system must be registered with rhsm in order to get access to the RHEL rpms. In this case, the system was not already registered and no credentials were given to convert2rhel to register it.",
+                        description="This system must be registered with RHSM in order to get access to RHEL rpms. In this case, the system has not been registered and no credentials were given to convert2rhel to register it.",
                         remediations="You may either register this system via subscription-manager before running convert2rhel or give convert2rhel credentials to do that for you. The credentials convert2rhel would need are either activation_key and organization or username and password. You can set these in a config file and then pass the file to convert2rhel with the --config-file option.",
                     )
                     return
@@ -226,7 +226,7 @@ class SubscribeSystem(actions.Action):
                 level="ERROR",
                 id="MISSING_SUBSCRIPTION_MANAGER_BINARY",
                 title="Missing subscription-manager binary",
-                description="There is a missing subscription-manager binary",
+                description="There is a missing subscription-manager binary.",
                 diagnosis="Failed to execute command: {}".format(e),
             )
         except exceptions.CriticalError as e:
@@ -246,7 +246,7 @@ class SubscribeSystem(actions.Action):
                 level="ERROR",
                 id="UNKNOWN_ERROR",
                 title="Unknown error",
-                description="The cause of this error is unknown, please look at the diagnosis for more information.",
+                description="The cause of this error is unknown. Look at the diagnosis for more information.",
                 diagnosis=str(e),
             )
         except ValueError as e:
@@ -254,7 +254,7 @@ class SubscribeSystem(actions.Action):
                 level="ERROR",
                 id="MISSING_REGISTRATION_COMBINATION",
                 title="Missing registration combination",
-                description="There are missing registration combinations",
+                description="There are missing registration combinations.",
                 diagnosis="One or more combinations were missing for subscription-manager parameters: {}".format(
                     str(e)
                 ),

--- a/convert2rhel/actions/pre_ponr_changes/transaction.py
+++ b/convert2rhel/actions/pre_ponr_changes/transaction.py
@@ -42,7 +42,7 @@ class ValidatePackageManagerTransaction(actions.Action):
         super(ValidatePackageManagerTransaction, self).run()
 
         try:
-            logger.task("Validate the %s transaction", pkgmanager.TYPE)
+            logger.task("Validate the main %s transaction", pkgmanager.TYPE)
             transaction_handler = pkgmanager.create_transaction_handler()
             transaction_handler.run_transaction(
                 validate_transaction=True,

--- a/convert2rhel/actions/system_checks/check_firewalld_availability.py
+++ b/convert2rhel/actions/system_checks/check_firewalld_availability.py
@@ -71,12 +71,12 @@ def _is_modules_cleanup_enabled():
     # If the config file has this option set to true/yes, then we need to
     # return True to ask the user to change it to False.
     if list(filter(CLEANUP_MODULES_ON_EXIT_REGEX.match, contents)):
-        logger.debug("CleanupModulesOnExit option enabled in {}".format(FIREWALLD_CONFIG_FILE))
+        logger.debug("CleanupModulesOnExit option is enabled in {}.".format(FIREWALLD_CONFIG_FILE))
         return True
 
     # Default to return False as it is possible that the CleanupModulesOnExit
     # is set to no in the config already.
-    logger.debug("CleanupModulesOnExit option is disabled in {}".format(FIREWALLD_CONFIG_FILE))
+    logger.debug("CleanupModulesOnExit option is disabled in {}.".format(FIREWALLD_CONFIG_FILE))
     return False
 
 
@@ -102,7 +102,7 @@ class CheckFirewalldAvailability(actions.Action):
                 self.set_result(
                     level="ERROR",
                     id="FIREWALLD_MODULES_CLEANUP_ON_EXIT_CONFIG",
-                    title="Firewalld is set to cleanup modules after exit.",
+                    title="Firewalld is set to cleanup modules after exit",
                     description="Firewalld running on Oracle Linux 8 can lead to a conversion failure.",
                     diagnosis=(
                         "We've detected that firewalld unit is running and that causes iptables and nftables "

--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -45,7 +45,7 @@ class Convert2rhelLatest(actions.Action):
 
     def run(self):
         """Make sure that we are running the latest downstream version of convert2rhel"""
-        logger.task("Check if this is the latest version of Convert2RHEL")
+        logger.task("Check if this is the latest version of convert2rhel")
 
         super(Convert2rhelLatest, self).run()
 
@@ -75,7 +75,7 @@ class Convert2rhelLatest(actions.Action):
                 level="WARNING",
                 id="CONVERT2RHEL_LATEST_CHECK_SKIP",
                 title="convert2rhel latest version check skip",
-                description="Did not perform the convert2hel latest version check",
+                description="Did not perform the convert2hel latest version check.",
                 diagnosis=diagnosis,
             )
             return
@@ -95,7 +95,7 @@ class Convert2rhelLatest(actions.Action):
                 continue
             convert2rhel_versions.append(parsed_pkg)
 
-        logger.debug("Found {} convert2rhel package(s)".format(len(convert2rhel_versions)))
+        logger.debug("Found {} convert2rhel package(s).".format(len(convert2rhel_versions)))
 
         # This loop will determine the latest available convert2rhel version in the yum repo.
         # It assigns the epoch, version, and release ex: ("0", "0.26", "1.el7") to the latest_available_version variable.
@@ -109,7 +109,7 @@ class Convert2rhelLatest(actions.Action):
             if ver_compare > 0:
                 latest_available_version = (package_version[1], package_version[2], package_version[3])
 
-        logger.debug("Found {} to be latest available version".format(latest_available_version[1]))
+        logger.debug("Found {} to be latest available version.".format(latest_available_version[1]))
         precise_available_version = ("0", latest_available_version[1], "0")
         precise_convert2rhel_version = ("0", running_convert2rhel_version, "0")
         # Get source files that we're running with import convert2rhel ; convert2rhel.__file__
@@ -185,7 +185,7 @@ class Convert2rhelLatest(actions.Action):
                     level="WARNING",
                     id="ALLOW_OLDER_VERSION_OPTION",
                     title="Outdated convert2rhel version detected",
-                    description="An outdated convert2rhel version has been detected",
+                    description="An outdated convert2rhel version has been detected.",
                     diagnosis=diagnosis,
                 )
             else:
@@ -193,7 +193,7 @@ class Convert2rhelLatest(actions.Action):
                     level="OVERRIDABLE",
                     id="OUT_OF_DATE",
                     title="Outdated convert2rhel version detected",
-                    description="An outdated convert2rhel version has been detected",
+                    description="An outdated convert2rhel version has been detected.",
                     diagnosis=(
                         "You are currently running {} and the latest version of convert2rhel is {}.\n"
                         "Only the latest version is supported for conversion.".format(

--- a/convert2rhel/actions/system_checks/dbus.py
+++ b/convert2rhel/actions/system_checks/dbus.py
@@ -30,21 +30,21 @@ class DbusIsRunning(actions.Action):
     def run(self):
         """Error out if we need to register with rhsm and the dbus daemon is not running."""
         super(DbusIsRunning, self).run()
-        logger.task("Check that DBus Daemon is running")
+        logger.task("Check that DBus daemon is running")
 
         if not subscription.should_subscribe():
             logger.info("Did not perform the check because we have been asked not to subscribe this system to RHSM.")
             return
 
         if system_info.dbus_running:
-            logger.info("DBus Daemon is running")
+            logger.info("DBus daemon is running.")
             return
 
         self.set_result(
             level="ERROR",
             id="DBUS_DAEMON_NOT_RUNNING",
             title="Dbus daemon not running",
-            description="The Dbus daemon is not running",
+            description="The Dbus daemon is not running.",
             diagnosis="Could not find a running DBus Daemon which is needed to register with subscription manager.",
-            remediations="Please start dbus using `systemctl start dbus`",
+            remediations="Start dbus using `systemctl start dbus`",
         )

--- a/convert2rhel/actions/system_checks/duplicate_packages.py
+++ b/convert2rhel/actions/system_checks/duplicate_packages.py
@@ -31,7 +31,7 @@ class DuplicatePackages(actions.Action):
         """Ensure that there are no duplicate system packages installed."""
         super(DuplicatePackages, self).run()
 
-        logger.task("Check if there are any duplicate installed packages on the system")
+        logger.task("Check if there are any duplicate packages installed on the system")
         output, ret_code = utils.run_subprocess(["/usr/bin/package-cleanup", "--dupes", "--quiet"], print_output=False)
         if not output:
             return

--- a/convert2rhel/actions/system_checks/efi.py
+++ b/convert2rhel/actions/system_checks/efi.py
@@ -78,7 +78,7 @@ class Efi(actions.Action):
                 level="ERROR",
                 id="BOOTLOADER_ERROR",
                 title="Bootloader error detected",
-                description="An unknown bootloader error occurred, please look at the diagnosis for more information.",
+                description="An unknown bootloader error occurred. Look at the diagnosis for more information.",
                 diagnosis=str(e),
             )
             return

--- a/convert2rhel/actions/system_checks/els.py
+++ b/convert2rhel/actions/system_checks/els.py
@@ -30,9 +30,10 @@ class ElsSystemCheck(actions.Action):
     id = "ELS_SYSTEM_CHECK"
 
     def run(self):
-        """Warn the user if their system is under ELS and past the ELS release date without using the --els cli option."""
+        """Warn users if their system is under ELS and past the ELS release date without using the --els cli option."""
         super(ElsSystemCheck, self).run()
 
+        logger.task("Warn about not using --els on a system in the ELS phase")
         if system_info.version.major == 7:
             current_datetime = datetime.date.today()
             # Turn ELS_RELEASE_DATE into a datetime object
@@ -44,7 +45,10 @@ class ElsSystemCheck(actions.Action):
                     level="WARNING",
                     id="ELS_COMMAND_LINE_OPTION_UNUSED",
                     title="The --els command line option is unused",
-                    description="Current system version is under Extended Lifecycle Support (ELS). You may want to consider using the --els"
-                    " command line option to land on a system patched with the latest security errata.",
+                    description="Current system version is under Extended Lifecycle Support (ELS). You may want to"
+                    " consider using the --els command line option to land on a system patched with the latest security"
+                    " errata.",
                 )
+        else:
+            logger.info("Applicable only to conversions to RHEL 7.")
         return

--- a/convert2rhel/actions/system_checks/eus.py
+++ b/convert2rhel/actions/system_checks/eus.py
@@ -30,9 +30,10 @@ class EusSystemCheck(actions.Action):
     id = "EUS_SYSTEM_CHECK"
 
     def run(self):
-        """Warn the user if their system is under EUS and past the EUS release date without using the --eus cli option."""
+        """Warn users if their system is under EUS and past the EUS release date without using the --eus cli option."""
         super(EusSystemCheck, self).run()
 
+        logger.task("Warn about not using --eus on a system in the EUS phase")
         current_version = "{}.{}".format(system_info.version.major, system_info.version.minor)
         eus_versions = list(EUS_MINOR_VERSIONS.keys())
         if current_version in eus_versions:
@@ -47,7 +48,22 @@ class EusSystemCheck(actions.Action):
                     level="WARNING",
                     id="EUS_COMMAND_LINE_OPTION_UNUSED",
                     title="The --eus command line option is unused",
-                    description="Current system version is under Extended Update Support (EUS). You may want to consider using the --eus"
-                    " command line option to land on a system patched with the latest security errata.",
+                    description="Current system version is under Extended Update Support (EUS). You may want to"
+                    " consider using the --eus command line option to land on a system patched with the latest security"
+                    " errata.",
                 )
+        else:
+            logger.info(
+                "Applicable only when converting the following system versions:\n{}".format(
+                    "\n".join(
+                        [
+                            "{} after {}".format(
+                                system_info.name,
+                                version,
+                            )
+                            for version in EUS_MINOR_VERSIONS
+                        ]
+                    )
+                )
+            )
         return

--- a/convert2rhel/actions/system_checks/grub_validity.py
+++ b/convert2rhel/actions/system_checks/grub_validity.py
@@ -31,17 +31,18 @@ class GrubValidity(actions.Action):
         is invalid.
         """
         super(GrubValidity, self).run()
-        logger.task("Check if the grub file is valid")
+        logger.task("Check validity of /etc/default/grub")
         output, ret_code = utils.run_subprocess(["grub2-mkconfig"], print_output=False)
 
         if ret_code != 0:
             self.set_result(
                 level="ERROR",
                 id="INVALID_GRUB_FILE",
-                title="Grub boot entry file is invalid",
-                description="The grub file seems to be invalid leaving the system in a"
-                " non-clean state and must be fixed before continuing the conversion"
-                " to ensure a smooth process.",
-                remediations="Check the grub file inside `/etc/default` directory and remove any "
-                "misconfigurations, then re-run the conversion.",
+                title="/etc/default/grub invalid",
+                description="The /etc/default/grub file seems to be invalid and must be fixed before continuing the"
+                "conversion.",
+                diagnosis="Calling grub2-mkconfig failed with:\n{}".format(output),
+                remediations="Fix issues reported by the grub2-mkconfig utility and re-run the conversion.",
             )
+        else:
+            logger.info("No issues found with the /etc/default/grub file.")

--- a/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
+++ b/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
@@ -96,7 +96,7 @@ class IsLoadedKernelLatest(actions.Action):
             logger.debug("Got the following output: %s", repoquery_output)
             logger.warning(
                 "Couldn't fetch the list of the most recent kernels available in "
-                "the repositories. Did not perform the loaded kernel check."
+                "the repositories. Did not perform the loaded kernel currency check."
             )
             self.add_message(
                 level="WARNING",
@@ -104,7 +104,7 @@ class IsLoadedKernelLatest(actions.Action):
                 title="Unable to fetch recent kernels",
                 description=(
                     "Couldn't fetch the list of the most recent kernels available in "
-                    "the repositories. Did not perform the loaded kernel check."
+                    "the repositories. Did not perform the loaded kernel currency check."
                 ),
             )
             return
@@ -132,14 +132,14 @@ class IsLoadedKernelLatest(actions.Action):
                 level="OVERRIDABLE",
                 id="KERNEL_CURRENCY_CHECK_FAIL",
                 title="Kernel currency check failed",
-                description="Please refer to the diagnosis for further information",
+                description="Refer to the diagnosis for further information.",
                 diagnosis=(
                     "Could not find any {} from repositories to compare against the loaded kernel.".format(
                         package_to_check
                     )
                 ),
                 remediations=(
-                    "Please check if you have any vendor repositories enabled to proceed with the conversion.\n"
+                    "Check if you have any vendor repositories enabled to proceed with the conversion.\n"
                     "If you wish to disregard this message, set the skip_kernel_currency_check inhibitor override in"
                     " the /etc/convert2rhel.ini config file to true."
                 ),
@@ -162,7 +162,7 @@ class IsLoadedKernelLatest(actions.Action):
                 level="WARNING",
                 id="INVALID_KERNEL_PACKAGE",
                 title="Invalid kernel package found",
-                description="Please refer to the diagnosis for further information",
+                description="Refer to the diagnosis for further information.",
                 diagnosis=str(exc),
             )
             return
@@ -172,7 +172,7 @@ class IsLoadedKernelLatest(actions.Action):
                 level="OVERRIDABLE",
                 id="INVALID_KERNEL_VERSION",
                 title="Invalid kernel version detected",
-                description="The loaded kernel version mismatch the latest one available in system repositories",
+                description="The loaded kernel version mismatch the latest one available in system repositories.",
                 diagnosis=(
                     "The version of the loaded kernel is different from the latest version in system repositories. \n"
                     " Latest kernel version available in {}: {}\n"

--- a/convert2rhel/actions/system_checks/package_updates.py
+++ b/convert2rhel/actions/system_checks/package_updates.py
@@ -42,7 +42,7 @@ class PackageUpdates(actions.Action):
                 level="INFO",
                 id="PACKAGE_UPDATES_CHECK_SKIP_NO_PUBLIC_REPOSITORIES",
                 title="Did not perform the package updates check",
-                description="Please refer to the diagnosis for further information",
+                description="Refer to the diagnosis for further information.",
                 diagnosis=(
                     "Did not perform the check because there were no publicly available %s %d.%d repositories available."
                     % (system_info.name, system_info.version.major, system_info.version.minor)
@@ -71,7 +71,7 @@ class PackageUpdates(actions.Action):
                 level="WARNING",
                 id="PACKAGE_UP_TO_DATE_CHECK_MESSAGE",
                 title="Package up to date check fail",
-                description="Please refer to the diagnosis for further information",
+                description="Refer to the diagnosis for further information.",
                 diagnosis=package_up_to_date_error_message,
             )
             return
@@ -79,7 +79,7 @@ class PackageUpdates(actions.Action):
         if len(packages_to_update) > 0:
             package_not_up_to_date_error_message = (
                 "The system has {} package(s) not updated based on repositories defined in the system repositories.\n"
-                "List of packages to update: {}.\n\n"
+                "List of packages to update: {}\n\n"
                 "Not updating the packages may cause the conversion to fail.\n"
                 "Consider updating the packages before proceeding with the conversion.".format(
                     len(packages_to_update), " ".join(packages_to_update)
@@ -90,7 +90,7 @@ class PackageUpdates(actions.Action):
                 level="WARNING",
                 id="OUT_OF_DATE_PACKAGES",
                 title="Outdated packages detected",
-                description="Please refer to the diagnosis for further information",
+                description="Refer to the diagnosis for further information.",
                 diagnosis=package_not_up_to_date_error_message,
                 remediations="Run yum update to update all the packages on the system.",
             )

--- a/convert2rhel/actions/system_checks/rhel_compatible_kernel.py
+++ b/convert2rhel/actions/system_checks/rhel_compatible_kernel.py
@@ -86,7 +86,7 @@ class RhelCompatibleKernel(actions.Action):
                     level="ERROR",
                     id=e.error_id,
                     title="Incompatible booted kernel version",
-                    description="Please refer to the diagnosis for further information",
+                    description="Refer to the diagnosis for further information.",
                     diagnosis=(
                         "The booted kernel version is incompatible with the standard RHEL kernel. {}".format(
                             bad_kernel_message

--- a/convert2rhel/actions/system_checks/tainted_kmods.py
+++ b/convert2rhel/actions/system_checks/tainted_kmods.py
@@ -57,7 +57,7 @@ class TaintedKmods(actions.Action):
                     level="OVERRIDABLE",
                     id="TAINTED_KMODS_DETECTED",
                     title="Tainted kernel modules detected",
-                    description="Please refer to the diagnosis for further information",
+                    description="Refer to the diagnosis for further information.",
                     diagnosis=diagnosis,
                     remediations=(
                         "Prevent the modules from loading by following {0}"
@@ -66,7 +66,7 @@ class TaintedKmods(actions.Action):
                         " tainted_kernel_module_check_skip inhibitor override in the /etc/convert2rhel.ini"
                         " config file to true. Overriding this check can be dangerous"
                         " so it is recommended that you do a system backup beforehand."
-                        " For information on what a tainted kernel module is, please refer to this documentation {1}".format(
+                        " For information on what a tainted kernel module is, refer to this documentation {1}".format(
                             LINK_PREVENT_KMODS_FROM_LOADING, LINK_TAINTED_KMOD_DOCS
                         )
                     ),
@@ -87,12 +87,12 @@ class TaintedKmods(actions.Action):
                 level="WARNING",
                 id="TAINTED_KMODS_DETECTED_MESSAGE",
                 title="Tainted kernel modules detected",
-                description="Please refer to the diagnosis for further information",
+                description="Refer to the diagnosis for further information.",
                 diagnosis=diagnosis,
                 remediations=(
                     "Prevent the modules from loading by following {0}"
                     " and run convert2rhel again to continue with the conversion."
-                    " For information on what a tainted kernel module is, please refer to this documentation {1}".format(
+                    " For information on what a tainted kernel module is, refer to this documentation {1}".format(
                         LINK_PREVENT_KMODS_FROM_LOADING, LINK_TAINTED_KMOD_DOCS
                     )
                 ),

--- a/convert2rhel/backup/__init__.py
+++ b/convert2rhel/backup/__init__.py
@@ -87,7 +87,7 @@ class BackupController:
         # if it is, we skip it
         for r in self._restorables:
             if r == restorable:
-                logger.debug("Skipping: {} has already been backed up".format(restorable.__class__.__name__))
+                logger.debug("Skipping: {} has already been backed up.".format(restorable.__class__.__name__))
                 return
 
         restorable.enable()

--- a/convert2rhel/backup/certs.py
+++ b/convert2rhel/backup/certs.py
@@ -123,7 +123,7 @@ class RestorablePEMCert(RestorableChange):
                 logger.critical_no_exit("Error({0}): {1}".format(err.errno, err.strerror))
                 raise exceptions.CriticalError(
                     id_="FAILED_TO_INSTALL_CERTIFICATE",
-                    title="Failed to install certificate.",
+                    title="Failed to install a certificate",
                     description="convert2rhel was unable to install a required certificate. This certificate allows the pre-conversion analysis to verify that packages are legitimate RHEL packages.",
                     diagnosis="Failed to install certificate {} to {}. Errno: {}, Error: {}".format(
                         self._get_source_cert_path, self._target_cert_dir, err.errno, err.strerror
@@ -172,7 +172,7 @@ class RestorablePEMCert(RestorableChange):
             if "not owned by any package" in output:
                 file_unowned = True
             elif "No such file or directory" in output:
-                logger.info("Certificate already removed from {}".format(self._target_cert_path))
+                logger.info("Certificate already removed from {}.".format(self._target_cert_path))
             else:
                 logger.warning(
                     "Unable to determine if a package owns certificate {}. Skipping removal.".format(
@@ -191,7 +191,7 @@ class RestorablePEMCert(RestorableChange):
 
         try:
             os.remove(self._target_cert_path)
-            logger.info("Certificate {} removed".format(self._target_cert_path))
+            logger.info("Certificate {} removed.".format(self._target_cert_path))
         except OSError as err:
             if err.errno == errno.ENOENT:
                 # Resolves RHSM error when removing certs, as the system might not have installed any certs yet

--- a/convert2rhel/backup/files.py
+++ b/convert2rhel/backup/files.py
@@ -65,7 +65,7 @@ class RestorableFile(RestorableChange):
                 logger.critical_no_exit("Error({}): {}".format(err.errno, err.strerror))
                 raise exceptions.CriticalError(
                     id_="FAILED_TO_SAVE_FILE_TO_BACKUP_DIR",
-                    title="Failed to copy file to the backup directory.",
+                    title="Failed to copy a file to the backup directory",
                     description=(
                         "Copying the current file has failed. This can lead to inconsistency during the rollbacks as "
                         "convert2rhel won't be able to restore the file in case of failures."
@@ -124,7 +124,7 @@ class RestorableFile(RestorableChange):
         if rollback:
             logger.task("Restore {} from backup".format(self.filepath))
         else:
-            logger.info("Restoring {} from backup".format(self.filepath))
+            logger.info("Restoring {} from backup.".format(self.filepath))
 
         if not self.enabled:
             logger.info("{} hasn't been backed up.".format(self.filepath))
@@ -201,11 +201,11 @@ class MissingFile(RestorableChange):
         logger.task("Remove file created during conversion {filepath}".format(filepath=self.filepath))
 
         if not os.path.isfile(self.filepath):
-            logger.info("File {filepath} wasn't created during conversion".format(filepath=self.filepath))
+            logger.info("File {filepath} wasn't created during conversion.".format(filepath=self.filepath))
         else:
             # Possible exceptions will be handled in the BackupController
             os.remove(self.filepath)
-            logger.info("File {filepath} removed".format(filepath=self.filepath))
+            logger.info("File {filepath} removed.".format(filepath=self.filepath))
 
             super(MissingFile, self).restore()
 

--- a/convert2rhel/backup/packages.py
+++ b/convert2rhel/backup/packages.py
@@ -81,7 +81,7 @@ class RestorablePackage(RestorableChange):
             return
 
         if not os.path.isdir(BACKUP_DIR):
-            logger.warning("Can't access {}".format(BACKUP_DIR))
+            logger.warning("Can't access {}.".format(BACKUP_DIR))
             return
 
         logger.info("Backing up the packages: {}.".format(",".join(self.pkgs)))
@@ -121,15 +121,17 @@ class RestorablePackage(RestorableChange):
 
         logger.task("Install removed packages")
         if not self._backedup_pkgs_paths:
-            logger.warning("Couldn't find a backup for {} package.".format(",".join(self.pkgs)))
+            logger.warning("Couldn't find a backup for the following package(s): {}".format(",".join(self.pkgs)))
             raise exceptions.CriticalError(
                 id_="FAILED_TO_INSTALL_PACKAGES",
-                title="Couldn't find package backup",
+                title="Couldn't find a package backup",
                 description=(
                     "While attempting to roll back changes, we encountered "
                     "an unexpected failure while we cannot find a package backup."
                 ),
-                diagnosis="Couldn't find a backup for {} package.".format(utils.format_sequence_as_message(self.pkgs)),
+                diagnosis="Couldn't find a backup for the following package(s): {}".format(
+                    utils.format_sequence_as_message(self.pkgs)
+                ),
             )
 
         self._install_local_rpms(replace=True, critical=True)
@@ -159,7 +161,7 @@ class RestorablePackage(RestorableChange):
                 logger.critical_no_exit("Error: Couldn't install {} packages.".format(pkgs_as_str))
                 raise exceptions.CriticalError(
                     id_="FAILED_TO_INSTALL_PACKAGES",
-                    title="Couldn't install packages.",
+                    title="Couldn't install packages",
                     description=(
                         "While attempting to roll back changes, we encountered "
                         "an unexpected failure while attempting to reinstall "
@@ -244,7 +246,7 @@ class RestorablePackageSet(RestorableChange):
         exit early.
         """
         if not self.pkgs_to_install:
-            logger.info("All packages were already installed")
+            logger.info("All packages were already installed.")
             return
 
         formatted_pkgs_sequence = utils.format_sequence_as_message(self.pkgs_to_install)
@@ -271,7 +273,7 @@ class RestorablePackageSet(RestorableChange):
             )
             raise exceptions.CriticalError(
                 id_="FAILED_TO_INSTALL_SCHEDULED_PACKAGES",
-                title="Failed to install scheduled packages.",
+                title="Failed to install scheduled packages",
                 description="convert2rhel was unable to install scheduled packages.",
                 diagnosis="Failed to install packages {}. Output: {}, Status: {}".format(
                     formatted_pkgs_sequence, output, ret_code
@@ -295,7 +297,7 @@ class RestorablePackageSet(RestorableChange):
             return
 
         logger.task("Remove installed packages")
-        logger.info("Removing set of installed pkgs: {}".format(utils.format_sequence_as_message(self.installed_pkgs)))
+        logger.info("Removing installed packages: {}".format(utils.format_sequence_as_message(self.installed_pkgs)))
         utils.remove_pkgs(self.installed_pkgs, critical=False)
 
         super(RestorablePackageSet, self).restore()

--- a/convert2rhel/backup/subscription.py
+++ b/convert2rhel/backup/subscription.py
@@ -59,7 +59,7 @@ class RestorableSystemSubscription(RestorableChange):
         except subscription.UnregisterError as e:
             logger.warning(str(e))
         except OSError:
-            logger.warning("subscription-manager not installed, skipping")
+            logger.warning("subscription-manager not installed, skipping.")
 
         super(RestorableSystemSubscription, self).restore()
 
@@ -82,7 +82,7 @@ class RestorableAutoAttachmentSubscription(RestorableChange):
 
     def restore(self):
         if self._is_attached:
-            logger.task("Removing auto-attached subscription")
+            logger.task("Remove auto-attached subscription")
             subscription.remove_subscription()
             super(RestorableAutoAttachmentSubscription, self).restore()
 
@@ -135,7 +135,7 @@ class RestorableDisableRepositories(RestorableChange):
         if not self.enabled:
             return
 
-        logger.task("Restoring state of the repositories")
+        logger.task("Restore state of the repositories")
 
         if self._repos_to_enable:
             logger.debug("Repositories to enable: {}".format(",".join(self._repos_to_enable)))

--- a/convert2rhel/main.py
+++ b/convert2rhel/main.py
@@ -88,7 +88,7 @@ def initialize_file_logging(log_name, log_dir):
     try:
         logger_module.archive_old_logger_files(log_name, log_dir)
     except (IOError, OSError) as e:
-        loggerinst.warning("Unable to archive previous log: {}".format(e))
+        loggerinst.warning("Unable to archive the previous log file: {}".format(e))
 
     logger_module.add_file_handler(log_name, log_dir)
 
@@ -405,7 +405,7 @@ def rollback_changes():
         backup.backup_control.pop_all()
     except IndexError as e:
         if e.args[0] == "No backups to restore":
-            loggerinst.info("During rollback there were no backups to restore")
+            loggerinst.info("During rollback there were no backups to restore.")
         else:
             raise
 

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -677,7 +677,7 @@ def replace_non_rhel_installed_kernel(version):
     if not path:
         logger.critical("Unable to download the RHEL kernel package.")
 
-    logger.info("Replacing {} {} with RHEL kernel with the same NEVRA ... ".format(system_info.name, pkg))
+    logger.info("Replacing {} {} with RHEL kernel with the same NEVRA.".format(system_info.name, pkg))
     output, ret_code = utils.run_subprocess(
         # The --nodeps is needed as some kernels depend on system-release (alias for redhat-release) and that package
         # is not installed at this stage.
@@ -702,7 +702,6 @@ def update_rhel_kernel():
     convert2rhel needs to install older RHEL kernel version first. In this function, RHEL kernel is updated to the
     latest available version.
     """
-    logger.info("Updating RHEL kernel.")
     pkgmanager.call_yum_cmd(command="update", args=["kernel"])
 
 
@@ -722,7 +721,7 @@ def clear_versionlock():
 
         backup.backup_control.push(RestorableFile(VERSIONLOCK_FILE_PATH))
 
-        logger.info("Clearing package versions locks...")
+        logger.info("Clearing package versions locks.")
         pkgmanager.call_yum_cmd("versionlock", args=["clear"], print_output=False)
     else:
         logger.info("Usage of YUM/DNF versionlock plugin not detected.")

--- a/convert2rhel/pkgmanager/handlers/dnf/__init__.py
+++ b/convert2rhel/pkgmanager/handlers/dnf/__init__.py
@@ -111,7 +111,7 @@ class DnfTransactionHandler(TransactionHandlerBase):
             logger.critical_no_exit("Failed to populate repository metadata.")
             raise exceptions.CriticalError(
                 id_="FAILED_TO_ENABLE_REPOS",
-                title="Failed to enable repositories.",
+                title="Failed to enable repositories",
                 description="We've encountered a failure when accessing repository metadata.",
                 diagnosis="Loading repository metadata failed with error {}.".format(str(e)),
             )
@@ -183,7 +183,7 @@ class DnfTransactionHandler(TransactionHandlerBase):
         :raises SystemExit: If we fail to resolve the dependencies or
             downloading the packages.
         """
-        logger.info("Resolving the dependencies of the packages in the dnf transaction set.")
+        logger.info("Resolving dependencies of the packages in the dnf transaction set.")
         try:
             self._base.resolve(allow_erasing=True)
         except pkgmanager.exceptions.DepsolveError as e:
@@ -191,7 +191,7 @@ class DnfTransactionHandler(TransactionHandlerBase):
             logger.critical_no_exit("Failed to resolve dependencies in the transaction.")
             raise exceptions.CriticalError(
                 id_="FAILED_TO_RESOLVE_DEPENDENCIES",
-                title="Failed to resolve dependencies.",
+                title="Failed to resolve dependencies",
                 description="During package transaction dnf failed to resolve the necessary dependencies needed for a package replacement.",
                 diagnosis="Resolve dependencies failed with error {}.".format(str(e)),
             )
@@ -204,7 +204,7 @@ class DnfTransactionHandler(TransactionHandlerBase):
             logger.critical_no_exit("Failed to download the transaction packages.")
             raise exceptions.CriticalError(
                 id_="FAILED_TO_DOWNLOAD_TRANSACTION_PACKAGES",
-                title="Failed to download packages in the transaction.",
+                title="Failed to download packages in the transaction",
                 description="During package transaction dnf failed to download the necessary packages needed for the transaction.",
                 diagnosis="Package download failed with error {}.".format(str(e)),
             )
@@ -231,11 +231,11 @@ class DnfTransactionHandler(TransactionHandlerBase):
             pkgmanager.exceptions.TransactionCheckError,
         ) as e:
             logger.debug("Got the following exception message: %s", e)
-            logger.critical_no_exit("Failed to validate the dnf transaction.")
+            logger.critical_no_exit("Failed to validate a dnf transaction.")
             raise exceptions.CriticalError(
                 id_="FAILED_TO_VALIDATE_TRANSACTION",
-                title="Failed to validate dnf transaction.",
-                description="During the dnf transaction execution an error occured and convert2rhel could no longer process the transaction.",
+                title="Failed to validate a dnf transaction",
+                description="During the dnf transaction execution an error occurred and convert2rhel could no longer process the transaction.",
                 diagnosis="Transaction processing failed with error: {}".format(str(e)),
             )
 

--- a/convert2rhel/pkgmanager/handlers/yum/__init__.py
+++ b/convert2rhel/pkgmanager/handlers/yum/__init__.py
@@ -163,7 +163,7 @@ class YumTransactionHandler(TransactionHandlerBase):
             logger.critical_no_exit("Failed to populate repository metadata.")
             raise exceptions.CriticalError(
                 id_="FAILED_TO_ENABLE_REPOS",
-                title="Failed to enable repositories.",
+                title="Failed to enable repositories",
                 description="We've encountered a failure when accessing repository metadata.",
                 diagnosis="Loading repository metadata failed with error {}.".format(str(e)),
             )
@@ -231,7 +231,7 @@ class YumTransactionHandler(TransactionHandlerBase):
             logger.critical_no_exit("There are no suitable mirrors available for the loaded repositories.")
             raise exceptions.CriticalError(
                 id_="FAILED_TO_LOAD_REPOSITORIES",
-                title="Failed to find suitable mirrors for the load repositories.",
+                title="Failed to find suitable mirrors for the load repositories",
                 description="All available mirrors were tried and none were available.",
                 diagnosis="Repository mirrors failed with error {}.".format(str(e)),
             )
@@ -265,7 +265,7 @@ class YumTransactionHandler(TransactionHandlerBase):
             return that message, otherwise, return None.
         :rtype: str | None
         """
-        logger.info("Resolving the dependencies of the packages in the yum transaction set.")
+        logger.info("Resolving dependencies of the packages in the yum transaction set.")
         ret_code, msg = self._base.resolveDeps()
 
         if ret_code == 1:
@@ -313,10 +313,10 @@ class YumTransactionHandler(TransactionHandlerBase):
             #  - pkgmanager.Errors.YumBaseError
             #  - pkgmanager.Errors.YumGPGCheckError
             logger.debug("Got the following exception message: %s", e)
-            logger.critical_no_exit("Failed to validate the yum transaction.")
+            logger.critical_no_exit("Failed to validate a yum transaction.")
             raise exceptions.CriticalError(
                 id_="FAILED_TO_VALIDATE_TRANSACTION",
-                title="Failed to validate yum transaction.",
+                title="Failed to validate a yum transaction",
                 description="During the yum transaction execution an error occurred and convert2rhel could no longer process the transaction.",
                 diagnosis="Transaction processing failed with error: {}".format(" ".join(e.value)),
             )
@@ -349,7 +349,7 @@ class YumTransactionHandler(TransactionHandlerBase):
                     if "Depsolving loop limit reached" not in messages and validate_transaction:
                         _resolve_yum_problematic_dependencies(messages)
 
-                    logger.info("Retrying to resolve dependencies %s", attempts)
+                    logger.info("Retrying to resolve dependencies - attempt %s.", attempts)
                     attempts += 1
                 else:
                     resolve_deps_finished = True
@@ -359,7 +359,7 @@ class YumTransactionHandler(TransactionHandlerBase):
                 logger.critical_no_exit("Failed to resolve dependencies in the transaction.")
                 raise exceptions.CriticalError(
                     id_="FAILED_TO_RESOLVE_DEPENDENCIES",
-                    title="Failed to resolve dependencies.",
+                    title="Failed to resolve dependencies",
                     description="During package transaction yum failed to resolve the necessary dependencies needed for a package replacement.",
                 )
         finally:

--- a/convert2rhel/redhatrelease.py
+++ b/convert2rhel/redhatrelease.py
@@ -36,7 +36,7 @@ def get_system_release_filepath():
     release_filepath = "/etc/system-release"  # RHEL 7/8 based OSes
     if os.path.isfile(release_filepath):
         return release_filepath
-    logger.critical("Error: Unable to find the /etc/system-release file containing the OS name and version")
+    logger.critical("Error: Unable to find the /etc/system-release file containing the OS name and version.")
 
 
 def get_system_release_content():

--- a/convert2rhel/repo.py
+++ b/convert2rhel/repo.py
@@ -239,5 +239,5 @@ def write_temporary_repofile(contents):
             raise exceptions.CriticalError(
                 id_="STORE_REPOFILE_FAILED",
                 title="Failed to store a repository file",
-                description="Failed to write a repository file contents to {}.\n" "Reason: {}".format(f.name, str(err)),
+                description="Failed to write a repository file contents to {}.\nReason: {}".format(f.name, str(err)),
             )

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -160,7 +160,7 @@ def register_system():
             )
 
         logger.info(
-            "%sRegistering the system using subscription-manager ...",
+            "%sRegistering the system using subscription-manager.",
             attempt_msg,
         )
 
@@ -216,7 +216,7 @@ def register_system():
             )
             raise exceptions.CriticalError(
                 id_="FAILED_TO_SUBSCRIBE_SYSTEM",
-                title="Failed to subscribe system.",
+                title="Failed to restore /etc/os-release",
                 description="Failed to restore the /etc/os-release file needed for subscribing the system.",
                 diagnosis="The restore failed with error {}.".format(str(e)),
             )
@@ -246,8 +246,10 @@ def register_system():
         logger.critical_no_exit("Unable to register the system through subscription-manager.")
         raise exceptions.CriticalError(
             id_="FAILED_TO_SUBSCRIBE_SYSTEM",
-            title="Failed to subscribe system.",
-            description="After several attempts, convert2rhel was unable to subscribe the system using subscription-manager. This issue might occur because of but not limited to DBus, file permission-related issues, bad credentials, or network issues.",
+            title="Failed to subscribe the system",
+            description="After several attempts, convert2rhel was unable to subscribe the system using"
+            " subscription-manager. This issue might occur because of but not limited to DBus,"
+            " file permission-related issues, bad credentials, or network issues.",
             diagnosis="System registration failed with error {}.".format(str(troublesome_exception)),
         )
 
@@ -441,14 +443,14 @@ class RegistrationCommand:
         # if we need one in the future.
         REGISTER_OPTS_DICT = dbus.Dictionary({}, signature="sv", variant_level=1)
 
-        logger.debug("Getting a handle to the system dbus")
+        logger.debug("Getting a handle to the system dbus.")
         system_bus = dbus.SystemBus()
 
         # Create a new bus so we can talk to rhsm privately (For security:
         # talking on the system bus might be eavesdropped in certain scenarios)
-        logger.debug("Getting a subscription-manager RegisterServer object from dbus")
+        logger.debug("Getting a subscription-manager RegisterServer object from dbus.")
         register_server = system_bus.get_object("com.redhat.RHSM1", "/com/redhat/RHSM1/RegisterServer")
-        logger.debug("Starting a private DBus to talk to subscription-manager")
+        logger.debug("Starting a private DBus to talk to subscription-manager.")
         address = register_server.Start(
             i18n.SUBSCRIPTION_MANAGER_LOCALE,
             dbus_interface="com.redhat.RHSM1.RegisterServer",
@@ -456,7 +458,7 @@ class RegistrationCommand:
 
         try:
             # Use the private bus to register the machine
-            logger.debug("Connecting to the private DBus")
+            logger.debug("Connecting to the private DBus.")
             private_bus = dbus.connection.Connection(address)
 
             try:
@@ -528,7 +530,7 @@ class RegistrationCommand:
 
         finally:
             # Always shut down the private bus
-            logger.debug("Shutting down private DBus instance")
+            logger.debug("Shutting down private DBus instance.")
             register_server.Stop(
                 i18n.SUBSCRIPTION_MANAGER_LOCALE,
                 dbus_interface="com.redhat.RHSM1.RegisterServer",
@@ -671,7 +673,7 @@ def attach_subscription():
     """
     # check if SCA is enabled
     if is_sca_enabled():
-        logger.info("Simple Content Access is enabled, skipping subscription attachment")
+        logger.info("Simple Content Access is enabled, skipping subscription attachment.")
         if tool_opts.pool:
             logger.warning(
                 "Because Simple Content Access is enabled the subscription specified by the pool ID will not be attached."
@@ -701,13 +703,13 @@ def attach_subscription():
         # Unsuccessful attachment, e.g. the pool ID is incorrect or the
         # number of purchased attachments has been depleted.
         logger.critical_no_exit(
-            "Unsuccessful attachment of a subscription. Please refer to https://access.redhat.com/management/"
+            "Unsuccessful attachment of a subscription. Refer to https://access.redhat.com/management/"
             " where you can either enable the SCA, create an activation key, or find a Pool ID of the subscription"
             " you wish to use and pass it to convert2rhel through the `--pool` CLI option."
         )
         raise exceptions.CriticalError(
             id_="FAILED_TO_ATTACH_SUBSCRIPTION",
-            title="Failed to attach a subscription to the system.",
+            title="Failed to attach a subscription to the system",
             description="convert2rhel was unable to attach a subscription to the system. An attached subscription is required for RHEL package installation.",
             remediations="Refer to https://access.redhat.com/management/ where you can enable Simple Content Access, create an activation key, or find a Pool ID of the subscription you wish to use and pass it to convert2rhel through the `--pool` CLI option.",
         )
@@ -731,7 +733,7 @@ def verify_rhsm_installed():
         )
         raise exceptions.CriticalError(
             id_="FAILED_TO_VERIFY_SUBSCRIPTION_MANAGER",
-            title="Failed to verify subscription-manager package.",
+            title="Failed to verify the subscription-manager package",
             description="The subscription-manager package is not installed correctly. Therefore, the pre-conversion analysis cannot verify that the correct package is installed on your system.",
             remediations="Manually installing subscription-manager before running convert2rhel.",
         )
@@ -752,7 +754,7 @@ def disable_repos():
         logger.critical_no_exit("Could not disable subscription-manager repositories:\n{}".format(output))
         raise exceptions.CriticalError(
             id_="FAILED_TO_DISABLE_SUBSCRIPTION_MANAGER_REPOSITORIES",
-            title="Could not disable repositories through subscription-manager.",
+            title="Could not disable repositories through subscription-manager",
             description="As part of the conversion process, convert2rhel disables all current subscription-manager repositories and enables only repositories required for the conversion. convert2rhel was unable to disable these repositories, and the conversion is unable to proceed.",
             diagnosis="Failed to disable repositories: {}.".format(output),
         )
@@ -802,7 +804,7 @@ def submgr_enable_repos(repos_to_enable):
             description=description,
         )
 
-    logger.info("Repositories enabled through subscription-manager")
+    logger.info("Repositories enabled through subscription-manager.")
 
 
 def needed_subscription_manager_pkgs():

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -457,7 +457,7 @@ class SystemInfo:
         current_version = repr(self.version)
 
         if tool_opts.eus and current_version in EUS_MINOR_VERSIONS:
-            logger.info("EUS argument detected, automatically evaluating system as EUS")
+            logger.info("EUS argument detected, automatically evaluating system as EUS.")
             return True
 
         return False

--- a/convert2rhel/toolopts/__init__.py
+++ b/convert2rhel/toolopts/__init__.py
@@ -67,13 +67,13 @@ class ToolOpts:
 
         if (cli_config.password or file_config.password) and not (cli_config.username or file_config.username):
             loggerinst.warning(
-                "You have passed the RHSM password without an associated username. Please provide a username together"
+                "You have passed the RHSM password without an associated username. Provide a username together"
                 " with the password."
             )
 
         if (cli_config.username or file_config.username) and not (cli_config.password or file_config.password):
             loggerinst.warning(
-                "You have passed the RHSM username without an associated password. Please provide a password together"
+                "You have passed the RHSM username without an associated password. Provide a password together"
                 " with the username."
             )
 

--- a/convert2rhel/toolopts/config.py
+++ b/convert2rhel/toolopts/config.py
@@ -196,7 +196,7 @@ class FileConfig(BaseConfig):
 
         for option in conf_options:
             if option.lower() not in supported_opts:
-                loggerinst.warning("Unsupported option '{}' in '{}'".format(option, header))
+                loggerinst.warning("Unsupported option '{}' in '{}'.".format(option, header))
                 continue
 
             # This is the only header that can contain boolean values for now.
@@ -292,13 +292,13 @@ class CliConfig(BaseConfig):
 
         if opts["username"] and not opts["password"]:
             loggerinst.warning(
-                "You have passed the RHSM username without an associated password. Please provide a password together"
+                "You have passed the RHSM username without an associated password. Provide a password together"
                 " with the username."
             )
 
         if opts["password"] and not opts["username"]:
             loggerinst.warning(
-                "You have passed the RHSM password without an associated username. Please provide a username together"
+                "You have passed the RHSM password without an associated username. Provide a username together"
                 " with the password."
             )
 

--- a/convert2rhel/unit_tests/actions/conversion/preserve_only_rhel_kernel_test.py
+++ b/convert2rhel/unit_tests/actions/conversion/preserve_only_rhel_kernel_test.py
@@ -238,8 +238,8 @@ class TestFixInvalidGrub2Entries:
                         actions.ActionMessage(
                             level="WARNING",
                             id="UNABLE_TO_GET_GRUB2_BOOT_LOADER_ENTRY",
-                            title="Unable to get the GRUB2 boot loader entry",
-                            description="Couldn't get the default GRUB2 boot loader entry:\nbootloader",
+                            title="Unable to get the GRUB2 bootloader entry",
+                            description="Couldn't get the default GRUB2 bootloader entry:\nbootloader",
                             diagnosis=None,
                             remediations=None,
                         ),
@@ -254,8 +254,8 @@ class TestFixInvalidGrub2Entries:
                         actions.ActionMessage(
                             level="WARNING",
                             id="UNABLE_TO_SET_GRUB2_BOOT_LOADER_ENTRY",
-                            title="Unable to set the GRUB2 boot loader entry",
-                            description="Couldn't set the default GRUB2 boot loader entry:\nbootloader",
+                            title="Unable to set the GRUB2 bootloader entry",
+                            description="Couldn't set the default GRUB2 bootloader entry:\nbootloader",
                             diagnosis=None,
                             remediations=None,
                         ),
@@ -364,9 +364,9 @@ class TestFixInvalidGrub2Entries:
         )
         fix_invalid_grub2_entries_instance.run()
         if expected:
-            assert "Fixing GRUB boot loader" in caplog.text
+            assert "Setting RHEL kernel" in caplog.text
         else:
-            assert "Fixing GRUB boot loader" not in caplog.text
+            assert "Setting RHEL kernel" not in caplog.text
 
 
 class TestFixDefaultKernel:
@@ -422,7 +422,7 @@ class TestFixDefaultKernel:
 
         warning_msgs = [r for r in caplog.records if r.levelname == "WARNING"]
         assert warning_msgs
-        assert "Detected leftover boot kernel, changing to RHEL kernel" in warning_msgs[-1].message
+        assert "Detected default boot kernel {}".format(old_kernel) in warning_msgs[-1].message
 
         (filename, content), _ = utils.store_content_to_file.call_args
         kernel_file_lines = content.splitlines()
@@ -456,7 +456,7 @@ class TestFixDefaultKernel:
         debug_records = [m for m in caplog.records if m.levelname == "DEBUG"]
 
         assert not warning_records
-        assert any("Boot kernel validated." in r.message for r in debug_records)
+        assert any("The default boot kernel is correct." in r.message for r in debug_records)
 
         for record in info_records:
             assert not re.search("Boot kernel [^ ]\\+ was changed to [^ ]\\+", record.message)

--- a/convert2rhel/unit_tests/actions/post_conversion/hostmetering_test.py
+++ b/convert2rhel/unit_tests/actions/post_conversion/hostmetering_test.py
@@ -169,7 +169,7 @@ def test_configure_host_metering(
             hostmetering_instance,
             level="ERROR",
             id="HOST_METERING_NOT_RUNNING",
-            title="Host metering service is not running.",
+            title="Host metering service is not running",
             description="host-metering.service is not running.",
             remediations="You can try to start the service manually"
             " by running following command:\n"
@@ -211,9 +211,9 @@ def test_configure_host_metering(
                     level="WARNING",
                     id="FORCED_CONFIGURE_HOST_METERING",
                     title="Configuration of host metering set to 'force'",
-                    description="Please note that this option is mainly used for testing and"
+                    description="Note that this option is mainly used for testing and"
                     " will configure host-metering unconditionally."
-                    " For generic usage please use the 'auto' option.",
+                    " For generic usage use the 'auto' option.",
                 )
             },
             actions.ActionResult(level="SUCCESS", id="SUCCESS"),
@@ -255,23 +255,21 @@ def test_configure_host_metering(
             ("yum install fail", 1),
             ("", ""),
             None,
-            set(
-                (
-                    actions.ActionMessage(
-                        level="WARNING",
-                        id="INSTALL_HOST_METERING_FAILURE",
-                        title="Failed to install host metering package.",
-                        description="When installing host metering package an error occurred meaning we can't"
-                        " enable host metering on the system.",
-                        diagnosis="`yum install host-metering` command returned 1 with message yum install fail",
-                        remediations="You can try install and set up the host metering"
-                        " manually using following commands:\n"
-                        " - `yum install host-metering`\n"
-                        " - `systemctl enable host-metering.service`\n"
-                        " - `systemctl start host-metering.service`",
-                    ),
+            {
+                actions.ActionMessage(
+                    level="WARNING",
+                    id="INSTALL_HOST_METERING_FAILURE",
+                    title="Failed to install the host-metering package",
+                    description="When installing the host-metering package an error occurred meaning we can't"
+                    " enable host metering on the system.",
+                    diagnosis="`yum install host-metering` command returned 1 with message yum install fail",
+                    remediations="You can try install and set up the host metering"
+                    " manually using following commands:\n"
+                    " - `yum install host-metering`\n"
+                    " - `systemctl enable host-metering.service`\n"
+                    " - `systemctl start host-metering.service`",
                 )
-            ),
+            },
             actions.ActionResult(level="SUCCESS", id="SUCCESS"),
         ),
         (
@@ -281,22 +279,20 @@ def test_configure_host_metering(
             ("", 0),
             ("systemctl enable host-metering.service", "Failed to enable"),
             None,
-            set(
-                (
-                    actions.ActionMessage(
-                        level="WARNING",
-                        id="CONFIGURE_HOST_METERING_FAILURE",
-                        title="Failed to enable and start host metering service.",
-                        description="The host metering service failed to start"
-                        " successfully and won't be able to keep track.",
-                        diagnosis="Command systemctl enable host-metering.service failed with Failed to enable",
-                        remediations="You can try set up the host metering"
-                        " service manually using following commands:\n"
-                        " - `systemctl enable host-metering.service`\n"
-                        " - `systemctl start host-metering.service`",
-                    ),
+            {
+                actions.ActionMessage(
+                    level="WARNING",
+                    id="CONFIGURE_HOST_METERING_FAILURE",
+                    title="Failed to enable and start the host metering service",
+                    description="The host metering service failed to start successfully and won't"
+                    " be able to report on the use of the system for the billing purposes.",
+                    diagnosis="Command systemctl enable host-metering.service failed with Failed to enable",
+                    remediations="You can try set up the host metering"
+                    " service manually using following commands:\n"
+                    " - `systemctl enable host-metering.service`\n"
+                    " - `systemctl start host-metering.service`",
                 )
-            ),
+            },
             actions.ActionResult(level="SUCCESS", id="SUCCESS"),
         ),
         (
@@ -310,7 +306,7 @@ def test_configure_host_metering(
             actions.ActionResult(
                 level="ERROR",
                 id="HOST_METERING_NOT_RUNNING",
-                title="Host metering service is not running.",
+                title="Host metering service is not running",
                 description="host-metering.service is not running.",
                 remediations="You can try to start the service manually"
                 " by running following command:\n"

--- a/convert2rhel/unit_tests/actions/post_conversion/modified_rpm_files_diff_test.py
+++ b/convert2rhel/unit_tests/actions/post_conversion/modified_rpm_files_diff_test.py
@@ -49,7 +49,7 @@ def test_modified_rpm_files_diff_with_no_rpm_va(
             actions.ActionMessage(
                 level="INFO",
                 id="SKIPPED_MODIFIED_RPM_FILES_DIFF",
-                title="Skipped comparison of 'rpm -Va' output from before and after the conversion.",
+                title="Skipped comparison of 'rpm -Va' output from before and after the conversion",
                 description="Comparison of 'rpm -Va' output was not performed due to missing output "
                 "of the 'rpm -Va' run before the conversion.",
                 diagnosis="This is caused mainly by using '--no-rpm-va' argument for convert2rhel.",
@@ -80,7 +80,7 @@ def test_modified_rpm_files_diff_with_no_rpm_va(
             actions.ActionMessage(
                 level="INFO",
                 id="FOUND_MODIFIED_RPM_FILES",
-                title="Modified rpm files from before and after the conversion were found.",
+                title="Modified rpm files from before and after the conversion were found",
                 description="Comparison of modified rpm files from before and after the conversion: \n"
                 "--- {path}/rpm_va.log\n"
                 "+++ {path}/rpm_va_after_conversion.log\n"

--- a/convert2rhel/unit_tests/actions/post_conversion/remove_tmp_dir_test.py
+++ b/convert2rhel/unit_tests/actions/post_conversion/remove_tmp_dir_test.py
@@ -63,7 +63,7 @@ def test_remove_tmp_dir_failure(remove_tmp_dir_instance, monkeypatch, tmpdir, ca
             actions.ActionMessage(
                 id="UNSUCCESSFUL_REMOVE_TMP_DIR",
                 level="WARNING",
-                title="Temporary folder {tmp_dir} wasn't removed.".format(tmp_dir=path),
+                title="Temporary folder {tmp_dir} wasn't removed".format(tmp_dir=path),
                 description=expected_message,
             ),
         ),

--- a/convert2rhel/unit_tests/actions/post_conversion/update_grub_test.py
+++ b/convert2rhel/unit_tests/actions/post_conversion/update_grub_test.py
@@ -244,7 +244,7 @@ def test_update_grub_error(update_grub_instance, monkeypatch, get_partition_erro
         level="ERROR",
         id="FAILED_TO_IDENTIFY_GRUB2_BLOCK_DEVICE",
         title="Failed to identify GRUB2 block device",
-        description="The block device could not be identified, please look at the diagnosis " "for more information.",
+        description="The block device could not be identified. Look at the diagnosis for more information.",
         diagnosis=diagnosis,
     )
 

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/backup_system_test.py
@@ -76,7 +76,7 @@ class TestBackupSystem:
     def test_backup_redhat_release_error_system_release_file(self, backup_redhat_release_action, monkeypatch):
         mock_sys_release_file = RestorableFileBackupMocked(
             id_="FAILED_TO_SAVE_FILE_TO_BACKUP_DIR",
-            title="Failed to copy file to the backup directory.",
+            title="Failed to copy a file to the backup directory",
             description="Failure while backing up a file.",
             diagnosis="Failed to backup /etc/system-release. Errno: 2, Error: File not found",
         )
@@ -88,7 +88,7 @@ class TestBackupSystem:
             backup_redhat_release_action,
             level="ERROR",
             id="FAILED_TO_SAVE_FILE_TO_BACKUP_DIR",
-            title="Failed to copy file to the backup directory.",
+            title="Failed to copy a file to the backup directory",
             description="Failure while backing up a file.",
             diagnosis="Failed to backup /etc/system-release. Errno: 2, Error: File not found",
         )
@@ -97,7 +97,7 @@ class TestBackupSystem:
         mock_sys_release_file = mock.create_autospec(backup_system.system_release_file.enable)
         mock_os_release_file = RestorableFileBackupMocked(
             id_="FAILED_TO_SAVE_FILE_TO_BACKUP_DIR",
-            title="Failed to copy file to the backup directory.",
+            title="Failed to copy a file to the backup directory",
             description="Failure while backing up a file.",
             diagnosis="Failed to backup /etc/os-release. Errno: 2, Error: File not found",
         )
@@ -111,7 +111,7 @@ class TestBackupSystem:
             backup_redhat_release_action,
             level="ERROR",
             id="FAILED_TO_SAVE_FILE_TO_BACKUP_DIR",
-            title="Failed to copy file to the backup directory.",
+            title="Failed to copy a file to the backup directory",
             description="Failure while backing up a file.",
             diagnosis="Failed to backup /etc/os-release. Errno: 2, Error: File not found",
         )
@@ -157,7 +157,7 @@ class TestBackupSystem:
             (
                 "S.5.?..5.      /etc/yum.repos.d/CentOS-Linux-AppStream.repo",
                 [],
-                "Skipping invalid output S.5.?..5.      /etc/yum.repos.d/CentOS-Linux-AppStream.repo",
+                "Skipping invalid output: S.5.?..5.      /etc/yum.repos.d/CentOS-Linux-AppStream.repo",
             ),
             (
                 "               ",
@@ -167,21 +167,21 @@ class TestBackupSystem:
             (
                 "SM5DLUGTP   cd   /etc/yum.repos.d/CentOS-Linux-AppStream.repo",
                 [],
-                "Skipping invalid output SM5DLUGTP   cd   /etc/yum.repos.d/CentOS-Linux-AppStream.repo",
+                "Skipping invalid output: SM5DLUGTP   cd   /etc/yum.repos.d/CentOS-Linux-AppStream.repo",
             ),
             (
                 """c     /etc/yum.repos.d/CentOS-Linux-AppStream.repo
                 S.5.?..T. c
                 """,
                 [],
-                "Skipping invalid output c     /etc/yum.repos.d/CentOS-Linux-AppStream.repo",
+                "Skipping invalid output: c     /etc/yum.repos.d/CentOS-Linux-AppStream.repo",
             ),
             (
                 """
                 S.5.?..T. c
                 """,
                 [],
-                "Skipping invalid output S.5.?..T. c",
+                "Skipping invalid output: S.5.?..T. c",
             ),
         ),
     )
@@ -220,7 +220,7 @@ class TestBackupSystem:
         monkeypatch.setattr(backup_system, "LOG_DIR", str(tmp_path))
 
         rpm_va_path = os.path.join(tmp_path, PRE_RPM_VA_LOG_FILENAME)
-        message = "Missing file {} in it's location".format(rpm_va_path)
+        message = "The file {} is missing.".format(rpm_va_path)
 
         with pytest.raises(SystemExit, match=message):
             backup_package_files_action._get_changed_package_files()

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/custom_repos_are_valid_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/custom_repos_are_valid_test.py
@@ -62,7 +62,7 @@ def test_custom_repos_are_invalid(custom_repos_are_valid_action, monkeypatch):
         id="UNABLE_TO_ACCESS_REPOSITORIES",
         title="Unable to access repositories",
         description="Access could not be made to the custom repositories.",
-        diagnosis="Unable to access the repositories passed through the --enablerepo option.",
+        diagnosis="Unable to access repositories passed through the --enablerepo option.",
         remediations="For more details, see YUM/DNF output:\nYUM/DNF failed",
     )
 
@@ -72,7 +72,4 @@ def test_custom_repos_are_valid_skip(custom_repos_are_valid_action, monkeypatch,
 
     custom_repos_are_valid_action.run()
 
-    assert (
-        "Did not perform the check of repositories due to the use of RHSM for the conversion."
-        in caplog.records[-1].message
-    )
+    assert "Skipping the check verifying the accessibility of the repositories." in caplog.records[-1].message

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/handle_packages_test.py
@@ -172,7 +172,7 @@ class TestRemoveSpecialPackages:
     def test_run_no_packages_to_remove(self, monkeypatch, remove_special_packages_instance, caplog):
         monkeypatch.setattr(pkghandler, "get_packages_to_remove", GetPackagesToRemoveMocked(return_value=[]))
         remove_special_packages_instance.run()
-        assert "No packages to backup and remove." in caplog.records[-1].message
+        assert "No packages to back up and remove." in caplog.records[-1].message
 
     def test_run_all_removed(self, monkeypatch, remove_special_packages_instance):
         pkgs_to_remove = [get_centos_logos_pkg_object()]
@@ -258,8 +258,8 @@ class TestRemoveSpecialPackages:
             remove_special_packages_instance,
             level="ERROR",
             id="SPECIAL_PACKAGE_REMOVAL_FAILED",
-            title="Failed to remove some packages necessary for the conversion.",
-            description="The cause of this error is unknown, please look at the diagnosis for more information.",
+            title="Failed to remove some packages necessary for the conversion",
+            description="The cause of this error is unknown. Look at the diagnosis for more information.",
             diagnosis="Raising SystemExit",
         )
 

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/kernel_modules_test.py
@@ -162,7 +162,7 @@ def test_ensure_compatibility_of_kmods(
         ),
         (
             HOST_MODULES_STUB_BAD,
-            "kernel-core-0:4.18.0-240.10.1.el8_3.x86_64\n" "kernel-core-0:4.19.0-240.10.1.el8_3.i486\n",
+            "kernel-core-0:4.18.0-240.10.1.el8_3.x86_64\nkernel-core-0:4.19.0-240.10.1.el8_3.i486\n",
             ("", 0),
             "CANNOT_COMPARE_PACKAGE_VERSIONS",
             "ERROR",
@@ -238,7 +238,7 @@ def test_ensure_compatibility_of_kmods_check_env_and_message(
     message = ensure_kernel_modules_compatibility_instance.messages[0]
     assert STATUS_CODE["WARNING"] == message.level
     assert "ALLOW_UNAVAILABLE_KERNEL_MODULES" == message.id
-    assert "Did not perform the ensure kernel modules compatibility check" == message.title
+    assert "Ignoring the check ensuring kernel module availability in RHEL" == message.title
     assert (
         "We will continue the conversion with the following kernel modules unavailable in RHEL:" in message.description
     )
@@ -316,7 +316,7 @@ def test_ensure_compatibility_of_kmods_excluded(
             level="OVERRIDABLE",
             id="UNSUPPORTED_KERNEL_MODULES",
             title="Unsupported kernel modules",
-            description="Unsupported kernel modules were found",
+            description="Unsupported kernel modules were found.",
             diagnosis="The following loaded kernel modules are not available in RHEL:",
             remediations="Ensure you have updated the kernel to the latest available version and rebooted the system.",
         )

--- a/convert2rhel/unit_tests/actions/pre_ponr_changes/subscription_test.py
+++ b/convert2rhel/unit_tests/actions/pre_ponr_changes/subscription_test.py
@@ -294,7 +294,7 @@ class TestSubscribeSystem:
             level="ERROR",
             id="SYSTEM_NOT_REGISTERED",
             title="Not registered with RHSM",
-            description="This system must be registered with rhsm in order to get access to the RHEL rpms. In this case, the system was not already registered and no credentials were given to convert2rhel to register it.",
+            description="This system must be registered with RHSM in order to get access to RHEL rpms. In this case, the system has not been registered and no credentials were given to convert2rhel to register it.",
             remediations="You may either register this system via subscription-manager before running convert2rhel or give convert2rhel credentials to do that for you. The credentials convert2rhel would need are either activation_key and organization or username and password. You can set these in a config file and then pass the file to convert2rhel with the --config-file option.",
         )
 

--- a/convert2rhel/unit_tests/actions/system_checks/check_firewalld_availability_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/check_firewalld_availability_test.py
@@ -169,6 +169,16 @@ CleanupModulesOnExit=yes
             True,
             True,
         ),
+        (
+            {
+                "content": """
+#CleanupModulesOnExit=yes
+CleanupModulesOnExit=no
+"""
+            },
+            True,
+            False,
+        ),
     ),
     indirect=("write_firewalld_mockup_config",),
 )
@@ -183,8 +193,10 @@ def test_is_modules_cleanup_config_commented(
             "Couldn't find CleanupModulesOnExit in firewalld.conf. Treating it as enabled because of default behavior."
             in caplog.records[-1].message
         )
+    elif expected:
+        assert "CleanupModulesOnExit option is enabled in " in caplog.records[-1].message
     else:
-        assert "CleanupModulesOnExit option enabled" in caplog.records[-1].message
+        assert "CleanupModulesOnExit option is disabled in " in caplog.records[-1].message
 
 
 @pytest.mark.skipif(pkgmanager.TYPE == "yum", reason="Test is only relevant for RHEL 8+")
@@ -299,7 +311,7 @@ SomethingElse=yes
             check_firewalld_availability_is_running_action,
             level="ERROR",
             id="FIREWALLD_MODULES_CLEANUP_ON_EXIT_CONFIG",
-            title="Firewalld is set to cleanup modules after exit.",
+            title="Firewalld is set to cleanup modules after exit",
             description="Firewalld running on Oracle Linux 8 can lead to a conversion failure.",
             diagnosis=(
                 "We've detected that firewalld unit is running and that causes iptables and nftables "

--- a/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/convert2rhel_latest_test.py
@@ -146,7 +146,7 @@ class TestCheckConvert2rhelLatest:
     def test_convert2rhel_latest_outdated_version_inhibitor(
         self, convert2rhel_latest_action_instance, prepare_convert2rhel_latest_action, monkeypatch, global_tool_opts
     ):
-        """When runnnig on a supported major version, we issue an error = inhibitor."""
+        """When running on a supported major version, we issue an error = inhibitor."""
         monkeypatch.setattr(convert2rhel_latest, "tool_opts", global_tool_opts)
         convert2rhel_latest_action_instance.run()
 
@@ -157,6 +157,7 @@ class TestCheckConvert2rhelLatest:
             level="OVERRIDABLE",
             id="OUT_OF_DATE",
             title="Outdated convert2rhel version detected",
+            description="An outdated convert2rhel version has been detected.",
             diagnosis=(
                 "You are currently running {} and the latest version of convert2rhel is {}.\n"
                 "Only the latest version is supported for conversion.".format(running_version, latest_version)
@@ -415,7 +416,7 @@ class TestCheckConvert2rhelLatest:
                 level="WARNING",
                 id="CONVERT2RHEL_LATEST_CHECK_SKIP",
                 title="convert2rhel latest version check skip",
-                description="Did not perform the convert2hel latest version check",
+                description="Did not perform the convert2hel latest version check.",
                 diagnosis=(
                     "Couldn't check if the current installed convert2rhel is the latest version.\n"
                     "repoquery failed with the following output:\nRepoquery did not run"
@@ -475,9 +476,11 @@ class TestCheckConvert2rhelLatest:
         ),
         indirect=True,
     )
-    def ttest_convert2rhel_latest_multiple_packages(
-        self, convert2rhel_latest_action_instance, prepare_convert2rhel_latest_action
+    def test_convert2rhel_latest_multiple_packages(
+        self, convert2rhel_latest_action_instance, prepare_convert2rhel_latest_action, monkeypatch, global_tool_opts
     ):
+        monkeypatch.setattr(convert2rhel_latest, "tool_opts", global_tool_opts)
+
         convert2rhel_latest_action_instance.run()
 
         running_version, latest_version = prepare_convert2rhel_latest_action
@@ -487,12 +490,13 @@ class TestCheckConvert2rhelLatest:
             level="OVERRIDABLE",
             id="OUT_OF_DATE",
             title="Outdated convert2rhel version detected",
-            description="An outdated convert2rhel version has been detected",
+            description="An outdated convert2rhel version has been detected.",
             diagnosis=(
                 "You are currently running {} and the latest version of convert2rhel is {}.\n"
                 "Only the latest version is supported for conversion.".format(running_version, latest_version)
             ),
-            remediations="If you want to disregard this check, then set the environment variable 'CONVERT2RHEL_ALLOW_OLDER_VERSION=1' to continue.",
+            remediations="If you want to disregard this check, set the allow_older_version inhibitor"
+            " override in the /etc/convert2rhel.ini config file to true.",
         )
 
     @pytest.mark.parametrize(
@@ -673,7 +677,7 @@ class TestCheckConvert2rhelLatest:
             level="OVERRIDABLE",
             id="OUT_OF_DATE",
             title="Outdated convert2rhel version detected",
-            description="An outdated convert2rhel version has been detected",
+            description="An outdated convert2rhel version has been detected.",
             diagnosis=(
                 "You are currently running {} and the latest version of convert2rhel is {}.\n"
                 "Only the latest version is supported for conversion.".format(running_version, latest_version)

--- a/convert2rhel/unit_tests/actions/system_checks/dbus_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/dbus_test.py
@@ -31,7 +31,7 @@ def dbus_is_running_action():
     (
         (False, True, "Did not perform the check because we have been asked not to subscribe this system to RHSM."),
         (False, False, "Did not perform the check because we have been asked not to subscribe this system to RHSM."),
-        (True, True, "DBus Daemon is running"),
+        (True, True, "DBus daemon is running."),
     ),
 )
 def test_check_dbus_is_running(
@@ -58,7 +58,7 @@ def test_check_dbus_is_running_not_running(monkeypatch, global_system_info, dbus
         dbus_is_running_action,
         level="ERROR",
         id="DBUS_DAEMON_NOT_RUNNING",
-        description="The Dbus daemon is not running",
+        description="The Dbus daemon is not running.",
         diagnosis="Could not find a running DBus Daemon which is needed to register with subscription manager.",
-        remediations="Please start dbus using `systemctl start dbus`",
+        remediations="Start dbus using `systemctl start dbus`",
     )

--- a/convert2rhel/unit_tests/actions/system_checks/efi_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/efi_test.py
@@ -100,7 +100,7 @@ class TestEFIChecks:
                 ExpectedMessage(
                     id="BOOTLOADER_ERROR",
                     title="Bootloader error detected",
-                    description="An unknown bootloader error occurred, please look at the diagnosis for more information.",
+                    description="An unknown bootloader error occurred. Look at the diagnosis for more information.",
                     diagnosis="errmsg",
                     remediations="",
                     log_msg="",

--- a/convert2rhel/unit_tests/actions/system_checks/els_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/els_test.py
@@ -49,7 +49,9 @@ class TestEus:
             (Version(9, 2), False),
         ),
     )
-    def test_els_warning_message(self, els_action, monkeypatch, global_tool_opts, version_string, message_reported):
+    def test_els_warning_message(
+        self, els_action, monkeypatch, global_tool_opts, version_string, message_reported, caplog
+    ):
         global_tool_opts.els = False
         monkeypatch.setattr(system_info, "version", version_string)
         monkeypatch.setattr(systeminfo, "tool_opts", global_tool_opts)
@@ -62,8 +64,9 @@ class TestEus:
                     level="WARNING",
                     id="ELS_COMMAND_LINE_OPTION_UNUSED",
                     title="The --els command line option is unused",
-                    description="Current system version is under Extended Lifecycle Support (ELS). You may want to consider using the --els"
-                    " command line option to land on a system patched with the latest security errata.",
+                    description="Current system version is under Extended Lifecycle Support (ELS). You may want to"
+                    " consider using the --els command line option to land on a system patched with the latest security"
+                    " errata.",
                 ),
             )
         )
@@ -73,3 +76,4 @@ class TestEus:
             assert expected.issubset(els_action.messages)
         else:
             assert els_action.messages == []
+            "Applicable only to conversions to RHEL 7." in caplog.records[-1].message

--- a/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/is_loaded_kernel_latest_test.py
@@ -119,7 +119,7 @@ class TestIsLoadedKernelLatest:
             id="INVALID_KERNEL_VERSION",
             level="OVERRIDABLE",
             title="Invalid kernel version detected",
-            description="The loaded kernel version mismatch the latest one available in system repositories",
+            description="The loaded kernel version mismatch the latest one available in system repositories.",
             diagnosis="The version of the loaded kernel is different from the latest version in system repositories.",
             remediations="To proceed with the conversion, update the kernel version by executing the following step:\n\n",
         )
@@ -142,7 +142,7 @@ class TestIsLoadedKernelLatest:
                 0,
                 "kernel-core",
                 "Invalid kernel package found",
-                "Please refer to the diagnosis for further information",
+                "Refer to the diagnosis for further information.",
                 "The package names ('kernel-core-1' and 'kernel-core-2') do not match. Can only compare versions for the same packages.",
                 None,
             ),
@@ -152,7 +152,7 @@ class TestIsLoadedKernelLatest:
                 0,
                 "kernel-core",
                 "Invalid kernel package found",
-                "Please refer to the diagnosis for further information",
+                "Refer to the diagnosis for further information.",
                 "Invalid package - kernel-core-1 .01-5.02, packages need to be in one of the following formats: NEVRA, NEVR, NVRA, NVR, ENVRA, ENVR.",
                 None,
             ),
@@ -238,7 +238,7 @@ class TestIsLoadedKernelLatest:
                 0,
                 "kernel",
                 "Invalid kernel package found",
-                "Please refer to the diagnosis for further information",
+                "Refer to the diagnosis for further information.",
                 "The following field(s) are invalid - release : 1.01-5",
                 None,
             ),
@@ -248,7 +248,7 @@ class TestIsLoadedKernelLatest:
                 0,
                 "kernel",
                 "Invalid kernel package found",
-                "Please refer to the diagnosis for further information",
+                "Refer to the diagnosis for further information.",
                 "The following field(s) are invalid - version : 1 .01",
                 None,
             ),
@@ -426,18 +426,16 @@ class TestIsLoadedKernelLatest:
             {"CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK": skip_check},
         )
 
-        expected_set = set(
-            (
-                actions.ActionMessage(
-                    level=level,
-                    id=id,
-                    title=title,
-                    description=description,
-                    diagnosis=diagnosis,
-                    remediations=remediations,
-                ),
+        expected_set = {
+            actions.ActionMessage(
+                level=level,
+                id=id,
+                title=title,
+                description=description,
+                diagnosis=diagnosis,
+                remediations=remediations,
             )
-        )
+        }
         is_loaded_kernel_latest_action.run()
         assert description in caplog.records[-1].message
         assert expected_set.issuperset(is_loaded_kernel_latest_action.messages)
@@ -464,7 +462,7 @@ class TestIsLoadedKernelLatest:
                 "Unable to fetch recent kernels",
                 (
                     "Couldn't fetch the list of the most recent kernels available in "
-                    "the repositories. Did not perform the loaded kernel check."
+                    "the repositories. Did not perform the loaded kernel currency check."
                 ),
                 None,
                 None,
@@ -549,10 +547,10 @@ class TestIsLoadedKernelLatest:
                 0,
                 "kernel-core",
                 "Kernel currency check failed",
-                "Please refer to the diagnosis for further information",
+                "Refer to the diagnosis for further information.",
                 "Could not find any {0} from repositories to compare against the loaded kernel.",
                 (
-                    "Please check if you have any vendor repositories enabled to proceed with the conversion.\n"
+                    "Check if you have any vendor repositories enabled to proceed with the conversion.\n"
                     "If you wish to disregard this message, set the skip_kernel_currency_check inhibitor override in"
                     " the /etc/convert2rhel.ini config file to true."
                 ),
@@ -775,7 +773,7 @@ class TestIsLoadedKernelLatest:
             level="OVERRIDABLE",
             id="INVALID_KERNEL_VERSION",
             title="Invalid kernel version detected",
-            description="The loaded kernel version mismatch the latest one available in system repositories",
+            description="The loaded kernel version mismatch the latest one available in system repositories.",
             diagnosis="The version of the loaded kernel is different from the latest version in system repositories.",
             remediations="To proceed with the conversion, update the kernel version by executing the following step:",
         )

--- a/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/package_updates_test.py
@@ -46,7 +46,7 @@ def test_check_package_updates_skip_on_not_latest_ol(pretend_os, caplog, package
                 level="INFO",
                 id="PACKAGE_UPDATES_CHECK_SKIP_NO_PUBLIC_REPOSITORIES",
                 title="Did not perform the package updates check",
-                description="Please refer to the diagnosis for further information",
+                description="Refer to the diagnosis for further information.",
                 diagnosis=diagnosis,
                 remediations=None,
                 variables={},
@@ -77,7 +77,7 @@ def test_check_package_updates_not_up_to_date(
     packages = ["package-2", "package-1"]
     diagnosis = (
         "The system has 2 package(s) not updated based on repositories defined in the system repositories.\n"
-        "List of packages to update: package-1 package-2.\n\n"
+        "List of packages to update: package-1 package-2\n\n"
         "Not updating the packages may cause the conversion to fail.\n"
         "Consider updating the packages before proceeding with the conversion."
     )
@@ -90,7 +90,7 @@ def test_check_package_updates_not_up_to_date(
                 level="WARNING",
                 id="OUT_OF_DATE_PACKAGES",
                 title="Outdated packages detected",
-                description="Please refer to the diagnosis for further information",
+                description="Refer to the diagnosis for further information.",
                 diagnosis=diagnosis,
                 remediations="Run yum update to update all the packages on the system.",
                 variables={},
@@ -118,7 +118,7 @@ def test_check_package_updates_with_repoerror_warning(pretend_os, monkeypatch, c
                 level="WARNING",
                 id="PACKAGE_UP_TO_DATE_CHECK_MESSAGE",
                 title="Package up to date check fail",
-                description="Please refer to the diagnosis for further information",
+                description="Refer to the diagnosis for further information.",
                 diagnosis=diagnosis,
                 remediations=None,
                 variables={},

--- a/convert2rhel/unit_tests/actions/system_checks/rhel_compatible_kernel_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/rhel_compatible_kernel_test.py
@@ -80,7 +80,7 @@ def test_check_rhel_compatible_kernel_failure(
         level="ERROR",
         id="UNEXPECTED_VERSION",
         title="Incompatible booted kernel version",
-        description="Please refer to the diagnosis for further information",
+        description="Refer to the diagnosis for further information.",
         diagnosis="The booted kernel version is incompatible with the standard RHEL kernel",
         remediations=(
             "To proceed with the conversion, boot into a kernel that is available in the {0} {1} base repository"

--- a/convert2rhel/unit_tests/actions/system_checks/tainted_kmods_test.py
+++ b/convert2rhel/unit_tests/actions/system_checks/tainted_kmods_test.py
@@ -71,7 +71,7 @@ def test_check_tainted_kmods(monkeypatch, command_return, is_error, tainted_kmod
             level="OVERRIDABLE",
             id="TAINTED_KMODS_DETECTED",
             title="Tainted kernel modules detected",
-            description="Please refer to the diagnosis for further information",
+            description="Refer to the diagnosis for further information.",
             diagnosis=(
                 "Tainted kernel modules detected:\n  system76_io\n  system76_acpi\nThird-party "
                 "components are not supported per our software support"
@@ -84,7 +84,7 @@ def test_check_tainted_kmods(monkeypatch, command_return, is_error, tainted_kmod
                 " tainted_kernel_module_check_skip inhibitor override in the /etc/convert2rhel.ini"
                 " config file to true. Overriding this check can be dangerous"
                 " so it is recommended that you do a system backup beforehand."
-                " For information on what a tainted kernel module is, please refer to this documentation {1}".format(
+                " For information on what a tainted kernel module is, refer to this documentation {1}".format(
                     LINK_PREVENT_KMODS_FROM_LOADING, LINK_TAINTED_KMOD_DOCS
                 )
             ),
@@ -128,7 +128,7 @@ def test_check_tainted_kmods_skip(monkeypatch, command_return, is_error, tainted
                     level="WARNING",
                     id="TAINTED_KMODS_DETECTED_MESSAGE",
                     title="Tainted kernel modules detected",
-                    description="Please refer to the diagnosis for further information",
+                    description="Refer to the diagnosis for further information.",
                     diagnosis=(
                         "Tainted kernel modules detected:\n  system76_io\n  system76_acpi\nThird-party "
                         "components are not supported per our software support"
@@ -137,7 +137,7 @@ def test_check_tainted_kmods_skip(monkeypatch, command_return, is_error, tainted
                     remediations=(
                         "Prevent the modules from loading by following {0}"
                         " and run convert2rhel again to continue with the conversion."
-                        " For information on what a tainted kernel module is, please refer to this documentation {1}".format(
+                        " For information on what a tainted kernel module is, refer to this documentation {1}".format(
                             LINK_PREVENT_KMODS_FROM_LOADING, LINK_TAINTED_KMOD_DOCS
                         )
                     ),

--- a/convert2rhel/unit_tests/backup/files_test.py
+++ b/convert2rhel/unit_tests/backup/files_test.py
@@ -343,9 +343,9 @@ class TestMissingFile:
     @pytest.mark.parametrize(
         ("exists", "enabled", "message"),
         (
-            (True, True, "File {filepath} removed"),
+            (True, True, "File {filepath} removed."),
             (True, False, None),
-            (False, True, "File {filepath} wasn't created during conversion"),
+            (False, True, "File {filepath} wasn't created during conversion."),
         ),
     )
     def test_created_file_restore(self, tmpdir, exists, enabled, message, caplog):
@@ -371,13 +371,13 @@ class TestMissingFile:
     @pytest.mark.parametrize(
         ("exists", "created", "message_push", "message_pop"),
         (
-            (False, True, "Marking file {filepath} as missing on system.", "File {filepath} removed"),
+            (False, True, "Marking file {filepath} as missing on system.", "File {filepath} removed."),
             (True, False, "The file {filepath} is present on the system before conversion, skipping it.", None),
             (
                 False,
                 False,
                 "Marking file {filepath} as missing on system.",
-                "File {filepath} wasn't created during conversion",
+                "File {filepath} wasn't created during conversion.",
             ),
         ),
     )

--- a/convert2rhel/unit_tests/backup/packages_test.py
+++ b/convert2rhel/unit_tests/backup/packages_test.py
@@ -144,9 +144,9 @@ class TestRestorablePackage:
         with pytest.raises(exceptions.CriticalError) as err:
             rp.restore()
 
-        assert err.value.diagnosis == "Couldn't find a backup for test.rpm package."
+        assert err.value.diagnosis == "Couldn't find a backup for the following package(s): test.rpm"
         assert utils.remove_orphan_folders.call_count == 1
-        assert "Couldn't find a backup for test.rpm package." in caplog.records[-1].message
+        assert "Couldn't find a backup for the following package(s): test.rpm" in caplog.records[-1].message
 
     def test_restore_second_restore(self, monkeypatch):
         monkeypatch.setattr(

--- a/convert2rhel/unit_tests/backup/subscription_test.py
+++ b/convert2rhel/unit_tests/backup/subscription_test.py
@@ -121,7 +121,7 @@ class TestRestorableSystemSubscription:
 
         system_subscription.restore()
 
-        assert "subscription-manager not installed, skipping" == caplog.messages[-1]
+        assert "subscription-manager not installed, skipping." == caplog.messages[-1]
 
 
 class TestRestorableAutoAttachmentSubscription:

--- a/convert2rhel/unit_tests/cli_test.py
+++ b/convert2rhel/unit_tests/cli_test.py
@@ -121,7 +121,7 @@ class TestTooloptsParseFromCLI:
 
         message = (
             "Failed to parse a valid subscription-manager server from the --serverurl option.\n"
-            "Please check for typos and run convert2rhel again with a corrected --serverurl.\n"
+            "Check for typos and run convert2rhel again with a corrected --serverurl.\n"
             "Supplied serverurl: {}\nError: ".format(serverurl)
         )
         assert message in caplog.records[-1].message
@@ -267,7 +267,7 @@ password = conf_pass
 activation_key = conf_key
             """,
             {"password": "password"},
-            "You have passed the RHSM password without an associated username. Please provide a username together with the password.",
+            "You have passed the RHSM password without an associated username. Provide a username together with the password.",
         ),
         (
             mock_cli_arguments(["-o", "org"]),
@@ -597,11 +597,11 @@ incomplete_rollback = 1
         (mock_cli_arguments(["-u", "user", "-p", "pass"]), "-u ***** -p *****"),
         (
             mock_cli_arguments(["-p", "pass"]),
-            "You have passed the RHSM password without an associated username. Please provide a username together with the password",
+            "You have passed the RHSM password without an associated username. Provide a username together with the password",
         ),
         (
             mock_cli_arguments(["-u", "user"]),
-            "You have passed the RHSM username without an associated password. Please provide a password together with the username",
+            "You have passed the RHSM username without an associated password. Provide a password together with the username",
         ),
     ),
 )

--- a/convert2rhel/unit_tests/pkgmanager/handlers/dnf/dnf_test.py
+++ b/convert2rhel/unit_tests/pkgmanager/handlers/dnf/dnf_test.py
@@ -293,7 +293,7 @@ class TestDnfTransactionHandler:
 
         assert pkgmanager.Base.resolve.call_count == 1
         assert pkgmanager.Base.download_packages.call_count == 1
-        assert "Resolving the dependencies of the packages in the dnf transaction set." in caplog.records[-2].message
+        assert "Resolving dependencies of the packages in the dnf transaction set." in caplog.records[-2].message
 
     @centos8
     def test_resolve_dependencies_resolve_exception(self, pretend_os, caplog, monkeypatch):
@@ -350,11 +350,11 @@ class TestDnfTransactionHandler:
             instance._process_transaction(validate_transaction=False)
 
         assert pkgmanager.Base.do_transaction.call_count == 1
-        assert "Failed to validate the dnf transaction." in caplog.records[-1].message
         assert "FAILED_TO_VALIDATE_TRANSACTION" in execinfo._excinfo[1].id
-        assert "Failed to validate dnf transaction." in execinfo._excinfo[1].title
+        assert "Failed to validate a dnf transaction." in caplog.records[-1].message
+        assert "Failed to validate a dnf transaction" in execinfo._excinfo[1].title
         assert (
-            "During the dnf transaction execution an error occured and convert2rhel could no longer process the transaction."
+            "During the dnf transaction execution an error occurred and convert2rhel could no longer process the transaction."
             in execinfo._excinfo[1].description
         )
         assert (
@@ -364,7 +364,7 @@ class TestDnfTransactionHandler:
 
     @centos8
     @pytest.mark.parametrize(
-        ("validate_transaction"),
+        "validate_transaction",
         ((True), (False)),
     )
     def test_run_transaction(self, pretend_os, validate_transaction, caplog, monkeypatch):

--- a/convert2rhel/unit_tests/pkgmanager/handlers/yum/yum_test.py
+++ b/convert2rhel/unit_tests/pkgmanager/handlers/yum/yum_test.py
@@ -248,9 +248,9 @@ class TestYumTransactionHandler:
 
         with pytest.raises(exceptions.CriticalError) as execinfo:
             instance._process_transaction(validate_transaction=False)
-        assert "Failed to validate the yum transaction." in caplog.records[-1].message
         assert "FAILED_TO_VALIDATE_TRANSACTION" in execinfo._excinfo[1].id
-        assert "Failed to validate yum transaction." in execinfo._excinfo[1].title
+        assert "Failed to validate a yum transaction." in caplog.records[-1].message
+        assert "Failed to validate a yum transaction" in execinfo._excinfo[1].title
         assert (
             "During the yum transaction execution an error occurred and convert2rhel could no longer process the transaction."
             in execinfo._excinfo[1].description
@@ -364,7 +364,7 @@ class TestYumTransactionHandler:
         with pytest.raises(exceptions.CriticalError):
             instance.run_transaction(True)
 
-        assert "Retrying to resolve dependencies 1" in caplog.records[-2].message
+        assert "Retrying to resolve dependencies - attempt 1." in caplog.records[-2].message
         assert "Failed to resolve dependencies in the transaction." in caplog.records[-1].message
 
     @centos7

--- a/convert2rhel/unit_tests/subscription_test.py
+++ b/convert2rhel/unit_tests/subscription_test.py
@@ -802,9 +802,7 @@ class TestRegistrationCommand:
             utils,
             "run_subprocess",
             RunSubprocessMocked(
-                return_string=(
-                    "system identity: 1234-56-78-9abc\n" "name: abc-123\n" "org name: Test\n" "org ID: 12345678910\n"
-                )
+                return_string=("system identity: 1234-56-78-9abc\nname: abc-123\norg name: Test\norg ID: 12345678910\n")
             ),
         )
 

--- a/convert2rhel/unit_tests/toolopts/toolopts_test.py
+++ b/convert2rhel/unit_tests/toolopts/toolopts_test.py
@@ -214,7 +214,7 @@ def test_handle_config_conflicts(config_sources, expected_message, expected_outp
                 ),
                 MockConfig(source="configuration file", username=None, org=None, activation_key=None, password=None),
             ],
-            "You have passed the RHSM password without an associated username. Please provide a username together"
+            "You have passed the RHSM password without an associated username. Provide a username together"
             " with the password.",
         ),
         # Config File - password without username
@@ -231,7 +231,7 @@ def test_handle_config_conflicts(config_sources, expected_message, expected_outp
                 ),
                 MockConfig(source="configuration file", username=None, org=None, activation_key=None, password="test"),
             ],
-            "You have passed the RHSM password without an associated username. Please provide a username together"
+            "You have passed the RHSM password without an associated username. Provide a username together"
             " with the password.",
         ),
         # CLI - username without password
@@ -248,7 +248,7 @@ def test_handle_config_conflicts(config_sources, expected_message, expected_outp
                 ),
                 MockConfig(source="configuration file", username=None, org=None, activation_key=None, password=None),
             ],
-            "You have passed the RHSM username without an associated password. Please provide a password together"
+            "You have passed the RHSM username without an associated password. Provide a password together"
             " with the username.",
         ),
         # Config File - username without password
@@ -265,7 +265,7 @@ def test_handle_config_conflicts(config_sources, expected_message, expected_outp
                 ),
                 MockConfig(source="configuration file", username="test", org=None, activation_key=None, password=None),
             ],
-            "You have passed the RHSM username without an associated password. Please provide a password together"
+            "You have passed the RHSM username without an associated password. Provide a password together"
             " with the username.",
         ),
         (

--- a/convert2rhel/unit_tests/utils/utils_test.py
+++ b/convert2rhel/unit_tests/utils/utils_test.py
@@ -1142,10 +1142,10 @@ def test_remove_epoch_from_yum_nevra_notation(pkg_nevra, nvra_without_epoch):
     (
         (
             "CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK",
-            True,
+            "1",
             "skip_kernel_currency_check",
-            "The environment variable CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK is deprecated and is set to be removed on Convert2RHEL 2.4.0.\n"
-            "Please, use the configuration file instead.",
+            "The environment variable CONVERT2RHEL_SKIP_KERNEL_CURRENCY_CHECK is deprecated and will be removed in convert2rhel 2.4.0.\n"
+            "Use the skip_kernel_currency_check option in the /etc/convert2rhel.ini configuration file.",
         ),
     ),
 )

--- a/convert2rhel/utils/__init__.py
+++ b/convert2rhel/utils/__init__.py
@@ -261,12 +261,12 @@ def run_as_child_process(func):
             # API) will keep executing until they finish their execution and
             # ignore the call for termination issued by the parent. To avoid
             # having "zombie" processes, we need to wait for them to finish.
-            logger.warning("Terminating child process...")
+            logger.warning("Terminating child process.")
             if process.is_alive():
-                logger.debug("Process with pid %s is alive", process.pid)
+                logger.debug("Process with pid %s is alive.", process.pid)
                 process.terminate()
 
-            logger.debug("Process with pid %s exited", process.pid)
+            logger.debug("Process with pid %s exited.", process.pid)
 
             # If there is a KeyboardInterrupt raised while the child process is
             # being executed, let's just re-raise it to the stack and move on.
@@ -511,7 +511,7 @@ def ask_to_continue():
         if cont == "y":
             break
         if cont == "n":
-            logger.critical("User canceled the conversion\n")
+            logger.critical("User canceled the conversion.\n")
 
 
 def prompt_user(question, password=False):
@@ -556,11 +556,11 @@ def remove_tmp_dir():
     """Remove temporary folder (TMP_DIR), not needed post-conversion."""
     try:
         shutil.rmtree(TMP_DIR)
-        logger.info("Temporary folder {} removed".format(TMP_DIR))
+        logger.info("Temporary folder {} removed.".format(TMP_DIR))
     except OSError as err:
         logger.warning("Failed removing temporary folder {}\nError ({}): {}".format(TMP_DIR, err.errno, err.strerror))
     except TypeError:
-        logger.warning("TypeError error while removing temporary folder {}".format(TMP_DIR))
+        logger.warning("TypeError error while removing temporary folder {}.".format(TMP_DIR))
 
 
 class DictWListValues(dict):
@@ -692,7 +692,7 @@ def remove_pkgs(pkgs_to_remove, critical=True):
     pkgs_removed = []
 
     if not pkgs_to_remove:
-        logger.info("No package to remove")
+        logger.info("No package to remove.")
         return pkgs_removed
 
     pkgs_failed_to_remove = []
@@ -714,7 +714,7 @@ def remove_pkgs(pkgs_to_remove, critical=True):
             logger.critical_no_exit("Error: Couldn't remove {}.".format(pkgs_as_str))
             raise exceptions.CriticalError(
                 id_="FAILED_TO_REMOVE_PACKAGES",
-                title="Couldn't remove packages.",
+                title="Couldn't remove packages",
                 description="While attempting to roll back changes, we encountered an unexpected failure while attempting to remove one or more of the packages we installed earlier.",
                 diagnosis="Couldn't remove {}.".format(pkgs_as_str),
             )
@@ -1135,8 +1135,10 @@ def warn_deprecated_env(env_name):
         return None
 
     root_logger.warning(
-        "The environment variable {} is deprecated and is set to be removed on Convert2RHEL 2.4.0.\n"
-        "Please, use the configuration file instead.".format(env_name)
+        "The environment variable {} is deprecated and will be removed in convert2rhel 2.4.0.\n"
+        "Use the {} option in the /etc/convert2rhel.ini configuration file.".format(
+            env_name, env_var_to_toolopts_map[env_name]
+        )
     )
     key = env_var_to_toolopts_map[env_name]
     value = os.getenv(env_name, None)

--- a/convert2rhel/utils/subscription.py
+++ b/convert2rhel/utils/subscription.py
@@ -59,7 +59,7 @@ def setup_rhsm_parts(opts):
                 # security practice.
                 loggerinst.critical(
                     "Failed to parse a valid subscription-manager server from the --serverurl option.\n"
-                    "Please check for typos and run convert2rhel again with a corrected --serverurl.\n"
+                    "Check for typos and run convert2rhel again with a corrected --serverurl.\n"
                     "Supplied serverurl: {}\nError: {}".format(opts.serverurl, e)
                 )
 

--- a/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
+++ b/tests/integration/tier0/non-destructive/basic-sanity-checks/test_basic_sanity_checks.py
@@ -213,7 +213,7 @@ def test_rhsm_error_logged(convert2rhel):
 
         # Wait until we reach the point where the RHEL certificate has been
         # installed otherwise we won't attempt to remove it.
-        assert c2r.expect("PRE_SUBSCRIPTION has succeeded") == 0
+        assert c2r.expect("The PRE_SUBSCRIPTION action has succeeded.") == 0
 
         # Remove the certificate ourselves
         for potential_cert in ("74.pem", "69.pem", "479.pem"):

--- a/tests/integration/tier0/non-destructive/config-file/test_config_file.py
+++ b/tests/integration/tier0/non-destructive/config-file/test_config_file.py
@@ -174,7 +174,7 @@ def test_config_standard_paths_priority_diff_methods(convert2rhel, c2r_config_se
             "WARNING - Either a password or an activation key can be used for system registration."
             " We're going to use the activation key."
         )
-        c2r.expect("SUBSCRIBE_SYSTEM has succeeded")
+        c2r.expect("The SUBSCRIBE_SYSTEM action has succeeded.")
 
     assert c2r.exitstatus == 0
 
@@ -211,6 +211,6 @@ def test_config_standard_paths_priority(convert2rhel, c2r_config_setup):
     with convert2rhel(f"analyze --serverurl {TEST_VARS['RHSM_SERVER_URL']} -y --debug") as c2r:
         c2r.expect("DEBUG - Found username in subscription_manager")
         c2r.expect("DEBUG - Found password in subscription_manager")
-        c2r.expect("SUBSCRIBE_SYSTEM has succeeded")
+        c2r.expect("The SUBSCRIBE_SYSTEM action has succeeded.")
 
     assert c2r.exitstatus == 0

--- a/tests/integration/tier0/non-destructive/cve-2022-1662/test_cve-2022-1662.py
+++ b/tests/integration/tier0/non-destructive/cve-2022-1662/test_cve-2022-1662.py
@@ -30,7 +30,7 @@ def test_passing_password_to_submgr_obfuscated(convert2rhel):
         # Just to be sure, try to run through all three tries
         # of the registration process in case the race condition applies
         for subscription_try in range(2):
-            c2r.expect("Registering the system using subscription-manager ...")
+            c2r.expect("Registering the system using subscription-manager.")
             # Run watchdog function using multiprocessing pool
             # as soon as Convert2RHEL tries to call subscription-manager
             with Pool(processes=1) as pool:
@@ -52,7 +52,7 @@ def test_passing_activation_key_to_submgr_obfuscated(convert2rhel):
         # Just to be sure, try to run through all three tries
         # of the registration process in case the race condition applies
         for subscription_try in range(2):
-            c2r.expect("Registering the system using subscription-manager ...")
+            c2r.expect("Registering the system using subscription-manager.")
             # Run watchdog function using multiprocessing pool
             # as soon as Convert2RHEL tries to call subscription-manager
             with Pool(processes=1) as pool:

--- a/tests/integration/tier0/non-destructive/enabled-repositories-after-analysis/test_enabled_repositories_after_analysis.py
+++ b/tests/integration/tier0/non-destructive/enabled-repositories-after-analysis/test_enabled_repositories_after_analysis.py
@@ -48,7 +48,7 @@ def test_enabled_repositories_after_analysis(
     with convert2rhel("analyze -y --debug") as c2r:
         c2r.expect("Enabling RHEL repositories:")
         c2r.expect("rhel-7-server-rpms")
-        c2r.expect("Rollback: Restoring state of the repositories")
+        c2r.expect("Rollback: Restore state of the repositories")
 
     assert c2r.exitstatus == 0
 

--- a/tests/integration/tier0/non-destructive/grub/test_invalid_changed_to_grub.py
+++ b/tests/integration/tier0/non-destructive/grub/test_invalid_changed_to_grub.py
@@ -51,9 +51,7 @@ def test_invalid_changes_to_grub_file(convert2rhel, grub_file_invalid):
             TEST_VARS["RHSM_SCA_PASSWORD"],
         )
     ) as c2r:
-        assert c2r.expect_exact("Prepare: Check if the grub file is valid") == 0
-        assert (
-            c2r.expect_exact("ERROR - (ERROR) GRUB_VALIDITY::INVALID_GRUB_FILE - Grub boot entry file is invalid") == 0
-        )
+        assert c2r.expect_exact("Prepare: Check validity of /etc/default/grub") == 0
+        assert c2r.expect_exact("ERROR - (ERROR) GRUB_VALIDITY::INVALID_GRUB_FILE - /etc/default/grub invalid") == 0
 
     assert c2r.exitstatus == 2

--- a/tests/integration/tier0/non-destructive/kernel/test_kernel_check_verification.py
+++ b/tests/integration/tier0/non-destructive/kernel/test_kernel_check_verification.py
@@ -44,7 +44,8 @@ def test_verify_latest_kernel_check_passes_with_failed_repoquery(convert2rhel, t
         c2r.sendline("y")
 
         c2r.expect(
-            "Couldn't fetch the list of the most recent kernels available in the repositories. Did not perform the loaded kernel check.",
+            "Couldn't fetch the list of the most recent kernels available in the repositories. Did not perform the"
+            " loaded kernel currency check.",
             timeout=300,
         )
         c2r.sendcontrol("c")

--- a/tests/integration/tier0/non-destructive/single-yum-transaction-validation/test_single_yum_transaction_validation.py
+++ b/tests/integration/tier0/non-destructive/single-yum-transaction-validation/test_single_yum_transaction_validation.py
@@ -80,7 +80,7 @@ def test_package_download_error(convert2rhel, shell, yum_cache):
             TEST_VARS["RHSM_SCA_PASSWORD"],
         )
     ) as c2r:
-        c2r.expect("Validate the {} transaction".format(PKGMANAGER))
+        c2r.expect("Validate the main {} transaction".format(PKGMANAGER))
         c2r.expect("Adding {} packages to the {} transaction set.".format(SERVER_SUB, PKGMANAGER))
 
         if SYSTEM_RELEASE_ENV in ("centos-7", "oracle-7", "amazon2"):
@@ -129,7 +129,7 @@ def test_transaction_validation_error(convert2rhel, shell, yum_cache):
             os.unlink("/var/cache/yum/x86_64/7Server/rhel-7-server-rpms/repomd.xml")
 
         remove_entitlement_certs()
-        c2r.expect("Failed to validate the yum transaction.", timeout=600)
+        c2r.expect("Failed to validate a yum transaction.", timeout=600)
 
         # Error header first
         c2r.expect("Pre-conversion analysis report", timeout=600)
@@ -195,7 +195,7 @@ def test_packages_with_in_name_period(shell, convert2rhel, packages_with_period)
         c2r.expect("Continue with the system conversion", timeout=300)
         c2r.sendline("y")
 
-        c2r.expect("VALIDATE_PACKAGE_MANAGER_TRANSACTION has succeeded")
+        c2r.expect("The VALIDATE_PACKAGE_MANAGER_TRANSACTION action has succeeded.")
 
     assert c2r.exitstatus == 0
 
@@ -228,7 +228,7 @@ def test_override_exclude_list_in_yum_config(convert2rhel, outdated_kernel, yum_
                     TEST_VARS["RHSM_SCA_PASSWORD"],
                 )
             ) as c2r:
-                c2r.expect("VALIDATE_PACKAGE_MANAGER_TRANSACTION has succeeded")
+                c2r.expect("The VALIDATE_PACKAGE_MANAGER_TRANSACTION action has succeeded.")
 
             assert c2r.exitstatus == 0
         except (AssertionError, pexpect.exceptions.EOF, pexpect.exceptions.TIMEOUT) as e:

--- a/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
+++ b/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_pre_register.py
@@ -23,7 +23,7 @@ def test_pre_registered_wont_unregister(shell, pre_registered, convert2rhel):
 
         c2r.expect("Subscription Manager is already present", timeout=300)
         c2r.expect(
-            "SUBSCRIBE_SYSTEM has succeeded",
+            "The SUBSCRIBE_SYSTEM action has succeeded.",
             timeout=600,
         )
         c2r.expect("Continue with the system conversion?")

--- a/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_rollback.py
+++ b/tests/integration/tier0/non-destructive/subscription-manager/test_sub_man_rollback.py
@@ -25,7 +25,7 @@ def test_sub_man_rollback(convert2rhel, shell, fixture_subman):
                 TEST_VARS["RHSM_SCA_PASSWORD"],
             )
         ) as c2r:
-            assert c2r.expect("Validate the dnf transaction") == 0
+            assert c2r.expect("Validate the main dnf transaction") == 0
             # At this point the centos-linux-release package is already installed
             c2r.sendcontrol("c")
             # Expect rollback, otherwise TIMEOUT

--- a/tests/integration/tier1/destructive/yum-conf-exclude-packages/test_yum_conf_exclude_packages.py
+++ b/tests/integration/tier1/destructive/yum-conf-exclude-packages/test_yum_conf_exclude_packages.py
@@ -19,6 +19,6 @@ def test_yum_conf_exclude_packages(convert2rhel, yum_conf_exclude):
             TEST_VARS["RHSM_SCA_PASSWORD"],
         )
     ) as c2r:
-        c2r.expect("IS_LOADED_KERNEL_LATEST has succeeded")
+        c2r.expect("The IS_LOADED_KERNEL_LATEST action has succeeded.")
 
     assert c2r.exitstatus == 0

--- a/tests/integration/tier1/non-destructive/httpd-package-transaction-error/test_httpd_package_transaction_error.py
+++ b/tests/integration/tier1/non-destructive/httpd-package-transaction-error/test_httpd_package_transaction_error.py
@@ -74,7 +74,7 @@ def test_httpd_package_transaction_error(shell, convert2rhel, handle_packages):
             timeout=900,
         )
         assert index == 0, "The analysis found an error. Probably related to the transaction check."
-        assert c2r.expect_exact("VALIDATE_PACKAGE_MANAGER_TRANSACTION has succeeded") == 0
+        assert c2r.expect_exact("The VALIDATE_PACKAGE_MANAGER_TRANSACTION action has succeeded.") == 0
 
     # Correct handling of the httpd package dependencies is expected
     assert c2r.exitstatus == 0


### PR DESCRIPTION
- no full stop at the end of a report message title
- no word please (technical writers' rule)
- ~~unique report message ids~~
  - breaking change => to be done under a separate PR targeted for 3.0.0
- fix typos
- add more details where messages are too short and vague
- make TASK tense consistent (making => make)
- ensure each Action has a task-level log message to not have only a stream of info-level messages without proper context
- ensure every Action prints what it's done (not just print "<actionID> has succeeded")
- boot loader => bootloader (we had a mix of these two possible variants)
- add unit tests to lines reported by caplog as uncovered (e.g. simply adding a full stop to a string triggers a codecov patch failure when the line was not previously covered)
- etc.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1761](https://issues.redhat.com/browse/RHELC-1761)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Label depicting the kind of PR it is <!-- kind/breaking kind/feature kind/bug-fix kind/security kind/tests etc. -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant


[RHELC-1761]: https://redhat.atlassian.net/browse/RHELC-1761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ