### PR TITLE
[RHELC-1792] Allow using % character in convert2rhel.ini

### DIFF
--- a/convert2rhel/toolopts/config.py
+++ b/convert2rhel/toolopts/config.py
@@ -20,6 +20,7 @@ import abc
 import copy
 import logging
 import os
+from sys import version_info
 
 import six
 
@@ -151,7 +152,14 @@ class FileConfig(BaseConfig):
             them.
         :type paths: list[str]
         """
-        config_file = configparser.ConfigParser()
+
+        # The reason for using the RawConfigParser and ConfigParser with interpolation set to None is to prevent
+        # interpreting % as a sign for string replacement. This interpolation feature would cause convert2rhel to fail
+        # if the user enters the % character in the config file, for example in the RHSM password.
+        if version_info.major < 3:
+            config_file = configparser.RawConfigParser()
+        else:
+            config_file = configparser.ConfigParser(interpolation=None)
         found_opts = {}
 
         for path in reversed(paths):

--- a/convert2rhel/unit_tests/toolopts/config_test.py
+++ b/convert2rhel/unit_tests/toolopts/config_test.py
@@ -86,9 +86,9 @@ username = "correct_username"
             (
                 """\
 [subscription_manager]
-password = correct_password
+password = %correct_password%
                 """,
-                {"password": "correct_password"},
+                {"password": "%correct_password%"},
             ),
             (
                 """\


### PR DESCRIPTION
Whenever a user entered the % character in the convert2rhel.ini config file, such as in the RHSM password, convert2rhel failed with an error:
```
configparser.InterpolationSyntaxError: '%' must be followed by '%' or '(', found: "%<STRING>"
```

The solution is to disable interpreting the % character as a sign for string replacement.

Related: https://access.redhat.com/solutions/7107977

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-1792](https://issues.redhat.com/browse/RHELC-1792) -->
- [RHELC-1792](https://issues.redhat.com/browse/RHELC-1792)

Checklist

- [x] PR has been tested manually in a VM (either author or reviewer)
- [x] Jira issue has been made public if possible
- [x] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] Label depicting the kind of PR it is <!-- kind/breaking kind/feature kind/bug-fix kind/security kind/tests etc. -->
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant


[RHELC-1792]: https://redhat.atlassian.net/browse/RHELC-1792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHELC-1792]: https://redhat.atlassian.net/browse/RHELC-1792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ