### PR TITLE
Remove leftover docs building set up

### DIFF
--- a/Containerfiles/centos9.Containerfile
+++ b/Containerfiles/centos9.Containerfile
@@ -5,7 +5,6 @@ ENV PIP pip3
 ENV PYTHONDONTWRITEBYTECODE 1
 
 ENV APP_DEV_DEPS "requirements/centos9.requirements.txt"
-ENV APP_DOCS_DEPS "docs/requirements.txt"
 ENV APP_MAIN_DEPS \
     util-linux \
     python3 \
@@ -28,8 +27,7 @@ RUN dnf update -y && dnf install -y $APP_MAIN_DEPS && dnf clean all
 FROM install_main_deps as install_dev_deps
 RUN curl $URL_GET_PIP | $PYTHON
 COPY $APP_DEV_DEPS $APP_DEV_DEPS
-COPY $APP_DOCS_DEPS $APP_DOCS_DEPS
-RUN $PIP install -r $APP_DEV_DEPS -r $APP_DOCS_DEPS
+RUN $PIP install -r $APP_DEV_DEPS
 
 FROM install_dev_deps as install_application
 RUN groupadd --gid=1000 -r app && \


### PR DESCRIPTION
Is causing the `build-centos9` action to fail: https://github.com/oamg/convert2rhel/actions/runs/25372681935/job/74399864853.

Follow-up to https://github.com/oamg/convert2rhel/pull/1487.