### PR TITLE
Add VS Code workspace file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ TAGS
 !.vscode/extensions.json
 docs/build/*
 docs/source/_autosummary
+*.code-workspace


### PR DESCRIPTION
To not bother devs with git reporting an unstaged file when using the VS Code IDE.