### PR TITLE
[RHELC-1780] Fix generating GRUB2 config file on UEFI EL9+

### DIFF
--- a/convert2rhel/actions/post_conversion/update_grub.py
+++ b/convert2rhel/actions/post_conversion/update_grub.py
@@ -54,12 +54,12 @@ class UpdateGrub(actions.Action):
                 id="GRUB2_CONFIG_CREATION_FAILED",
                 title="The grub2-mkconfig call failed to complete",
                 description=(
-                    "The grub2-mkconfig call failed with output: '{0}'. The conversion will continue but there"
-                    " may be issues with the current grub2 config and image formats.".format(output)
+                    "The grub2-mkconfig call failed with output:\n'{0}'.\nThe conversion will continue but there"
+                    " may be issues with the current grub2 config and image formats.".format(output.rstrip("\n"))
                 ),
                 remediations="If there are issues with the current grub2 config and image we recommend manually "
-                "re-generating them with 'grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg' and"
-                "'grub2-install [block device, e.g. /dev/sda]'.",
+                "re-generating them with 'grub2-mkconfig -o {0}' and"
+                "'grub2-install [block device, e.g. /dev/sda]'.".format(grub2_config_file),
             )
             return
 

--- a/convert2rhel/actions/post_conversion/update_grub.py
+++ b/convert2rhel/actions/post_conversion/update_grub.py
@@ -53,13 +53,11 @@ class UpdateGrub(actions.Action):
                 level="WARNING",
                 id="GRUB2_CONFIG_CREATION_FAILED",
                 title="The grub2-mkconfig call failed to complete",
-                description=(
-                    "The grub2-mkconfig call failed with output:\n'{0}'.\nThe conversion will continue but there"
-                    " may be issues with the current grub2 config and image formats.".format(output.rstrip("\n"))
-                ),
-                remediations="If there are issues with the current grub2 config and image we recommend manually "
-                "re-generating them with 'grub2-mkconfig -o {0}' and"
-                "'grub2-install [block device, e.g. /dev/sda]'.".format(grub2_config_file),
+                description="There may be issues with the bootloader configuration."
+                " Follow the recommended remediation before rebooting the system.",
+                diagnosis="The grub2-mkconfig call failed with output:\n'{0}'".format(output.rstrip("\n")),
+                remediations="Resolve the problem reported in the diagnosis and then run 'grub2-mkconfig -o {0}' and"
+                " 'grub2-install [block device, e.g. /dev/sda]'.".format(grub2_config_file),
             )
             return
 

--- a/convert2rhel/grub.py
+++ b/convert2rhel/grub.py
@@ -502,6 +502,8 @@ def get_grub_config_file():
     """
     grub_config_path = GRUB2_BIOS_CONFIG_FILE
 
+    # On RHEL 9 the path to the grub config file on UEFI has been unified with the one on BIOS. See:
+    #  https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/9.0_release_notes/index#enhancement_boot-loader
     if is_efi() and systeminfo.system_info.version.major < 9:
         grub_config_path = os.path.join(RHEL_EFIDIR_CANONICAL_PATH, "grub.cfg")
 

--- a/convert2rhel/grub.py
+++ b/convert2rhel/grub.py
@@ -502,7 +502,7 @@ def get_grub_config_file():
     """
     grub_config_path = GRUB2_BIOS_CONFIG_FILE
 
-    if is_efi():
+    if is_efi() and systeminfo.system_info.version.major < 9:
         grub_config_path = os.path.join(RHEL_EFIDIR_CANONICAL_PATH, "grub.cfg")
 
     return grub_config_path

--- a/convert2rhel/unit_tests/actions/post_conversion/update_grub_test.py
+++ b/convert2rhel/unit_tests/actions/post_conversion/update_grub_test.py
@@ -102,13 +102,12 @@ def test_update_grub(
                         id="GRUB2_CONFIG_CREATION_FAILED",
                         title="The grub2-mkconfig call failed to complete",
                         description=(
-                            "The grub2-mkconfig call failed with output:\n'output'.\nThe conversion will continue but there"
-                            " may be issues with the current grub2 config and image formats."
+                            "There may be issues with the bootloader configuration."
+                            " Follow the recommended remediation before rebooting the system."
                         ),
-                        diagnosis=None,
-                        remediations="If there are issues with the current grub2 config and image we recommend manually "
-                        "re-generating them with 'grub2-mkconfig -o /boot/grub2/grub.cfg' and"
-                        "'grub2-install [block device, e.g. /dev/sda]'.",
+                        diagnosis="The grub2-mkconfig call failed with output:\n'output'",
+                        remediations="Resolve the problem reported in the diagnosis and then run 'grub2-mkconfig -o"
+                        " /boot/grub2/grub.cfg' and 'grub2-install [block device, e.g. /dev/sda]'.",
                     ),
                 )
             ),
@@ -126,13 +125,12 @@ def test_update_grub(
                         id="GRUB2_CONFIG_CREATION_FAILED",
                         title="The grub2-mkconfig call failed to complete",
                         description=(
-                            "The grub2-mkconfig call failed with output:\n'output'.\nThe conversion will continue but there"
-                            " may be issues with the current grub2 config and image formats."
+                            "There may be issues with the bootloader configuration."
+                            " Follow the recommended remediation before rebooting the system."
                         ),
-                        diagnosis=None,
-                        remediations="If there are issues with the current grub2 config and image we recommend manually "
-                        "re-generating them with 'grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg' and"
-                        "'grub2-install [block device, e.g. /dev/sda]'.",
+                        diagnosis="The grub2-mkconfig call failed with output:\n'output'",
+                        remediations="Resolve the problem reported in the diagnosis and then run 'grub2-mkconfig -o"
+                        " /boot/efi/EFI/redhat/grub.cfg' and 'grub2-install [block device, e.g. /dev/sda]'.",
                     ),
                 )
             ),
@@ -150,13 +148,12 @@ def test_update_grub(
                         id="GRUB2_CONFIG_CREATION_FAILED",
                         title="The grub2-mkconfig call failed to complete",
                         description=(
-                            "The grub2-mkconfig call failed with output:\n'output'.\nThe conversion will continue but there"
-                            " may be issues with the current grub2 config and image formats."
+                            "There may be issues with the bootloader configuration."
+                            " Follow the recommended remediation before rebooting the system."
                         ),
-                        diagnosis=None,
-                        remediations="If there are issues with the current grub2 config and image we recommend manually "
-                        "re-generating them with 'grub2-mkconfig -o /boot/grub2/grub.cfg' and"
-                        "'grub2-install [block device, e.g. /dev/sda]'.",
+                        diagnosis="The grub2-mkconfig call failed with output:\n'output'",
+                        remediations="Resolve the problem reported in the diagnosis and then run 'grub2-mkconfig -o"
+                        " /boot/grub2/grub.cfg' and 'grub2-install [block device, e.g. /dev/sda]'.",
                     ),
                 )
             ),

--- a/convert2rhel/unit_tests/grub_test.py
+++ b/convert2rhel/unit_tests/grub_test.py
@@ -469,13 +469,16 @@ def test__remove_orig_boot_entry(
 
 
 @pytest.mark.parametrize(
-    ("is_efi", "config_path"),
+    ("is_efi", "config_path", "releasever_major"),
     (
-        (False, "/boot/grub2/grub.cfg"),
-        (True, "/boot/efi/EFI/redhat/grub.cfg"),
+        (False, "/boot/grub2/grub.cfg", 8),
+        (True, "/boot/efi/EFI/redhat/grub.cfg", 8),
+        (True, "/boot/grub2/grub.cfg", 9),
+        (False, "/boot/grub2/grub.cfg", 9),
     ),
 )
-def test_get_grub_config_file(is_efi, config_path, monkeypatch):
+def test_get_grub_config_file(is_efi, config_path, releasever_major, monkeypatch):
+    monkeypatch.setattr("convert2rhel.systeminfo.system_info.version", mock.Mock(major=releasever_major))
     monkeypatch.setattr("convert2rhel.grub.is_efi", mock.Mock(return_value=is_efi))
     config_file = grub.get_grub_config_file()
 


### PR DESCRIPTION
The output of the `grub2-mkconfig` call suggests to not use `/boot/efi/EFI/redhat/grub.cfg` as an output file, but use the `/boot/grub2/grub.cfg` instead.
Check what major version of OS is running and assign the grub config variable based on that.
Additionally, make the grub config into a variable inside the remediation - do not always advise to use the `/boot/efi/EFI/redhat/grub.cfg` 
Reformat the action message.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1780](https://issues.redhat.com/browse/RHELC-1780)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Label depicting the kind of PR it is <!-- kind/breaking kind/feature kind/bug-fix kind/security kind/tests etc. -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant


[RHELC-1780]: https://redhat.atlassian.net/browse/RHELC-1780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ