### PR TITLE
Fix ValueError crash when terminal columns is zero

### DIFF
--- a/convert2rhel/unit_tests/utils/utils_test.py
+++ b/convert2rhel/unit_tests/utils/utils_test.py
@@ -23,6 +23,7 @@ import logging
 import os
 import re
 import shutil
+import struct
 import sys
 
 from pickle import PicklingError
@@ -1172,3 +1173,47 @@ def test_warn_deprecated_env_wrong_name(global_tool_opts, monkeypatch, caplog):
     for item, value in global_tool_opts.__dict__.items():
         assert default_tool_opts.__dict__[item] == value
     assert not caplog.text
+
+
+class TestGetTerminalSize:
+    @mock.patch("convert2rhel.utils.shutil.get_terminal_size", create=True, side_effect=AttributeError)
+    @mock.patch("convert2rhel.utils.sys.stdout")
+    @mock.patch("convert2rhel.utils.fcntl.ioctl")
+    def test_zero_columns_falls_back_to_80(self, mock_ioctl, mock_stdout, _):
+        mock_stdout.isatty.return_value = True
+        mock_stdout.fileno.return_value = 1
+        mock_ioctl.return_value = struct.pack("HHHH", 24, 0, 0, 0)
+        assert utils.get_terminal_size() == (80, 24)
+
+    @mock.patch("convert2rhel.utils.shutil.get_terminal_size", create=True, side_effect=AttributeError)
+    @mock.patch("convert2rhel.utils.sys.stdout")
+    @mock.patch("convert2rhel.utils.fcntl.ioctl")
+    def test_zero_rows_falls_back_to_24(self, mock_ioctl, mock_stdout, _):
+        mock_stdout.isatty.return_value = True
+        mock_stdout.fileno.return_value = 1
+        mock_ioctl.return_value = struct.pack("HHHH", 0, 100, 0, 0)
+        assert utils.get_terminal_size() == (100, 24)
+
+    @mock.patch("convert2rhel.utils.shutil.get_terminal_size", create=True, side_effect=AttributeError)
+    @mock.patch("convert2rhel.utils.sys.stdout")
+    @mock.patch("convert2rhel.utils.fcntl.ioctl")
+    def test_both_zero_falls_back_to_defaults(self, mock_ioctl, mock_stdout, _):
+        mock_stdout.isatty.return_value = True
+        mock_stdout.fileno.return_value = 1
+        mock_ioctl.return_value = struct.pack("HHHH", 0, 0, 0, 0)
+        assert utils.get_terminal_size() == (80, 24)
+
+    @mock.patch("convert2rhel.utils.shutil.get_terminal_size", create=True, side_effect=AttributeError)
+    @mock.patch("convert2rhel.utils.sys.stdout")
+    @mock.patch("convert2rhel.utils.fcntl.ioctl")
+    def test_normal_values_pass_through(self, mock_ioctl, mock_stdout, _):
+        mock_stdout.isatty.return_value = True
+        mock_stdout.fileno.return_value = 1
+        mock_ioctl.return_value = struct.pack("HHHH", 50, 120, 0, 0)
+        assert utils.get_terminal_size() == (120, 50)
+
+    @mock.patch("convert2rhel.utils.shutil.get_terminal_size", create=True, side_effect=AttributeError)
+    @mock.patch("convert2rhel.utils.sys.stdout")
+    def test_non_tty_returns_defaults(self, mock_stdout, _):
+        mock_stdout.isatty.return_value = False
+        assert utils.get_terminal_size() == (80, 24)

--- a/convert2rhel/utils/__init__.py
+++ b/convert2rhel/utils/__init__.py
@@ -990,7 +990,9 @@ def get_terminal_size():
     size = struct.unpack("HHHH", terminal_info)[:2]
     # The fcntl data has height, width but shutil.get_terminal_size, which
     # we're emulating uses width, height.
-    return (size[1], size[0])
+    columns = size[1] or 80
+    rows = size[0] or 24
+    return (columns, rows)
 
 
 def hide_secrets(


### PR DESCRIPTION
## Description
Fix a crash in the pre-conversion analysis report when terminal columns
is reported as 0 (e.g. `stty cols 0`).
On Python 2.7 (RHEL/CentOS 7), `get_terminal_size()` uses `fcntl.ioctl`
to query the terminal dimensions and returns the raw value with no
validation. When columns is 0, `textwrap.wrap()` raises
`ValueError: invalid width 0 (must be > 0)` during report formatting.
On Python 3, `shutil.get_terminal_size()` already guards against this
with `size.columns or fallback[0]`. This PR applies the same `or`
fallback pattern to the Python 2 codepath.

## Changes
- `convert2rhel/utils/__init__.py`: Add fallback to 80 columns / 24 rows
  when ioctl returns 0 in `get_terminal_size()`
- `convert2rhel/unit_tests/utils/utils_test.py`: Add `TestGetTerminalSize`
  class with 5 tests covering zero columns, zero rows, both zero, normal
  values, and non-tty fallback