### PR TITLE
[RHELC-1682] Remove debug messages when comparing c2r versions

### DIFF
--- a/convert2rhel/actions/system_checks/convert2rhel_latest.py
+++ b/convert2rhel/actions/system_checks/convert2rhel_latest.py
@@ -99,7 +99,6 @@ class Convert2rhelLatest(actions.Action):
         # This loop will determine the latest available convert2rhel version in the yum repo.
         # It assigns the epoch, version, and release ex: ("0", "0.26", "1.el7") to the latest_available_version variable.
         for package_version in convert2rhel_versions:
-            logger.debug("...comparing version {}".format(latest_available_version[1]))
             # rpm.labelCompare(pkg1, pkg2) compare two package version strings and return
             # -1 if latest_version is greater than package_version, 0 if they are equal, 1 if package_version is greater than latest_version
             ver_compare = rpm.labelCompare(
@@ -107,9 +106,6 @@ class Convert2rhelLatest(actions.Action):
             )
 
             if ver_compare > 0:
-                logger.debug(
-                    "...found {} to be newer than {}, updating".format(package_version[2], latest_available_version[1])
-                )
                 latest_available_version = (package_version[1], package_version[2], package_version[3])
 
         logger.debug("Found {} to be latest available version".format(latest_available_version[1]))


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
The tool version check iterates over all the versions available in the convert2rhel repository. 
While doing so, it provides unnecessary information in the debug messages.
Remove the debug messages to keep the output less polluted.
<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
- [RHELC-1682](https://issues.redhat.com/browse/RHELC-1682)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Label depicting the kind of PR it is <!-- kind/breaking kind/feature kind/bug-fix kind/security kind/tests etc. -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
