### PR TITLE
chore: replace percent strings for logging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ minimum_pre_commit_version: "2.9.0"
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.7.3
+    rev: v0.8.2
     hooks:
       # Run the linter.
       - id: ruff
@@ -42,6 +42,6 @@ repos:
       - id: gitleaks
         stages: [manual, pre-push]
   - repo: https://github.com/jendrikseipp/vulture
-    rev: v2.13
+    rev: v2.14
     hooks:
       - id: vulture

--- a/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
+++ b/convert2rhel/actions/system_checks/is_loaded_kernel_latest.py
@@ -39,8 +39,10 @@ class IsLoadedKernelLatest(actions.Action):
 
         if system_info.id == "oracle" and system_info.eus_system:
             logger.info(
-                "Did not perform the check because there were no publicly available %s %d.%d repositories available."
-                % (system_info.name, system_info.version.major, system_info.version.minor)
+                "Did not perform the check because there were no publicly available %s %d.%d repositories available.",
+                system_info.name,
+                system_info.version.major,
+                system_info.version.minor,
             )
             return
 

--- a/convert2rhel/actions/system_checks/package_updates.py
+++ b/convert2rhel/actions/system_checks/package_updates.py
@@ -35,8 +35,9 @@ class PackageUpdates(actions.Action):
 
         if system_info.id == "oracle" and system_info.eus_system:
             logger.info(
-                "Did not perform the check because there were no publicly available %s %d.%d repositories available."
-                % (system_info.name, system_info.version.major, system_info.version.minor)
+                "Did not perform the check because there were no publicly available {} {}.{} repositories available.".format(
+                    system_info.name, system_info.version.major, system_info.version.minor
+                )
             )
             self.add_message(
                 level="INFO",
@@ -44,8 +45,9 @@ class PackageUpdates(actions.Action):
                 title="Did not perform the package updates check",
                 description="Please refer to the diagnosis for further information",
                 diagnosis=(
-                    "Did not perform the check because there were no publicly available %s %d.%d repositories available."
-                    % (system_info.name, system_info.version.major, system_info.version.minor)
+                    "Did not perform the check because there were no publicly available {} {}.{} repositories available.".format(
+                        system_info.name, system_info.version.major, system_info.version.minor
+                    )
                 ),
             )
             return

--- a/convert2rhel/actions/system_checks/rhel_compatible_kernel.py
+++ b/convert2rhel/actions/system_checks/rhel_compatible_kernel.py
@@ -131,8 +131,9 @@ def _bad_kernel_version(kernel_release):
         )
 
     logger.debug(
-        "Booted kernel version '%s' corresponds to the version available in RHEL %d"
-        % (kernel_version, system_info.version.major)
+        "Booted kernel version '{}' corresponds to the version available in RHEL {}".format(
+            kernel_version, system_info.version.major
+        )
     )
     return False
 

--- a/convert2rhel/applock.py
+++ b/convert2rhel/applock.py
@@ -72,7 +72,7 @@ class ApplicationLock:
             status = "locked"
         else:
             status = "unlocked"
-        return "%s PID %d %s" % (self._pidfile, self._pid, status)
+        return "{} PID {} {}".format(self._pidfile, self._pid, status)
 
     def _try_create(self):
         """Try to create the lock file. If this succeeds, the lock file
@@ -149,10 +149,10 @@ class ApplicationLock:
             raise ApplicationLockedError("Lock file {} is corrupt".format(self._pidfile))
 
         if self._pid_exists(pid):
-            raise ApplicationLockedError("%s locked by process %d" % (self._pidfile, pid))
+            raise ApplicationLockedError("{} locked by process {}".format(self._pidfile, pid))
         # The lock file was created by a process that has exited;
         # remove it and try again.
-        logger.info("Cleaning up lock held by exited process %d." % pid)
+        logger.info("Cleaning up lock held by exited process %d.", pid)
         os.unlink(self._pidfile)
         self.try_to_lock(_recursive=True)
 

--- a/convert2rhel/backup/packages.py
+++ b/convert2rhel/backup/packages.py
@@ -166,8 +166,9 @@ class RestorablePackage(RestorableChange):
                         "one or more packages that we removed as part of the "
                         "conversion."
                     ),
-                    diagnosis="Couldn't install %s packages. Command: %s Output: %s Status: %d"
-                    % (pkgs_as_str, cmd, output, ret_code),
+                    diagnosis="Couldn't install {} packages. Command: {} Output: {} Status: {}".format(
+                        pkgs_as_str, cmd, output, ret_code
+                    ),
                 )
 
             logger.warning("Couldn't install {} packages.".format(pkgs_as_str))

--- a/convert2rhel/pkghandler.py
+++ b/convert2rhel/pkghandler.py
@@ -328,8 +328,7 @@ def format_pkg_info(pkgs, disable_repos=None):
     max_nvra_length = max(len(nvra) for nvra in package_info)
 
     header = (
-        "%-*s  %-*s  %s"
-        % (
+        "{}-{}  {}-{}  {}".format(
             max_nvra_length,
             "Package",
             max_packager_length,
@@ -339,8 +338,7 @@ def format_pkg_info(pkgs, disable_repos=None):
         + "\n"
     )
     header_underline = (
-        "%-*s  %-*s  %s"
-        % (
+        "{}-{}  {}-{}  {}".format(
             max_nvra_length,
             "-" * len("Package"),
             max_packager_length,
@@ -358,8 +356,7 @@ def format_pkg_info(pkgs, disable_repos=None):
     pkg_list = ""
     for package, info in package_info.items():
         pkg_list += (
-            "%-*s  %-*s  %s"
-            % (
+            "{}-{}  {}-{}  {}".format(
                 max_nvra_length,
                 package,
                 max_packager_length,

--- a/convert2rhel/pkgmanager/handlers/dnf/callback.py
+++ b/convert2rhel/pkgmanager/handlers/dnf/callback.py
@@ -196,7 +196,7 @@ class PackageDownloadCallback(pkgmanager.DownloadProgress):
         if status:
             # the error message, no trimming
             if status == pkgmanager.callback.STATUS_DRPM and self.total_drpm > 1:
-                message = "(%d/%d) [%s %d/%d]: %s" % (
+                message = "({}/{}) [{} {}/{}]: {}".format(
                     self.done_files,
                     self.total_files,
                     self._STATUS_MAPPING[status],
@@ -206,7 +206,7 @@ class PackageDownloadCallback(pkgmanager.DownloadProgress):
                 )
                 message = "{} - {}".format(message, err_msg)
             else:
-                message = "(%d/%d) [%s]: %s" % (
+                message = "({}/{}) [{}]: {}".format(
                     self.done_files,
                     self.total_files,
                     self._STATUS_MAPPING.get(status, "Unknown"),
@@ -214,7 +214,7 @@ class PackageDownloadCallback(pkgmanager.DownloadProgress):
                 )
         else:
             if self.total_files > 1:
-                message = "(%d/%d): %s" % (self.done_files, self.total_files, package)
+                message = "({}/{}): {}".format(self.done_files, self.total_files, package)
 
         if message:
             logger.info(message)

--- a/convert2rhel/subscription.py
+++ b/convert2rhel/subscription.py
@@ -154,7 +154,7 @@ def register_system():
     while attempt < MAX_NUM_OF_ATTEMPTS_TO_SUBSCRIBE:
         attempt_msg = ""
         if attempt > 0:
-            attempt_msg = "Attempt %d of %d: " % (
+            attempt_msg = "Attempt {} of {}: ".format(
                 attempt + 1,
                 MAX_NUM_OF_ATTEMPTS_TO_SUBSCRIBE,
             )

--- a/convert2rhel/systeminfo.py
+++ b/convert2rhel/systeminfo.py
@@ -185,10 +185,10 @@ class SystemInfo:
 
     def print_system_information(self):
         """Print system related information."""
-        logger.info("%-20s %s" % ("Name:", self.name))
-        logger.info("%-20s %s" % ("OS version:", self.version))
-        logger.info("%-20s %s" % ("Architecture:", self.arch))
-        logger.info("%-20s %s" % ("Config filename:", self.cfg_filename))
+        logger.info("%-20s %s", "Name:", self.name)
+        logger.info("%-20s %s", "OS version:", self.version)
+        logger.info("%-20s %s", "Architecture:", self.arch)
+        logger.info("%-20s %s", "Config filename:", self.cfg_filename)
 
     @staticmethod
     def get_system_release_file_content():
@@ -284,7 +284,7 @@ class SystemInfo:
         return arch
 
     def _get_cfg_filename(self):
-        cfg_filename = "%s-%d-%s.cfg" % (
+        cfg_filename = "{}-{}-{}.cfg".format(
             self.id,
             self.version.major,
             self.arch,


### PR DESCRIPTION
This replaces logging with their best counterpart. Either normal logging
methods with arguments, or by utilizing `.format()`

Depends on #1431