### PR TITLE
Disable Oracle Linux 7.9 test pipelines

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -391,61 +391,61 @@ jobs:
       - sanity-el7
       - sanity-centos
 
-  - &tests-tier0-oraclelinux-7
-    job: tests
-    # Run tests on-demand
-    manual_trigger: true
-    # Do not merge the PR into the target branch, in case the merge is broken
-    # Given we are rebasing the source branches regularly, we do not need this feature enabled
-    merge_pr_in_ci: false
-    trigger: pull_request
-    identifier: "tier0-ol7"
-    tmt_plan: "tier0/core"
-    # Run on Red Testing Farm Hat Ranch, tag resources to sst_conversions
-    use_internal_tf: True
-    # For some targets we use official AWS marketplace images, those do not support root ssh login as default,
-    # therefore we need to pass post-install-script to enable root login on the host
-    tf_post_install_script: '#!/bin/bash\nsudo sed -i "s/^.*ssh-rsa/ssh-rsa/" /root/.ssh/authorized_keys'
-    targets:
-      epel-7-x86_64:
-        distros: ["OL7.9-x86_64-HVM-2023-01-05"]
-    tf_extra_params:
-      environments:
-        - tmt:
-            context:
-              distro: "oracle-7"
-          settings:
-            provisioning:
-              tags:
-                BusinessUnit: sst_conversions
-      settings:
-        pipeline:
-            parallel-limit: 20
-    labels:
-      - el7
-      - oracle7
-      - oracle
-      - tier0
-      - tier0-oracle7
-      - tier0-el7
-      - tier0-oracle
-
-  - &tests-sanity-oraclelinux-7
-    <<: *tests-tier0-oraclelinux-7
-    identifier: "sanity-ol7"
-    tmt_plan: "tier0/sanity"
-    labels:
-      - el7
-      - oracle7
-      - oracle
-      - tier0
-      - tier0-oracle7
-      - tier0-el7
-      - tier0-oracle
-      - sanity
-      - sanity-oracle7
-      - sanity-el7
-      - sanity-oracle
+#   - &tests-tier0-oraclelinux-7
+#     job: tests
+#     # Run tests on-demand
+#     manual_trigger: true
+#     # Do not merge the PR into the target branch, in case the merge is broken
+#     # Given we are rebasing the source branches regularly, we do not need this feature enabled
+#     merge_pr_in_ci: false
+#     trigger: pull_request
+#     identifier: "tier0-ol7"
+#     tmt_plan: "tier0/core"
+#     # Run on Red Testing Farm Hat Ranch, tag resources to sst_conversions
+#     use_internal_tf: True
+#     # For some targets we use official AWS marketplace images, those do not support root ssh login as default,
+#     # therefore we need to pass post-install-script to enable root login on the host
+#     tf_post_install_script: '#!/bin/bash\nsudo sed -i "s/^.*ssh-rsa/ssh-rsa/" /root/.ssh/authorized_keys'
+#     targets:
+#       epel-7-x86_64:
+#         distros: ["OL7.9-x86_64-HVM-2023-01-05"]
+#     tf_extra_params:
+#       environments:
+#         - tmt:
+#             context:
+#               distro: "oracle-7"
+#           settings:
+#             provisioning:
+#               tags:
+#                 BusinessUnit: sst_conversions
+#       settings:
+#         pipeline:
+#             parallel-limit: 20
+#     labels:
+#       - el7
+#       - oracle7
+#       - oracle
+#       - tier0
+#       - tier0-oracle7
+#       - tier0-el7
+#       - tier0-oracle
+#
+#   - &tests-sanity-oraclelinux-7
+#     <<: *tests-tier0-oraclelinux-7
+#     identifier: "sanity-ol7"
+#     tmt_plan: "tier0/sanity"
+#     labels:
+#       - el7
+#       - oracle7
+#       - oracle
+#       - tier0
+#       - tier0-oracle7
+#       - tier0-el7
+#       - tier0-oracle
+#       - sanity
+#       - sanity-oracle7
+#       - sanity-el7
+#       - sanity-oracle
 
   - &tests-tier0-oraclelinux-8
     job: tests
@@ -749,18 +749,18 @@ jobs:
       - tier1-el7
       - tier1-centos
 
-  - &tests-tier1-manual-oraclelinux-7
-    <<: *tests-tier0-oraclelinux-7
-    identifier: "tier1-ol7"
-    tmt_plan: "tier1"
-    labels:
-      - el7
-      - oracle7
-      - oracle
-      - tier1
-      - tier1-oracle7
-      - tier1-el7
-      - tier1-oracle
+#   - &tests-tier1-manual-oraclelinux-7
+#     <<: *tests-tier0-oraclelinux-7
+#     identifier: "tier1-ol7"
+#     tmt_plan: "tier1"
+#     labels:
+#       - el7
+#       - oracle7
+#       - oracle
+#       - tier1
+#       - tier1-oracle7
+#       - tier1-el7
+#       - tier1-oracle
 
   - &tests-tier1-manual-centos8
     <<: *tests-tier0-centos8
@@ -891,14 +891,14 @@ jobs:
     trigger: commit
     branch: main
 
-  - &tests-main-tier1-oraclelinux-7
-    <<: *tests-tier0-oraclelinux-7
-    # Run test automatically with merge commit to main branch
-    manual_trigger: false
-    identifier: "tier1-ol7"
-    tmt_plan: "tier1"
-    trigger: commit
-    branch: main
+#   - &tests-main-tier1-oraclelinux-7
+#     <<: *tests-tier0-oraclelinux-7
+#     # Run test automatically with merge commit to main branch
+#     manual_trigger: false
+#     identifier: "tier1-ol7"
+#     tmt_plan: "tier1"
+#     trigger: commit
+#     branch: main
 
   - &tests-main-tier1-centos8
     <<: *tests-tier0-centos8


### PR DESCRIPTION
* Oracle Linux 7.9 image we used for testing got removed from AWS, disable the pipelines until a new image is available

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RHELC-](https://issues.redhat.com/browse/RHELC-) -->
-

Checklist

- [ ] PR has been tested manually in a VM (either author or reviewer)
- [ ] Jira issue has been made public if possible
- [ ] `[RHELC-]` or `[HMS-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] Label depicting the kind of PR it is <!-- kind/breaking kind/feature kind/bug-fix kind/security kind/tests etc. -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
- [ ] When merged: Jira issue has been updated to `Release Pending` if relevant
