### PR TITLE
Revert Sphinx requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx==8.2.3
-sphinx_autodoc_typehints==3.2.0
+Sphinx==7.4.7 # need to use this version as Sphinx 8+ requires py3.11+ and CentOS Stream 9 we use for building docs has py3.9
+sphinx_autodoc_typehints==2.3.0  # can't use newer due to the Sphinx 7.4.7 requirement


### PR DESCRIPTION
Reverting https://github.com/oamg/convert2rhel/pull/1450 and https://github.com/oamg/convert2rhel/pull/1465.
We need to keep using Sphinx==7.4.7 because Sphinx v8+ requires py3.11+ and CentOS Stream 9 we use for building docs has py3.9.