### PR TITLE
Update Python version in manpage workflow to 3.13

### DIFF
--- a/.github/workflows/generate_manpage.yml
+++ b/.github/workflows/generate_manpage.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.13.3
+          python-version: 3.13
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
The version 3.13.3 of Python is not available in the Ubuntu 22.04