### PR TITLE
Bump version to 2.2.0

### DIFF
--- a/convert2rhel/__init__.py
+++ b/convert2rhel/__init__.py
@@ -1,2 +1,2 @@
 __metaclass__ = type
-__version__ = "2.1.0"
+__version__ = "2.2.0"

--- a/packaging/convert2rhel.spec
+++ b/packaging/convert2rhel.spec
@@ -9,8 +9,8 @@
 %endif
 
 Name:           convert2rhel
-Version:        2.1.0
-Release:        2%{?dist}
+Version:        2.2.0
+Release:        1%{?dist}
 Summary:        Automates the conversion of RHEL derivative distributions to RHEL
 
 License:        GPLv3+
@@ -69,9 +69,9 @@ Requires:       grub2-tools
 The purpose of the convert2rhel tool is to provide an automated way of
 converting the installed other-than-RHEL OS distribution to Red Hat Enterprise
 Linux (RHEL). The tool replaces all the original OS-signed packages with the
-RHEL ones. Available are conversions of CentOS Linux 7/8, Oracle Linux 7/8/9,
-Alma Linux 8/9, Rocky Linux 8/9 and Scientific Linux 7 to the respective major
-version of RHEL.
+RHEL ones. Available are conversions of CentOS Linux 7/8, CentOS Stream 8/9,
+Oracle Linux 7/8/9, Alma Linux 8/9, Rocky Linux 8/9 and Scientific Linux 7
+to the respective major version of RHEL.
 
 %prep
 %setup -q
@@ -125,6 +125,26 @@ install -m 0600 config/convert2rhel.ini %{buildroot}%{_sysconfdir}/convert2rhel.
 %attr(0644,root,root) %{_mandir}/man8/%{name}.8*
 
 %changelog
+* Thu Nov 28 2024 Michal Bocek <mbocek@redhat.com> 2.2.0
+- Rename GPG fingerprint to key_id
+- Port environment variables to config file
+- Add pre-conversion check for invalid grub file
+- Add deprecation notice about environment variables
+- Enable checking for EL9 convert2rhel latest version
+- Include EUS/ELS switches in breadcrumbs
+- Load inhibitor override env vars into the toolopts structure
+- Advise users to back up their system
+- Change out-of-date packages overridable inhibitor to a warning
+- Handle failing duplicate package check on EL9
+- Always check accessibility of --enablerepo repos
+- Fix missing /etc/yum.repos.d/ directory on EL9
+- Make the check for initramfs validity more robust
+- Make exit codes consistent when inhibitors found
+- Fix the latest RHEL kernel not set as default on CentOS Stream 9
+- Don't update RHSM facts with sub-man not present
+- Handle yum failing on trying to reach inaccessible --enablerepo repos
+
+
 * Wed Aug 21 2024 Preston Watson <prwatson@redhat.com> 2.1.0
 - Use public CDN instead of paywalled CDN and FTP
 - Remove RuntimeWarning caused by bufsize value of run_subprocess


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Enhancements 🎉
* [RHELC-961] Rename GPG fingerprint to key_id by @r0x0d in https://github.com/oamg/convert2rhel/pull/1280
* [RHELC-1507] Port environment variables to config file by @r0x0d in https://github.com/oamg/convert2rhel/pull/1272
* [RHELC-1601] Add pre-conversion check for invalid grub file by @pr-watson in https://github.com/oamg/convert2rhel/pull/1368
* [RHELC-1508] Add deprecation notice about environment variables by @r0x0d in https://github.com/oamg/convert2rhel/pull/1386
* [RHELC-1598] Enable checking for EL9 convert2rhel latest version by @pr-watson in https://github.com/oamg/convert2rhel/pull/1397
* [RHELC-1725] Include EUS/ELS switches in breadcrumbs by @pr-watson in https://github.com/oamg/convert2rhel/pull/1395
* [RHELC-1169]  Advise users to back up their system by @Andrew-ang9 in https://github.com/oamg/convert2rhel/pull/1235
* [RHELC-1578] Change out-of-date packages overridable inhibitor to a warning by @pr-watson in https://github.com/oamg/convert2rhel/pull/1385
### Bug Fixes 🐛
* [RHELC-1675] Handle failing duplicate package check on EL9 by @pr-watson in https://github.com/oamg/convert2rhel/pull/1363
* [RHELC-1747] Always check accessibility of --enablerepo repos by @r0x0d in https://github.com/oamg/convert2rhel/pull/1288
* [RHELC-1677] Fix missing /etc/yum.repos.d/ directory on EL9 by @hosekadam in https://github.com/oamg/convert2rhel/pull/1389
* [RHELC-1711] Make the check for initramfs validity more robust by @danmyway in https://github.com/oamg/convert2rhel/pull/1359
* [RHELC-1736] Make exit codes consistent when inhibitors found by @hosekadam in https://github.com/oamg/convert2rhel/pull/1392
* [RHELC-1717] Fix the latest RHEL kernel not set as default on CentOS Stream 9 by @hosekadam in https://github.com/oamg/convert2rhel/pull/1403
* [RHELC-1728] Don't update RHSM facts with sub-man not present by @bocekm in https://github.com/oamg/convert2rhel/pull/1435
* [RHELC-1753] Handle yum failing on trying to reach inaccessible --enablerepo repos by @hosekadam in https://github.com/oamg/convert2rhel/pull/1425
### Test Coverage Enhancements 🔧
* [RHELC-1615, RHELC-1602] Add integration test coverage for EL9 systems by @danmyway in https://github.com/oamg/convert2rhel/pull/946
* [RHELC-1615] CentOS Stream 9 test coverage by @danmyway in https://github.com/oamg/convert2rhel/pull/1354

## New Contributors
* @SerCantus made their first contribution in https://github.com/oamg/convert2rhel/pull/1265

**Full Changelog**: https://github.com/oamg/convert2rhel/compare/v2.1.0...v2.2.0